### PR TITLE
fix: correct Swamp Dragon ability to paralyze instead of poison

### DIFF
--- a/packages/shared/src/enemies/red.ts
+++ b/packages/shared/src/enemies/red.ts
@@ -9,7 +9,7 @@
  * @module enemies/red
  *
  * @remarks Enemies in this module:
- * - Swamp Dragon - Swift, poison, high armor
+ * - Swamp Dragon - Swift, paralyze, high armor
  * - Fire Dragon - Fire attack, physical + fire resistance
  * - Ice Dragon - Ice attack, physical + ice resistance, paralyze
  * - High Dragon - ColdFire attack, fire + ice resistance, brutal
@@ -24,7 +24,6 @@ import {
 import { ENEMY_COLOR_RED, type EnemyDefinition } from "./types.js";
 import {
   ABILITY_SWIFT,
-  ABILITY_POISON,
   ABILITY_PARALYZE,
   ABILITY_BRUTAL,
 } from "./abilities.js";
@@ -62,7 +61,7 @@ export const RED_ENEMIES: Record<RedEnemyId, EnemyDefinition> = {
     armor: 9,
     fame: 7,
     resistances: [],
-    abilities: [ABILITY_SWIFT, ABILITY_POISON],
+    abilities: [ABILITY_SWIFT, ABILITY_PARALYZE],
   },
   [ENEMY_FIRE_DRAGON]: {
     id: ENEMY_FIRE_DRAGON,


### PR DESCRIPTION
## Summary
Fixed incorrect ability assignment on the Swamp Dragon enemy. The enemy was using `ABILITY_POISON` when it should use `ABILITY_PARALYZE` according to the official Mage Knight board game stats.

## Changes
- Changed `abilities: [ABILITY_SWIFT, ABILITY_POISON]` to `abilities: [ABILITY_SWIFT, ABILITY_PARALYZE]` in `packages/shared/src/enemies/red.ts`
- Updated the doc comment to reflect the correct ability
- Removed unused `ABILITY_POISON` import

## Test Plan
- [x] All existing tests pass
- [x] Build completes successfully
- [x] Lint passes

## Acceptance Criteria
- [x] Replace ABILITY_POISON with ABILITY_PARALYZE

Closes #431