### PR TITLE
refactor(core): Split commands/index.ts into domain-based factory modules for LLM optimization

### DIFF
--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -1,0 +1,237 @@
+/**
+ * Card Command Factories
+ *
+ * Factory functions that translate card-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/cards
+ *
+ * @remarks Factories in this module:
+ * - createPlayCardCommandFromAction - Play a card from hand
+ * - createPlayCardSidewaysCommandFromAction - Play a card sideways for move/influence/attack/block
+ * - createResolveChoiceCommandFromAction - Resolve a pending choice from a card effect
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction, CardId, ManaSourceInfo } from "@mage-knight/shared";
+import {
+  PLAY_CARD_ACTION,
+  PLAY_CARD_SIDEWAYS_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  MANA_BLACK,
+} from "@mage-knight/shared";
+import { createPlayCardCommand } from "../playCardCommand.js";
+import {
+  createPlayCardSidewaysCommand,
+  type SidewaysAs,
+} from "../playCardSidewaysCommand.js";
+import { createResolveChoiceCommand } from "../resolveChoiceCommand.js";
+import { getCard } from "../../validActions/cards.js";
+import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
+import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
+import type { Player } from "../../../types/player.js";
+
+/**
+ * Helper to get card id from play card action.
+ */
+function getCardIdFromAction(action: PlayerAction): CardId | null {
+  if (action.type === PLAY_CARD_ACTION && "cardId" in action) {
+    return action.cardId;
+  }
+  return null;
+}
+
+/**
+ * Helper to get card id from sideways action.
+ */
+function getCardIdFromSidewaysAction(action: PlayerAction): CardId | null {
+  if (action.type === PLAY_CARD_SIDEWAYS_ACTION && "cardId" in action) {
+    return action.cardId;
+  }
+  return null;
+}
+
+/**
+ * Helper to get sideways choice from action.
+ */
+function getSidewaysChoice(action: PlayerAction): SidewaysAs | null {
+  if (action.type === PLAY_CARD_SIDEWAYS_ACTION && "as" in action) {
+    return action.as as SidewaysAs;
+  }
+  return null;
+}
+
+/**
+ * Helper to get powered status and mana source from action.
+ */
+function getPlayCardDetails(action: PlayerAction): {
+  powered: boolean;
+  manaSource: ManaSourceInfo | undefined;
+  manaSources: readonly ManaSourceInfo[] | undefined;
+} | null {
+  if (action.type === PLAY_CARD_ACTION) {
+    return {
+      powered: action.powered,
+      manaSource: action.manaSource,
+      manaSources: action.manaSources,
+    };
+  }
+  return null;
+}
+
+/**
+ * Auto-infer mana source for spell basic plays when no source is specified.
+ * If there's exactly one valid mana source, use it automatically.
+ */
+function autoInferSpellBasicManaSource(
+  state: GameState,
+  player: Player,
+  cardId: CardId
+): ManaSourceInfo | undefined {
+  const card = getCard(cardId);
+  if (!card) return undefined;
+
+  // Only auto-infer for spells
+  if (card.cardType !== DEED_CARD_TYPE_SPELL) return undefined;
+
+  // Find the spell's color (non-black color in poweredBy)
+  const spellColor = card.poweredBy.find((c) => c !== MANA_BLACK);
+  if (!spellColor) return undefined;
+
+  // Get all available sources for this color
+  const sources = getAvailableManaSourcesForColor(state, player, spellColor);
+
+  // Only auto-infer if there's exactly one source
+  if (sources.length === 1) {
+    return sources[0];
+  }
+
+  return undefined;
+}
+
+/**
+ * Helper to get choice index from action.
+ */
+function getChoiceIndexFromAction(action: PlayerAction): number | null {
+  if (action.type === RESOLVE_CHOICE_ACTION && "choiceIndex" in action) {
+    return action.choiceIndex;
+  }
+  return null;
+}
+
+/**
+ * Play card command factory.
+ * Creates a command to play a card from the player's hand.
+ */
+export const createPlayCardCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  const cardId = getCardIdFromAction(action);
+  if (!cardId) return null;
+
+  const details = getPlayCardDetails(action);
+  if (!details) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return null;
+
+  const handIndex = player.hand.indexOf(cardId);
+  if (handIndex === -1) return null;
+
+  // Handle spell with manaSources (plural)
+  if (details.manaSources && details.manaSources.length > 0) {
+    return createPlayCardCommand({
+      playerId,
+      cardId,
+      handIndex,
+      powered: details.powered,
+      manaSources: details.manaSources,
+    });
+  }
+
+  // Handle action card with manaSource (singular)
+  if (details.manaSource) {
+    return createPlayCardCommand({
+      playerId,
+      cardId,
+      handIndex,
+      powered: details.powered,
+      manaSource: details.manaSource,
+    });
+  }
+
+  // For spell basic plays without manaSource, try to auto-infer
+  if (!details.powered && !details.manaSource) {
+    const inferredSource = autoInferSpellBasicManaSource(state, player, cardId);
+    if (inferredSource) {
+      return createPlayCardCommand({
+        playerId,
+        cardId,
+        handIndex,
+        powered: false,
+        manaSource: inferredSource,
+      });
+    }
+  }
+
+  return createPlayCardCommand({
+    playerId,
+    cardId,
+    handIndex,
+    powered: details.powered,
+  });
+};
+
+/**
+ * Play card sideways command factory.
+ * Creates a command to play a card sideways for move/influence/attack/block.
+ */
+export const createPlayCardSidewaysCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  const cardId = getCardIdFromSidewaysAction(action);
+  if (!cardId) return null;
+
+  const sidewaysChoice = getSidewaysChoice(action);
+  if (!sidewaysChoice) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return null;
+
+  const handIndex = player.hand.indexOf(cardId);
+  if (handIndex === -1) return null;
+
+  return createPlayCardSidewaysCommand({
+    playerId,
+    cardId,
+    handIndex,
+    as: sidewaysChoice,
+  });
+};
+
+/**
+ * Resolve choice command factory.
+ * Creates a command to resolve a pending choice from a card effect.
+ */
+export const createResolveChoiceCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  const choiceIndex = getChoiceIndexFromAction(action);
+  if (choiceIndex === null) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player?.pendingChoice) return null;
+
+  return createResolveChoiceCommand({
+    playerId,
+    choiceIndex,
+    previousPendingChoice: player.pendingChoice,
+  });
+};

