### PR TITLE
Add GitHub CLI auto-installation on Claude session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,5 +5,18 @@
     "typescript-lsp@claude-plugins-official": true,
     "code-review@claude-plugins-official": true,
     "feature-dev@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install-gh-cli.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/install-gh-cli.sh
+++ b/scripts/install-gh-cli.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Installs GitHub CLI (gh) if not already available
+# Used by SessionStart hook for Claude Code sessions
+
+set -e
+
+GH_VERSION="2.63.2"
+INSTALL_DIR="$HOME/.local/bin"
+
+# Ensure ~/.local/bin is in PATH for this session and future sessions
+if [[ ":$PATH:" != *":$INSTALL_DIR:"* ]]; then
+    export PATH="$INSTALL_DIR:$PATH"
+    # Add to .bashrc if not already there
+    if ! grep -q 'export PATH="$HOME/.local/bin:$PATH"' "$HOME/.bashrc" 2>/dev/null; then
+        echo 'export PATH="$HOME/.local/bin:$PATH"' >> "$HOME/.bashrc"
+    fi
+fi
+
+# Check if gh is already installed and working
+if command -v gh &> /dev/null || [ -x "$INSTALL_DIR/gh" ]; then
+    echo "gh CLI already installed"
+    exit 0
+fi
+
+echo "Installing gh CLI v$GH_VERSION..."
+
+# Create install directory
+mkdir -p "$INSTALL_DIR"
+
+# Download and extract gh
+curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" | tar xz -C /tmp
+
+# Move binary to install directory
+mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" "$INSTALL_DIR/"
+
+# Verify installation
+if [ -x "$INSTALL_DIR/gh" ]; then
+    echo "gh CLI installed successfully to $INSTALL_DIR/gh"
+else
+    echo "Warning: gh CLI installation may have failed"
+fi
+
+# Clean up
+rm -rf "/tmp/gh_${GH_VERSION}_linux_amd64"
+
+exit 0


### PR DESCRIPTION
## Summary
This PR adds automatic installation of GitHub CLI (gh) when Claude Code sessions start, ensuring the tool is available for development workflows without manual setup.

## Changes
- **Updated `.claude/settings.json`**: Added a `SessionStart` hook that triggers the gh CLI installation script when a Claude session begins
- **Added `scripts/install-gh-cli.sh`**: New installation script that:
  - Downloads and installs GitHub CLI v2.63.2 to `~/.local/bin`
  - Ensures `~/.local/bin` is in the PATH for both current and future sessions
  - Checks if gh is already installed to avoid redundant downloads
  - Includes verification and cleanup steps

## Implementation Details
- The script uses a SessionStart hook with a "startup" matcher to run automatically
- Installation is idempotent—it skips installation if gh is already available
- The script adds the install directory to `.bashrc` for persistence across sessions
- Uses curl to download the pre-built Linux binary, keeping the installation lightweight and fast
- Includes proper error handling with `set -e` and verification checks

https://claude.ai/code/session_014ALz9Hv7LqbJFE4aXsQSnw