### PR TITLE
feat: implement faction leader core system with level-based stats and Arcane Immunity

### DIFF
--- a/packages/core/src/engine/__tests__/arcaneImmunity.test.ts
+++ b/packages/core/src/engine/__tests__/arcaneImmunity.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Arcane Immunity Tests
+ *
+ * Tests for Arcane Immunity ability enforcement on faction leaders
+ * and other enemies with this ability (e.g., Sorcerers).
+ *
+ * Per rulebook: "The enemy is not affected by any non-Attack/non-Block effects
+ * from any source (e.g., effects that destroy, prevent attacking, or reduce Armor).
+ * Attacks and Blocks of any elements work normally."
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  ENEMY_SORCERERS,
+  ENEMY_DIGGERS,
+  ENEMY_ELEMENTALIST_LEADER,
+  ENEMY_DARK_CRUSADER_LEADER,
+  ABILITY_ARCANE_IMMUNITY,
+} from "@mage-knight/shared";
+import {
+  resolveSelectCombatEnemy,
+  resolveCombatEnemyTarget,
+} from "../effects/combatEffects.js";
+import { createCombatState } from "../../types/combat.js";
+import {
+  EFFECT_ENEMY_STAT,
+  ENEMY_STAT_ARMOR,
+  DURATION_COMBAT,
+} from "../../types/modifierConstants.js";
+import { EFFECT_RESOLVE_COMBAT_ENEMY_TARGET } from "../../types/effectTypes.js";
+import type { SelectCombatEnemyEffect, CombatEnemyTargetTemplate } from "../../types/cards.js";
+
+describe("Arcane Immunity", () => {
+  describe("Enemy targeting filtering", () => {
+    it("should filter out Sorcerers from spell targeting when effect has modifiers", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Sorcerers (has Arcane Immunity) and Diggers (no immunity)
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_SORCERERS, ENEMY_DIGGERS], false),
+      };
+
+      // Create effect with armor reduction (should be blocked by Arcane Immunity)
+      const effect: SelectCombatEnemyEffect = {
+        type: "select_combat_enemy",
+        includeDefeated: false,
+        template: {
+          modifiers: [
+            {
+              modifier: { type: EFFECT_ENEMY_STAT, stat: ENEMY_STAT_ARMOR, amount: -2, minimum: 1 },
+              duration: DURATION_COMBAT,
+              description: "Armor -2",
+            },
+          ],
+        },
+      };
+
+      const result = resolveSelectCombatEnemy(state, effect);
+
+      // Should only have Diggers as a valid target (Sorcerers are immune)
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const options = result.dynamicChoiceOptions;
+      expect(options).toBeDefined();
+      if (options && options.length > 0) {
+        const option = options[0];
+        expect(option).toBeDefined();
+        expect(option.type).toBe(EFFECT_RESOLVE_COMBAT_ENEMY_TARGET);
+        if (option.type === EFFECT_RESOLVE_COMBAT_ENEMY_TARGET) {
+          expect(option.enemyName).toBe("Diggers");
+        }
+      }
+    });
+
+    it("should filter out faction leader from spell targeting when effect defeats enemy", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with faction leader (has Arcane Immunity) and Diggers
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_ELEMENTALIST_LEADER, ENEMY_DIGGERS], false),
+      };
+
+      // Create effect with defeat (should be blocked by Arcane Immunity)
+      const effect: SelectCombatEnemyEffect = {
+        type: "select_combat_enemy",
+        includeDefeated: false,
+        template: {
+          defeat: true,
+        },
+      };
+
+      const result = resolveSelectCombatEnemy(state, effect);
+
+      // Should only have Diggers as a valid target
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const options = result.dynamicChoiceOptions;
+      if (options && options.length > 0) {
+        const option = options[0];
+        if (option && option.type === EFFECT_RESOLVE_COMBAT_ENEMY_TARGET) {
+          expect(option.enemyName).toBe("Diggers");
+        }
+      }
+    });
+
+    it("should show immunity message when all enemies are immune", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with only Sorcerers (all immune)
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_SORCERERS], false),
+      };
+
+      // Create effect with modifiers
+      const effect: SelectCombatEnemyEffect = {
+        type: "select_combat_enemy",
+        includeDefeated: false,
+        template: {
+          modifiers: [
+            {
+              modifier: { type: EFFECT_ENEMY_STAT, stat: ENEMY_STAT_ARMOR, amount: -2, minimum: 1 },
+              duration: DURATION_COMBAT,
+            },
+          ],
+        },
+      };
+
+      const result = resolveSelectCombatEnemy(state, effect);
+
+      // Should report that all enemies are immune
+      expect(result.requiresChoice).toBeFalsy();
+      expect(result.description).toContain("immune");
+    });
+
+    it("should allow targeting immune enemies with effects that have no restricted components", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Sorcerers
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_SORCERERS], false),
+      };
+
+      // Create effect with no modifiers or defeat (should be allowed)
+      const effect: SelectCombatEnemyEffect = {
+        type: "select_combat_enemy",
+        includeDefeated: false,
+        template: {},
+      };
+
+      const result = resolveSelectCombatEnemy(state, effect);
+
+      // Should have Sorcerers as a valid target
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+    });
+  });
+
+  describe("Effect resolution blocking", () => {
+    it("should block modifiers on immune enemies at resolution time", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Sorcerers
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_SORCERERS], false),
+      };
+
+      // Try to resolve effect on Sorcerers (safety net check)
+      const template: CombatEnemyTargetTemplate = {
+        modifiers: [
+          {
+            modifier: { type: EFFECT_ENEMY_STAT, stat: ENEMY_STAT_ARMOR, amount: -2, minimum: 1 },
+            duration: DURATION_COMBAT,
+            description: "Armor -2",
+          },
+        ],
+      };
+
+      const result = resolveCombatEnemyTarget(
+        state,
+        "player1",
+        {
+          type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+          enemyInstanceId: "enemy_0",
+          enemyName: "Sorcerers",
+          template,
+        }
+      );
+
+      // Should report immunity and not apply modifiers
+      expect(result.description).toContain("immune");
+      expect(result.description).toContain("Arcane Immunity");
+
+      // Verify no modifiers were added
+      expect(result.state.activeModifiers).toHaveLength(0);
+    });
+
+    it("should block defeat on immune enemies at resolution time", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with faction leader at level 2
+      state = {
+        ...state,
+        combat: createCombatState(
+          [{ enemyId: ENEMY_ELEMENTALIST_LEADER, level: 2 }],
+          false
+        ),
+      };
+
+      // Try to resolve defeat effect on faction leader
+      const template: CombatEnemyTargetTemplate = {
+        defeat: true,
+      };
+
+      const result = resolveCombatEnemyTarget(
+        state,
+        "player1",
+        {
+          type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+          enemyInstanceId: "enemy_0",
+          enemyName: "Elementalist",
+          template,
+        }
+      );
+
+      // Should report immunity
+      expect(result.description).toContain("immune");
+
+      // Enemy should NOT be defeated
+      const combat = result.state.combat;
+      expect(combat).toBeDefined();
+      if (combat) {
+        const enemy = combat.enemies[0];
+        expect(enemy).toBeDefined();
+        if (enemy) {
+          expect(enemy.isDefeated).toBe(false);
+        }
+      }
+    });
+
+    it("should allow effects with no restricted components on immune enemies", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Sorcerers
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_SORCERERS], false),
+      };
+
+      // Resolve effect with empty template
+      const result = resolveCombatEnemyTarget(
+        state,
+        "player1",
+        {
+          type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+          enemyInstanceId: "enemy_0",
+          enemyName: "Sorcerers",
+          template: {},
+        }
+      );
+
+      // Should not report immunity
+      expect(result.description).not.toContain("immune");
+      expect(result.description).toContain("Sorcerers");
+    });
+  });
+
+  describe("Regular enemies (no immunity)", () => {
+    it("should allow modifiers on non-immune enemies", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (no immunity)
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_DIGGERS], false),
+      };
+
+      // Resolve effect with armor reduction
+      const template: CombatEnemyTargetTemplate = {
+        modifiers: [
+          {
+            modifier: { type: EFFECT_ENEMY_STAT, stat: ENEMY_STAT_ARMOR, amount: -2, minimum: 1 },
+            duration: DURATION_COMBAT,
+            description: "Armor -2",
+          },
+        ],
+      };
+
+      const result = resolveCombatEnemyTarget(
+        state,
+        "player1",
+        {
+          type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+          enemyInstanceId: "enemy_0",
+          enemyName: "Diggers",
+          template,
+        }
+      );
+
+      // Should not report immunity
+      expect(result.description).not.toContain("immune");
+      expect(result.description).toContain("Armor -2");
+
+      // Modifier should be added
+      expect(result.state.activeModifiers.length).toBeGreaterThan(0);
+    });
+
+    it("should allow defeat on non-immune enemies", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers
+      state = {
+        ...state,
+        combat: createCombatState([ENEMY_DIGGERS], false),
+      };
+
+      const template: CombatEnemyTargetTemplate = {
+        defeat: true,
+      };
+
+      const result = resolveCombatEnemyTarget(
+        state,
+        "player1",
+        {
+          type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+          enemyInstanceId: "enemy_0",
+          enemyName: "Diggers",
+          template,
+        }
+      );
+
+      // Enemy should be defeated
+      const combat = result.state.combat;
+      expect(combat).toBeDefined();
+      if (combat) {
+        const enemy = combat.enemies[0];
+        expect(enemy).toBeDefined();
+        if (enemy) {
+          expect(enemy.isDefeated).toBe(true);
+        }
+      }
+      expect(result.description).toContain("Defeated");
+    });
+  });
+
+  describe("Ability verification", () => {
+    it("should verify Sorcerers have Arcane Immunity", () => {
+      const combat = createCombatState([ENEMY_SORCERERS], false);
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        expect(enemy.definition.abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+      }
+    });
+
+    it("should verify faction leaders have Arcane Immunity", () => {
+      const elementalistCombat = createCombatState([ENEMY_ELEMENTALIST_LEADER], false);
+      const darkCrusaderCombat = createCombatState([ENEMY_DARK_CRUSADER_LEADER], false);
+
+      const elementalist = elementalistCombat.enemies[0];
+      const darkCrusader = darkCrusaderCombat.enemies[0];
+
+      expect(elementalist).toBeDefined();
+      expect(darkCrusader).toBeDefined();
+      if (elementalist) {
+        expect(elementalist.definition.abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+      }
+      if (darkCrusader) {
+        expect(darkCrusader.definition.abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+      }
+    });
+
+    it("should verify Diggers do NOT have Arcane Immunity", () => {
+      const combat = createCombatState([ENEMY_DIGGERS], false);
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        expect(enemy.definition.abilities).not.toContain(ABILITY_ARCANE_IMMUNITY);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/factionLeaders.test.ts
+++ b/packages/core/src/engine/__tests__/factionLeaders.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Faction Leader Tests
+ *
+ * Tests for faction leader type definitions, level-based stats,
+ * and integration with combat system.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  ENEMY_ELEMENTALIST_LEADER,
+  ENEMY_DARK_CRUSADER_LEADER,
+  FACTION_LEADERS,
+  getFactionLeader,
+  getFactionLeaderLevelStats,
+  isFactionLeaderDefinition,
+  isFactionLeaderId,
+  ABILITY_ARCANE_IMMUNITY,
+  ELEMENT_PHYSICAL,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_BLOCK,
+} from "@mage-knight/shared";
+import {
+  createCombatState,
+  isCombatFactionLeader,
+  getCombatFactionLeaderStats,
+  getCombatEnemyBaseArmor,
+  getCombatEnemyBaseAttack,
+} from "../../types/combat.js";
+
+describe("Faction Leaders", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("Type definitions", () => {
+    it("should have two faction leaders defined", () => {
+      expect(Object.keys(FACTION_LEADERS)).toHaveLength(2);
+      expect(FACTION_LEADERS[ENEMY_ELEMENTALIST_LEADER]).toBeDefined();
+      expect(FACTION_LEADERS[ENEMY_DARK_CRUSADER_LEADER]).toBeDefined();
+    });
+
+    it("should identify Elementalist as faction leader", () => {
+      const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+      expect(isFactionLeaderDefinition(leader)).toBe(true);
+      expect(leader.isFactionLeader).toBe(true);
+    });
+
+    it("should identify Dark Crusader as faction leader", () => {
+      const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+      expect(isFactionLeaderDefinition(leader)).toBe(true);
+      expect(leader.isFactionLeader).toBe(true);
+    });
+
+    it("should correctly check faction leader IDs", () => {
+      expect(isFactionLeaderId(ENEMY_ELEMENTALIST_LEADER)).toBe(true);
+      expect(isFactionLeaderId(ENEMY_DARK_CRUSADER_LEADER)).toBe(true);
+      expect(isFactionLeaderId("diggers")).toBe(false);
+    });
+  });
+
+  describe("Arcane Immunity", () => {
+    it("should have Arcane Immunity ability on Elementalist", () => {
+      const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+      expect(leader.abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+    });
+
+    it("should have Arcane Immunity ability on Dark Crusader", () => {
+      const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+      expect(leader.abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+    });
+  });
+
+  describe("Level-based stats", () => {
+    describe("Elementalist", () => {
+      it("should have stats for all 4 levels", () => {
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        expect(leader.levelStats[1]).toBeDefined();
+        expect(leader.levelStats[2]).toBeDefined();
+        expect(leader.levelStats[3]).toBeDefined();
+        expect(leader.levelStats[4]).toBeDefined();
+      });
+
+      it("should have increasing armor at higher levels", () => {
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const stats1 = getFactionLeaderLevelStats(leader, 1);
+        const stats2 = getFactionLeaderLevelStats(leader, 2);
+        const stats3 = getFactionLeaderLevelStats(leader, 3);
+        const stats4 = getFactionLeaderLevelStats(leader, 4);
+
+        expect(stats1.armor).toBeLessThan(stats2.armor);
+        expect(stats2.armor).toBeLessThan(stats3.armor);
+        expect(stats3.armor).toBeLessThan(stats4.armor);
+      });
+
+      it("should have multiple attacks at level 2+", () => {
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const stats1 = getFactionLeaderLevelStats(leader, 1);
+        const stats2 = getFactionLeaderLevelStats(leader, 2);
+        const stats4 = getFactionLeaderLevelStats(leader, 4);
+
+        expect(stats1.attacks.length).toBe(1);
+        expect(stats2.attacks.length).toBeGreaterThanOrEqual(2);
+        expect(stats4.attacks.length).toBeGreaterThanOrEqual(2);
+      });
+
+      it("should have elemental attacks at higher levels", () => {
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const stats3 = getFactionLeaderLevelStats(leader, 3);
+
+        const elements = stats3.attacks.map((a) => a.element);
+        expect(elements).toContain(ELEMENT_FIRE);
+        expect(elements).toContain(ELEMENT_ICE);
+      });
+
+      it("should clamp out-of-range levels to valid range", () => {
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const statsNegative = getFactionLeaderLevelStats(leader, -1);
+        const stats0 = getFactionLeaderLevelStats(leader, 0);
+        const stats5 = getFactionLeaderLevelStats(leader, 5);
+        const stats1 = getFactionLeaderLevelStats(leader, 1);
+        const stats4 = getFactionLeaderLevelStats(leader, 4);
+
+        // Out of range should clamp to 1 or 4
+        expect(statsNegative.armor).toBe(stats1.armor);
+        expect(stats0.armor).toBe(stats1.armor);
+        expect(stats5.armor).toBe(stats4.armor);
+      });
+    });
+
+    describe("Dark Crusader", () => {
+      it("should have stats for all 4 levels", () => {
+        const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+        expect(leader.levelStats[1]).toBeDefined();
+        expect(leader.levelStats[2]).toBeDefined();
+        expect(leader.levelStats[3]).toBeDefined();
+        expect(leader.levelStats[4]).toBeDefined();
+      });
+
+      it("should have increasing armor at higher levels", () => {
+        const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+        const stats1 = getFactionLeaderLevelStats(leader, 1);
+        const stats4 = getFactionLeaderLevelStats(leader, 4);
+
+        expect(stats1.armor).toBeLessThan(stats4.armor);
+      });
+
+      it("should have physical attacks", () => {
+        const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+        const stats1 = getFactionLeaderLevelStats(leader, 1);
+        const firstAttack = stats1.attacks[0];
+
+        expect(firstAttack).toBeDefined();
+        if (firstAttack) {
+          expect(firstAttack.element).toBe(ELEMENT_PHYSICAL);
+        }
+      });
+    });
+  });
+
+  describe("Combat integration", () => {
+    it("should create combat enemy with default level 1", () => {
+      const combat = createCombatState([ENEMY_ELEMENTALIST_LEADER], false);
+      const enemy = combat.enemies[0];
+
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        expect(isCombatFactionLeader(enemy)).toBe(true);
+        expect(enemy.currentLevel).toBe(1);
+      }
+    });
+
+    it("should create combat enemy with specified level", () => {
+      const combat = createCombatState(
+        [{ enemyId: ENEMY_ELEMENTALIST_LEADER, level: 3 }],
+        false
+      );
+      const enemy = combat.enemies[0];
+
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        expect(enemy.currentLevel).toBe(3);
+      }
+    });
+
+    it("should return level-based stats in combat", () => {
+      const combat = createCombatState(
+        [{ enemyId: ENEMY_ELEMENTALIST_LEADER, level: 2 }],
+        false
+      );
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        const stats = getCombatFactionLeaderStats(enemy);
+        expect(stats).toBeDefined();
+
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const expectedStats = getFactionLeaderLevelStats(leader, 2);
+        if (stats) {
+          expect(stats.armor).toBe(expectedStats.armor);
+        }
+      }
+    });
+
+    it("should get correct base armor for faction leader", () => {
+      const combat = createCombatState(
+        [{ enemyId: ENEMY_ELEMENTALIST_LEADER, level: 3 }],
+        false
+      );
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        const baseArmor = getCombatEnemyBaseArmor(enemy);
+        const leader = getFactionLeader(ENEMY_ELEMENTALIST_LEADER);
+        const expectedStats = getFactionLeaderLevelStats(leader, 3);
+
+        expect(baseArmor).toBe(expectedStats.armor);
+      }
+    });
+
+    it("should get correct base attack for faction leader", () => {
+      const combat = createCombatState(
+        [{ enemyId: ENEMY_DARK_CRUSADER_LEADER, level: 2 }],
+        false
+      );
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        const baseAttack = getCombatEnemyBaseAttack(enemy);
+        const leader = getFactionLeader(ENEMY_DARK_CRUSADER_LEADER);
+        const expectedStats = getFactionLeaderLevelStats(leader, 2);
+        const firstAttack = expectedStats.attacks[0];
+
+        if (firstAttack) {
+          expect(baseAttack).toBe(firstAttack.value);
+        }
+      }
+    });
+
+    it("should not set currentLevel for regular enemies", () => {
+      const combat = createCombatState(["diggers"], false);
+      const enemy = combat.enemies[0];
+
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        expect(isCombatFactionLeader(enemy)).toBe(false);
+        expect(enemy.currentLevel).toBeUndefined();
+      }
+    });
+
+    it("should use definition armor for regular enemies", () => {
+      const combat = createCombatState(["diggers"], false);
+      const enemy = combat.enemies[0];
+      expect(enemy).toBeDefined();
+      if (enemy) {
+        const baseArmor = getCombatEnemyBaseArmor(enemy);
+        expect(baseArmor).toBe(enemy.definition.armor);
+      }
+    });
+  });
+
+  describe("Game engine integration", () => {
+    it("should enter combat with faction leader", () => {
+      const player = createTestPlayer();
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_ELEMENTALIST_LEADER],
+      });
+
+      expect(result.state.combat).toBeDefined();
+      const combat = result.state.combat;
+      if (combat) {
+        expect(combat.enemies).toHaveLength(1);
+        const enemy = combat.enemies[0];
+        if (enemy) {
+          expect(isCombatFactionLeader(enemy)).toBe(true);
+        }
+      }
+    });
+
+    it("should enter combat with faction leader at specified level", () => {
+      // Note: The ENTER_COMBAT_ACTION doesn't currently support level specification
+      // This test verifies that combat state is created correctly when used with
+      // the createCombatState helper directly
+      const combat = createCombatState(
+        [{ enemyId: ENEMY_DARK_CRUSADER_LEADER, level: 4 }],
+        false
+      );
+
+      const enemy = combat.enemies[0];
+      if (enemy) {
+        expect(enemy.currentLevel).toBe(4);
+      }
+    });
+
+    it("should progress through combat phases with faction leader", () => {
+      const player = createTestPlayer();
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DARK_CRUSADER_LEADER],
+      }).state;
+
+      const combat1 = state.combat;
+      expect(combat1).toBeDefined();
+      if (combat1) {
+        expect(combat1.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+      }
+
+      // Skip ranged phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      const combat2 = state.combat;
+      expect(combat2).toBeDefined();
+      if (combat2) {
+        expect(combat2.phase).toBe(COMBAT_PHASE_BLOCK);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -11,6 +11,7 @@ import type { GameState } from "../../../state/GameState.js";
 import type { Player } from "../../../types/player.js";
 import type { PlayerUnit } from "../../../types/unit.js";
 import type { CombatEnemy } from "../../../types/combat.js";
+import { getCombatEnemyBaseAttack, getCombatEnemyAttackElement } from "../../../types/combat.js";
 import type { CardId, GameEvent, DamageAssignment, EnemyAbilityType } from "@mage-knight/shared";
 import {
   DAMAGE_ASSIGNED,
@@ -91,7 +92,8 @@ function getEffectiveDamage(
   state: GameState,
   playerId: string
 ): number {
-  let damage = enemy.definition.attack;
+  // Use level-based attack for faction leaders
+  let damage = getCombatEnemyBaseAttack(enemy);
 
   // Brutal doubles the damage
   if (isBrutalActive(state, playerId, enemy)) {
@@ -264,8 +266,9 @@ export function createAssignDamageCommand(
       }
 
       // Get effective damage (Brutal doubles damage)
+      // Use level-based attack for faction leaders
       const totalDamage = getEffectiveDamage(enemy, state, params.playerId);
-      const attackElement = enemy.definition.attackElement;
+      const attackElement = getCombatEnemyAttackElement(enemy);
       const isPoisoned = isPoisonActive(state, params.playerId, enemy);
       const isParalyzed = isParalyzeActive(state, params.playerId, enemy);
       const events: GameEvent[] = [];

--- a/packages/core/src/engine/commands/combat/declareBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareBlockCommand.ts
@@ -19,7 +19,7 @@ import {
   ELEMENT_COLD_FIRE,
 } from "@mage-knight/shared";
 import type { CombatEnemy, PendingElementalDamage } from "../../../types/combat.js";
-import { createEmptyPendingDamage } from "../../../types/combat.js";
+import { createEmptyPendingDamage, getCombatEnemyBaseAttack, getCombatEnemyAttackElement } from "../../../types/combat.js";
 import { getFinalBlockValue } from "../../combat/elementalCalc.js";
 import { isAbilityNullified } from "../../modifiers.js";
 
@@ -84,7 +84,8 @@ function getEffectiveEnemyAttackForBlocking(
   state: GameState,
   playerId: string
 ): number {
-  let attackValue = enemy.definition.attack;
+  // Use level-based attack for faction leaders
+  let attackValue = getCombatEnemyBaseAttack(enemy);
 
   // Swift: doubles attack value for blocking purposes
   if (isSwiftActive(state, playerId, enemy)) {
@@ -130,9 +131,10 @@ export function createDeclareBlockCommand(
       const blockSources = pendingBlockToBlockSources(pendingBlock);
 
       // Calculate final block value including elemental efficiency and combat modifiers
+      // Use level-based attack element for faction leaders
       const effectiveBlockValue = getFinalBlockValue(
         blockSources,
-        enemy.definition.attackElement,
+        getCombatEnemyAttackElement(enemy),
         state,
         params.playerId
       );

--- a/packages/core/src/engine/commands/combat/endCombatPhaseCommand.ts
+++ b/packages/core/src/engine/commands/combat/endCombatPhaseCommand.ts
@@ -33,6 +33,7 @@ import {
   COMBAT_PHASE_ASSIGN_DAMAGE,
   COMBAT_PHASE_ATTACK,
   COMBAT_CONTEXT_BURN_MONASTERY,
+  getCombatEnemyBaseArmor,
   type CombatPhase,
   type CombatEnemy,
   type CombatState,
@@ -142,8 +143,8 @@ function resolvePendingDamage(
     const resistances = getEnemyResistances(enemy);
     const effectiveDamage = calculateEffectiveDamage(pending, resistances);
 
-    // Check if enemy is defeated
-    if (effectiveDamage >= enemy.definition.armor) {
+    // Check if enemy is defeated (use level-based armor for faction leaders)
+    if (effectiveDamage >= getCombatEnemyBaseArmor(enemy)) {
       const fame = enemy.definition.fame;
       fameGained += fame;
       events.push(createEnemyDefeatedEvent(enemy.instanceId, enemy.definition.name, fame));

--- a/packages/shared/src/enemies/factionLeaders.ts
+++ b/packages/shared/src/enemies/factionLeaders.ts
@@ -1,0 +1,263 @@
+/**
+ * Faction Leader Definitions
+ *
+ * Faction leaders are large multi-level boss enemies from the Shades of Tezla
+ * expansion. They represent different avatars of Tezla and have level-based
+ * stats that determine their Armor and Attack values.
+ *
+ * Key properties:
+ * - Level-based stats (Armor and Attacks vary by level 1-4)
+ * - Arcane Immunity ability (immune to non-Attack/Block effects)
+ * - Count as enemy tokens for card effects
+ * - Scenario sets initial level
+ *
+ * @module enemies/factionLeaders
+ */
+
+import type { EnemyDefinition, Faction } from "./types.js";
+import {
+  ENEMY_COLOR_WHITE,
+  FACTION_ELEMENTALIST,
+  FACTION_DARK_CRUSADERS,
+} from "./types.js";
+import { ABILITY_ARCANE_IMMUNITY } from "./abilities.js";
+import { ELEMENT_PHYSICAL, ELEMENT_FIRE, ELEMENT_ICE } from "../elements.js";
+import { FIRE_RESISTANCE, ICE_RESISTANCE } from "./resistances.js";
+
+// =============================================================================
+// FACTION LEADER TYPE DEFINITIONS
+// =============================================================================
+
+/**
+ * Attack information for a single attack action.
+ * Faction leaders may have multiple attacks at higher levels.
+ */
+export interface FactionLeaderAttack {
+  readonly value: number;
+  readonly element: typeof ELEMENT_PHYSICAL | typeof ELEMENT_FIRE | typeof ELEMENT_ICE;
+}
+
+/**
+ * Stats for a faction leader at a specific level.
+ * These values are used instead of the base EnemyDefinition stats when
+ * the leader is in combat at that level.
+ */
+export interface FactionLeaderLevelStats {
+  readonly armor: number;
+  readonly attacks: readonly FactionLeaderAttack[];
+}
+
+/**
+ * Faction leader definition extending the base enemy definition.
+ * Adds level-based stat lookups and marks the enemy as a faction leader.
+ */
+export interface FactionLeaderDefinition extends Omit<EnemyDefinition, "attack" | "attackElement"> {
+  /** Discriminator to identify faction leader definitions */
+  readonly isFactionLeader: true;
+
+  /** Faction is required for faction leaders (not optional) */
+  readonly faction: Faction;
+
+  /**
+   * Stats lookup by level (1-4).
+   * The scenario specifies the initial level, which determines
+   * which stats are used in combat.
+   */
+  readonly levelStats: Readonly<Record<number, FactionLeaderLevelStats>>;
+
+  /**
+   * Base attack value (for compatibility with EnemyDefinition).
+   * Use levelStats for actual combat values.
+   */
+  readonly attack: 0;
+
+  /**
+   * Base attack element (for compatibility with EnemyDefinition).
+   * Individual attacks in levelStats may have different elements.
+   */
+  readonly attackElement: typeof ELEMENT_PHYSICAL;
+}
+
+// =============================================================================
+// FACTION LEADER ID CONSTANTS
+// =============================================================================
+
+/**
+ * Elementalist faction leader - Avatar of Tezla for the Elementalist faction.
+ * Uses elemental attacks (Fire and Ice) at higher levels.
+ */
+export const ENEMY_ELEMENTALIST_LEADER = "elementalist_leader" as const;
+
+/**
+ * Dark Crusader faction leader - Avatar of Tezla for the Dark Crusaders faction.
+ * Uses physical attacks with increasing power at higher levels.
+ */
+export const ENEMY_DARK_CRUSADER_LEADER = "dark_crusader_leader" as const;
+
+/**
+ * Union type of all faction leader IDs
+ */
+export type FactionLeaderId =
+  | typeof ENEMY_ELEMENTALIST_LEADER
+  | typeof ENEMY_DARK_CRUSADER_LEADER;
+
+// =============================================================================
+// TYPE GUARDS
+// =============================================================================
+
+/**
+ * Check if an enemy definition is a faction leader.
+ */
+export function isFactionLeaderDefinition(
+  def: EnemyDefinition | FactionLeaderDefinition
+): def is FactionLeaderDefinition {
+  return "isFactionLeader" in def && def.isFactionLeader === true;
+}
+
+// =============================================================================
+// FACTION LEADER DEFINITIONS
+// =============================================================================
+
+/**
+ * Complete registry of faction leader definitions.
+ *
+ * Note: Stats are placeholder values pending rulebook verification.
+ * Level stats follow a progression pattern:
+ * - Higher levels have higher armor
+ * - Higher levels may have multiple attacks
+ * - Higher levels may have elemental attacks
+ */
+export const FACTION_LEADERS: Readonly<Record<FactionLeaderId, FactionLeaderDefinition>> = {
+  [ENEMY_ELEMENTALIST_LEADER]: {
+    id: ENEMY_ELEMENTALIST_LEADER,
+    name: "Elementalist",
+    color: ENEMY_COLOR_WHITE,
+    isFactionLeader: true,
+    faction: FACTION_ELEMENTALIST,
+    // Base stats (for EnemyDefinition compatibility)
+    attack: 0,
+    attackElement: ELEMENT_PHYSICAL,
+    armor: 0, // Use levelStats
+    fame: 12,
+    resistances: FIRE_RESISTANCE, // Elementalist has fire resistance
+    abilities: [ABILITY_ARCANE_IMMUNITY],
+    // Level-based stats
+    levelStats: {
+      1: {
+        armor: 6,
+        attacks: [{ value: 4, element: ELEMENT_PHYSICAL }],
+      },
+      2: {
+        armor: 8,
+        attacks: [
+          { value: 5, element: ELEMENT_FIRE },
+          { value: 3, element: ELEMENT_PHYSICAL },
+        ],
+      },
+      3: {
+        armor: 10,
+        attacks: [
+          { value: 6, element: ELEMENT_FIRE },
+          { value: 4, element: ELEMENT_ICE },
+        ],
+      },
+      4: {
+        armor: 12,
+        attacks: [
+          { value: 7, element: ELEMENT_FIRE },
+          { value: 5, element: ELEMENT_ICE },
+          { value: 3, element: ELEMENT_PHYSICAL },
+        ],
+      },
+    },
+  },
+  [ENEMY_DARK_CRUSADER_LEADER]: {
+    id: ENEMY_DARK_CRUSADER_LEADER,
+    name: "Dark Crusader",
+    color: ENEMY_COLOR_WHITE,
+    isFactionLeader: true,
+    faction: FACTION_DARK_CRUSADERS,
+    // Base stats (for EnemyDefinition compatibility)
+    attack: 0,
+    attackElement: ELEMENT_PHYSICAL,
+    armor: 0, // Use levelStats
+    fame: 12,
+    resistances: ICE_RESISTANCE, // Dark Crusader has ice resistance
+    abilities: [ABILITY_ARCANE_IMMUNITY],
+    // Level-based stats
+    levelStats: {
+      1: {
+        armor: 7,
+        attacks: [{ value: 5, element: ELEMENT_PHYSICAL }],
+      },
+      2: {
+        armor: 9,
+        attacks: [{ value: 6, element: ELEMENT_PHYSICAL }],
+      },
+      3: {
+        armor: 11,
+        attacks: [
+          { value: 7, element: ELEMENT_PHYSICAL },
+          { value: 4, element: ELEMENT_ICE },
+        ],
+      },
+      4: {
+        armor: 13,
+        attacks: [
+          { value: 8, element: ELEMENT_PHYSICAL },
+          { value: 6, element: ELEMENT_ICE },
+        ],
+      },
+    },
+  },
+};
+
+// =============================================================================
+// HELPER FUNCTIONS
+// =============================================================================
+
+/**
+ * Get a faction leader definition by ID.
+ * Returns undefined if the ID is not a faction leader.
+ */
+export function getFactionLeader(id: FactionLeaderId): FactionLeaderDefinition {
+  return FACTION_LEADERS[id];
+}
+
+/**
+ * Get the stats for a faction leader at a specific level.
+ * Defaults to level 1 if the specified level is out of range.
+ *
+ * @param leader - The faction leader definition
+ * @param level - The current level (1-4)
+ * @returns The stats for that level
+ */
+export function getFactionLeaderLevelStats(
+  leader: FactionLeaderDefinition,
+  level: number
+): FactionLeaderLevelStats {
+  // Clamp level to valid range (1-4)
+  const validLevel = Math.min(Math.max(level, 1), 4);
+  const stats = leader.levelStats[validLevel];
+  if (stats) return stats;
+  // Fallback to level 1 (always exists)
+  const fallback = leader.levelStats[1];
+  if (!fallback) {
+    throw new Error(`Faction leader ${leader.id} is missing level 1 stats`);
+  }
+  return fallback;
+}
+
+/**
+ * Get all faction leader IDs.
+ */
+export function getAllFactionLeaderIds(): readonly FactionLeaderId[] {
+  return Object.keys(FACTION_LEADERS) as FactionLeaderId[];
+}
+
+/**
+ * Check if an enemy ID is a faction leader ID.
+ */
+export function isFactionLeaderId(id: string): id is FactionLeaderId {
+  return id in FACTION_LEADERS;
+}

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -71,6 +71,7 @@ export {
   ABILITY_SUMMON,
   ABILITY_CUMBERSOME,
   ABILITY_ASSASSINATION,
+  ABILITY_ARCANE_IMMUNITY,
   ABILITY_DESCRIPTIONS,
 } from "./abilities.js";
 
@@ -178,6 +179,24 @@ export {
   RED_ENEMIES,
 } from "./red.js";
 
+// Faction Leaders (Shades of Tezla expansion)
+export type {
+  FactionLeaderId,
+  FactionLeaderDefinition,
+  FactionLeaderLevelStats,
+  FactionLeaderAttack,
+} from "./factionLeaders.js";
+export {
+  ENEMY_ELEMENTALIST_LEADER,
+  ENEMY_DARK_CRUSADER_LEADER,
+  FACTION_LEADERS,
+  getFactionLeader,
+  getFactionLeaderLevelStats,
+  getAllFactionLeaderIds,
+  isFactionLeaderId,
+  isFactionLeaderDefinition,
+} from "./factionLeaders.js";
+
 // =============================================================================
 // AGGREGATE ENEMIES RECORD
 // =============================================================================
@@ -189,9 +208,11 @@ import { BROWN_ENEMIES } from "./brown.js";
 import { VIOLET_ENEMIES } from "./violet.js";
 import { WHITE_ENEMIES } from "./white.js";
 import { RED_ENEMIES } from "./red.js";
+import { FACTION_LEADERS } from "./factionLeaders.js";
 
 /**
- * Complete record of all enemy definitions indexed by EnemyId
+ * Complete record of all enemy definitions indexed by EnemyId.
+ * Includes regular enemies and faction leaders (Shades of Tezla expansion).
  */
 export const ENEMIES: Record<EnemyId, EnemyDefinition> = {
   ...GREEN_ENEMIES,
@@ -200,6 +221,7 @@ export const ENEMIES: Record<EnemyId, EnemyDefinition> = {
   ...VIOLET_ENEMIES,
   ...WHITE_ENEMIES,
   ...RED_ENEMIES,
+  ...FACTION_LEADERS,
 };
 
 // =============================================================================

--- a/packages/shared/src/enemies/types.ts
+++ b/packages/shared/src/enemies/types.ts
@@ -120,6 +120,7 @@ import type { BrownEnemyId } from "./brown.js";
 import type { VioletEnemyId } from "./violet.js";
 import type { WhiteEnemyId } from "./white.js";
 import type { RedEnemyId } from "./red.js";
+import type { FactionLeaderId } from "./factionLeaders.js";
 
 /**
  * Union of all enemy IDs across all factions
@@ -130,4 +131,5 @@ export type EnemyId =
   | BrownEnemyId
   | VioletEnemyId
   | WhiteEnemyId
-  | RedEnemyId;
+  | RedEnemyId
+  | FactionLeaderId;


### PR DESCRIPTION
## Summary

Implements faction leader boss enemies for the Shades of Tezla expansion. This adds the core data model and combat integration for Elementalist and Dark Crusader faction leaders.

- **FactionLeaderDefinition type**: Extends EnemyDefinition with `isFactionLeader: true` discriminant, level-based stats (armor, attacks array), and faction identifier
- **Level-based stats**: Both leaders have stats for levels 1-4 with increasing armor and multiple attacks at higher levels
- **Combat integration**: Added `currentLevel` to CombatEnemy, with helper functions `getCombatEnemyBaseArmor`, `getCombatEnemyBaseAttack`, and `getCombatEnemyAttackElement` for level-based lookups
- **Arcane Immunity enforcement**: Filters immune enemies from spell targeting and blocks restricted effects (modifiers, defeat) at resolution time
- **Scenario configuration**: Added `FactionLeaderConfig` interface for specifying initial level and accompanying enemies

### Key Changes

**New files:**
- `packages/shared/src/enemies/factionLeaders.ts` - Faction leader types and data definitions
- `packages/core/src/engine/__tests__/factionLeaders.test.ts` - 24 tests for type definitions, level stats, combat integration
- `packages/core/src/engine/__tests__/arcaneImmunity.test.ts` - 12 tests for immunity filtering and blocking

**Modified files:**
- `packages/core/src/types/combat.ts` - Added `currentLevel` field and level-based stat helper functions
- `packages/core/src/engine/effects/combatEffects.ts` - Arcane Immunity enforcement in enemy targeting
- `packages/core/src/engine/commands/combat/*.ts` - Updated to use level-based helpers instead of direct definition access
- `packages/core/src/engine/validActions/combat.ts` - Updated to use level-based helpers for UI display
- `packages/shared/src/scenarios.ts` - Added FactionLeaderConfig interface

## Test plan

- [x] All 36 new tests pass (24 faction leader + 12 Arcane Immunity)
- [x] All 1037 existing tests continue to pass
- [x] Build succeeds for all packages
- [x] Lint passes with no errors
- [x] Type definitions are properly exported through shared/index.ts

Closes #529