### PR TITLE
feat(scoring): add scoring system type definitions to shared package

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -258,3 +258,6 @@ export * from "./siteRewards.js";
 
 // Ruins tokens (Ancient Ruins yellow tokens)
 export * from "./ruinsTokens.js";
+
+// Scoring system types and constants
+export * from "./scoring/index.js";

--- a/packages/shared/src/scoring/constants.ts
+++ b/packages/shared/src/scoring/constants.ts
@@ -1,0 +1,242 @@
+/**
+ * Scoring system constants for Mage Knight
+ *
+ * Constants for base score modes, achievement modes, and achievement categories.
+ * Based on the scoring system architecture design (#443).
+ */
+
+import type {
+  BaseScoreMode,
+  AchievementMode,
+  AchievementCategory,
+  ScoringModuleType,
+} from "./types.js";
+
+// =============================================================================
+// BASE SCORE MODE CONSTANTS
+// =============================================================================
+
+/**
+ * Individual Fame - Each player's own Fame (competitive modes)
+ */
+export const BASE_SCORE_INDIVIDUAL_FAME =
+  "individual_fame" as const satisfies BaseScoreMode;
+
+/**
+ * Lowest Fame - Use the lowest Fame of all players (co-op modes)
+ */
+export const BASE_SCORE_LOWEST_FAME =
+  "lowest_fame" as const satisfies BaseScoreMode;
+
+/**
+ * Victory Points - Alternative scoring system (some team scenarios)
+ */
+export const BASE_SCORE_VICTORY_POINTS =
+  "victory_points" as const satisfies BaseScoreMode;
+
+/**
+ * None - No scoring, position/condition-based victory only
+ */
+export const BASE_SCORE_NONE = "none" as const satisfies BaseScoreMode;
+
+// =============================================================================
+// ACHIEVEMENT MODE CONSTANTS
+// =============================================================================
+
+/**
+ * Competitive - Compare players, award titles to winners
+ */
+export const ACHIEVEMENT_MODE_COMPETITIVE =
+  "competitive" as const satisfies AchievementMode;
+
+/**
+ * Solo - No titles (no comparison), just calculate per-category scores
+ */
+export const ACHIEVEMENT_MODE_SOLO = "solo" as const satisfies AchievementMode;
+
+/**
+ * Co-op Best Only - No titles, score only best player per category
+ */
+export const ACHIEVEMENT_MODE_COOP_BEST_ONLY =
+  "coop_best_only" as const satisfies AchievementMode;
+
+// =============================================================================
+// ACHIEVEMENT CATEGORY CONSTANTS
+// =============================================================================
+
+/**
+ * Greatest Knowledge - Spells and Advanced Actions
+ * +2 per Spell, +1 per Advanced Action
+ * Title: +3 (+1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_KNOWLEDGE =
+  "greatest_knowledge" as const satisfies AchievementCategory;
+
+/**
+ * Greatest Loot - Artifacts and Crystals
+ * +2 per Artifact, +1 per 2 crystals
+ * Title: +3 (+1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_LOOT =
+  "greatest_loot" as const satisfies AchievementCategory;
+
+/**
+ * Greatest Leader - Unit levels
+ * +1 per unit level (wounded units count as half)
+ * Title: +3 (+1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_LEADER =
+  "greatest_leader" as const satisfies AchievementCategory;
+
+/**
+ * Greatest Conqueror - Shields on fortified sites
+ * +2 per shield on keep/tower/monastery
+ * Title: +3 (+1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_CONQUEROR =
+  "greatest_conqueror" as const satisfies AchievementCategory;
+
+/**
+ * Greatest Adventurer - Shields on adventure sites
+ * +2 per shield on adventure site
+ * Title: +3 (+1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_ADVENTURER =
+  "greatest_adventurer" as const satisfies AchievementCategory;
+
+/**
+ * Greatest Beating - Wounds in deck (negative)
+ * -2 per wound in deck
+ * Penalty: -3 for most wounds (-1 if tied)
+ */
+export const ACHIEVEMENT_GREATEST_BEATING =
+  "greatest_beating" as const satisfies AchievementCategory;
+
+/**
+ * All achievement categories in standard order
+ */
+export const ALL_ACHIEVEMENT_CATEGORIES: readonly AchievementCategory[] = [
+  ACHIEVEMENT_GREATEST_KNOWLEDGE,
+  ACHIEVEMENT_GREATEST_LOOT,
+  ACHIEVEMENT_GREATEST_LEADER,
+  ACHIEVEMENT_GREATEST_CONQUEROR,
+  ACHIEVEMENT_GREATEST_ADVENTURER,
+  ACHIEVEMENT_GREATEST_BEATING,
+] as const;
+
+// =============================================================================
+// SCORING MODULE TYPE CONSTANTS
+// =============================================================================
+
+/**
+ * City Conquest - Points for conquering cities
+ */
+export const SCORING_MODULE_CITY_CONQUEST =
+  "city_conquest" as const satisfies ScoringModuleType;
+
+/**
+ * Time Efficiency - Points for early completion (solo/co-op)
+ */
+export const SCORING_MODULE_TIME_EFFICIENCY =
+  "time_efficiency" as const satisfies ScoringModuleType;
+
+/**
+ * Objective Completion - Points for completing scenario objectives
+ */
+export const SCORING_MODULE_OBJECTIVE_COMPLETION =
+  "objective_completion" as const satisfies ScoringModuleType;
+
+/**
+ * Mine Liberation - Points for liberating mines
+ */
+export const SCORING_MODULE_MINE = "mine" as const satisfies ScoringModuleType;
+
+/**
+ * Relic Hunting - Points for finding relic pieces
+ */
+export const SCORING_MODULE_RELIC =
+  "relic" as const satisfies ScoringModuleType;
+
+/**
+ * Faction Enemies - Points for faction-specific achievements
+ */
+export const SCORING_MODULE_FACTION =
+  "faction" as const satisfies ScoringModuleType;
+
+/**
+ * Volkare - Points for defeating Volkare (Lost Legion)
+ */
+export const SCORING_MODULE_VOLKARE =
+  "volkare" as const satisfies ScoringModuleType;
+
+/**
+ * All scoring module types
+ */
+export const ALL_SCORING_MODULE_TYPES: readonly ScoringModuleType[] = [
+  SCORING_MODULE_CITY_CONQUEST,
+  SCORING_MODULE_TIME_EFFICIENCY,
+  SCORING_MODULE_OBJECTIVE_COMPLETION,
+  SCORING_MODULE_MINE,
+  SCORING_MODULE_RELIC,
+  SCORING_MODULE_FACTION,
+  SCORING_MODULE_VOLKARE,
+] as const;
+
+// =============================================================================
+// SCORING CONSTANTS
+// =============================================================================
+
+/**
+ * Standard title bonus for achievement winners
+ */
+export const TITLE_BONUS_WINNER = 3;
+
+/**
+ * Standard title bonus when tied for achievement
+ */
+export const TITLE_BONUS_TIED = 1;
+
+/**
+ * Penalty for most wounds (Greatest Beating)
+ */
+export const TITLE_PENALTY_MOST_WOUNDS = -3;
+
+/**
+ * Penalty when tied for most wounds
+ */
+export const TITLE_PENALTY_MOST_WOUNDS_TIED = -1;
+
+/**
+ * Points per spell for Greatest Knowledge
+ */
+export const POINTS_PER_SPELL = 2;
+
+/**
+ * Points per advanced action for Greatest Knowledge
+ */
+export const POINTS_PER_ADVANCED_ACTION = 1;
+
+/**
+ * Points per artifact for Greatest Loot
+ */
+export const POINTS_PER_ARTIFACT = 2;
+
+/**
+ * Crystals needed for 1 point in Greatest Loot
+ */
+export const CRYSTALS_PER_POINT = 2;
+
+/**
+ * Points per shield on keep/tower/monastery for Greatest Conqueror
+ */
+export const POINTS_PER_FORTIFIED_SHIELD = 2;
+
+/**
+ * Points per shield on adventure site for Greatest Adventurer
+ */
+export const POINTS_PER_ADVENTURE_SHIELD = 2;
+
+/**
+ * Points per wound for Greatest Beating (negative)
+ */
+export const POINTS_PER_WOUND = -2;

