### PR TITLE
fix(client): Reset tactic selection state on round transition

### DIFF
--- a/packages/client/src/components/Hand/PixiTacticCarousel.tsx
+++ b/packages/client/src/components/Hand/PixiTacticCarousel.tsx
@@ -151,6 +151,12 @@ export function PixiTacticCarousel({ viewMode, isActive = true }: PixiTacticCaro
     setManaSourceComplete(true);
   }, []));
 
+  // Reset selection state when tactics change (new round)
+  useEffect(() => {
+    selectionInProgressRef.current = false;
+    setSelectedTactic(null);
+  }, [availableTactics]);
+
   // Load atlas on mount
   useEffect(() => {
     loadAtlas().then(() => setAtlasLoaded(true));


### PR DESCRIPTION
## Summary
Fixes the night tactic card selection soft-lock where cards don't render after day→night transition.

## Changes
- Add `useEffect` hook in `PixiTacticCarousel.tsx` to reset `selectionInProgressRef` and `selectedTactic` state when `availableTactics` changes (indicating a new round)

## Root Cause
The `selectionInProgressRef` was set to `true` when a tactic was selected but was **never reset to `false`** when a new round began. This caused the `updateSprites` effect to early-return, preventing night tactic cards from rendering.

## Test Plan
1. Start a game and complete the day round (select a day tactic like "Early Bird")
2. End the round and transition to night
3. Verify night tactic cards render correctly with deal animation
4. Verify hover effects work (blue glow for night theme)
5. Select a night tactic and verify the game continues normally
6. Repeat for night→day transition

Closes #65