### PR TITLE
feat: add City Conquest scoring module

### DIFF
--- a/packages/core/src/engine/scoring/modules/__tests__/cityConquest.test.ts
+++ b/packages/core/src/engine/scoring/modules/__tests__/cityConquest.test.ts
@@ -1,0 +1,713 @@
+/**
+ * City Conquest Scoring Module Tests
+ */
+
+import { describe, it, expect } from "vitest";
+import { calculateCityConquestScore } from "../cityConquest.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+} from "../../../__tests__/testHelpers.js";
+import type { GameState } from "../../../../state/GameState.js";
+import type { CityState, CityShield } from "../../../../types/city.js";
+import type { CityConquestModule } from "@mage-knight/shared";
+import { SCORING_MODULE_CITY_CONQUEST } from "@mage-knight/shared";
+import { CITY_COLOR_RED, CITY_COLOR_BLUE, CITY_COLOR_GREEN } from "../../../../types/mapConstants.js";
+import type { CityColor } from "../../../../types/map.js";
+
+/**
+ * Default city conquest configuration for testing
+ */
+const defaultConfig: CityConquestModule = {
+  type: SCORING_MODULE_CITY_CONQUEST,
+  leaderPoints: 7,
+  participantPoints: 4,
+  titleName: "Greatest City Conqueror",
+  titleBonus: 5,
+  titleTiedBonus: 2,
+};
+
+/**
+ * Create a city state with specified shields
+ */
+function createCityState(
+  color: CityColor,
+  shields: readonly CityShield[],
+  leaderId: string | null = null,
+  isConquered = true
+): CityState {
+  return {
+    color,
+    level: 1,
+    garrison: [],
+    shields,
+    isConquered,
+    leaderId,
+  };
+}
+
+/**
+ * Create a test state with specified cities and players
+ */
+function createTestStateWithCities(
+  playerIds: string[],
+  cities: Partial<Record<CityColor, CityState>>
+): GameState {
+  const players = playerIds.map((id) =>
+    createTestPlayer({ id, position: { q: 0, r: 0 } })
+  );
+
+  const baseState = createTestGameState({
+    players,
+    turnOrder: playerIds,
+  });
+
+  return {
+    ...baseState,
+    cities,
+  };
+}
+
+describe("City Conquest Scoring Module", () => {
+  describe("Base Scoring", () => {
+    it("should return 0 points when no cities conquered", () => {
+      const state = createTestStateWithCities(["player1", "player2"], {});
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results).toHaveLength(2);
+      expect(results[0].points).toBe(0);
+      expect(results[0].breakdown).toHaveLength(0);
+      expect(results[1].points).toBe(0);
+      expect(results[1].breakdown).toHaveLength(0);
+    });
+
+    it("should award leader points for leading a city", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1 leads 1 city = 7 points + 5 title bonus = 12
+      expect(results[0].points).toBe(12);
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities led",
+        points: 7,
+        quantity: 1,
+      });
+      // player2 has no participation
+      expect(results[1].points).toBe(0);
+    });
+
+    it("should award participant points for participating without leading", () => {
+      // player1 has 3 shields (leader), player2 has 1 shield (participant)
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player1", order: 3 },
+            { playerId: "player2", order: 4 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1 leads = 7 points + 5 title (most shields)
+      expect(results[0].points).toBe(12);
+      // player2 participates = 4 points
+      expect(results[1].points).toBe(4);
+      expect(results[1].breakdown).toContainEqual({
+        description: "Cities participated",
+        points: 4,
+        quantity: 1,
+      });
+    });
+
+    it("should award both leader and participant points for different cities", () => {
+      // player1 leads red, participates in blue
+      // player2 leads blue
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+          ],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [
+            { playerId: "player2", order: 1 },
+            { playerId: "player2", order: 2 },
+            { playerId: "player1", order: 3 },
+          ],
+          "player2"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1: 7 (led red) + 4 (participated blue) = 11 base
+      // player1 has 3 shields total, player2 has 2 shields total
+      // player1 wins title outright = +5
+      expect(results[0].points).toBe(11 + 5); // 16
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities led",
+        points: 7,
+        quantity: 1,
+      });
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities participated",
+        points: 4,
+        quantity: 1,
+      });
+      expect(results[0].title?.isTied).toBe(false);
+
+      // player2: 7 (led blue) = 7 base, no title
+      expect(results[1].points).toBe(7);
+      expect(results[1].title).toBeUndefined();
+    });
+
+    it("should handle player with no participation", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(
+        ["player1", "player2", "player3"],
+        cities
+      );
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player3 has no participation
+      expect(results[2].points).toBe(0);
+      expect(results[2].breakdown).toHaveLength(0);
+      expect(results[2].title).toBeUndefined();
+    });
+
+    it("should not count unconquered cities", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1",
+          false // not conquered
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].points).toBe(0);
+      expect(results[0].breakdown).toHaveLength(0);
+    });
+  });
+
+  describe("Title Calculation", () => {
+    it("should award title to player with most total shields", () => {
+      // player1: 3 shields, player2: 2 shields
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player2", order: 3 },
+          ],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player2", order: 2 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1 has title (most shields)
+      expect(results[0].title).toEqual({
+        name: "Greatest City Conqueror",
+        bonus: 5,
+        isTied: false,
+      });
+      expect(results[1].title).toBeUndefined();
+    });
+
+    it("should break ties using earliest shield order", () => {
+      // Both have 2 shields, but player2 placed first shield earlier
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player2", order: 1 }, // player2's first shield
+            { playerId: "player1", order: 2 }, // player1's first shield
+            { playerId: "player1", order: 3 },
+            { playerId: "player2", order: 4 },
+          ],
+          "player2" // player2 leads due to earlier order
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player2 wins title due to earliest first shield
+      expect(results[0].title).toBeUndefined(); // player1
+      expect(results[1].title).toEqual({
+        name: "Greatest City Conqueror",
+        bonus: 5,
+        isTied: false,
+      });
+    });
+
+    it("should award tied bonus when shields and orders match", () => {
+      // Both players have 1 shield each with same order number
+      // (In separate cities, so order 1 for each)
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [{ playerId: "player2", order: 1 }],
+          "player2"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // Both get tied bonus
+      expect(results[0].title).toEqual({
+        name: "Greatest City Conqueror",
+        bonus: 2,
+        isTied: true,
+      });
+      expect(results[1].title).toEqual({
+        name: "Greatest City Conqueror",
+        bonus: 2,
+        isTied: true,
+      });
+    });
+
+    it("should not award title when no cities conquered", () => {
+      const state = createTestStateWithCities(["player1", "player2"], {});
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].title).toBeUndefined();
+      expect(results[1].title).toBeUndefined();
+    });
+
+    it("should award title in single player game", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].title).toEqual({
+        name: "Greatest City Conqueror",
+        bonus: 5,
+        isTied: false,
+      });
+    });
+  });
+
+  describe("Breakdown Generation", () => {
+    it("should include cities led in breakdown", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities led",
+        points: 14, // 7 * 2
+        quantity: 2,
+      });
+    });
+
+    it("should include cities participated in breakdown", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player2", order: 2 },
+          ],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player2", order: 2 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player2 participated in 2 cities
+      expect(results[1].breakdown).toContainEqual({
+        description: "Cities participated",
+        points: 8, // 4 * 2
+        quantity: 2,
+      });
+    });
+
+    it("should have empty breakdown when no participation", () => {
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[1].breakdown).toHaveLength(0);
+    });
+
+    it("should set correct moduleType", () => {
+      const state = createTestStateWithCities(["player1"], {});
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].moduleType).toBe(SCORING_MODULE_CITY_CONQUEST);
+    });
+  });
+
+  describe("Multi-City Scenarios", () => {
+    it("should handle multiple cities with different leaders", () => {
+      // player1 leads red, player2 leads blue, player3 leads green
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [{ playerId: "player2", order: 1 }],
+          "player2"
+        ),
+        [CITY_COLOR_GREEN]: createCityState(
+          CITY_COLOR_GREEN,
+          [{ playerId: "player3", order: 1 }],
+          "player3"
+        ),
+      };
+      const state = createTestStateWithCities(
+        ["player1", "player2", "player3"],
+        cities
+      );
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // All three lead one city each = 7 points each
+      // All tied for shields = +2 each
+      expect(results[0].points).toBe(9);
+      expect(results[1].points).toBe(9);
+      expect(results[2].points).toBe(9);
+
+      // All have tied title
+      expect(results[0].title?.isTied).toBe(true);
+      expect(results[1].title?.isTied).toBe(true);
+      expect(results[2].title?.isTied).toBe(true);
+    });
+
+    it("should count shields across all cities for title", () => {
+      // player1: 2 shields in red, 3 shields in blue = 5 total
+      // player2: 1 shield in red, 1 shield in blue = 2 total
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player2", order: 3 },
+          ],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player1", order: 3 },
+            { playerId: "player2", order: 4 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1 has most shields, wins title
+      expect(results[0].title).toBeDefined();
+      expect(results[0].title?.isTied).toBe(false);
+      expect(results[1].title).toBeUndefined();
+    });
+
+    it("should handle complex participation patterns", () => {
+      // player1: leads red, participates in blue and green
+      // player2: leads blue, participates in red
+      // player3: leads green, no other participation
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player2", order: 3 },
+          ],
+          "player1"
+        ),
+        [CITY_COLOR_BLUE]: createCityState(
+          CITY_COLOR_BLUE,
+          [
+            { playerId: "player2", order: 1 },
+            { playerId: "player2", order: 2 },
+            { playerId: "player1", order: 3 },
+          ],
+          "player2"
+        ),
+        [CITY_COLOR_GREEN]: createCityState(
+          CITY_COLOR_GREEN,
+          [
+            { playerId: "player3", order: 1 },
+            { playerId: "player3", order: 2 },
+            { playerId: "player1", order: 3 },
+          ],
+          "player3"
+        ),
+      };
+      const state = createTestStateWithCities(
+        ["player1", "player2", "player3"],
+        cities
+      );
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // player1: 7 (lead red) + 4 (blue) + 4 (green) = 15 base
+      // player1 has 4 shields total, most shields, wins title
+      expect(results[0].points).toBe(15 + 5); // 20
+
+      // player2: 7 (lead blue) + 4 (red) = 11 base
+      // player2 has 3 shields
+      expect(results[1].points).toBe(11);
+
+      // player3: 7 (lead green) = 7 base
+      // player3 has 2 shields
+      expect(results[2].points).toBe(7);
+    });
+  });
+
+  describe("Configuration Overrides", () => {
+    it("should use custom leader points", () => {
+      const customConfig: CityConquestModule = {
+        ...defaultConfig,
+        leaderPoints: 10,
+      };
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, customConfig);
+
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities led",
+        points: 10,
+        quantity: 1,
+      });
+    });
+
+    it("should use custom participant points", () => {
+      const customConfig: CityConquestModule = {
+        ...defaultConfig,
+        participantPoints: 3,
+      };
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player2", order: 2 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1", "player2"], cities);
+
+      const results = calculateCityConquestScore(state, customConfig);
+
+      expect(results[1].breakdown).toContainEqual({
+        description: "Cities participated",
+        points: 3,
+        quantity: 1,
+      });
+    });
+
+    it("should use custom title bonuses", () => {
+      const customConfig: CityConquestModule = {
+        ...defaultConfig,
+        titleBonus: 8,
+        titleTiedBonus: 4,
+      };
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, customConfig);
+
+      expect(results[0].title?.bonus).toBe(8);
+    });
+
+    it("should use custom title name", () => {
+      const customConfig: CityConquestModule = {
+        ...defaultConfig,
+        titleName: "Master Conqueror",
+      };
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [{ playerId: "player1", order: 1 }],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, customConfig);
+
+      expect(results[0].title?.name).toBe("Master Conqueror");
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle city with empty shields array (theoretical)", () => {
+      // This shouldn't happen in practice, but handle gracefully
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(CITY_COLOR_RED, [], null),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results[0].points).toBe(0);
+      expect(results[0].title).toBeUndefined();
+    });
+
+    it("should handle many players with varying participation", () => {
+      const playerIds = ["p1", "p2", "p3", "p4", "p5"];
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "p1", order: 1 },
+            { playerId: "p2", order: 2 },
+            { playerId: "p3", order: 3 },
+          ],
+          "p1"
+        ),
+      };
+      const state = createTestStateWithCities(playerIds, cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      expect(results).toHaveLength(5);
+      // p1 leads
+      expect(results[0].points).toBeGreaterThan(0);
+      // p2 and p3 participated
+      expect(results[1].points).toBe(4);
+      expect(results[2].points).toBe(4);
+      // p4 and p5 didn't participate
+      expect(results[3].points).toBe(0);
+      expect(results[4].points).toBe(0);
+    });
+
+    it("should handle single player with multiple shields in same city", () => {
+      // Player has 5 shields on a city (defeated 5 enemies)
+      const cities: Partial<Record<CityColor, CityState>> = {
+        [CITY_COLOR_RED]: createCityState(
+          CITY_COLOR_RED,
+          [
+            { playerId: "player1", order: 1 },
+            { playerId: "player1", order: 2 },
+            { playerId: "player1", order: 3 },
+            { playerId: "player1", order: 4 },
+            { playerId: "player1", order: 5 },
+          ],
+          "player1"
+        ),
+      };
+      const state = createTestStateWithCities(["player1"], cities);
+
+      const results = calculateCityConquestScore(state, defaultConfig);
+
+      // Still only leads 1 city = 7 points + 5 title
+      expect(results[0].points).toBe(12);
+      expect(results[0].breakdown).toContainEqual({
+        description: "Cities led",
+        points: 7,
+        quantity: 1,
+      });
+    });
+  });
+});

