### PR TITLE
feat: Add unit damage targeting to ValidActions

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -184,6 +184,7 @@ export type {
   CombatOptions,
   BlockOption,
   DamageAssignmentOption,
+  UnitDamageTarget,
   // Incremental attack allocation types
   ElementalDamageValues,
   AvailableAttackPool,

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -10,6 +10,7 @@ import type { CardId, ManaColor, BasicManaColor, SkillId } from "../ids.js";
 import type { TacticId } from "../tactics.js";
 import type { RestType, AttackType, AttackElement } from "../actions.js";
 import type { CombatPhase } from "../combatPhases.js";
+import type { Element } from "../elements.js";
 import type {
   PLAY_SIDEWAYS_AS_ATTACK,
   PLAY_SIDEWAYS_AS_BLOCK,
@@ -216,10 +217,41 @@ export interface BlockOption {
   readonly isBlocked: boolean;
 }
 
+/**
+ * Information about a unit that can receive damage during ASSIGN_DAMAGE phase.
+ */
+export interface UnitDamageTarget {
+  /** Unique instance ID for this unit */
+  readonly unitInstanceId: string;
+  /** Unit display name */
+  readonly unitName: string;
+  /** Unit's armor value (damage absorbed per wound) */
+  readonly armor: number;
+  /** Whether unit has resistance to the attack element */
+  readonly isResistantToAttack: boolean;
+  /** Whether unit already had damage assigned this combat (can't assign again) */
+  readonly alreadyAssignedThisCombat: boolean;
+  /** Whether unit is currently wounded */
+  readonly isWounded: boolean;
+  /** Computed: true if unit can receive damage (!isWounded && !alreadyAssignedThisCombat) */
+  readonly canBeAssigned: boolean;
+}
+
 export interface DamageAssignmentOption {
   readonly enemyInstanceId: string;
   readonly enemyName: string;
+  /** Enemy's attack element (physical, fire, ice, cold_fire) */
+  readonly attackElement: Element;
+  /** Whether enemy has Brutal ability (doubles damage) */
+  readonly isBrutal: boolean;
+  /** Raw attack value before Brutal modifier */
+  readonly rawAttackValue: number;
+  /** Total damage to assign (2x if Brutal) */
+  readonly totalDamage: number;
+  /** @deprecated Use totalDamage instead */
   readonly unassignedDamage: number;
+  /** Units available to absorb damage (empty if units not allowed in combat) */
+  readonly availableUnits: readonly UnitDamageTarget[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
Extend combat ValidActions to include unit targeting information during the ASSIGN_DAMAGE phase. This provides the UI with all data needed to build a damage assignment interface where players can choose to assign damage to their units.

## Changes
- Add `UnitDamageTarget` interface with unit info, resistance status, and assignability
- Extend `DamageAssignmentOption` with enemy attack element, Brutal status, and available units
- Add `computeAvailableUnitTargets()` function to calculate which units can receive damage
- Add comprehensive tests for damage assignment valid actions

## New Data Available
**Per Enemy:**
- `attackElement` - physical, fire, ice, or cold_fire
- `isBrutal` - whether enemy has Brutal ability (doubles damage)
- `rawAttackValue` / `totalDamage` - attack value before/after Brutal

**Per Available Unit:**
- `armor` - damage absorbed per wound
- `isResistantToAttack` - computed based on enemy's attack element
- `alreadyAssignedThisCombat` - can't assign again if already absorbed damage
- `isWounded` - can't assign to wounded units
- `canBeAssigned` - computed: `!isWounded && !alreadyAssignedThisCombat`

## Test Plan
- [x] All existing tests pass
- [x] New tests cover enemy attack info, unit targets, and edge cases
- [x] Manually verified in UI - damage assignment options show correct unit data

Closes #74