### PR TITLE
refactor(core): Extract elemental value helpers to reduce duplication

### DIFF
--- a/packages/core/src/engine/commands/combat/assignAttackCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignAttackCommand.ts
@@ -22,9 +22,13 @@ import {
   ATTACK_ELEMENT_ICE,
   ATTACK_ELEMENT_COLD_FIRE,
 } from "@mage-knight/shared";
-import type { AccumulatedAttack, ElementalAttackValues } from "../../../types/player.js";
+import type { AccumulatedAttack } from "../../../types/player.js";
 import type { PendingElementalDamage } from "../../../types/combat.js";
 import { createEmptyPendingDamage } from "../../../types/combat.js";
+import {
+  getElementalValue,
+  addToElementalValues,
+} from "../../helpers/elementalValueHelpers.js";
 
 export const ASSIGN_ATTACK_COMMAND = "ASSIGN_ATTACK" as const;
 
@@ -86,19 +90,6 @@ function getAvailableAttack(
   return accumulated - alreadyAssigned;
 }
 
-function getElementalValue(elements: ElementalAttackValues, element: AttackElement): number {
-  switch (element) {
-    case ATTACK_ELEMENT_FIRE:
-      return elements.fire;
-    case ATTACK_ELEMENT_ICE:
-      return elements.ice;
-    case ATTACK_ELEMENT_COLD_FIRE:
-      return elements.coldFire;
-    default:
-      return elements.physical;
-  }
-}
-
 /**
  * Update accumulated attack values by adding to a specific type/element combo.
  */
@@ -133,23 +124,6 @@ function addToAccumulatedAttack(
         ...attack,
         normalElements: addToElementalValues(attack.normalElements, element, amount),
       };
-  }
-}
-
-function addToElementalValues(
-  values: ElementalAttackValues,
-  element: AttackElement,
-  amount: number
-): ElementalAttackValues {
-  switch (element) {
-    case ATTACK_ELEMENT_FIRE:
-      return { ...values, fire: values.fire + amount };
-    case ATTACK_ELEMENT_ICE:
-      return { ...values, ice: values.ice + amount };
-    case ATTACK_ELEMENT_COLD_FIRE:
-      return { ...values, coldFire: values.coldFire + amount };
-    default:
-      return { ...values, physical: values.physical + amount };
   }
 }
 