--- a/packages/core/src/engine/commands/factories/combat.ts
+++ b/packages/core/src/engine/commands/factories/combat.ts
@@ -1,0 +1,124 @@
+/**
+ * Combat Command Factories
+ *
+ * Factory functions that translate combat-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/combat
+ *
+ * @remarks Factories in this module:
+ * - createEnterCombatCommandFromAction - Start combat at current location
+ * - createEndCombatPhaseCommandFromAction - Advance to next combat phase
+ * - createDeclareBlockCommandFromAction - Declare block against enemy
+ * - createDeclareAttackCommandFromAction - Declare attack against enemy
+ * - createAssignDamageCommandFromAction - Assign unblocked damage
+ */
+
+import type { CommandFactory } from "./types.js";
+import {
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  DECLARE_BLOCK_ACTION,
+  DECLARE_ATTACK_ACTION,
+  ASSIGN_DAMAGE_ACTION,
+} from "@mage-knight/shared";
+import {
+  createEnterCombatCommand,
+  createEndCombatPhaseCommand,
+  createDeclareBlockCommand,
+  createDeclareAttackCommand,
+  createAssignDamageCommand,
+} from "../combat/index.js";
+
+/**
+ * Enter combat command factory.
+ * Creates a command to start combat with enemies at the current location.
+ */
+export const createEnterCombatCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ENTER_COMBAT_ACTION) return null;
+  return createEnterCombatCommand({
+    playerId,
+    enemyIds: action.enemyIds,
+    ...(action.isAtFortifiedSite === undefined
+      ? {}
+      : { isAtFortifiedSite: action.isAtFortifiedSite }),
+  });
+};
+
+/**
+ * End combat phase command factory.
+ * Creates a command to advance to the next combat phase.
+ */
+export const createEndCombatPhaseCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== END_COMBAT_PHASE_ACTION) return null;
+  return createEndCombatPhaseCommand({ playerId });
+};
+
+/**
+ * Declare block command factory.
+ * Creates a command to declare a block against an enemy attack.
+ */
+export const createDeclareBlockCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== DECLARE_BLOCK_ACTION) return null;
+  return createDeclareBlockCommand({
+    playerId,
+    targetEnemyInstanceId: action.targetEnemyInstanceId,
+    // blocks now read from player.combatAccumulator.blockSources by the command
+  });
+};
+
+/**
+ * Declare attack command factory.
+ * Creates a command to declare attacks against enemies.
+ */
+export const createDeclareAttackCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== DECLARE_ATTACK_ACTION) return null;
+  return createDeclareAttackCommand({
+    playerId,
+    targetEnemyInstanceIds: action.targetEnemyInstanceIds,
+    attacks: action.attacks,
+    attackType: action.attackType,
+  });
+};
+
+/**
+ * Assign damage command factory.
+ * Creates a command to assign unblocked damage to player/units.
+ */
+export const createAssignDamageCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ASSIGN_DAMAGE_ACTION) return null;
+
+  // Only include assignments if provided
+  if (action.assignments) {
+    return createAssignDamageCommand({
+      playerId,
+      enemyInstanceId: action.enemyInstanceId,
+      assignments: action.assignments,
+    });
+  }
+
+  return createAssignDamageCommand({
+    playerId,
+    enemyInstanceId: action.enemyInstanceId,
+  });
+};

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -1,0 +1,197 @@
+/**
+ * Command Factories Module
+ *
+ * This module provides factory functions that translate PlayerAction objects
+ * into executable Command objects. Factories are organized by domain:
+ *
+ * | Domain | Module | Description |
+ * |--------|--------|-------------|
+ * | Movement | `movement.ts` | Move, Explore |
+ * | Cards | `cards.ts` | PlayCard, PlayCardSideways, ResolveChoice |
+ * | Combat | `combat.ts` | EnterCombat, EndCombatPhase, DeclareBlock, DeclareAttack, AssignDamage |
+ * | Units | `units.ts` | RecruitUnit, ActivateUnit |
+ * | Turn | `turn.ts` | EndTurn, Rest, AnnounceEndOfRound |
+ * | Sites | `sites.ts` | Interact, EnterSite, ResolveGladeWound, ResolveDeepMine |
+ * | Tactics | `tactics.ts` | SelectTactic, ActivateTactic, ResolveTacticDecision, RerollSourceDice |
+ * | Offers | `offers.ts` | BuySpell, LearnAdvancedAction, SelectReward |
+ *
+ * @module commands/factories
+ */
+
+import {
+  MOVE_ACTION,
+  END_TURN_ACTION,
+  EXPLORE_ACTION,
+  PLAY_CARD_ACTION,
+  PLAY_CARD_SIDEWAYS_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  REST_ACTION,
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  DECLARE_BLOCK_ACTION,
+  DECLARE_ATTACK_ACTION,
+  ASSIGN_DAMAGE_ACTION,
+  RECRUIT_UNIT_ACTION,
+  ACTIVATE_UNIT_ACTION,
+  INTERACT_ACTION,
+  ANNOUNCE_END_OF_ROUND_ACTION,
+  ENTER_SITE_ACTION,
+  SELECT_TACTIC_ACTION,
+  SELECT_REWARD_ACTION,
+  ACTIVATE_TACTIC_ACTION,
+  RESOLVE_TACTIC_DECISION_ACTION,
+  REROLL_SOURCE_DICE_ACTION,
+  RESOLVE_GLADE_WOUND_ACTION,
+  RESOLVE_DEEP_MINE_ACTION,
+  BUY_SPELL_ACTION,
+  LEARN_ADVANCED_ACTION_ACTION,
+} from "@mage-knight/shared";
+
+// Re-export the CommandFactory type
+export type { CommandFactory } from "./types.js";
+
+// Movement factories
+export {
+  createMoveCommandFromAction,
+  createExploreCommandFromAction,
+} from "./movement.js";
+
+// Card factories
+export {
+  createPlayCardCommandFromAction,
+  createPlayCardSidewaysCommandFromAction,
+  createResolveChoiceCommandFromAction,
+} from "./cards.js";
+
+// Combat factories
+export {
+  createEnterCombatCommandFromAction,
+  createEndCombatPhaseCommandFromAction,
+  createDeclareBlockCommandFromAction,
+  createDeclareAttackCommandFromAction,
+  createAssignDamageCommandFromAction,
+} from "./combat.js";
+
+// Unit factories
+export {
+  createRecruitUnitCommandFromAction,
+  createActivateUnitCommandFromAction,
+} from "./units.js";
+
+// Turn factories
+export {
+  createEndTurnCommandFromAction,
+  createRestCommandFromAction,
+  createAnnounceEndOfRoundCommandFromAction,
+} from "./turn.js";
+
+// Site factories
+export {
+  createInteractCommandFromAction,
+  createEnterSiteCommandFromAction,
+  createResolveGladeWoundCommandFromAction,
+  createResolveDeepMineCommandFromAction,
+} from "./sites.js";
+
+// Tactics factories
+export {
+  createSelectTacticCommandFromAction,
+  createActivateTacticCommandFromAction,
+  createResolveTacticDecisionCommandFromAction,
+  createRerollSourceDiceCommandFromAction,
+} from "./tactics.js";
+
+// Offers factories
+export {
+  createBuySpellCommandFromAction,
+  createLearnAdvancedActionCommandFromAction,
+  createSelectRewardCommandFromAction,
+} from "./offers.js";
+
+// Import all factories for the registry
+import {
+  createMoveCommandFromAction,
+  createExploreCommandFromAction,
+} from "./movement.js";
+
+import {
+  createPlayCardCommandFromAction,
+  createPlayCardSidewaysCommandFromAction,
+  createResolveChoiceCommandFromAction,
+} from "./cards.js";
+
+import {
+  createEnterCombatCommandFromAction,
+  createEndCombatPhaseCommandFromAction,
+  createDeclareBlockCommandFromAction,
+  createDeclareAttackCommandFromAction,
+  createAssignDamageCommandFromAction,
+} from "./combat.js";
+
+import {
+  createRecruitUnitCommandFromAction,
+  createActivateUnitCommandFromAction,
+} from "./units.js";
+
+import {
+  createEndTurnCommandFromAction,
+  createRestCommandFromAction,
+  createAnnounceEndOfRoundCommandFromAction,
+} from "./turn.js";
+
+import {
+  createInteractCommandFromAction,
+  createEnterSiteCommandFromAction,
+  createResolveGladeWoundCommandFromAction,
+  createResolveDeepMineCommandFromAction,
+} from "./sites.js";
+
+import {
+  createSelectTacticCommandFromAction,
+  createActivateTacticCommandFromAction,
+  createResolveTacticDecisionCommandFromAction,
+  createRerollSourceDiceCommandFromAction,
+} from "./tactics.js";
+
+import {
+  createBuySpellCommandFromAction,
+  createLearnAdvancedActionCommandFromAction,
+  createSelectRewardCommandFromAction,
+} from "./offers.js";
+
+import type { CommandFactory } from "./types.js";
+
+/**
+ * Registry mapping action types to their factory functions.
+ *
+ * Used by `createCommandForAction` to dispatch to the correct factory
+ * based on the action type.
+ */
+export const commandFactoryRegistry: Record<string, CommandFactory> = {
+  [MOVE_ACTION]: createMoveCommandFromAction,
+  [END_TURN_ACTION]: createEndTurnCommandFromAction,
+  [EXPLORE_ACTION]: createExploreCommandFromAction,
+  [PLAY_CARD_ACTION]: createPlayCardCommandFromAction,
+  [PLAY_CARD_SIDEWAYS_ACTION]: createPlayCardSidewaysCommandFromAction,
+  [RESOLVE_CHOICE_ACTION]: createResolveChoiceCommandFromAction,
+  [REST_ACTION]: createRestCommandFromAction,
+  [ENTER_COMBAT_ACTION]: createEnterCombatCommandFromAction,
+  [END_COMBAT_PHASE_ACTION]: createEndCombatPhaseCommandFromAction,
+  [DECLARE_BLOCK_ACTION]: createDeclareBlockCommandFromAction,
+  [DECLARE_ATTACK_ACTION]: createDeclareAttackCommandFromAction,
+  [ASSIGN_DAMAGE_ACTION]: createAssignDamageCommandFromAction,
+  [RECRUIT_UNIT_ACTION]: createRecruitUnitCommandFromAction,
+  [ACTIVATE_UNIT_ACTION]: createActivateUnitCommandFromAction,
+  [INTERACT_ACTION]: createInteractCommandFromAction,
+  [ANNOUNCE_END_OF_ROUND_ACTION]: createAnnounceEndOfRoundCommandFromAction,
+  [ENTER_SITE_ACTION]: createEnterSiteCommandFromAction,
+  [SELECT_TACTIC_ACTION]: createSelectTacticCommandFromAction,
+  [SELECT_REWARD_ACTION]: createSelectRewardCommandFromAction,
+  [ACTIVATE_TACTIC_ACTION]: createActivateTacticCommandFromAction,
+  [RESOLVE_TACTIC_DECISION_ACTION]: createResolveTacticDecisionCommandFromAction,
+  [REROLL_SOURCE_DICE_ACTION]: createRerollSourceDiceCommandFromAction,
+  [RESOLVE_GLADE_WOUND_ACTION]: createResolveGladeWoundCommandFromAction,
+  [RESOLVE_DEEP_MINE_ACTION]: createResolveDeepMineCommandFromAction,
+  [BUY_SPELL_ACTION]: createBuySpellCommandFromAction,
+  [LEARN_ADVANCED_ACTION_ACTION]: createLearnAdvancedActionCommandFromAction,
+};

