### PR TITLE
feat: add Hydra enemy (Brown)

### DIFF
--- a/packages/shared/src/enemies/brown.ts
+++ b/packages/shared/src/enemies/brown.ts
@@ -16,6 +16,7 @@
  * - Shadow - ColdFire attack, elusive
  * - Fire Elemental - Fire attack, fire resistance, Elementalist faction
  * - Mummy - Ice+physical resistance, poison
+ * - Hydra - Multiple attacks (2, 2, 2), ice resistance
  */
 
 import { ELEMENT_PHYSICAL, ELEMENT_COLD_FIRE, ELEMENT_FIRE } from "../elements.js";
@@ -41,6 +42,7 @@ export const ENEMY_WEREWOLF = "werewolf" as const;
 export const ENEMY_SHADOW = "shadow" as const;
 export const ENEMY_FIRE_ELEMENTAL = "fire_elemental" as const;
 export const ENEMY_MUMMY = "mummy" as const;
+export const ENEMY_HYDRA = "hydra" as const;
 
 /**
  * Union type of all brown (Dungeon monster) enemy IDs
@@ -53,7 +55,8 @@ export type BrownEnemyId =
   | typeof ENEMY_WEREWOLF
   | typeof ENEMY_SHADOW
   | typeof ENEMY_FIRE_ELEMENTAL
-  | typeof ENEMY_MUMMY;
+  | typeof ENEMY_MUMMY
+  | typeof ENEMY_HYDRA;
 
 // =============================================================================
 // BROWN ENEMY DEFINITIONS
@@ -148,5 +151,21 @@ export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
     fame: 4,
     resistances: [RESIST_ICE, RESIST_PHYSICAL],
     abilities: [ABILITY_POISON],
+  },
+  [ENEMY_HYDRA]: {
+    id: ENEMY_HYDRA,
+    name: "Hydra",
+    color: ENEMY_COLOR_BROWN,
+    attack: 2,
+    attackElement: ELEMENT_PHYSICAL,
+    armor: 6,
+    fame: 5,
+    resistances: [RESIST_ICE],
+    abilities: [],
+    attacks: [
+      { damage: 2, element: ELEMENT_PHYSICAL },
+      { damage: 2, element: ELEMENT_PHYSICAL },
+      { damage: 2, element: ELEMENT_PHYSICAL },
+    ],
   },
 };

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -139,6 +139,7 @@ export {
   ENEMY_SHADOW,
   ENEMY_FIRE_ELEMENTAL,
   ENEMY_MUMMY,
+  ENEMY_HYDRA,
   BROWN_ENEMIES,
 } from "./brown.js";
 


### PR DESCRIPTION
## Summary
- Added Hydra enemy to the Brown (Dungeon Monsters) category
- First enemy in the codebase to use the Multiple Attacks feature from #370

## Changes
- Added `ENEMY_HYDRA` constant in `packages/shared/src/enemies/brown.ts`
- Added to `BrownEnemyId` union type
- Added Hydra enemy definition with correct stats:
  - **Attack**: Multiple Attacks (2, 2, 2) - three physical attacks of 2 damage each
  - **Armor**: 6
  - **Fame**: 5
  - **Resistances**: Ice
  - **Abilities**: None
- Exported `ENEMY_HYDRA` from `packages/shared/src/enemies/index.ts`

## Test Plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All tests pass (`pnpm test`) - 998 tests in core, 48 in server
- [x] Multiple Attacks mechanics are already covered by `combatMultiAttack.test.ts` (13 tests)

## Acceptance Criteria
- [x] Add `ENEMY_HYDRA` constant
- [x] Add to `BrownEnemyId` union type
- [x] Add enemy definition with correct stats
- [x] Multiple Attacks ability must be implemented (#370) - ✅ Already implemented

Closes #402