--- a/packages/shared/src/scoring/index.ts
+++ b/packages/shared/src/scoring/index.ts
@@ -1,0 +1,79 @@
+/**
+ * Scoring system exports for Mage Knight
+ *
+ * This module provides the type definitions and constants for the scoring system.
+ * Based on the scoring system architecture design (#443).
+ */
+
+// Re-export all types
+export type {
+  // Base score modes
+  BaseScoreMode,
+  // Achievement configuration
+  AchievementMode,
+  AchievementCategory,
+  AchievementCategoryOverride,
+  AchievementsConfig,
+  // Scoring module types
+  ScoringModuleType,
+  CityConquestModule,
+  TimeEfficiencyModule,
+  ObjectiveConfig,
+  ObjectiveCompletionModule,
+  MineModule,
+  RelicModule,
+  FactionModule,
+  VolkareModule,
+  ScoringModuleConfig,
+  // Scenario configuration
+  ScenarioScoringConfig,
+  // Result types
+  AchievementCategoryScore,
+  AchievementScoreResult,
+  ModuleScoreResult,
+  ModuleScoreBreakdown,
+  PlayerScoreResult,
+  FinalScoreResult,
+} from "./types.js";
+
+// Re-export all constants
+export {
+  // Base score mode constants
+  BASE_SCORE_INDIVIDUAL_FAME,
+  BASE_SCORE_LOWEST_FAME,
+  BASE_SCORE_VICTORY_POINTS,
+  BASE_SCORE_NONE,
+  // Achievement mode constants
+  ACHIEVEMENT_MODE_COMPETITIVE,
+  ACHIEVEMENT_MODE_SOLO,
+  ACHIEVEMENT_MODE_COOP_BEST_ONLY,
+  // Achievement category constants
+  ACHIEVEMENT_GREATEST_KNOWLEDGE,
+  ACHIEVEMENT_GREATEST_LOOT,
+  ACHIEVEMENT_GREATEST_LEADER,
+  ACHIEVEMENT_GREATEST_CONQUEROR,
+  ACHIEVEMENT_GREATEST_ADVENTURER,
+  ACHIEVEMENT_GREATEST_BEATING,
+  ALL_ACHIEVEMENT_CATEGORIES,
+  // Scoring module type constants
+  SCORING_MODULE_CITY_CONQUEST,
+  SCORING_MODULE_TIME_EFFICIENCY,
+  SCORING_MODULE_OBJECTIVE_COMPLETION,
+  SCORING_MODULE_MINE,
+  SCORING_MODULE_RELIC,
+  SCORING_MODULE_FACTION,
+  SCORING_MODULE_VOLKARE,
+  ALL_SCORING_MODULE_TYPES,
+  // Scoring value constants
+  TITLE_BONUS_WINNER,
+  TITLE_BONUS_TIED,
+  TITLE_PENALTY_MOST_WOUNDS,
+  TITLE_PENALTY_MOST_WOUNDS_TIED,
+  POINTS_PER_SPELL,
+  POINTS_PER_ADVANCED_ACTION,
+  POINTS_PER_ARTIFACT,
+  CRYSTALS_PER_POINT,
+  POINTS_PER_FORTIFIED_SHIELD,
+  POINTS_PER_ADVENTURE_SHIELD,
+  POINTS_PER_WOUND,
+} from "./constants.js";