--- a/packages/core/src/engine/commands/factories/movement.ts
+++ b/packages/core/src/engine/commands/factories/movement.ts
@@ -1,0 +1,140 @@
+/**
+ * Movement Command Factories
+ *
+ * Factory functions that translate movement-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/movement
+ *
+ * @remarks Factories in this module:
+ * - createMoveCommandFromAction - Move player to adjacent hex
+ * - createExploreCommandFromAction - Explore and reveal new tile
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction, HexCoord } from "@mage-knight/shared";
+import {
+  MOVE_ACTION,
+  EXPLORE_ACTION,
+  hexKey,
+  getAllNeighbors,
+  TIME_OF_DAY_DAY,
+} from "@mage-knight/shared";
+import { SITE_PROPERTIES } from "../../../data/siteProperties.js";
+import { createMoveCommand } from "../moveCommand.js";
+import { createExploreCommand } from "../exploreCommand.js";
+import { getEffectiveTerrainCost } from "../../modifiers.js";
+
+/**
+ * Helper to get move target from action.
+ */
+function getMoveTarget(action: PlayerAction): HexCoord | null {
+  if (action.type === MOVE_ACTION && "target" in action) {
+    return action.target;
+  }
+  return null;
+}
+
+/**
+ * Check if moving from one hex to another would reveal unrevealed enemies.
+ * Only applies during Day, when moving adjacent to fortified sites.
+ */
+function checkWouldRevealEnemies(
+  state: GameState,
+  from: HexCoord,
+  to: HexCoord
+): boolean {
+  // Only reveal during Day
+  if (state.timeOfDay !== TIME_OF_DAY_DAY) return false;
+
+  const fromNeighbors = new Set(getAllNeighbors(from).map(hexKey));
+  const toNeighbors = getAllNeighbors(to);
+
+  for (const neighbor of toNeighbors) {
+    const key = hexKey(neighbor);
+    // Skip hexes already adjacent to 'from' position
+    if (fromNeighbors.has(key)) continue;
+
+    const hex = state.map.hexes[key];
+    if (!hex?.site) continue;
+
+    // Check if it's a fortified site
+    const props = SITE_PROPERTIES[hex.site.type];
+    if (!props.fortified) continue;
+
+    // Check if it has unrevealed enemies
+    const hasUnrevealedEnemies = hex.enemies.some((e) => !e.isRevealed);
+    if (hasUnrevealedEnemies) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Move command factory.
+ * Creates a command to move the player to an adjacent hex.
+ */
+export const createMoveCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  const player = state.players.find((p) => p.id === playerId);
+  const target = getMoveTarget(action);
+
+  if (!player?.position || !target) return null;
+
+  const hex = state.map.hexes[hexKey(target)];
+  if (!hex) return null;
+
+  const terrainCost = getEffectiveTerrainCost(state, hex.terrain, playerId);
+
+  // Check if this move would reveal hidden enemies
+  const wouldRevealEnemies = checkWouldRevealEnemies(
+    state,
+    player.position,
+    target
+  );
+
+  return createMoveCommand({
+    playerId,
+    from: player.position,
+    to: target,
+    terrainCost,
+    hadMovedThisTurn: player.hasMovedThisTurn,
+    ...(wouldRevealEnemies && { wouldRevealEnemies: true }),
+  });
+};
+
+/**
+ * Explore command factory.
+ * Creates a command to explore and reveal a new map tile.
+ */
+export const createExploreCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== EXPLORE_ACTION) return null;
+
+  const { direction, fromTileCoord } = action;
+  if (!direction || !fromTileCoord) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player?.position) return null;
+
+  // Draw a tile (SIMPLE: take first from countryside, then core)
+  const tileId =
+    state.map.tileDeck.countryside[0] ?? state.map.tileDeck.core[0];
+  if (!tileId) return null;
+
+  return createExploreCommand({
+    playerId,
+    fromHex: fromTileCoord,
+    direction,
+    tileId,
+  });
+};

