### PR TITLE
feat: add Fire Elemental enemy (Brown, Elementalist)

### DIFF
--- a/packages/shared/src/enemies/brown.ts
+++ b/packages/shared/src/enemies/brown.ts
@@ -14,17 +14,18 @@
  * - Crypt Worm - Fortified, underground
  * - Werewolf - Swift predator
  * - Shadow - ColdFire attack, elusive
+ * - Fire Elemental - Fire attack, fire resistance, Elementalist faction
  */
 
-import { ELEMENT_PHYSICAL, ELEMENT_COLD_FIRE } from "../elements.js";
-import { ENEMY_COLOR_BROWN, type EnemyDefinition } from "./types.js";
+import { ELEMENT_PHYSICAL, ELEMENT_COLD_FIRE, ELEMENT_FIRE } from "../elements.js";
+import { ENEMY_COLOR_BROWN, FACTION_ELEMENTALIST, type EnemyDefinition } from "./types.js";
 import {
   ABILITY_BRUTAL,
   ABILITY_PARALYZE,
   ABILITY_FORTIFIED,
   ABILITY_SWIFT,
 } from "./abilities.js";
-import { RESIST_PHYSICAL } from "./resistances.js";
+import { RESIST_PHYSICAL, RESIST_FIRE } from "./resistances.js";
 
 // =============================================================================
 // BROWN ENEMY ID CONSTANTS
@@ -36,6 +37,7 @@ export const ENEMY_MEDUSA = "medusa" as const;
 export const ENEMY_CRYPT_WORM = "crypt_worm" as const;
 export const ENEMY_WEREWOLF = "werewolf" as const;
 export const ENEMY_SHADOW = "shadow" as const;
+export const ENEMY_FIRE_ELEMENTAL = "fire_elemental" as const;
 
 /**
  * Union type of all brown (Dungeon monster) enemy IDs
@@ -46,7 +48,8 @@ export type BrownEnemyId =
   | typeof ENEMY_MEDUSA
   | typeof ENEMY_CRYPT_WORM
   | typeof ENEMY_WEREWOLF
-  | typeof ENEMY_SHADOW;
+  | typeof ENEMY_SHADOW
+  | typeof ENEMY_FIRE_ELEMENTAL;
 
 // =============================================================================
 // BROWN ENEMY DEFINITIONS
@@ -118,5 +121,17 @@ export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
     fame: 4,
     resistances: [],
     abilities: [], // Elusive, arcane immunity not modeled yet
+  },
+  [ENEMY_FIRE_ELEMENTAL]: {
+    id: ENEMY_FIRE_ELEMENTAL,
+    name: "Fire Elemental",
+    color: ENEMY_COLOR_BROWN,
+    attack: 7,
+    attackElement: ELEMENT_FIRE,
+    armor: 6,
+    fame: 4,
+    resistances: [RESIST_FIRE],
+    abilities: [],
+    faction: FACTION_ELEMENTALIST,
   },
 };

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -137,6 +137,7 @@ export {
   ENEMY_CRYPT_WORM,
   ENEMY_WEREWOLF,
   ENEMY_SHADOW,
+  ENEMY_FIRE_ELEMENTAL,
   BROWN_ENEMIES,
 } from "./brown.js";
 


### PR DESCRIPTION
## Summary
- Add Fire Elemental as a new brown (Dungeon Monster) enemy
- Fire Elemental has 7 Fire attack, 6 Armor, 4 Fame
- Includes Fire Resistance and belongs to Elementalist faction

## Changes
- `packages/shared/src/enemies/brown.ts`: Added `ENEMY_FIRE_ELEMENTAL` constant, added to `BrownEnemyId` union type, added definition to `BROWN_ENEMIES` record
- `packages/shared/src/enemies/index.ts`: Export `ENEMY_FIRE_ELEMENTAL`

## Test Plan
- [x] Build passes
- [x] Lint passes  
- [x] All existing tests pass (998 tests)

## Acceptance Criteria
All criteria from issue #389 have been addressed:
- [x] Add ENEMY_FIRE_ELEMENTAL constant
- [x] Add to BrownEnemyId union type
- [x] Add definition to BROWN_ENEMIES record
- [x] Include faction: FACTION_ELEMENTALIST

Closes #389