### PR TITLE
Wire MageKnightEngine to GameServer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+**PRs should always target the `main` branch.**
+
 ## Build & Test Commands
 
 ```bash

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@
 
 // Types
 export type * from "./types/index.js";
+export { Hero, HEROES } from "./types/index.js";
 
 // State
 export type {
@@ -38,7 +39,11 @@ export {
   allowsMultipleHeroes,
 } from "./data/siteProperties.js";
 
-// Engine (modifier system, calculations)
+// Engine
+export { MageKnightEngine, createEngine } from "./engine/index.js";
+export type { ActionResult } from "./engine/index.js";
+
+// Modifiers
 export type { ExpirationTrigger } from "./engine/index.js";
 export {
   // Query helpers

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,7 +7,8 @@
   "types": "./dist/esm/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "test": "echo 'Server tests not yet configured'",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint src/"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
     "@eslint/js": "^9.17.0",
     "eslint": "^9.17.0",
     "typescript": "^5.7.2",
-    "typescript-eslint": "^8.19.0"
+    "typescript-eslint": "^8.19.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/server/src/__tests__/GameServer.test.ts
+++ b/packages/server/src/__tests__/GameServer.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createGameServer, GameServer } from "../index.js";
+import type { GameEvent, ClientGameState } from "@mage-knight/shared";
+import type { HexState } from "@mage-knight/core";
+
+describe("GameServer", () => {
+  let server: GameServer;
+
+  beforeEach(() => {
+    server = createGameServer();
+  });
+
+  describe("connection", () => {
+    it("should allow players to connect", () => {
+      const callback = vi.fn();
+
+      server.initializeGame(["player1"]);
+      server.connect("player1", callback);
+
+      // Should receive initial state
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, state] = callback.mock.calls[0] as [GameEvent[], ClientGameState];
+      expect(state.players).toHaveLength(1);
+      expect(state.players[0].id).toBe("player1");
+    });
+
+    it("should send filtered state to each player", () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      server.initializeGame(["player1", "player2"]);
+      server.connect("player1", callback1);
+      server.connect("player2", callback2);
+
+      const state1 = callback1.mock.calls[0][1] as ClientGameState;
+
+      // Each player should see their own hand as array
+      // and other player's hand as number
+      const p1InState1 = state1.players.find((p) => p.id === "player1");
+      const p2InState1 = state1.players.find((p) => p.id === "player2");
+
+      expect(Array.isArray(p1InState1?.hand)).toBe(true);
+      expect(typeof p2InState1?.hand).toBe("number");
+
+      // Verify callback2 was also called (player2 receives state)
+      expect(callback2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("action handling", () => {
+    it("should process action and broadcast to all players", () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      server.initializeGame(["player1", "player2"]);
+      server.connect("player1", callback1);
+      server.connect("player2", callback2);
+
+      // Clear initial connection calls
+      callback1.mockClear();
+      callback2.mockClear();
+
+      // Player1 sends an action (will fail validation since not on map, but that's ok)
+      server.handleAction("player1", { type: "END_TURN" });
+
+      // Both players should receive the broadcast
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledTimes(1);
+    });
+
+    it("should update state after valid action", () => {
+      server.initializeGame(["player1"]);
+
+      // Manually set up state for a valid move
+      const state = server.getState();
+      const testHex: HexState = {
+        coord: { q: 0, r: 0 },
+        terrain: "plains",
+        tileId: "starting_a",
+        site: null,
+        enemies: [],
+        shieldTokens: [],
+        rampagingEnemies: [],
+      };
+      const targetHex: HexState = {
+        coord: { q: 1, r: 0 },
+        terrain: "plains",
+        tileId: "starting_a",
+        site: null,
+        enemies: [],
+        shieldTokens: [],
+        rampagingEnemies: [],
+      };
+      const updatedState = {
+        ...state,
+        players: [
+          {
+            ...state.players[0],
+            position: { q: 0, r: 0 },
+            movePoints: 4,
+          },
+        ],
+        map: {
+          ...state.map,
+          hexes: {
+            "0,0": testHex,
+            "1,0": targetHex,
+          },
+        },
+      };
+
+      // Hacky but works for testing - directly set state
+      (server as unknown as { state: typeof updatedState }).state =
+        updatedState;
+
+      const callback = vi.fn();
+      server.connect("player1", callback);
+      callback.mockClear();
+
+      // Now move
+      server.handleAction("player1", { type: "MOVE", target: { q: 1, r: 0 } });
+
+      // Should have moved
+      const newState = server.getState();
+      expect(newState.players[0].position).toEqual({ q: 1, r: 0 });
+
+      // Should have received PLAYER_MOVED event
+      const [events] = callback.mock.calls[0] as [GameEvent[]];
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "PLAYER_MOVED",
+          playerId: "player1",
+        })
+      );
+    });
+  });
+
+  describe("multiplayer broadcast", () => {
+    it("should broadcast to all players when one acts", () => {
+      const callbacks = [vi.fn(), vi.fn(), vi.fn()];
+
+      server.initializeGame(["player1", "player2", "player3"]);
+      server.connect("player1", callbacks[0]);
+      server.connect("player2", callbacks[1]);
+      server.connect("player3", callbacks[2]);
+
+      callbacks.forEach((cb) => cb.mockClear());
+
+      server.handleAction("player1", { type: "UNDO" });
+
+      // All three should receive broadcast
+      expect(callbacks[0]).toHaveBeenCalledTimes(1);
+      expect(callbacks[1]).toHaveBeenCalledTimes(1);
+      expect(callbacks[2]).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("game initialization", () => {
+    it("should broadcast GAME_STARTED event on initialization", () => {
+      const callback = vi.fn();
+
+      server.connect("player1", callback);
+      callback.mockClear();
+
+      server.initializeGame(["player1", "player2"]);
+
+      // Should have broadcast GAME_STARTED
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [events] = callback.mock.calls[0] as [GameEvent[]];
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          type: "GAME_STARTED",
+          playerCount: 2,
+        })
+      );
+    });
+
+    it("should assign different heroes to players", () => {
+      server.initializeGame(["player1", "player2", "player3", "player4"]);
+
+      const state = server.getState();
+      const heroIds = state.players.map((p) => p.hero);
+
+      // All 4 players should have different heroes
+      const uniqueHeroes = new Set(heroIds);
+      expect(uniqueHeroes.size).toBe(4);
+    });
+  });
+
+  describe("getStateForPlayer", () => {
+    it("should return filtered state for specific player", () => {
+      server.initializeGame(["player1", "player2"]);
+
+      const state1 = server.getStateForPlayer("player1");
+      const state2 = server.getStateForPlayer("player2");
+
+      // Player1's view should show their hand as array
+      const p1InState1 = state1.players.find((p) => p.id === "player1");
+      expect(Array.isArray(p1InState1?.hand)).toBe(true);
+
+      // Player2's view should show player1's hand as number
+      const p1InState2 = state2.players.find((p) => p.id === "player1");
+      expect(typeof p1InState2?.hand).toBe("number");
+    });
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,14 @@
  * Server wrapper that connects the game engine to clients
  */
 
-import { type GameState, createInitialGameState } from "@mage-knight/core";
+import {
+  type GameState,
+  type Player,
+  createInitialGameState,
+  MageKnightEngine,
+  createEngine,
+  Hero,
+} from "@mage-knight/core";
 import {
   LocalConnection,
   type GameConnection,
@@ -12,84 +19,139 @@ import {
   type ActionResult,
   type GameEvent,
   type ClientGameState,
+  type ClientPlayer,
+  type ClientPlayerUnit,
+  type ClientManaToken,
   type EventCallback,
 } from "@mage-knight/shared";
 
 // ============================================================================
-// Single-player game instance (uses LocalConnection)
+// State conversion - full GameState to filtered ClientGameState
 // ============================================================================
-
-export interface GameInstance {
-  readonly engine: GameEngine;
-  readonly connection: GameConnection;
-}
 
 /**
  * Convert full GameState to ClientGameState for a specific player.
- * For now this is a placeholder that returns minimal data.
- * TODO: Implement proper state filtering (hide other players' hands, deck contents, etc.)
+ * Filters sensitive information (other players' hands, deck contents, etc.)
  */
 export function toClientState(
-  _state: GameState,
-  _forPlayerId: string
+  state: GameState,
+  forPlayerId: string
 ): ClientGameState {
-  // Placeholder - return minimal valid ClientGameState
   return {
-    phase: "setup",
-    timeOfDay: "day",
-    round: 1,
-    turnOrder: [],
-    currentPlayerId: "",
-    endOfRoundAnnouncedBy: null,
-    players: [],
+    phase: state.phase,
+    timeOfDay: state.timeOfDay,
+    round: state.round,
+    currentPlayerId: state.turnOrder[state.currentPlayerIndex] ?? "",
+    turnOrder: state.turnOrder,
+    endOfRoundAnnouncedBy: state.endOfRoundAnnouncedBy,
+
+    players: state.players.map((player) =>
+      toClientPlayer(player, forPlayerId)
+    ),
+
     map: {
-      hexes: {},
-      tiles: [],
+      hexes: Object.fromEntries(
+        Object.entries(state.map.hexes).map(([key, hex]) => [
+          key,
+          {
+            coord: hex.coord,
+            terrain: hex.terrain,
+            tileId: hex.tileId,
+            site: hex.site
+              ? {
+                  type: hex.site.type,
+                  owner: hex.site.owner,
+                  isConquered: hex.site.isConquered,
+                  isBurned: hex.site.isBurned,
+                  ...(hex.site.cityColor && { cityColor: hex.site.cityColor }),
+                  ...(hex.site.mineColor && { mineColor: hex.site.mineColor }),
+                }
+              : null,
+            enemies: hex.enemies.map(String),
+            shieldTokens: [...hex.shieldTokens],
+            rampagingEnemies: hex.rampagingEnemies.map(String),
+          },
+        ])
+      ),
+      tiles: state.map.tiles,
     },
+
     source: {
-      dice: [],
+      dice: state.source.dice,
     },
+
     offers: {
-      units: [],
-      advancedActions: { cards: [] },
-      spells: { cards: [] },
-      commonSkills: [],
-      monasteryAdvancedActions: [],
+      units: state.offers.units,
+      advancedActions: state.offers.advancedActions,
+      spells: state.offers.spells,
+      commonSkills: state.offers.commonSkills,
+      monasteryAdvancedActions: state.offers.monasteryAdvancedActions ?? [],
     },
-    combat: null,
-    scenarioEndTriggered: false,
+
+    combat: state.combat,
+
+    // Only show deck counts, not contents
     deckCounts: {
-      spells: 0,
-      advancedActions: 0,
-      artifacts: 0,
-      regularUnits: 0,
-      eliteUnits: 0,
+      spells: state.decks.spells.length,
+      advancedActions: state.decks.advancedActions.length,
+      artifacts: state.decks.artifacts.length,
+      regularUnits: state.decks.regularUnits.length,
+      eliteUnits: state.decks.eliteUnits.length,
     },
-    woundPileCount: 10,
+
+    woundPileCount: state.woundPileCount,
+    scenarioEndTriggered: state.scenarioEndTriggered,
   };
 }
 
-// ============================================================================
-// Server-side engine interface (returns full state, not filtered)
-// ============================================================================
+function toClientPlayer(player: Player, forPlayerId: string): ClientPlayer {
+  const isCurrentPlayer = player.id === forPlayerId;
 
-/**
- * Result of processing an action on the server.
- * Contains full GameState (not filtered) so server can filter per-player.
- */
-export interface ServerActionResult {
-  readonly events: readonly GameEvent[];
-  readonly state: GameState;
-}
+  return {
+    id: player.id,
+    heroId: player.hero,
+    position: player.position,
+    fame: player.fame,
+    level: player.level,
+    reputation: player.reputation,
+    armor: player.armor,
+    handLimit: player.handLimit,
+    commandTokens: player.commandTokens,
 
-/**
- * Server-side game engine interface.
- * Unlike GameEngine in shared (which returns ClientGameState),
- * this returns full GameState for the server to filter.
- */
-export interface ServerGameEngine {
-  getState(): GameState;
-  processAction(playerId: string, action: PlayerAction): ServerActionResult;
+    // Show full hand to self, only count to others
+    hand: isCurrentPlayer ? player.hand : player.hand.length,
+    deckCount: player.deck.length,
+    discardCount: player.discard.length,
+    playArea: player.playArea,
+
+    units: player.units.map(
+      (unit): ClientPlayerUnit => ({
+        cardId: unit.cardId,
+        isSpent: unit.isSpent,
+        isWounded: unit.isWounded,
+        woundCount: unit.woundCount,
+      })
+    ),
+
+    skills: player.skills,
+    crystals: player.crystals,
+
+    movePoints: player.movePoints,
+    influencePoints: player.influencePoints,
+    pureMana: player.pureMana.map(
+      (token): ClientManaToken => ({
+        color: token.color,
+        source: token.source,
+      })
+    ),
+    hasMovedThisTurn: player.hasMovedThisTurn,
+    hasTakenActionThisTurn: player.hasTakenActionThisTurn,
+    usedManaFromSource: player.usedManaFromSource,
+
+    knockedOut: player.knockedOut,
+    tacticCardId: player.tacticCard,
+    roundOrderTokenFaceDown: player.roundOrderTokenFaceDown,
+  };
 }
 
 // ============================================================================
@@ -101,18 +163,40 @@ export interface ServerGameEngine {
  * Broadcasts events and filtered state to all connected clients.
  */
 export class GameServer {
-  private readonly engine: ServerGameEngine;
+  private engine: MageKnightEngine;
+  private state: GameState;
   private readonly connections: Map<string, EventCallback> = new Map();
 
-  constructor(engine: ServerGameEngine) {
-    this.engine = engine;
+  constructor() {
+    this.engine = createEngine();
+    this.state = createInitialGameState();
   }
 
   /**
-   * Player joins and provides their callback for receiving events/state.
+   * Initialize game with players.
+   */
+  initializeGame(playerIds: string[]): void {
+    this.state = this.createGameWithPlayers(playerIds);
+
+    // Broadcast initial state to all connected players
+    this.broadcastState([
+      {
+        type: "GAME_STARTED",
+        playerCount: playerIds.length,
+        scenario: "conquest", // placeholder
+      },
+    ]);
+  }
+
+  /**
+   * Player connects and provides their callback for receiving events/state.
    */
   connect(playerId: string, callback: EventCallback): void {
     this.connections.set(playerId, callback);
+
+    // Send current state to newly connected player
+    const clientState = toClientState(this.state, playerId);
+    callback([], clientState);
   }
 
   /**
@@ -123,58 +207,140 @@ export class GameServer {
   }
 
   /**
-   * Get current state for a specific player (filtered).
-   */
-  getStateForPlayer(playerId: string): ClientGameState {
-    return toClientState(this.engine.getState(), playerId);
-  }
-
-  /**
    * Player sends an action. Broadcasts result to ALL connected players.
    */
   handleAction(playerId: string, action: PlayerAction): void {
-    const result = this.engine.processAction(playerId, action);
+    // Process through engine
+    const result = this.engine.processAction(this.state, playerId, action);
 
-    // Broadcast to ALL connected players, each with their own filtered state
-    for (const [pid, callback] of this.connections) {
-      const filteredState = toClientState(result.state, pid);
-      callback(result.events, filteredState);
-    }
+    // Update server state
+    this.state = result.state;
+
+    // Broadcast to all connected players
+    this.broadcastState(result.events);
   }
-}
 
-// ============================================================================
-// Placeholder engine implementation
-// ============================================================================
-
-class PlaceholderEngine implements ServerGameEngine {
-  private state: GameState = createInitialGameState();
-
+  /**
+   * Get current state (for testing/debugging).
+   */
   getState(): GameState {
     return this.state;
   }
 
-  processAction(_playerId: string, _action: PlayerAction): ServerActionResult {
-    // Placeholder - no game logic yet
+  /**
+   * Get filtered state for a specific player.
+   */
+  getStateForPlayer(playerId: string): ClientGameState {
+    return toClientState(this.state, playerId);
+  }
+
+  /**
+   * Broadcast events and filtered state to all connections.
+   */
+  private broadcastState(events: readonly GameEvent[]): void {
+    for (const [playerId, callback] of this.connections) {
+      const clientState = toClientState(this.state, playerId);
+      callback(events, clientState);
+    }
+  }
+
+  /**
+   * Create initial game state with players.
+   */
+  private createGameWithPlayers(playerIds: string[]): GameState {
+    const baseState = createInitialGameState();
+
+    const players = playerIds.map((id, index) => this.createPlayer(id, index));
+
     return {
-      events: [],
-      state: this.state,
+      ...baseState,
+      phase: "round" as const,
+      turnOrder: playerIds,
+      currentPlayerIndex: 0,
+      players,
+    };
+  }
+
+  /**
+   * Create a player with default values.
+   */
+  private createPlayer(id: string, index: number): Player {
+    const heroes: readonly Hero[] = [
+      Hero.Arythea,
+      Hero.Tovak,
+      Hero.Goldyx,
+      Hero.Norowas,
+    ];
+    const heroIndex = index % heroes.length;
+    const hero = heroes[heroIndex] ?? Hero.Arythea;
+
+    return {
+      id,
+      hero,
+      position: null, // Not on map yet
+      fame: 0,
+      level: 1,
+      reputation: 0,
+      armor: 2,
+      handLimit: 5,
+      commandTokens: 1,
+      hand: [],
+      deck: [],
+      discard: [],
+      units: [],
+      skills: [],
+      skillCooldowns: {
+        usedThisRound: [],
+        usedThisTurn: [],
+        usedThisCombat: [],
+        activeUntilNextTurn: [],
+      },
+      crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      tacticCard: null,
+      knockedOut: false,
+      roundOrderTokenFaceDown: false,
+      movePoints: 0,
+      influencePoints: 0,
+      playArea: [],
+      pureMana: [],
+      usedManaFromSource: false,
+      hasMovedThisTurn: false,
+      hasTakenActionThisTurn: false,
     };
   }
 }
 
+// ============================================================================
+// Single-player game instance (uses LocalConnection)
+// ============================================================================
+
+export interface GameInstance {
+  readonly engine: GameEngine;
+  readonly connection: GameConnection;
+}
+
 /**
- * Adapter to make ServerGameEngine compatible with GameEngine interface.
+ * Adapter to make MageKnightEngine compatible with GameEngine interface.
  * Used for LocalConnection which expects GameEngine.
  */
 class EngineAdapter implements GameEngine {
+  private state: GameState;
+  private readonly mageKnightEngine: MageKnightEngine;
+
   constructor(
-    private readonly serverEngine: ServerGameEngine,
     private readonly playerId: string
-  ) {}
+  ) {
+    this.mageKnightEngine = createEngine();
+    this.state = createInitialGameState();
+  }
 
   processAction(playerId: string, action: PlayerAction): ActionResult {
-    const result = this.serverEngine.processAction(playerId, action);
+    const result = this.mageKnightEngine.processAction(
+      this.state,
+      playerId,
+      action
+    );
+    this.state = result.state;
     return {
       events: result.events,
       state: toClientState(result.state, this.playerId),
@@ -190,8 +356,7 @@ class EngineAdapter implements GameEngine {
  * Create a single-player game instance with LocalConnection.
  */
 export function createGame(playerId: string): GameInstance {
-  const serverEngine = new PlaceholderEngine();
-  const engineAdapter = new EngineAdapter(serverEngine, playerId);
+  const engineAdapter = new EngineAdapter(playerId);
   const connection = new LocalConnection(engineAdapter, playerId);
 
   return {
@@ -204,6 +369,8 @@ export function createGame(playerId: string): GameInstance {
  * Create a multiplayer game server.
  */
 export function createGameServer(): GameServer {
-  const engine = new PlaceholderEngine();
-  return new GameServer(engine);
+  return new GameServer();
 }
+
+// Re-export types
+export type { EventCallback } from "@mage-knight/shared";

--- a/packages/server/tsconfig.build.json
+++ b/packages/server/tsconfig.build.json
@@ -6,5 +6,6 @@
     "declaration": true,
     "declarationMap": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__/**/*"]
 }

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,9 @@ importers:
       typescript-eslint:
         specifier: ^8.19.0
         version: 8.51.0(eslint@9.39.2)(typescript@5.9.3)
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
## Summary
- Wire up `MageKnightEngine` to `GameServer` for action processing
- Implement `toClientState()` to filter full game state per-player (hides hands, deck contents)
- Add `initializeGame()` method with player setup and `GAME_STARTED` broadcast
- Export `MageKnightEngine` and `Hero` from `@mage-knight/core`
- Add integration tests for GameServer (8 tests)
- Add note to CLAUDE.md to always target `main` branch for PRs

## Test plan
- [x] All existing tests pass (shared: 12, core: 15, server: 8)
- [x] Build succeeds with no type errors
- [x] Lint passes