--- a/packages/core/src/engine/commands/factories/offers.ts
+++ b/packages/core/src/engine/commands/factories/offers.ts
@@ -1,0 +1,102 @@
+/**
+ * Offers Command Factories
+ *
+ * Factory functions that translate offer-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/offers
+ *
+ * @remarks Factories in this module:
+ * - createBuySpellCommandFromAction - Buy a spell from the spell offer
+ * - createLearnAdvancedActionCommandFromAction - Learn an advanced action
+ * - createSelectRewardCommandFromAction - Select a reward from pending rewards
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { PlayerAction, CardId } from "@mage-knight/shared";
+import {
+  BUY_SPELL_ACTION,
+  LEARN_ADVANCED_ACTION_ACTION,
+  SELECT_REWARD_ACTION,
+} from "@mage-knight/shared";
+import { createBuySpellCommand } from "../buySpellCommand.js";
+import { createLearnAdvancedActionCommand } from "../learnAdvancedActionCommand.js";
+import { createSelectRewardCommand } from "../selectRewardCommand.js";
+
+/**
+ * Helper to get buy spell params from action.
+ */
+function getBuySpellParams(action: PlayerAction): { cardId: CardId } | null {
+  if (action.type === BUY_SPELL_ACTION && "cardId" in action) {
+    return { cardId: action.cardId };
+  }
+  return null;
+}
+
+/**
+ * Helper to get learn advanced action params from action.
+ */
+function getLearnAdvancedActionParams(
+  action: PlayerAction
+): { cardId: CardId; fromMonastery: boolean } | null {
+  if (
+    action.type === LEARN_ADVANCED_ACTION_ACTION &&
+    "cardId" in action &&
+    "fromMonastery" in action
+  ) {
+    return { cardId: action.cardId, fromMonastery: action.fromMonastery };
+  }
+  return null;
+}
+
+/**
+ * Buy spell command factory.
+ * Creates a command to buy a spell from the spell offer.
+ */
+export const createBuySpellCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const params = getBuySpellParams(action);
+  if (!params) return null;
+  return createBuySpellCommand({
+    playerId,
+    cardId: params.cardId,
+  });
+};
+
+/**
+ * Learn advanced action command factory.
+ * Creates a command to learn an advanced action from the offer or monastery.
+ */
+export const createLearnAdvancedActionCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const params = getLearnAdvancedActionParams(action);
+  if (!params) return null;
+  return createLearnAdvancedActionCommand({
+    playerId,
+    cardId: params.cardId,
+    fromMonastery: params.fromMonastery,
+  });
+};
+
+/**
+ * Select reward command factory.
+ * Creates a command to select a reward from pending rewards.
+ */
+export const createSelectRewardCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== SELECT_REWARD_ACTION) return null;
+  return createSelectRewardCommand({
+    playerId,
+    cardId: action.cardId,
+    rewardIndex: action.rewardIndex,
+  });
+};

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -1,0 +1,124 @@
+/**
+ * Site Command Factories
+ *
+ * Factory functions that translate site-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/sites
+ *
+ * @remarks Factories in this module:
+ * - createInteractCommandFromAction - Interact with a site (healing, recruiting)
+ * - createEnterSiteCommandFromAction - Enter an adventure site
+ * - createResolveGladeWoundCommandFromAction - Resolve Magical Glade wound choice
+ * - createResolveDeepMineCommandFromAction - Resolve Deep Mine crystal color choice
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { PlayerAction, GladeWoundChoice, BasicManaColor } from "@mage-knight/shared";
+import {
+  INTERACT_ACTION,
+  ENTER_SITE_ACTION,
+  RESOLVE_GLADE_WOUND_ACTION,
+  RESOLVE_DEEP_MINE_ACTION,
+} from "@mage-knight/shared";
+import { createInteractCommand } from "../interactCommand.js";
+import { createEnterSiteCommand } from "../enterSiteCommand.js";
+import { createResolveGladeWoundCommand } from "../resolveGladeWoundCommand.js";
+import { createResolveDeepMineChoiceCommand } from "../resolveDeepMineChoiceCommand.js";
+
+/**
+ * Helper to get glade wound choice from action.
+ */
+function getGladeWoundChoiceFromAction(
+  action: PlayerAction
+): GladeWoundChoice | null {
+  if (action.type === RESOLVE_GLADE_WOUND_ACTION && "choice" in action) {
+    return action.choice;
+  }
+  return null;
+}
+
+/**
+ * Helper to get deep mine color choice from action.
+ */
+function getDeepMineColorFromAction(
+  action: PlayerAction
+): BasicManaColor | null {
+  if (action.type === RESOLVE_DEEP_MINE_ACTION && "color" in action) {
+    return action.color;
+  }
+  return null;
+}
+
+/**
+ * Interact command factory.
+ * Creates a command to interact with a site (healing, recruiting, etc.).
+ */
+export const createInteractCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== INTERACT_ACTION) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return null;
+
+  // For now, influence must be calculated from player's influencePoints
+  // In a full implementation, we'd track influence from played cards
+  const influenceAvailable = player.influencePoints;
+
+  return createInteractCommand({
+    playerId,
+    healing: action.healing ?? 0,
+    influenceAvailable,
+    previousHand: [...player.hand],
+  });
+};
+
+/**
+ * Enter site command factory.
+ * Creates a command to enter an adventure site.
+ */
+export const createEnterSiteCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ENTER_SITE_ACTION) return null;
+  return createEnterSiteCommand({ playerId });
+};
+
+/**
+ * Resolve glade wound command factory.
+ * Creates a command to resolve the Magical Glade wound discard choice.
+ */
+export const createResolveGladeWoundCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const choice = getGladeWoundChoiceFromAction(action);
+  if (!choice) return null;
+  return createResolveGladeWoundCommand({
+    playerId,
+    choice,
+  });
+};
+
+/**
+ * Resolve deep mine command factory.
+ * Creates a command to resolve the Deep Mine crystal color choice.
+ */
+export const createResolveDeepMineCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const color = getDeepMineColorFromAction(action);
+  if (!color) return null;
+  return createResolveDeepMineChoiceCommand({
+    playerId,
+    color,
+  });
+};

--- a/packages/core/src/engine/commands/factories/tactics.ts
+++ b/packages/core/src/engine/commands/factories/tactics.ts
@@ -1,0 +1,96 @@
+/**
+ * Tactics Command Factories
+ *
+ * Factory functions that translate tactics-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/tactics
+ *
+ * @remarks Factories in this module:
+ * - createSelectTacticCommandFromAction - Select a tactic card at start of round
+ * - createActivateTacticCommandFromAction - Activate a tactic's special ability
+ * - createResolveTacticDecisionCommandFromAction - Resolve a tactic decision
+ * - createRerollSourceDiceCommandFromAction - Reroll source dice (Mana Search tactic)
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { PlayerAction, TacticId } from "@mage-knight/shared";
+import {
+  SELECT_TACTIC_ACTION,
+  ACTIVATE_TACTIC_ACTION,
+  RESOLVE_TACTIC_DECISION_ACTION,
+  REROLL_SOURCE_DICE_ACTION,
+} from "@mage-knight/shared";
+import { createSelectTacticCommand } from "../selectTacticCommand.js";
+import { createActivateTacticCommand } from "../activateTacticCommand.js";
+import { createResolveTacticDecisionCommand } from "../resolveTacticDecisionCommand.js";
+import { createRerollSourceDiceCommand } from "../rerollSourceDiceCommand.js";
+
+/**
+ * Helper to get tactic id from action.
+ */
+function getTacticIdFromAction(action: PlayerAction): TacticId | null {
+  if (action.type === SELECT_TACTIC_ACTION && "tacticId" in action) {
+    return action.tacticId;
+  }
+  return null;
+}
+
+/**
+ * Select tactic command factory.
+ * Creates a command to select a tactic card at the start of a round.
+ */
+export const createSelectTacticCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const tacticId = getTacticIdFromAction(action);
+  if (!tacticId) return null;
+  return createSelectTacticCommand({ playerId, tacticId });
+};
+
+/**
+ * Activate tactic command factory.
+ * Creates a command to activate a tactic's special ability.
+ */
+export const createActivateTacticCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ACTIVATE_TACTIC_ACTION) return null;
+  return createActivateTacticCommand({ playerId, tacticId: action.tacticId });
+};
+
+/**
+ * Resolve tactic decision command factory.
+ * Creates a command to resolve a pending tactic decision.
+ */
+export const createResolveTacticDecisionCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_TACTIC_DECISION_ACTION) return null;
+  return createResolveTacticDecisionCommand({
+    playerId,
+    decision: action.decision,
+  });
+};
+
+/**
+ * Reroll source dice command factory (Mana Search tactic).
+ * Creates a command to reroll selected source dice.
+ */
+export const createRerollSourceDiceCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== REROLL_SOURCE_DICE_ACTION) return null;
+  return createRerollSourceDiceCommand({
+    playerId,
+    dieIds: action.dieIds,
+  });
+};