--- a/packages/core/src/engine/scoring/modules/cityConquest.ts
+++ b/packages/core/src/engine/scoring/modules/cityConquest.ts
@@ -1,0 +1,238 @@
+/**
+ * City Conquest Scoring Module
+ *
+ * Calculates scores for city conquest achievements.
+ * Used by: Full Conquest, Blitz Conquest, co-op scenarios
+ *
+ * Scoring rules:
+ * - +7 Fame per city led (player with most shields on city)
+ * - +4 Fame per city participated (has shield, not leader)
+ * - Greatest City Conqueror title: +5 (winner) or +2 (tied)
+ */
+
+import type {
+  CityConquestModule,
+  ModuleScoreResult,
+  ModuleScoreBreakdown,
+} from "@mage-knight/shared";
+import { SCORING_MODULE_CITY_CONQUEST } from "@mage-knight/shared";
+import type { GameState } from "../../../state/GameState.js";
+import type { CityState } from "../../../types/city.js";
+
+/**
+ * Statistics for a player's city conquest participation
+ */
+interface PlayerCityStats {
+  /** Number of cities where player is the leader */
+  readonly citiesLed: number;
+  /** Number of cities where player has shields but is not leader */
+  readonly citiesParticipated: number;
+  /** Total shields placed across all cities */
+  readonly totalShields: number;
+  /** Earliest shield order (for tie-breaking), null if no shields */
+  readonly firstShieldOrder: number | null;
+}
+
+/**
+ * Default stats for players with no participation
+ */
+const DEFAULT_STATS: PlayerCityStats = {
+  citiesLed: 0,
+  citiesParticipated: 0,
+  totalShields: 0,
+  firstShieldOrder: null,
+};
+
+/**
+ * Calculate a player's city conquest statistics
+ */
+function calculatePlayerCityStats(
+  conqueredCities: readonly CityState[],
+  playerId: string
+): PlayerCityStats {
+  let citiesLed = 0;
+  let citiesParticipated = 0;
+  let totalShields = 0;
+  let firstShieldOrder: number | null = null;
+
+  for (const city of conqueredCities) {
+    const playerShields = city.shields.filter((s) => s.playerId === playerId);
+    const shieldCount = playerShields.length;
+
+    if (shieldCount > 0) {
+      totalShields += shieldCount;
+
+      // Track earliest shield order for tie-breaking
+      const minOrder = Math.min(...playerShields.map((s) => s.order));
+      if (firstShieldOrder === null || minOrder < firstShieldOrder) {
+        firstShieldOrder = minOrder;
+      }
+
+      // Check if player leads this city
+      if (city.leaderId === playerId) {
+        citiesLed += 1;
+      } else {
+        citiesParticipated += 1;
+      }
+    }
+  }
+
+  return {
+    citiesLed,
+    citiesParticipated,
+    totalShields,
+    firstShieldOrder,
+  };
+}
+
+/**
+ * Get stats for a player from the map, with safe fallback
+ */
+function getPlayerStats(
+  playerStats: ReadonlyMap<string, PlayerCityStats>,
+  playerId: string
+): PlayerCityStats {
+  return playerStats.get(playerId) ?? DEFAULT_STATS;
+}
+
+/**
+ * Determine the title winner based on total shields.
+ * Tie-breaker: player who placed their first shield earliest wins.
+ */
+function determineTitleWinners(
+  playerStats: ReadonlyMap<string, PlayerCityStats>,
+  playerIds: readonly string[]
+): { winnerIds: readonly string[]; isTied: boolean } {
+  // Find players with any shields
+  const playersWithShields = playerIds.filter(
+    (id) => getPlayerStats(playerStats, id).totalShields > 0
+  );
+
+  if (playersWithShields.length === 0) {
+    return { winnerIds: [], isTied: false };
+  }
+
+  // Find max shields
+  let maxShields = 0;
+  for (const id of playersWithShields) {
+    const shields = getPlayerStats(playerStats, id).totalShields;
+    if (shields > maxShields) {
+      maxShields = shields;
+    }
+  }
+
+  // Find all players with max shields
+  const playersWithMax = playersWithShields.filter(
+    (id) => getPlayerStats(playerStats, id).totalShields === maxShields
+  );
+
+  if (playersWithMax.length === 1) {
+    return { winnerIds: playersWithMax, isTied: false };
+  }
+
+  // Tie by shield count: use earliest shield order as tiebreaker
+  let earliestOrder = Infinity;
+  for (const id of playersWithMax) {
+    const stats = getPlayerStats(playerStats, id);
+    // Players with shields always have firstShieldOrder set
+    const order = stats.firstShieldOrder ?? Infinity;
+    if (order < earliestOrder) {
+      earliestOrder = order;
+    }
+  }
+
+  // Find all players who have the earliest order (may still be tied)
+  const winnersWithEarliestOrder = playersWithMax.filter((id) => {
+    const stats = getPlayerStats(playerStats, id);
+    return stats.firstShieldOrder === earliestOrder;
+  });
+
+  return {
+    winnerIds: winnersWithEarliestOrder,
+    isTied: winnersWithEarliestOrder.length > 1,
+  };
+}
+
+/**
+ * Calculate city conquest scores for all players.
+ *
+ * @param state - Current game state
+ * @param config - City conquest module configuration
+ * @returns Array of scoring results, one per player
+ */
+export function calculateCityConquestScore(
+  state: GameState,
+  config: CityConquestModule
+): readonly ModuleScoreResult[] {
+  // Get all conquered cities
+  const conqueredCities = Object.values(state.cities).filter(
+    (city): city is CityState => city !== undefined && city.isConquered
+  );
+
+  // Calculate stats for each player
+  const playerStats = new Map<string, PlayerCityStats>();
+  for (const player of state.players) {
+    playerStats.set(
+      player.id,
+      calculatePlayerCityStats(conqueredCities, player.id)
+    );
+  }
+
+  // Determine title winner(s)
+  const { winnerIds, isTied } = determineTitleWinners(
+    playerStats,
+    state.players.map((p) => p.id)
+  );
+  const winnerIdSet = new Set(winnerIds);
+
+  // Build results for each player
+  const results: ModuleScoreResult[] = [];
+  for (const player of state.players) {
+    const stats = getPlayerStats(playerStats, player.id);
+    const leaderScore = stats.citiesLed * config.leaderPoints;
+    const participantScore = stats.citiesParticipated * config.participantPoints;
+    const basePoints = leaderScore + participantScore;
+
+    // Determine title bonus
+    let titleBonus = 0;
+    const hasTitle = winnerIdSet.has(player.id);
+    if (hasTitle) {
+      titleBonus = isTied ? config.titleTiedBonus : config.titleBonus;
+    }
+
+    // Build breakdown
+    const breakdown: ModuleScoreBreakdown[] = [];
+    if (stats.citiesLed > 0) {
+      breakdown.push({
+        description: "Cities led",
+        points: leaderScore,
+        quantity: stats.citiesLed,
+      });
+    }
+    if (stats.citiesParticipated > 0) {
+      breakdown.push({
+        description: "Cities participated",
+        points: participantScore,
+        quantity: stats.citiesParticipated,
+      });
+    }
+
+    // Build the result object, conditionally including title
+    const result: ModuleScoreResult = {
+      moduleType: SCORING_MODULE_CITY_CONQUEST,
+      points: basePoints + titleBonus,
+      breakdown,
+      ...(hasTitle && {
+        title: {
+          name: config.titleName,
+          bonus: titleBonus,
+          isTied,
+        },
+      }),
+    };
+
+    results.push(result);
+  }
+
+  return results;
+}