--- a/packages/shared/src/scoring/types.ts
+++ b/packages/shared/src/scoring/types.ts
@@ -1,0 +1,355 @@
+/**
+ * Scoring system type definitions for Mage Knight
+ *
+ * Provides the type foundation for all scoring implementations.
+ * Based on the scoring system architecture design (#443).
+ */
+
+// =============================================================================
+// BASE SCORE MODES
+// =============================================================================
+
+/**
+ * Base score calculation mode
+ *
+ * - individual_fame: Each player's own Fame (competitive)
+ * - lowest_fame: Lowest Fame of all players (co-op)
+ * - victory_points: Alternative point-based system
+ * - none: No scoring, victory by position/condition
+ */
+export type BaseScoreMode =
+  | "individual_fame"
+  | "lowest_fame"
+  | "victory_points"
+  | "none";
+
+// =============================================================================
+// ACHIEVEMENT CONFIGURATION
+// =============================================================================
+
+/**
+ * Achievement scoring mode
+ *
+ * - competitive: Compare players, award titles
+ * - solo: No titles (no comparison)
+ * - coop_best_only: No titles, score only best player per category
+ */
+export type AchievementMode = "competitive" | "solo" | "coop_best_only";
+
+/**
+ * Standard achievement categories from the rulebook
+ */
+export type AchievementCategory =
+  | "greatest_knowledge"
+  | "greatest_loot"
+  | "greatest_leader"
+  | "greatest_conqueror"
+  | "greatest_adventurer"
+  | "greatest_beating";
+
+/**
+ * Configuration for overriding a specific achievement category
+ * (used by scenarios like Dungeon Lords that modify scoring)
+ */
+export interface AchievementCategoryOverride {
+  /** Points per qualifying item (e.g., 4 instead of 2 for dungeons) */
+  readonly pointsPerItem?: number;
+  /** Custom title name (e.g., "Greatest Dungeon Crawler") */
+  readonly titleName?: string;
+  /** Custom title bonus (e.g., +5 instead of +3) */
+  readonly titleBonus?: number;
+  /** Custom tied bonus (e.g., +2 instead of +1) */
+  readonly titleTiedBonus?: number;
+}
+
+/**
+ * Configuration for the achievements scoring subsystem
+ */
+export interface AchievementsConfig {
+  /** Whether achievements are enabled for this scenario */
+  readonly enabled: boolean;
+  /** How achievements are calculated and titles awarded */
+  readonly mode: AchievementMode;
+  /** Optional overrides for specific achievement categories */
+  readonly overrides?: Partial<
+    Record<AchievementCategory, AchievementCategoryOverride>
+  >;
+}
+
+// =============================================================================
+// SCORING MODULE TYPES
+// =============================================================================
+
+/**
+ * Types of scoring modules that can be enabled per scenario
+ */
+export type ScoringModuleType =
+  | "city_conquest"
+  | "time_efficiency"
+  | "objective_completion"
+  | "mine"
+  | "relic"
+  | "faction"
+  | "volkare";
+
+/**
+ * Base interface for all scoring modules
+ */
+interface BaseScoringModule {
+  readonly type: ScoringModuleType;
+}
+
+/**
+ * City Conquest scoring module
+ *
+ * Used by: Full Conquest, Blitz Conquest, co-op scenarios
+ */
+export interface CityConquestModule extends BaseScoringModule {
+  readonly type: "city_conquest";
+  /** Points for leading a city assault (+7 default) */
+  readonly leaderPoints: number;
+  /** Points for participating in city assault (+4 default) */
+  readonly participantPoints: number;
+  /** Title for most city shields */
+  readonly titleName: string;
+  /** Title bonus for winner (+5 default) */
+  readonly titleBonus: number;
+  /** Title bonus when tied (+2 default) */
+  readonly titleTiedBonus: number;
+}
+
+/**
+ * Time Efficiency scoring module
+ *
+ * Used by: Solo/co-op scenarios with round limits
+ */
+export interface TimeEfficiencyModule extends BaseScoringModule {
+  readonly type: "time_efficiency";
+  /** Points per round finished early (+30 default) */
+  readonly pointsPerEarlyRound: number;
+  /** Points per card left in Dummy deck (+1 default) */
+  readonly pointsPerDummyCard: number;
+  /** Bonus if End of Round not announced (+5 default) */
+  readonly bonusIfRoundNotAnnounced: number;
+}
+
+/**
+ * Configuration for a single objective
+ */
+export interface ObjectiveConfig {
+  /** Unique identifier for this objective */
+  readonly id: string;
+  /** Human-readable description */
+  readonly description: string;
+  /** Points per completion of this objective */
+  readonly pointsEach: number;
+  /** Bonus if all instances of this objective are completed */
+  readonly allCompletedBonus?: number;
+  /** Bonus if every player participated in completing this objective */
+  readonly everyPlayerParticipatedBonus?: number;
+}
+
+/**
+ * Objective Completion scoring module
+ *
+ * Used by: Solo/co-op scenarios with specific objectives
+ */
+export interface ObjectiveCompletionModule extends BaseScoringModule {
+  readonly type: "objective_completion";
+  /** List of objectives that can be completed */
+  readonly objectives: readonly ObjectiveConfig[];
+}
+
+/**
+ * Mine Liberation scoring module
+ *
+ * Used by: Mine Liberation scenario
+ */
+export interface MineModule extends BaseScoringModule {
+  readonly type: "mine";
+  /** Points per mine on Countryside tiles (+4 default) */
+  readonly countrysidePoints: number;
+  /** Points per mine on Core tiles (+7 default) */
+  readonly corePoints: number;
+  /** Title for most mines liberated */
+  readonly titleName: string;
+  /** Title bonus for winner (+5 default) */
+  readonly titleBonus: number;
+  /** Title bonus when tied (+2 default) */
+  readonly titleTiedBonus: number;
+}
+
+/**
+ * Relic Hunting scoring module
+ *
+ * Used by: Lost Relic scenarios
+ */
+export interface RelicModule extends BaseScoringModule {
+  readonly type: "relic";
+  /** Points per relic piece found */
+  readonly pointsPerPiece: number;
+  /** Bonus if every player found at least one piece */
+  readonly everyPlayerFoundBonus?: number;
+  /** Bonus if all pieces are found */
+  readonly allPiecesFoundBonus?: number;
+  /** Title for most relic pieces (competitive only) */
+  readonly titleName?: string;
+  /** Title bonus for winner */
+  readonly titleBonus?: number;
+  /** Title bonus when tied */
+  readonly titleTiedBonus?: number;
+}
+
+/**
+ * Faction scoring module
+ *
+ * Used by: Faction-specific scenarios (Orc, Draconum, etc.)
+ */
+export interface FactionModule extends BaseScoringModule {
+  readonly type: "faction";
+  /** Name of the faction */
+  readonly factionName: string;
+  /** Title for most shields on faction sites/leaders */
+  readonly titleName: string;
+  /** Title bonus for winner (+5 default) */
+  readonly titleBonus: number;
+  /** Title bonus when tied (+2 default) */
+  readonly titleTiedBonus: number;
+}
+
+/**
+ * Volkare scoring module
+ *
+ * Used by: Lost Legion scenarios
+ */
+export interface VolkareModule extends BaseScoringModule {
+  readonly type: "volkare";
+  /** Base bonus for defeating Volkare (varies by Combat level) */
+  readonly baseBonus: number;
+  /** Points per card left in Volkare's deck */
+  readonly pointsPerCard: number;
+  /** Multiplier based on Race level (1, 1.5, or 2) */
+  readonly raceMultiplier: number;
+}
+
+/**
+ * Union of all scoring module configurations
+ */
+export type ScoringModuleConfig =
+  | CityConquestModule
+  | TimeEfficiencyModule
+  | ObjectiveCompletionModule
+  | MineModule
+  | RelicModule
+  | FactionModule
+  | VolkareModule;
+
+// =============================================================================
+// SCENARIO SCORING CONFIGURATION
+// =============================================================================
+
+/**
+ * Complete scoring configuration for a scenario
+ *
+ * Defines how scores are calculated at game end.
+ */
+export interface ScenarioScoringConfig {
+  /** How base scores are calculated */
+  readonly baseScoreMode: BaseScoreMode;
+  /** Standard achievements configuration */
+  readonly achievements: AchievementsConfig;
+  /** Additional scoring modules enabled for this scenario */
+  readonly modules: readonly ScoringModuleConfig[];
+}
+
+// =============================================================================
+// RESULT TYPES
+// =============================================================================
+
+/**
+ * Score breakdown for a single achievement category
+ */
+export interface AchievementCategoryScore {
+  /** The achievement category */
+  readonly category: AchievementCategory;
+  /** Base points earned (before title bonus) */
+  readonly basePoints: number;
+  /** Title bonus earned (winner/tied/penalty) */
+  readonly titleBonus: number;
+  /** Total points for this category */
+  readonly totalPoints: number;
+  /** Whether this player won the title */
+  readonly hasTitle: boolean;
+  /** Whether tied for the title */
+  readonly isTied: boolean;
+}
+
+/**
+ * Complete achievement scoring result for a player
+ */
+export interface AchievementScoreResult {
+  /** Scores for each achievement category */
+  readonly categoryScores: readonly AchievementCategoryScore[];
+  /** Total achievement points */
+  readonly totalAchievementPoints: number;
+}
+
+/**
+ * Score result from a scoring module
+ */
+export interface ModuleScoreResult {
+  /** The module type */
+  readonly moduleType: ScoringModuleType;
+  /** Points earned from this module */
+  readonly points: number;
+  /** Breakdown of how points were earned */
+  readonly breakdown: readonly ModuleScoreBreakdown[];
+  /** Title earned from this module (if any) */
+  readonly title?: {
+    readonly name: string;
+    readonly bonus: number;
+    readonly isTied: boolean;
+  };
+}
+
+/**
+ * Individual item in a module score breakdown
+ */
+export interface ModuleScoreBreakdown {
+  /** Description of the scoring item */
+  readonly description: string;
+  /** Points earned for this item */
+  readonly points: number;
+  /** Quantity (if applicable) */
+  readonly quantity?: number;
+}
+
+/**
+ * Complete scoring result for a single player
+ */
+export interface PlayerScoreResult {
+  /** The player's ID */
+  readonly playerId: string;
+  /** Base score (Fame or other base) */
+  readonly baseScore: number;
+  /** Achievement scoring results (if enabled) */
+  readonly achievements?: AchievementScoreResult;
+  /** Results from each enabled scoring module */
+  readonly moduleResults: readonly ModuleScoreResult[];
+  /** Final total score */
+  readonly totalScore: number;
+}
+
+/**
+ * Complete scoring result for the entire game
+ */
+export interface FinalScoreResult {
+  /** Configuration used for scoring */
+  readonly config: ScenarioScoringConfig;
+  /** Results for each player */
+  readonly playerResults: readonly PlayerScoreResult[];
+  /** Player IDs in order from highest to lowest score */
+  readonly rankings: readonly string[];
+  /** Whether there was a tie for first place */
+  readonly isTied: boolean;
+}