--- a/packages/core/src/engine/commands/factories/turn.ts
+++ b/packages/core/src/engine/commands/factories/turn.ts
@@ -1,0 +1,68 @@
+/**
+ * Turn Command Factories
+ *
+ * Factory functions that translate turn lifecycle PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/turn
+ *
+ * @remarks Factories in this module:
+ * - createEndTurnCommandFromAction - End the current player's turn
+ * - createRestCommandFromAction - Rest to draw cards and optionally announce end of round
+ * - createAnnounceEndOfRoundCommandFromAction - Announce end of round
+ */
+
+import type { CommandFactory } from "./types.js";
+import { REST_ACTION, ANNOUNCE_END_OF_ROUND_ACTION } from "@mage-knight/shared";
+import { createEndTurnCommand } from "../endTurnCommand.js";
+import { createRestCommand } from "../restCommand.js";
+import { createAnnounceEndOfRoundCommand } from "../announceEndOfRoundCommand.js";
+
+/**
+ * End turn command factory.
+ * Creates a command to end the current player's turn.
+ */
+export const createEndTurnCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  _action
+) => {
+  return createEndTurnCommand({ playerId });
+};
+
+/**
+ * Rest command factory.
+ * Creates a command to rest, drawing cards and optionally announcing end of round.
+ */
+export const createRestCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== REST_ACTION) return null;
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return null;
+
+  return createRestCommand({
+    playerId,
+    restType: action.restType,
+    discardCardIds: action.discardCardIds,
+    announceEndOfRound: action.announceEndOfRound ?? false,
+    previousHand: [...player.hand],
+    previousDiscard: [...player.discard],
+  });
+};
+
+/**
+ * Announce end of round command factory.
+ * Creates a command to announce that this player wants to end the round.
+ */
+export const createAnnounceEndOfRoundCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ANNOUNCE_END_OF_ROUND_ACTION) return null;
+  return createAnnounceEndOfRoundCommand({ playerId });
+};

--- a/packages/core/src/engine/commands/factories/types.ts
+++ b/packages/core/src/engine/commands/factories/types.ts
@@ -1,0 +1,31 @@
+/**
+ * Command Factory Types
+ *
+ * Type definitions for command factory functions that translate
+ * PlayerAction objects into executable Command objects.
+ *
+ * @module commands/factories/types
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import type { Command } from "../../commands.js";
+
+/**
+ * Factory function type for creating Commands from PlayerActions.
+ *
+ * Each factory function:
+ * 1. Validates the action has required fields
+ * 2. Extracts parameters from the action
+ * 3. Creates and returns the appropriate Command object
+ *
+ * @param state - Current game state
+ * @param playerId - ID of the player performing the action
+ * @param action - The player action to translate
+ * @returns A Command object or null if the action cannot be translated
+ */
+export type CommandFactory = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+) => Command | null;

--- a/packages/core/src/engine/commands/factories/units.ts
+++ b/packages/core/src/engine/commands/factories/units.ts
@@ -1,0 +1,53 @@
+/**
+ * Unit Command Factories
+ *
+ * Factory functions that translate unit-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/units
+ *
+ * @remarks Factories in this module:
+ * - createRecruitUnitCommandFromAction - Recruit a unit from an offer
+ * - createActivateUnitCommandFromAction - Activate a unit's ability
+ */
+
+import type { CommandFactory } from "./types.js";
+import { RECRUIT_UNIT_ACTION, ACTIVATE_UNIT_ACTION } from "@mage-knight/shared";
+import {
+  createRecruitUnitCommand,
+  createActivateUnitCommand,
+} from "../units/index.js";
+
+/**
+ * Recruit unit command factory.
+ * Creates a command to recruit a unit from an offer.
+ */
+export const createRecruitUnitCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RECRUIT_UNIT_ACTION) return null;
+  return createRecruitUnitCommand({
+    playerId,
+    unitId: action.unitId,
+    influenceSpent: action.influenceSpent,
+  });
+};
+
+/**
+ * Activate unit command factory.
+ * Creates a command to activate a unit's ability.
+ */
+export const createActivateUnitCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ACTIVATE_UNIT_ACTION) return null;
+  return createActivateUnitCommand({
+    playerId,
+    unitInstanceId: action.unitInstanceId,
+    abilityIndex: action.abilityIndex,
+  });
+};

--- a/packages/core/src/engine/commands/index.ts
+++ b/packages/core/src/engine/commands/index.ts
@@ -1,754 +1,49 @@
 /**
- * Command factory registry
+ * Commands Module
+ *
+ * This module provides the command pattern implementation for game actions.
+ * Commands translate PlayerAction objects into executable state changes
+ * with full undo support.
+ *
+ * ## Architecture
+ *
+ * - **Factory functions** in `./factories/` translate PlayerAction → Command
+ * - **Command implementations** handle execute() and undo()
+ * - **Registry** maps action types to factories for dispatching
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { createCommandForAction } from './commands';
+ *
+ * const command = createCommandForAction(state, playerId, action);
+ * if (command) {
+ *   const result = command.execute(state);
+ * }
+ * ```
+ *
+ * @module commands
  */
 
 import type { GameState } from "../../state/GameState.js";
-import type { PlayerAction, HexCoord, CardId } from "@mage-knight/shared";
-import {
-  MOVE_ACTION,
-  END_TURN_ACTION,
-  EXPLORE_ACTION,
-  PLAY_CARD_ACTION,
-  PLAY_CARD_SIDEWAYS_ACTION,
-  RESOLVE_CHOICE_ACTION,
-  REST_ACTION,
-  ENTER_COMBAT_ACTION,
-  END_COMBAT_PHASE_ACTION,
-  DECLARE_BLOCK_ACTION,
-  DECLARE_ATTACK_ACTION,
-  ASSIGN_DAMAGE_ACTION,
-  RECRUIT_UNIT_ACTION,
-  ACTIVATE_UNIT_ACTION,
-  INTERACT_ACTION,
-  ANNOUNCE_END_OF_ROUND_ACTION,
-  ENTER_SITE_ACTION,
-  SELECT_TACTIC_ACTION,
-  SELECT_REWARD_ACTION,
-  ACTIVATE_TACTIC_ACTION,
-  RESOLVE_TACTIC_DECISION_ACTION,
-  REROLL_SOURCE_DICE_ACTION,
-  RESOLVE_GLADE_WOUND_ACTION,
-  RESOLVE_DEEP_MINE_ACTION,
-  BUY_SPELL_ACTION,
-  LEARN_ADVANCED_ACTION_ACTION,
-  hexKey,
-  getAllNeighbors,
-  TIME_OF_DAY_DAY,
-  type TacticId,
-  type GladeWoundChoice,
-  type BasicManaColor,
-} from "@mage-knight/shared";
-import { SITE_PROPERTIES } from "../../data/siteProperties.js";
+import type { PlayerAction } from "@mage-knight/shared";
 import type { Command } from "../commands.js";