--- a/packages/core/src/engine/scoring/modules/index.ts
+++ b/packages/core/src/engine/scoring/modules/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Scoring Modules Dispatcher
+ *
+ * Routes scoring calculations to the appropriate module based on type.
+ * Each scenario can enable multiple scoring modules which are all calculated here.
+ */
+
+import type { ScoringModuleConfig, ModuleScoreResult } from "@mage-knight/shared";
+import { SCORING_MODULE_CITY_CONQUEST } from "@mage-knight/shared";
+import type { GameState } from "../../../state/GameState.js";
+import { calculateCityConquestScore } from "./cityConquest.js";
+
+/**
+ * Calculate scores for all enabled scoring modules.
+ *
+ * @param state - Current game state
+ * @param modules - Array of module configurations enabled for this scenario
+ * @returns Array of scoring results for each player from each module
+ */
+export function calculateModuleScores(
+  state: GameState,
+  modules: readonly ScoringModuleConfig[]
+): readonly ModuleScoreResult[] {
+  const results: ModuleScoreResult[] = [];
+
+  for (const module of modules) {
+    switch (module.type) {
+      case SCORING_MODULE_CITY_CONQUEST:
+        results.push(...calculateCityConquestScore(state, module));
+        break;
+
+      // Future modules will be added here:
+      // case SCORING_MODULE_TIME_EFFICIENCY:
+      //   results.push(...calculateTimeEfficiencyScore(state, module));
+      //   break;
+      // case SCORING_MODULE_OBJECTIVE_COMPLETION:
+      //   results.push(...calculateObjectiveCompletionScore(state, module));
+      //   break;
+
+      default:
+        // Type assertion to ensure exhaustive checking when new modules are added
+        // This will cause a compile error if a new module type is added to the union
+        // but not handled in this switch
+        throw new Error(
+          `Unknown scoring module type: ${(module as ScoringModuleConfig).type}`
+        );
+    }
+  }
+
+  return results;
+}
+
+// Re-export individual module calculators for direct access if needed
+export { calculateCityConquestScore } from "./cityConquest.js";


