### PR TITLE
feat(client): Wire site action handlers to open OfferView tabs

### DIFF
--- a/packages/client/src/components/GameBoard/PixiHexGrid.tsx
+++ b/packages/client/src/components/GameBoard/PixiHexGrid.tsx
@@ -59,12 +59,14 @@ import {
 export interface PixiHexGridProps {
   /** Callback when user wants to navigate to unit offer panel */
   onNavigateToUnitOffer?: () => void;
+  /** Callback when user wants to navigate to spell offer panel */
+  onNavigateToSpellOffer?: () => void;
 }
 
 /**
  * PixiJS Hex Grid Component
  */
-export function PixiHexGrid({ onNavigateToUnitOffer }: PixiHexGridProps = {}) {
+export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: PixiHexGridProps = {}) {
   // Refs for PixiJS objects
   const containerRef = useRef<HTMLDivElement>(null);
   const appRef = useRef<Application | null>(null);
@@ -191,16 +193,14 @@ export function PixiHexGrid({ onNavigateToUnitOffer }: PixiHexGridProps = {}) {
         console.log("Heal action - not yet implemented");
         break;
       case "recruit":
-        // TODO: Open offers view to units tab
-        console.log("Recruit action - open offers view");
+        onNavigateToUnitOffer?.();
         break;
       case "buySpell":
-        // TODO: Open offers view to spells tab
-        console.log("Buy spell action - open offers view");
+        onNavigateToSpellOffer?.();
         break;
       case "buyAA":
-        // TODO: Open offers view to AA tab
-        console.log("Buy AA action - open offers view");
+        // Monastery AAs are shown in the units pane alongside regular units
+        onNavigateToUnitOffer?.();
         break;
       case "burn":
         sendAction({ type: BURN_MONASTERY_ACTION });
@@ -210,7 +210,7 @@ export function PixiHexGrid({ onNavigateToUnitOffer }: PixiHexGridProps = {}) {
         break;
     }
     handleCloseSiteActionList();
-  }, [sendAction, player?.position, handleOpenSitePanel, handleCloseSiteActionList]);
+  }, [sendAction, player?.position, handleOpenSitePanel, handleCloseSiteActionList, onNavigateToUnitOffer, onNavigateToSpellOffer]);
 
   // Calculate screen position for hero (for action list)
   const getHeroScreenPosition = useCallback((): { x: number; y: number } | null => {

--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -21,7 +21,7 @@ import { ManaSearchReroll } from "./Overlays/ManaSearchReroll";
 import { GladeWoundDecision } from "./Overlays/GladeWoundDecision";
 import { LevelUpRewardSelection } from "./Overlays/LevelUpRewardSelection";
 import { CombatOverlay, PixiCombatOverlay } from "./Combat";
-import { OfferView } from "./OfferView";
+import { OfferView, type OfferPane } from "./OfferView";
 
 export function GameView() {
   const { state } = useGame();
@@ -30,6 +30,7 @@ export function GameView() {
   const { isInCinematic } = useCinematic();
   const { isOverlayActive } = useOverlay();
   const [isOfferViewVisible, setIsOfferViewVisible] = useState(false);
+  const [offerViewInitialTab, setOfferViewInitialTab] = useState<OfferPane>("units");
 
   // Show combat overlay when in combat
   // Note: We check state.combat existence, not validActions.combat
@@ -52,6 +53,13 @@ export function GameView() {
 
   // Handle navigating to unit offer from SitePanel
   const handleNavigateToUnitOffer = useCallback(() => {
+    setOfferViewInitialTab("units");
+    setIsOfferViewVisible(true);
+  }, []);
+
+  // Handle navigating to spell offer from site actions
+  const handleNavigateToSpellOffer = useCallback(() => {
+    setOfferViewInitialTab("spells");
     setIsOfferViewVisible(true);
   }, []);
 
@@ -99,11 +107,14 @@ export function GameView() {
       <TopBar />
 
       {/* Offer View - Inscryption-style offer display */}
-      <OfferView isVisible={isOfferViewVisible} onClose={handleOfferViewClose} />
+      <OfferView isVisible={isOfferViewVisible} onClose={handleOfferViewClose} initialTab={offerViewInitialTab} />
 
       <main className="app__main">
         <div className="app__board">
-          <PixiHexGrid onNavigateToUnitOffer={handleNavigateToUnitOffer} />
+          <PixiHexGrid
+            onNavigateToUnitOffer={handleNavigateToUnitOffer}
+            onNavigateToSpellOffer={handleNavigateToSpellOffer}
+          />
           <ManaSourceOverlay />
         </div>
       </main>

--- a/packages/client/src/components/OfferView/OfferView.tsx
+++ b/packages/client/src/components/OfferView/OfferView.tsx
@@ -17,12 +17,14 @@ export type OfferPane = "units" | "spells" | "advancedActions";
 export interface OfferViewProps {
   isVisible: boolean;
   onClose: () => void;
+  /** Optional initial tab to show when opening. Defaults to "units". */
+  initialTab?: OfferPane;
 }
 
-export function OfferView({ isVisible, onClose }: OfferViewProps) {
+export function OfferView({ isVisible, onClose, initialTab }: OfferViewProps) {
   // Register as overlay when visible to disable hex tooltips
   useRegisterOverlay(isVisible);
 
   // Delegate entirely to the Pixi implementation
-  return <PixiOfferView isVisible={isVisible} onClose={onClose} />;
+  return <PixiOfferView isVisible={isVisible} onClose={onClose} initialTab={initialTab} />;
 }

--- a/packages/client/src/components/OfferView/PixiOfferView.tsx
+++ b/packages/client/src/components/OfferView/PixiOfferView.tsx
@@ -41,6 +41,8 @@ type OfferPane = "units" | "spells" | "advancedActions";
 interface PixiOfferViewProps {
   isVisible: boolean;
   onClose: () => void;
+  /** Optional initial tab to show when opening. Defaults to "units". */
+  initialTab?: OfferPane;
 }
 
 interface CardData {
@@ -105,7 +107,7 @@ function getHoverRotation(cardId: string, index: number): number {
 // Component
 // ============================================
 
-export function PixiOfferView({ isVisible, onClose }: PixiOfferViewProps) {
+export function PixiOfferView({ isVisible, onClose, initialTab = "units" }: PixiOfferViewProps) {
   const uniqueId = useId();
   const { app, overlayLayer } = usePixiApp();
   const { state, sendAction } = useGame();
@@ -529,7 +531,7 @@ export function PixiOfferView({ isVisible, onClose }: PixiOfferViewProps) {
 
       const tabBg = new Graphics();
       tabBg.roundRect(0, 0, tabWidth, 32, 4);
-      tabBg.fill({ color: tab.pane === "units" ? COLORS.TAB_ACTIVE : COLORS.TAB_BG });
+      tabBg.fill({ color: tab.pane === initialTab ? COLORS.TAB_ACTIVE : COLORS.TAB_BG });
       tabContainer.addChild(tabBg);
 
       const tabText = new Text({
@@ -620,9 +622,9 @@ export function PixiOfferView({ isVisible, onClose }: PixiOfferViewProps) {
     hintText.position.set(trayWidth / 2, trayHeight - 20);
     trayContainer.addChild(hintText);
 
-    // Build initial cards
-    currentPaneRef.current = "units";
-    buildCards(cardsContainer, "units", animManager);
+    // Build initial cards with the specified initial tab
+    currentPaneRef.current = initialTab;
+    buildCards(cardsContainer, initialTab, animManager);
 
     // Capture refs for cleanup
     const tabContainers = tabContainersRef.current;
@@ -652,7 +654,7 @@ export function PixiOfferView({ isVisible, onClose }: PixiOfferViewProps) {
         rootContainerRef.current = null;
       }
     };
-  }, [app, overlayLayer, isVisible, state, player, uniqueId, screenWidth, screenHeight, cardWidth, cardHeight, trayWidth, trayPadding, buildCards, switchPane]);
+  }, [app, overlayLayer, isVisible, state, player, uniqueId, screenWidth, screenHeight, cardWidth, cardHeight, trayWidth, trayPadding, buildCards, switchPane, initialTab]);
 
   // Keyboard handling
   useEffect(() => {


### PR DESCRIPTION
## Summary

Wire up site action handlers to open the OfferView to the correct tab when players select recruit, buy spell, or training actions from the site action list.

## Changes

- Add `initialTab` prop to `OfferView` and `PixiOfferView` components to specify which tab to show when opening
- Wire `recruit` action → opens Units tab
- Wire `buySpell` action → opens Spells tab
- Wire `buyAA` (monastery training) → opens Units tab (where monastery AAs are displayed alongside regular units)

## Test Plan

1. Stand on a conquered Village, press Space, select "Recruit" → OfferView opens with Units tab
2. Stand on a conquered Mage Tower, press Space, select "Buy Spell" → OfferView opens with Spells tab
3. Stand on a Monastery, press Space, select "Training" → OfferView opens with Units tab
4. Verify Q/W/E keyboard shortcuts still switch between tabs after opening

Closes #63