### PR TITLE
Fix hex tooltip persisting over combat and offer menu

### DIFF
--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -3,7 +3,7 @@ import { useGame } from "../hooks/useGame";
 import { useMyPlayer } from "../hooks/useMyPlayer";
 import { useGameIntro } from "../contexts/GameIntroContext";
 import { useCinematic } from "../contexts/CinematicContext";
-import { useOverlay } from "../contexts/OverlayContext";
+import { useOverlay, useRegisterOverlay } from "../contexts/OverlayContext";
 import { UnifiedCardMenu } from "./CardInteraction";
 import { PixiHexGrid } from "./GameBoard/PixiHexGrid";
 import { ManaSourceOverlay } from "./GameBoard/ManaSourceOverlay";
@@ -31,6 +31,15 @@ export function GameView() {
   const { isOverlayActive } = useOverlay();
   const [isOfferViewVisible, setIsOfferViewVisible] = useState(false);
 
+  // Show combat overlay when in combat
+  // Note: We check state.combat existence, not validActions.combat
+  // validActions.combat may be undefined during choice resolution, but we still want
+  // to show the combat scene (enemies, phase rail, etc.) while the player makes their choice
+  const inCombat = state?.combat != null;
+
+  // Register combat as an overlay to disable hex tooltips during combat
+  useRegisterOverlay(inCombat);
+
   // Handle offer view state from PlayerHand
   const handleOfferViewChange = useCallback((isVisible: boolean) => {
     setIsOfferViewVisible(isVisible);
@@ -49,12 +58,6 @@ export function GameView() {
   if (!state) {
     return <div className="loading">Loading game state...</div>;
   }
-
-  // Show combat overlay when in combat
-  // Note: We check state.combat existence, not validActions.combat
-  // validActions.combat may be undefined during choice resolution, but we still want
-  // to show the combat scene (enemies, phase rail, etc.) while the player makes their choice
-  const inCombat = state.combat !== null;
 
   // Check if we're in tactic selection mode
   // Only dim the world after intro completes - don't dim during the theatrical reveal

--- a/packages/client/src/components/OfferView/OfferView.tsx
+++ b/packages/client/src/components/OfferView/OfferView.tsx
@@ -8,6 +8,7 @@
  * and to avoid DOM/Pixi coordination issues.
  */
 
+import { useRegisterOverlay } from "../../contexts/OverlayContext";
 import { PixiOfferView } from "./PixiOfferView";
 
 // Offer pane types (exported for external use)
@@ -19,6 +20,9 @@ export interface OfferViewProps {
 }
 
 export function OfferView({ isVisible, onClose }: OfferViewProps) {
+  // Register as overlay when visible to disable hex tooltips
+  useRegisterOverlay(isVisible);
+
   // Delegate entirely to the Pixi implementation
   return <PixiOfferView isVisible={isVisible} onClose={onClose} />;
 }


### PR DESCRIPTION
## Summary

Fixes the hex tooltip persisting over combat overlay and offer menu by registering them as overlays.

## Changes

- **GameView.tsx**: Register combat state as an overlay via `useRegisterOverlay(inCombat)` - moved `inCombat` calculation before the early return to satisfy hook rules
- **OfferView.tsx**: Register offer view as an overlay via `useRegisterOverlay(isVisible)`

The `HexTooltip` already checks `!isOverlayActive` before rendering, but combat and offer view weren't registering themselves. Now they do, following the existing pattern used by `ChoiceSelection`, `UnifiedCardMenu`, etc.

## Test Plan

1. Hover over a hex with a site to show the tooltip
2. Press 4 to open the offer menu → tooltip should disappear
3. Close offer menu → tooltip should not reappear until hovering again
4. Hover over a hex, then enter combat → tooltip should disappear
5. Exit combat → tooltip should not reappear until hovering again

Closes #69