### PR DESCRIPTION
## Summary

Implement the City Conquest scoring module (#447) used by conquest scenarios.

**Scoring rules:**
- +7 Fame per city led (player with most shields on city)
- +4 Fame per city participated (has shield, not leader)
- Greatest City Conqueror title: +5 (winner) or +2 (tied)
- Tie-breaker: earliest shield order wins title

## Changes

- `packages/core/src/engine/scoring/modules/cityConquest.ts` - Main module implementation with pure scoring functions
- `packages/core/src/engine/scoring/modules/index.ts` - Module dispatcher for routing scoring calculations
- `packages/core/src/engine/scoring/modules/__tests__/cityConquest.test.ts` - Comprehensive test suite (25 test cases)

## Test Plan

- [x] All 1033 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Linting passes (`pnpm lint`)
- [x] Test coverage includes:
  - Base scoring (leader/participant points)
  - Title calculation with tie-breaking
  - Multi-player scenarios (2-5 players)
  - Configuration overrides
  - Edge cases (no cities, empty shields)

## Acceptance Criteria

All criteria from issue #447 have been addressed:
- [x] +7 Fame per city led
- [x] +4 Fame per city participated (not led)
- [x] Greatest City Conqueror title awarded (+5)
- [x] Tied title awards +2 each
- [x] Works with multiple players
- [x] Integrates with scoring system architecture

Closes #447