-import { createMoveCommand } from "./moveCommand.js";
-import { createEndTurnCommand } from "./endTurnCommand.js";
-import { createExploreCommand } from "./exploreCommand.js";
-import { createPlayCardCommand } from "./playCardCommand.js";
-import { createPlayCardSidewaysCommand } from "./playCardSidewaysCommand.js";
-import type { SidewaysAs } from "./playCardSidewaysCommand.js";
-import { createResolveChoiceCommand } from "./resolveChoiceCommand.js";
-import { createRestCommand } from "./restCommand.js";
-import { getEffectiveTerrainCost } from "../modifiers.js";
-import {
-  createEnterCombatCommand,
-  createEndCombatPhaseCommand,
-  createDeclareBlockCommand,
-  createDeclareAttackCommand,
-  createAssignDamageCommand,
-} from "./combat/index.js";
-import { createRecruitUnitCommand, createActivateUnitCommand } from "./units/index.js";
-import { createInteractCommand } from "./interactCommand.js";
-import { getCard } from "../validActions/cards.js";
-import { DEED_CARD_TYPE_SPELL } from "../../types/cards.js";
-import { getAvailableManaSourcesForColor } from "../validActions/mana.js";
-import type { Player } from "../../types/player.js";
-import type { ManaSourceInfo } from "@mage-knight/shared";
-import { MANA_BLACK } from "@mage-knight/shared";
-import { createAnnounceEndOfRoundCommand } from "./announceEndOfRoundCommand.js";
-import { createEnterSiteCommand } from "./enterSiteCommand.js";
-import { createSelectTacticCommand } from "./selectTacticCommand.js";
-import { createSelectRewardCommand } from "./selectRewardCommand.js";
-import { createActivateTacticCommand } from "./activateTacticCommand.js";
-import { createResolveTacticDecisionCommand } from "./resolveTacticDecisionCommand.js";
-import { createRerollSourceDiceCommand } from "./rerollSourceDiceCommand.js";
-import { createResolveGladeWoundCommand } from "./resolveGladeWoundCommand.js";
-import { createResolveDeepMineChoiceCommand } from "./resolveDeepMineChoiceCommand.js";
-import { createBuySpellCommand } from "./buySpellCommand.js";
-import { createLearnAdvancedActionCommand } from "./learnAdvancedActionCommand.js";
+import { commandFactoryRegistry } from "./factories/index.js";
 
-// Command factory function type
-type CommandFactory = (
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-) => Command | null;
-
-// Helper to get move target
-function getMoveTarget(action: PlayerAction): HexCoord | null {
-  if (action.type === MOVE_ACTION && "target" in action) {
-    return action.target;
-  }
-  return null;
-}
+// Re-export CommandFactory type
+export type { CommandFactory } from "./factories/index.js";
 
 /**
- * Check if moving from one hex to another would reveal unrevealed enemies.
- * Only applies during Day, when moving adjacent to fortified sites.
+ * Create a command for a player action.
+ *
+ * Uses the command factory registry to dispatch to the appropriate
+ * factory function based on the action type.
+ *
+ * @param state - Current game state
+ * @param playerId - ID of the player performing the action
+ * @param action - The player action to translate
+ * @returns A Command object or null if the action type is not supported
  */