### PR DESCRIPTION
## Summary

Add the core type definitions and constants for the scoring system as defined in the scoring system architecture design (#443). This provides the foundation for all scoring implementations.

- Created `packages/shared/src/scoring/types.ts` with all scoring type definitions
- Created `packages/shared/src/scoring/constants.ts` with scoring constants
- Created `packages/shared/src/scoring/index.ts` with re-exports
- Exported scoring module from shared package's main index

## Type Definitions Included

### Base Score Modes
- `BaseScoreMode`: `individual_fame` | `lowest_fame` | `victory_points` | `none`

### Achievement Configuration
- `AchievementMode`: `competitive` | `solo` | `coop_best_only`
- `AchievementCategory`: 6 standard categories (knowledge, loot, leader, etc.)
- `AchievementsConfig`: Full achievement configuration interface

### Scoring Modules
- `CityConquestModule` - City conquest scoring
- `TimeEfficiencyModule` - Solo/co-op time efficiency scoring
- `ObjectiveCompletionModule` - Scenario objectives scoring
- `MineModule` - Mine liberation scoring
- `RelicModule` - Relic hunting scoring
- `FactionModule` - Faction-specific scoring
- `VolkareModule` - Lost Legion Volkare scoring

### Result Types
- `AchievementCategoryScore`, `AchievementScoreResult` - Achievement results
- `ModuleScoreResult`, `ModuleScoreBreakdown` - Module results
- `PlayerScoreResult`, `FinalScoreResult` - Complete scoring results

## Test Plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [x] Types are properly exported from shared package

## Acceptance Criteria

All criteria from issue #560 have been addressed:
- [x] All type definitions from the design doc are implemented
- [x] Types are exported from shared package's main index
- [x] No runtime code, types and constants only
- [x] Build passes: `pnpm build`
- [x] Types follow project conventions (branded types where appropriate)

Closes #560