--- a/packages/core/src/engine/commands/combat/assignBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignBlockCommand.ts
@@ -21,6 +21,10 @@ import {
 import type { ElementalAttackValues } from "../../../types/player.js";
 import type { PendingElementalDamage } from "../../../types/combat.js";
 import { createEmptyPendingDamage } from "../../../types/combat.js";
+import {
+  getElementalValue,
+  addToElementalValues,
+} from "../../helpers/elementalValueHelpers.js";
 
 export const ASSIGN_BLOCK_COMMAND = "ASSIGN_BLOCK" as const;
 
@@ -43,39 +47,6 @@ function getAvailableBlock(
   const accumulated = getElementalValue(blockElements, element);
   const alreadyAssigned = getElementalValue(assignedBlockElements, element);
   return accumulated - alreadyAssigned;
-}
-
-function getElementalValue(elements: ElementalAttackValues, element: AttackElement): number {
-  switch (element) {
-    case ATTACK_ELEMENT_FIRE:
-      return elements.fire;
-    case ATTACK_ELEMENT_ICE:
-      return elements.ice;
-    case ATTACK_ELEMENT_COLD_FIRE:
-      return elements.coldFire;
-    default:
-      return elements.physical;
-  }
-}
-
-/**
- * Add to elemental values.
- */
-function addToElementalValues(
-  values: ElementalAttackValues,
-  element: AttackElement,
-  amount: number
-): ElementalAttackValues {
-  switch (element) {
-    case ATTACK_ELEMENT_FIRE:
-      return { ...values, fire: values.fire + amount };
-    case ATTACK_ELEMENT_ICE:
-      return { ...values, ice: values.ice + amount };
-    case ATTACK_ELEMENT_COLD_FIRE:
-      return { ...values, coldFire: values.coldFire + amount };
-    default:
-      return { ...values, physical: values.physical + amount };
-  }
 }
 
 /**

--- a/packages/core/src/engine/helpers/elementalValueHelpers.ts
+++ b/packages/core/src/engine/helpers/elementalValueHelpers.ts
@@ -1,0 +1,53 @@
+/**
+ * Elemental Value Helpers
+ *
+ * Utility functions for accessing and manipulating elemental attack/block values.
+ * Used by combat assignment validators and commands.
+ */
+
+import type { AttackElement } from "@mage-knight/shared";
+import {
+  ATTACK_ELEMENT_FIRE,
+  ATTACK_ELEMENT_ICE,
+  ATTACK_ELEMENT_COLD_FIRE,
+} from "@mage-knight/shared";
+import type { ElementalAttackValues } from "../../types/player.js";
+
+/**
+ * Get the value for a specific element from an ElementalAttackValues object.
+ */
+export function getElementalValue(
+  elements: ElementalAttackValues,
+  element: AttackElement
+): number {
+  switch (element) {
+    case ATTACK_ELEMENT_FIRE:
+      return elements.fire;
+    case ATTACK_ELEMENT_ICE:
+      return elements.ice;
+    case ATTACK_ELEMENT_COLD_FIRE:
+      return elements.coldFire;
+    default:
+      return elements.physical;
+  }
+}
+
+/**
+ * Create a new ElementalAttackValues with an amount added to a specific element.
+ */
+export function addToElementalValues(
+  values: ElementalAttackValues,
+  element: AttackElement,
+  amount: number
+): ElementalAttackValues {
+  switch (element) {
+    case ATTACK_ELEMENT_FIRE:
+      return { ...values, fire: values.fire + amount };
+    case ATTACK_ELEMENT_ICE:
+      return { ...values, ice: values.ice + amount };
+    case ATTACK_ELEMENT_COLD_FIRE:
+      return { ...values, coldFire: values.coldFire + amount };
+    default:
+      return { ...values, physical: values.physical + amount };
+  }
+}

--- a/packages/core/src/engine/helpers/index.ts
+++ b/packages/core/src/engine/helpers/index.ts
@@ -59,3 +59,9 @@ export {
   revealRuinsToken,
 } from "./ruinsTokenHelpers.js";
 export type { RuinsTokenPiles, DrawRuinsTokenResult } from "./ruinsTokenHelpers.js";
+
+// Elemental value helpers
+export {
+  getElementalValue,
+  addToElementalValues,
+} from "./elementalValueHelpers.js";

--- a/packages/core/src/engine/validators/combatValidators/attackAssignmentValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/attackAssignmentValidators.ts
@@ -20,8 +20,9 @@ import {
   ATTACK_ELEMENT_COLD_FIRE,
 } from "@mage-knight/shared";
 import { createEmptyPendingDamage, COMBAT_PHASE_RANGED_SIEGE } from "../../../types/combat.js";
-import type { AccumulatedAttack, ElementalAttackValues } from "../../../types/player.js";
+import type { AccumulatedAttack } from "../../../types/player.js";
 import { getFortificationLevel } from "./fortificationValidators.js";
+import { getElementalValue } from "../../helpers/elementalValueHelpers.js";
 import {
   NOT_IN_COMBAT,
   WRONG_COMBAT_PHASE,
@@ -46,19 +47,6 @@ function getAvailableAttack(
 ): number {
   let accumulated = 0;
   let alreadyAssigned = 0;
-
-  const getElementalValue = (elements: ElementalAttackValues, el: AttackElement): number => {
-    switch (el) {
-      case ATTACK_ELEMENT_FIRE:
-        return elements.fire;
-      case ATTACK_ELEMENT_ICE:
-        return elements.ice;
-      case ATTACK_ELEMENT_COLD_FIRE:
-        return elements.coldFire;
-      default:
-        return elements.physical;
-    }
-  };
 
   switch (attackType) {
     case ATTACK_TYPE_RANGED:

--- a/packages/core/src/engine/validators/combatValidators/blockAssignmentValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/blockAssignmentValidators.ts
@@ -17,6 +17,7 @@ import {
 } from "@mage-knight/shared";
 import { COMBAT_PHASE_BLOCK } from "../../../types/combat.js";
 import type { ElementalAttackValues } from "../../../types/player.js";
+import { getElementalValue } from "../../helpers/elementalValueHelpers.js";
 import {
   NOT_IN_COMBAT,
   WRONG_COMBAT_PHASE,
@@ -37,19 +38,6 @@ function getAvailableBlock(
   assignedBlockElements: ElementalAttackValues,
   element: AttackElement
 ): number {
-  const getElementalValue = (elements: ElementalAttackValues, el: AttackElement): number => {
-    switch (el) {
-      case ATTACK_ELEMENT_FIRE:
-        return elements.fire;
-      case ATTACK_ELEMENT_ICE:
-        return elements.ice;
-      case ATTACK_ELEMENT_COLD_FIRE:
-        return elements.coldFire;
-      default:
-        return elements.physical;
-    }
-  };
-
   const accumulated = getElementalValue(blockElements, element);
   const alreadyAssigned = getElementalValue(assignedBlockElements, element);
 


### PR DESCRIPTION
Consolidate duplicated getElementalValue() and addToElementalValues()
functions from 4 combat files into a shared helper module. This
reduces code duplication and ensures consistent elemental value
handling across attack/block assignment validators and commands.