-function checkWouldRevealEnemies(
-  state: GameState,
-  from: HexCoord,
-  to: HexCoord
-): boolean {
-  // Only reveal during Day
-  if (state.timeOfDay !== TIME_OF_DAY_DAY) return false;
-
-  const fromNeighbors = new Set(getAllNeighbors(from).map(hexKey));
-  const toNeighbors = getAllNeighbors(to);
-
-  for (const neighbor of toNeighbors) {
-    const key = hexKey(neighbor);
-    // Skip hexes already adjacent to 'from' position
-    if (fromNeighbors.has(key)) continue;
-
-    const hex = state.map.hexes[key];
-    if (!hex?.site) continue;
-
-    // Check if it's a fortified site
-    const props = SITE_PROPERTIES[hex.site.type];
-    if (!props.fortified) continue;
-
-    // Check if it has unrevealed enemies
-    const hasUnrevealedEnemies = hex.enemies.some((e) => !e.isRevealed);
-    if (hasUnrevealedEnemies) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-// Move command factory
-function createMoveCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const player = state.players.find((p) => p.id === playerId);
-  const target = getMoveTarget(action);
-
-  if (!player?.position || !target) return null;
-
-  const hex = state.map.hexes[hexKey(target)];
-  if (!hex) return null;
-
-  const terrainCost = getEffectiveTerrainCost(state, hex.terrain, playerId);
-
-  // Check if this move would reveal hidden enemies
-  const wouldRevealEnemies = checkWouldRevealEnemies(state, player.position, target);
-
-  return createMoveCommand({
-    playerId,
-    from: player.position,
-    to: target,
-    terrainCost,
-    hadMovedThisTurn: player.hasMovedThisTurn,
-    ...(wouldRevealEnemies && { wouldRevealEnemies: true }),
-  });
-}
-
-// End turn command factory
-function createEndTurnCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  _action: PlayerAction
-): Command {
-  return createEndTurnCommand({ playerId });
-}
-
-// Explore command factory
-function createExploreCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== EXPLORE_ACTION) return null;
-
-  const { direction, fromTileCoord } = action;
-  if (!direction || !fromTileCoord) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player?.position) return null;
-
-  // Draw a tile (SIMPLE: take first from countryside, then core)
-  const tileId =
-    state.map.tileDeck.countryside[0] ?? state.map.tileDeck.core[0];
-  if (!tileId) return null;
-
-  return createExploreCommand({
-    playerId,
-    fromHex: fromTileCoord,
-    direction,
-    tileId,
-  });
-}
-
-// Helper to get card id from action
-function getCardIdFromAction(action: PlayerAction): CardId | null {
-  if (action.type === PLAY_CARD_ACTION && "cardId" in action) {
-    return action.cardId;
-  }
-  return null;
-}
-
-// Helper to get card id from sideways action
-function getCardIdFromSidewaysAction(action: PlayerAction): CardId | null {
-  if (action.type === PLAY_CARD_SIDEWAYS_ACTION && "cardId" in action) {
-    return action.cardId;
-  }
-  return null;
-}
-
-// Helper to get sideways choice
-function getSidewaysChoice(action: PlayerAction): SidewaysAs | null {
-  if (action.type === PLAY_CARD_SIDEWAYS_ACTION && "as" in action) {
-    return action.as as SidewaysAs;
-  }
-  return null;
-}
-
-// Helper to get powered status and mana source from action
-function getPlayCardDetails(action: PlayerAction): {
-  powered: boolean;
-  manaSource: import("@mage-knight/shared").ManaSourceInfo | undefined;
-  manaSources: readonly import("@mage-knight/shared").ManaSourceInfo[] | undefined;
-} | null {
-  if (action.type === PLAY_CARD_ACTION) {
-    return {
-      powered: action.powered,
-      manaSource: action.manaSource,
-      manaSources: action.manaSources,
-    };
-  }
-  return null;
-}
-
-/**
- * Auto-infer mana source for spell basic plays when no source is specified.
- * If there's exactly one valid mana source, use it automatically.
- */
-function autoInferSpellBasicManaSource(
-  state: GameState,
-  player: Player,
-  cardId: CardId
-): ManaSourceInfo | undefined {
-  const card = getCard(cardId);
-  if (!card) return undefined;
-
-  // Only auto-infer for spells
-  if (card.cardType !== DEED_CARD_TYPE_SPELL) return undefined;
-
-  // Find the spell's color (non-black color in poweredBy)
-  const spellColor = card.poweredBy.find((c) => c !== MANA_BLACK);
-  if (!spellColor) return undefined;
-
-  // Get all available sources for this color
-  const sources = getAvailableManaSourcesForColor(state, player, spellColor);
-
-  // Only auto-infer if there's exactly one source
-  if (sources.length === 1) {
-    return sources[0];
-  }
-
-  return undefined;
-}
-
-// Play card command factory
-function createPlayCardCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const cardId = getCardIdFromAction(action);
-  if (!cardId) return null;
-
-  const details = getPlayCardDetails(action);
-  if (!details) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player) return null;
-
-  const handIndex = player.hand.indexOf(cardId);
-  if (handIndex === -1) return null;
-
-  // Handle spell with manaSources (plural)
-  if (details.manaSources && details.manaSources.length > 0) {
-    return createPlayCardCommand({
-      playerId,
-      cardId,
-      handIndex,
-      powered: details.powered,
-      manaSources: details.manaSources,
-    });
-  }
-
-  // Handle action card with manaSource (singular)
-  if (details.manaSource) {
-    return createPlayCardCommand({
-      playerId,
-      cardId,
-      handIndex,
-      powered: details.powered,
-      manaSource: details.manaSource,
-    });
-  }
-
-  // For spell basic plays without manaSource, try to auto-infer
-  if (!details.powered && !details.manaSource) {
-    const inferredSource = autoInferSpellBasicManaSource(state, player, cardId);
-    if (inferredSource) {
-      return createPlayCardCommand({
-        playerId,
-        cardId,
-        handIndex,
-        powered: false,
-        manaSource: inferredSource,
-      });
-    }
-  }
-
-  return createPlayCardCommand({
-    playerId,
-    cardId,
-    handIndex,
-    powered: details.powered,
-  });
-}
-
-// Play card sideways command factory
-function createPlayCardSidewaysCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const cardId = getCardIdFromSidewaysAction(action);
-  if (!cardId) return null;
-
-  const sidewaysChoice = getSidewaysChoice(action);
-  if (!sidewaysChoice) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player) return null;
-
-  const handIndex = player.hand.indexOf(cardId);
-  if (handIndex === -1) return null;
-
-  return createPlayCardSidewaysCommand({
-    playerId,
-    cardId,
-    handIndex,
-    as: sidewaysChoice,
-  });
-}
-
-// Helper to get choice index from action
-function getChoiceIndexFromAction(action: PlayerAction): number | null {
-  if (action.type === RESOLVE_CHOICE_ACTION && "choiceIndex" in action) {
-    return action.choiceIndex;
-  }
-  return null;
-}
-
-// Resolve choice command factory
-function createResolveChoiceCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const choiceIndex = getChoiceIndexFromAction(action);
-  if (choiceIndex === null) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player?.pendingChoice) return null;
-
-  return createResolveChoiceCommand({
-    playerId,
-    choiceIndex,
-    previousPendingChoice: player.pendingChoice,
-  });
-}
-
-// Rest command factory
-function createRestCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== REST_ACTION) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player) return null;
-
-  return createRestCommand({
-    playerId,
-    restType: action.restType,
-    discardCardIds: action.discardCardIds,
-    announceEndOfRound: action.announceEndOfRound ?? false,
-    previousHand: [...player.hand],
-    previousDiscard: [...player.discard],
-  });
-}
-
-// Enter combat command factory
-function createEnterCombatCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ENTER_COMBAT_ACTION) return null;
-  return createEnterCombatCommand({
-    playerId,
-    enemyIds: action.enemyIds,
-    ...(action.isAtFortifiedSite === undefined
-      ? {}
-      : { isAtFortifiedSite: action.isAtFortifiedSite }),
-  });
-}
-
-// End combat phase command factory
-function createEndCombatPhaseCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== END_COMBAT_PHASE_ACTION) return null;
-  return createEndCombatPhaseCommand({ playerId });
-}
-
-// Declare block command factory
-function createDeclareBlockCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== DECLARE_BLOCK_ACTION) return null;
-  return createDeclareBlockCommand({
-    playerId,
-    targetEnemyInstanceId: action.targetEnemyInstanceId,
-    // blocks now read from player.combatAccumulator.blockSources by the command
-  });
-}
-
-// Declare attack command factory
-function createDeclareAttackCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== DECLARE_ATTACK_ACTION) return null;
-  return createDeclareAttackCommand({
-    playerId,
-    targetEnemyInstanceIds: action.targetEnemyInstanceIds,
-    attacks: action.attacks,
-    attackType: action.attackType,
-  });
-}
-
-// Assign damage command factory
-function createAssignDamageCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ASSIGN_DAMAGE_ACTION) return null;
-
-  // Only include assignments if provided
-  if (action.assignments) {
-    return createAssignDamageCommand({
-      playerId,
-      enemyInstanceId: action.enemyInstanceId,
-      assignments: action.assignments,
-    });
-  }
-
-  return createAssignDamageCommand({
-    playerId,
-    enemyInstanceId: action.enemyInstanceId,
-  });
-}
-
-// Recruit unit command factory
-function createRecruitUnitCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== RECRUIT_UNIT_ACTION) return null;
-  return createRecruitUnitCommand({
-    playerId,
-    unitId: action.unitId,
-    influenceSpent: action.influenceSpent,
-  });
-}
-
-// Activate unit command factory
-function createActivateUnitCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ACTIVATE_UNIT_ACTION) return null;
-  return createActivateUnitCommand({
-    playerId,
-    unitInstanceId: action.unitInstanceId,
-    abilityIndex: action.abilityIndex,
-  });
-}
-
-// Interact command factory
-function createInteractCommandFromAction(
-  state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== INTERACT_ACTION) return null;
-
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player) return null;
-
-  // For now, influence must be calculated from player's influencePoints
-  // In a full implementation, we'd track influence from played cards
-  const influenceAvailable = player.influencePoints;
-
-  return createInteractCommand({
-    playerId,
-    healing: action.healing ?? 0,
-    influenceAvailable,
-    previousHand: [...player.hand],
-  });
-}
-
-// Announce end of round command factory
-function createAnnounceEndOfRoundCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ANNOUNCE_END_OF_ROUND_ACTION) return null;
-  return createAnnounceEndOfRoundCommand({ playerId });
-}
-
-// Enter site command factory
-function createEnterSiteCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ENTER_SITE_ACTION) return null;
-  return createEnterSiteCommand({ playerId });
-}
-
-// Helper to get tactic id from action
-function getTacticIdFromAction(action: PlayerAction): TacticId | null {
-  if (action.type === SELECT_TACTIC_ACTION && "tacticId" in action) {
-    return action.tacticId;
-  }
-  return null;
-}
-
-// Select tactic command factory
-function createSelectTacticCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const tacticId = getTacticIdFromAction(action);
-  if (!tacticId) return null;
-  return createSelectTacticCommand({ playerId, tacticId });
-}
-
-// Activate tactic command factory
-function createActivateTacticCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== ACTIVATE_TACTIC_ACTION) return null;
-  return createActivateTacticCommand({ playerId, tacticId: action.tacticId });
-}
-
-// Select reward command factory
-function createSelectRewardCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== SELECT_REWARD_ACTION) return null;
-  return createSelectRewardCommand({
-    playerId,
-    cardId: action.cardId,
-    rewardIndex: action.rewardIndex,
-  });
-}
-
-// Resolve tactic decision command factory
-function createResolveTacticDecisionCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== RESOLVE_TACTIC_DECISION_ACTION) return null;
-  return createResolveTacticDecisionCommand({
-    playerId,
-    decision: action.decision,
-  });
-}
-
-// Reroll source dice command factory (Mana Search tactic)
-function createRerollSourceDiceCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  if (action.type !== REROLL_SOURCE_DICE_ACTION) return null;
-  return createRerollSourceDiceCommand({
-    playerId,
-    dieIds: action.dieIds,
-  });
-}
-
-// Helper to get glade wound choice from action
-function getGladeWoundChoiceFromAction(action: PlayerAction): GladeWoundChoice | null {
-  if (action.type === RESOLVE_GLADE_WOUND_ACTION && "choice" in action) {
-    return action.choice;
-  }
-  return null;
-}
-
-// Resolve glade wound command factory
-function createResolveGladeWoundCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const choice = getGladeWoundChoiceFromAction(action);
-  if (!choice) return null;
-  return createResolveGladeWoundCommand({
-    playerId,
-    choice,
-  });
-}
-
-// Helper to get deep mine color choice from action
-function getDeepMineColorFromAction(action: PlayerAction): BasicManaColor | null {
-  if (action.type === RESOLVE_DEEP_MINE_ACTION && "color" in action) {
-    return action.color;
-  }
-  return null;
-}
-
-// Resolve deep mine command factory
-function createResolveDeepMineCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const color = getDeepMineColorFromAction(action);
-  if (!color) return null;
-  return createResolveDeepMineChoiceCommand({
-    playerId,
-    color,
-  });
-}
-
-// === Buy Spell command factory ===
-
-// Helper to get buy spell params from action
-function getBuySpellParams(
-  action: PlayerAction
-): { cardId: CardId } | null {
-  if (action.type === BUY_SPELL_ACTION && "cardId" in action) {
-    return { cardId: action.cardId };
-  }
-  return null;
-}
-
-// Buy spell command factory
-function createBuySpellCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const params = getBuySpellParams(action);
-  if (!params) return null;
-  return createBuySpellCommand({
-    playerId,
-    cardId: params.cardId,
-  });
-}
-
-// === Learn Advanced Action command factory ===
-
-// Helper to get learn advanced action params from action
-function getLearnAdvancedActionParams(
-  action: PlayerAction
-): { cardId: CardId; fromMonastery: boolean } | null {
-  if (
-    action.type === LEARN_ADVANCED_ACTION_ACTION &&
-    "cardId" in action &&
-    "fromMonastery" in action
-  ) {
-    return { cardId: action.cardId, fromMonastery: action.fromMonastery };
-  }
-  return null;
-}
-
-// Learn advanced action command factory
-function createLearnAdvancedActionCommandFromAction(
-  _state: GameState,
-  playerId: string,
-  action: PlayerAction
-): Command | null {
-  const params = getLearnAdvancedActionParams(action);
-  if (!params) return null;
-  return createLearnAdvancedActionCommand({
-    playerId,
-    cardId: params.cardId,
-    fromMonastery: params.fromMonastery,
-  });
-}
-
-// Command factory registry
-const commandFactoryRegistry: Record<string, CommandFactory> = {
-  [MOVE_ACTION]: createMoveCommandFromAction,
-  [END_TURN_ACTION]: createEndTurnCommandFromAction,
-  [EXPLORE_ACTION]: createExploreCommandFromAction,
-  [PLAY_CARD_ACTION]: createPlayCardCommandFromAction,
-  [PLAY_CARD_SIDEWAYS_ACTION]: createPlayCardSidewaysCommandFromAction,
-  [RESOLVE_CHOICE_ACTION]: createResolveChoiceCommandFromAction,
-  [REST_ACTION]: createRestCommandFromAction,
-  [ENTER_COMBAT_ACTION]: createEnterCombatCommandFromAction,
-  [END_COMBAT_PHASE_ACTION]: createEndCombatPhaseCommandFromAction,
-  [DECLARE_BLOCK_ACTION]: createDeclareBlockCommandFromAction,
-  [DECLARE_ATTACK_ACTION]: createDeclareAttackCommandFromAction,
-  [ASSIGN_DAMAGE_ACTION]: createAssignDamageCommandFromAction,
-  [RECRUIT_UNIT_ACTION]: createRecruitUnitCommandFromAction,
-  [ACTIVATE_UNIT_ACTION]: createActivateUnitCommandFromAction,
-  [INTERACT_ACTION]: createInteractCommandFromAction,
-  [ANNOUNCE_END_OF_ROUND_ACTION]: createAnnounceEndOfRoundCommandFromAction,
-  [ENTER_SITE_ACTION]: createEnterSiteCommandFromAction,
-  [SELECT_TACTIC_ACTION]: createSelectTacticCommandFromAction,
-  [SELECT_REWARD_ACTION]: createSelectRewardCommandFromAction,
-  [ACTIVATE_TACTIC_ACTION]: createActivateTacticCommandFromAction,
-  [RESOLVE_TACTIC_DECISION_ACTION]: createResolveTacticDecisionCommandFromAction,
-  [REROLL_SOURCE_DICE_ACTION]: createRerollSourceDiceCommandFromAction,
-  [RESOLVE_GLADE_WOUND_ACTION]: createResolveGladeWoundCommandFromAction,
-  [RESOLVE_DEEP_MINE_ACTION]: createResolveDeepMineCommandFromAction,
-  [BUY_SPELL_ACTION]: createBuySpellCommandFromAction,
-  [LEARN_ADVANCED_ACTION_ACTION]: createLearnAdvancedActionCommandFromAction,
-};
-
-// Get command for an action
 export function createCommandForAction(
   state: GameState,
   playerId: string,
@@ -761,34 +56,54 @@ export function createCommandForAction(
   return factory(state, playerId, action);
 }
 
-// Re-export command types and individual factories
+// ============================================================================
+// RE-EXPORTS - Command types and implementations
+// ============================================================================
+
+// Core command types
 export * from "../commands.js";
+
+// Move command
 export { createMoveCommand, type MoveCommandParams } from "./moveCommand.js";
+
+// Reveal tile command
 export {
   createRevealTileCommand,
   type RevealTileCommandParams,
 } from "./revealTileCommand.js";
+
+// End turn command
 export {
   createEndTurnCommand,
   type EndTurnCommandParams,
 } from "./endTurnCommand.js";
+
+// Explore command
 export {
   createExploreCommand,
   type ExploreCommandParams,
 } from "./exploreCommand.js";
+
+// Play card command
 export {
   createPlayCardCommand,
   type PlayCardCommandParams,
 } from "./playCardCommand.js";
+
+// Play card sideways command
 export {
   createPlayCardSidewaysCommand,
   type PlayCardSidewaysCommandParams,
   type SidewaysAs,
 } from "./playCardSidewaysCommand.js";
+
+// Resolve choice command
 export {
   createResolveChoiceCommand,
   type ResolveChoiceCommandParams,
 } from "./resolveChoiceCommand.js";
+
+// Rest command
 export {
   createRestCommand,
   type RestCommandParams,
@@ -874,6 +189,13 @@ export {
   type ResolveGladeWoundCommandParams,
   RESOLVE_GLADE_WOUND_COMMAND,
 } from "./resolveGladeWoundCommand.js";
+
+// Deep Mine crystal choice command
+export {
+  createResolveDeepMineChoiceCommand,
+  type ResolveDeepMineChoiceCommandParams,
+  RESOLVE_DEEP_MINE_COMMAND,
+} from "./resolveDeepMineChoiceCommand.js";
 
 // Buy spell command
 export {


### PR DESCRIPTION
Split the 890-line commands/index.ts into focused factory modules:
- factories/types.ts - CommandFactory type definition
- factories/movement.ts - Move, Explore factories
- factories/cards.ts - PlayCard, PlayCardSideways, ResolveChoice factories
- factories/combat.ts - Combat-related factories (EnterCombat, EndCombatPhase, etc.)
- factories/units.ts - RecruitUnit, ActivateUnit factories
- factories/turn.ts - EndTurn, Rest, AnnounceEndOfRound factories
- factories/sites.ts - Interact, EnterSite, ResolveGladeWound, ResolveDeepMine factories
- factories/tactics.ts - Tactic-related factories
- factories/offers.ts - BuySpell, LearnAdvancedAction, SelectReward factories
- factories/index.ts - Registry and re-exports

The main index.ts is now a thin file (~210 lines) that imports the registry
and provides createCommandForAction plus re-exports.