### PR TITLE
feat: implement standard achievements scoring system

### DIFF
--- a/packages/core/src/engine/__tests__/scoring.test.ts
+++ b/packages/core/src/engine/__tests__/scoring.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Tests for the Standard Achievements Scoring System
+ *
+ * Tests all 6 achievement categories:
+ * - Greatest Knowledge: +2 per Spell, +1 per Advanced Action
+ * - Greatest Loot: +2 per Artifact, +1 per 2 crystals
+ * - Greatest Leader: +1 per unit level (wounded = half, floor)
+ * - Greatest Conqueror: +2 per shield on keep/mage tower/monastery
+ * - Greatest Adventurer: +2 per shield on adventure site
+ * - Greatest Beating: -2 per wound in deck
+ *
+ * Also tests title bonuses and tie handling.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateGreatestKnowledge,
+  calculateGreatestLoot,
+  calculateGreatestLeader,
+  calculateGreatestConqueror,
+  calculateGreatestAdventurer,
+  calculateGreatestBeating,
+} from "../scoring/achievementCalculators.js";
+import {
+  calculateAchievementResults,
+  calculateFinalScores,
+  createDefaultScoringConfig,
+} from "../scoring/standardAchievements.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+import { SiteType } from "../../types/map.js";
+import {
+  CARD_WOUND,
+  hexKey,
+  UNIT_PEASANTS,
+  UNIT_FIRE_MAGES,
+  CARD_FIREBALL,
+  CARD_SNOWSTORM,
+  CARD_SHIELD_BASH,
+  CARD_ICE_SHIELD,
+  CARD_ENDLESS_BAG_OF_GOLD,
+  ACHIEVEMENT_GREATEST_KNOWLEDGE,
+  ACHIEVEMENT_GREATEST_BEATING,
+  ACHIEVEMENT_MODE_COMPETITIVE,
+  TERRAIN_PLAINS,
+} from "@mage-knight/shared";
+
+describe("Achievement Score Calculators", () => {
+  describe("calculateGreatestKnowledge", () => {
+    it("returns 0 for player with no spells or advanced actions", () => {
+      const player = createTestPlayer({
+        hand: [],
+        deck: [],
+        discard: [],
+      });
+
+      expect(calculateGreatestKnowledge(player)).toBe(0);
+    });
+
+    it("calculates +2 per spell", () => {
+      const player = createTestPlayer({
+        hand: [CARD_FIREBALL],
+        deck: [CARD_SNOWSTORM],
+        discard: [],
+      });
+
+      // 2 spells * 2 points = 4
+      expect(calculateGreatestKnowledge(player)).toBe(4);
+    });
+
+    it("calculates +1 per advanced action", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        deck: [],
+        discard: [CARD_ICE_SHIELD],
+      });
+
+      // 2 advanced actions * 1 point = 2
+      expect(calculateGreatestKnowledge(player)).toBe(2);
+    });
+
+    it("calculates combined score for spells and advanced actions", () => {
+      const player = createTestPlayer({
+        hand: [CARD_FIREBALL, CARD_SHIELD_BASH],
+        deck: [CARD_SNOWSTORM],
+        discard: [CARD_ICE_SHIELD],
+      });
+
+      // 2 spells * 2 = 4, 2 AAs * 1 = 2, total = 6
+      expect(calculateGreatestKnowledge(player)).toBe(6);
+    });
+  });
+
+  describe("calculateGreatestLoot", () => {
+    it("returns 0 for player with no artifacts or crystals", () => {
+      const player = createTestPlayer({
+        hand: [],
+        deck: [],
+        discard: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      expect(calculateGreatestLoot(player)).toBe(0);
+    });
+
+    it("calculates +2 per artifact", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_BAG_OF_GOLD],
+        deck: [],
+        discard: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      // 1 artifact * 2 points = 2
+      expect(calculateGreatestLoot(player)).toBe(2);
+    });
+
+    it("calculates +1 per 2 crystals (floor)", () => {
+      const player = createTestPlayer({
+        hand: [],
+        deck: [],
+        discard: [],
+        crystals: { red: 2, blue: 1, green: 2, white: 0 },
+      });
+
+      // 5 crystals / 2 = 2 (floor)
+      expect(calculateGreatestLoot(player)).toBe(2);
+    });
+
+    it("calculates combined score for artifacts and crystals", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_BAG_OF_GOLD],
+        deck: [],
+        discard: [],
+        crystals: { red: 3, blue: 3, green: 0, white: 0 },
+      });
+
+      // 1 artifact * 2 = 2, 6 crystals / 2 = 3, total = 5
+      expect(calculateGreatestLoot(player)).toBe(5);
+    });
+  });
+
+  describe("calculateGreatestLeader", () => {
+    it("returns 0 for player with no units", () => {
+      const player = createTestPlayer({
+        units: [],
+      });
+
+      expect(calculateGreatestLeader(player)).toBe(0);
+    });
+
+    it("calculates +1 per unit level for healthy units", () => {
+      const player = createTestPlayer({
+        units: [
+          { instanceId: "u1", unitId: UNIT_PEASANTS, state: "ready", wounded: false, usedResistanceThisCombat: false },
+          { instanceId: "u2", unitId: UNIT_FIRE_MAGES, state: "ready", wounded: false, usedResistanceThisCombat: false },
+        ],
+      });
+
+      // Peasants (level 1) + Fire Mages (level 3) = 4
+      expect(calculateGreatestLeader(player)).toBe(4);
+    });
+
+    it("calculates half level (floor) for wounded units", () => {
+      const player = createTestPlayer({
+        units: [
+          { instanceId: "u1", unitId: UNIT_PEASANTS, state: "ready", wounded: true, usedResistanceThisCombat: false },
+          { instanceId: "u2", unitId: UNIT_FIRE_MAGES, state: "ready", wounded: true, usedResistanceThisCombat: false },
+        ],
+      });
+
+      // Wounded Peasants (level 1): floor(1/2) = 0
+      // Wounded Fire Mages (level 3): floor(3/2) = 1
+      // Total = 1
+      expect(calculateGreatestLeader(player)).toBe(1);
+    });
+
+    it("calculates mixed healthy and wounded units", () => {
+      const player = createTestPlayer({
+        units: [
+          { instanceId: "u1", unitId: UNIT_PEASANTS, state: "ready", wounded: false, usedResistanceThisCombat: false },
+          { instanceId: "u2", unitId: UNIT_FIRE_MAGES, state: "ready", wounded: true, usedResistanceThisCombat: false },
+        ],
+      });
+
+      // Healthy Peasants: 1
+      // Wounded Fire Mages: floor(3/2) = 1
+      // Total = 2
+      expect(calculateGreatestLeader(player)).toBe(2);
+    });
+  });
+
+  describe("calculateGreatestConqueror", () => {
+    it("returns 0 for player with no conquered sites", () => {
+      const state = createTestGameState();
+      const player = state.players[0];
+      if (!player) throw new Error("Test setup error: no player");
+
+      expect(calculateGreatestConqueror(player, state)).toBe(0);
+    });
+
+    it("calculates +2 per shield on keep", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.Keep, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestConqueror(player, state)).toBe(2);
+    });
+
+    it("calculates +2 per shield on mage tower", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.MageTower, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestConqueror(player, state)).toBe(2);
+    });
+
+    it("calculates +2 per shield on monastery", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.Monastery, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestConqueror(player, state)).toBe(2);
+    });
+  });
+
+  describe("calculateGreatestAdventurer", () => {
+    it("returns 0 for player with no conquered adventure sites", () => {
+      const state = createTestGameState();
+      const player = state.players[0];
+      if (!player) throw new Error("Test setup error: no player");
+
+      expect(calculateGreatestAdventurer(player, state)).toBe(0);
+    });
+
+    it("calculates +2 per shield on dungeon", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.Dungeon, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestAdventurer(player, state)).toBe(2);
+    });
+
+    it("calculates +2 per shield on tomb", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.Tomb, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestAdventurer(player, state)).toBe(2);
+    });
+
+    it("calculates +2 per shield on monster den", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          ...createTestGameState().map,
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              coord: { q: 0, r: 0 },
+              terrain: TERRAIN_PLAINS,
+              tileId: "starting_a" as const,
+              site: { type: SiteType.MonsterDen, owner: "player1", isConquered: true, isBurned: false },
+              enemies: [],
+              shieldTokens: ["player1"],
+              rampagingEnemies: [],
+              ruinsToken: null,
+            },
+          },
+        },
+      });
+
+      expect(calculateGreatestAdventurer(player, state)).toBe(2);
+    });
+  });
+
+  describe("calculateGreatestBeating", () => {
+    it("returns 0 for player with no wounds", () => {
+      const player = createTestPlayer({
+        hand: [],
+        deck: [],
+        discard: [],
+      });
+
+      expect(calculateGreatestBeating(player)).toBe(0);
+    });
+
+    it("calculates -2 per wound in deck", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        deck: [CARD_WOUND, CARD_WOUND],
+        discard: [],
+      });
+
+      // 3 wounds * -2 = -6
+      expect(calculateGreatestBeating(player)).toBe(-6);
+    });
+
+    it("counts wounds in all deck locations", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        deck: [CARD_WOUND],
+        discard: [CARD_WOUND],
+      });
+
+      // 3 wounds * -2 = -6
+      expect(calculateGreatestBeating(player)).toBe(-6);
+    });
+  });
+});
+
+describe("Achievement Title Bonuses", () => {
+  describe("Competitive multiplayer", () => {
+    it("awards +3 to sole winner", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [CARD_FIREBALL, CARD_SNOWSTORM], // 4 points
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [CARD_FIREBALL], // 2 points
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const config = {
+        enabled: true,
+        mode: ACHIEVEMENT_MODE_COMPETITIVE as const,
+      };
+
+      const results = calculateAchievementResults([player1, player2], state, config);
+      const p1Result = results.get("player1");
+      const p2Result = results.get("player2");
+
+      // Player 1 should have Greatest Knowledge title with +3 bonus
+      const p1Knowledge = p1Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_KNOWLEDGE
+      );
+      expect(p1Knowledge?.basePoints).toBe(4);
+      expect(p1Knowledge?.titleBonus).toBe(3);
+      expect(p1Knowledge?.hasTitle).toBe(true);
+      expect(p1Knowledge?.isTied).toBe(false);
+
+      // Player 2 should not have the title
+      const p2Knowledge = p2Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_KNOWLEDGE
+      );
+      expect(p2Knowledge?.basePoints).toBe(2);
+      expect(p2Knowledge?.titleBonus).toBe(0);
+      expect(p2Knowledge?.hasTitle).toBe(false);
+    });
+
+    it("awards +1 to each tied player", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [CARD_FIREBALL], // 2 points
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [CARD_SNOWSTORM], // 2 points
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const config = {
+        enabled: true,
+        mode: ACHIEVEMENT_MODE_COMPETITIVE as const,
+      };
+
+      const results = calculateAchievementResults([player1, player2], state, config);
+      const p1Result = results.get("player1");
+      const p2Result = results.get("player2");
+
+      // Both should have +1 for tie
+      const p1Knowledge = p1Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_KNOWLEDGE
+      );
+      expect(p1Knowledge?.titleBonus).toBe(1);
+      expect(p1Knowledge?.hasTitle).toBe(true);
+      expect(p1Knowledge?.isTied).toBe(true);
+
+      const p2Knowledge = p2Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_KNOWLEDGE
+      );
+      expect(p2Knowledge?.titleBonus).toBe(1);
+      expect(p2Knowledge?.hasTitle).toBe(true);
+      expect(p2Knowledge?.isTied).toBe(true);
+    });
+
+    it("no bonus when tied at 0 for Greatest Knowledge", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [], // 0 spells/AAs
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [], // 0 spells/AAs
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const config = {
+        enabled: true,
+        mode: ACHIEVEMENT_MODE_COMPETITIVE as const,
+      };
+
+      const results = calculateAchievementResults([player1, player2], state, config);
+      const p1Result = results.get("player1");
+
+      const p1Knowledge = p1Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_KNOWLEDGE
+      );
+      expect(p1Knowledge?.basePoints).toBe(0);
+      expect(p1Knowledge?.titleBonus).toBe(0);
+      expect(p1Knowledge?.hasTitle).toBe(false);
+    });
+
+    it("awards -3 penalty for most wounds (Greatest Beating)", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND], // -6 points
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [CARD_WOUND], // -2 points
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const config = {
+        enabled: true,
+        mode: ACHIEVEMENT_MODE_COMPETITIVE as const,
+      };
+
+      const results = calculateAchievementResults([player1, player2], state, config);
+      const p1Result = results.get("player1");
+      const p2Result = results.get("player2");
+
+      // Player 1 has more wounds, gets -3 penalty
+      const p1Beating = p1Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_BEATING
+      );
+      expect(p1Beating?.basePoints).toBe(-6);
+      expect(p1Beating?.titleBonus).toBe(-3);
+      expect(p1Beating?.hasTitle).toBe(true);
+
+      // Player 2 has fewer wounds, no penalty
+      const p2Beating = p2Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_BEATING
+      );
+      expect(p2Beating?.basePoints).toBe(-2);
+      expect(p2Beating?.titleBonus).toBe(0);
+      expect(p2Beating?.hasTitle).toBe(false);
+    });
+
+    it("no penalty when tied at 0 wounds for Greatest Beating", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [], // 0 wounds
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [], // 0 wounds
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const config = {
+        enabled: true,
+        mode: ACHIEVEMENT_MODE_COMPETITIVE as const,
+      };
+
+      const results = calculateAchievementResults([player1, player2], state, config);
+      const p1Result = results.get("player1");
+
+      const p1Beating = p1Result?.categoryScores.find(
+        (s) => s.category === ACHIEVEMENT_GREATEST_BEATING
+      );
+      expect(p1Beating?.basePoints).toBe(0);
+      expect(p1Beating?.titleBonus).toBe(0);
+      expect(p1Beating?.hasTitle).toBe(false);
+    });
+  });
+});
+
+describe("Final Score Calculation", () => {
+  it("calculates total score from fame + achievements", () => {
+    const player1 = createTestPlayer({
+      id: "player1",
+      fame: 50,
+      hand: [CARD_FIREBALL, CARD_SNOWSTORM], // 4 points knowledge
+    });
+
+    const state = createTestGameState({
+      players: [player1],
+    });
+
+    const scoringConfig = createDefaultScoringConfig(true); // Solo mode
+    const result = calculateFinalScores(state, scoringConfig);
+
+    expect(result.playerResults.length).toBe(1);
+    expect(result.playerResults[0]?.baseScore).toBe(50);
+    // In solo mode, no title bonuses, so just base achievement points
+    expect(result.playerResults[0]?.achievements?.totalAchievementPoints).toBe(4);
+    expect(result.playerResults[0]?.totalScore).toBe(54);
+  });
+
+  it("determines winner based on total score", () => {
+    const player1 = createTestPlayer({
+      id: "player1",
+      fame: 40,
+      hand: [CARD_FIREBALL, CARD_SNOWSTORM], // 4 points
+    });
+    const player2 = createTestPlayer({
+      id: "player2",
+      fame: 50,
+      hand: [], // 0 points
+    });
+
+    const state = createTestGameState({
+      players: [player1, player2],
+    });
+
+    const scoringConfig = createDefaultScoringConfig(false); // Competitive
+    const result = calculateFinalScores(state, scoringConfig);
+
+    // Player 1: 40 fame + 4 base + 3 title bonus = 47
+    // Player 2: 50 fame + 0 = 50
+    // Player 2 wins
+    expect(result.rankings[0]).toBe("player2");
+    expect(result.isTied).toBe(false);
+  });
+
+  it("detects ties", () => {
+    const player1 = createTestPlayer({
+      id: "player1",
+      fame: 50,
+      hand: [],
+    });
+    const player2 = createTestPlayer({
+      id: "player2",
+      fame: 50,
+      hand: [],
+    });
+
+    const state = createTestGameState({
+      players: [player1, player2],
+    });
+
+    const scoringConfig = createDefaultScoringConfig(false);
+    const result = calculateFinalScores(state, scoringConfig);
+
+    expect(result.isTied).toBe(true);
+  });
+});

--- a/packages/core/src/engine/commands/endRoundCommand.ts
+++ b/packages/core/src/engine/commands/endRoundCommand.ts
@@ -50,6 +50,7 @@ import { CORE_TILE_ID_PREFIX, SYSTEM_PLAYER_ID } from "../engineConstants.js";
 import { revealRuinsToken } from "../helpers/ruinsTokenHelpers.js";
 import { countUnburnedMonasteries } from "../helpers/monasteryHelpers.js";
 import type { HexState } from "../../types/map.js";
+import { calculateFinalScores, createDefaultScoringConfig } from "../scoring/index.js";
 
 /**
  * Check if any core tile has been revealed on the map.
@@ -79,17 +80,21 @@ export function createEndRoundCommand(): Command {
       // Check if we're in final turns (scenario end was triggered)
       // Rulebook: "If the Round ends during this [final turns], the game ends immediately."
       if (state.scenarioEndTriggered && state.finalTurnsRemaining !== null && state.finalTurnsRemaining > 0) {
-        // Calculate final scores (simplified - just fame for now)
-        const finalScores = state.players.map((p) => ({
-          playerId: p.id,
-          score: p.fame,
+        // Calculate final scores using the full scoring system
+        const isSolo = state.players.length === 1;
+        const scoringConfig = createDefaultScoringConfig(isSolo);
+        const finalScoreResult = calculateFinalScores(state, scoringConfig);
+
+        // Convert to simple format for event
+        const finalScores = finalScoreResult.playerResults.map((r) => ({
+          playerId: r.playerId,
+          score: r.totalScore,
         }));
 
-        // Sort by score descending
-        finalScores.sort((a, b) => b.score - a.score);
-
-        // Determine winner (highest score)
-        const winningPlayerId = finalScores[0]?.playerId ?? null;
+        // Determine winner (highest score, or null if tied)
+        const winningPlayerId = finalScoreResult.isTied
+          ? null
+          : finalScoreResult.rankings[0] ?? null;
 
         events.push({
           type: ROUND_ENDED,
@@ -108,6 +113,7 @@ export function createEndRoundCommand(): Command {
             finalTurnsRemaining: 0,
             gameEnded: true,
             winningPlayerId,
+            finalScoreResult,
           },
           events,
         };

--- a/packages/core/src/engine/scoring/achievementCalculators.ts
+++ b/packages/core/src/engine/scoring/achievementCalculators.ts
@@ -1,0 +1,239 @@
+/**
+ * Achievement Score Calculators
+ *
+ * Implements the 6 standard achievement category calculations for Mage Knight:
+ * - Greatest Knowledge: +2 per Spell, +1 per Advanced Action
+ * - Greatest Loot: +2 per Artifact, +1 per 2 crystals
+ * - Greatest Leader: +1 per unit level (wounded = half, floor)
+ * - Greatest Conqueror: +2 per shield on keep/mage tower/monastery
+ * - Greatest Adventurer: +2 per shield on adventure site
+ * - Greatest Beating: -2 per wound in deck (penalty)
+ *
+ * Based on rulebook text for Standard Achievements Scoring.
+ */
+
+import type { Player } from "../../types/player.js";
+import type { GameState } from "../../state/GameState.js";
+import type { HexState } from "../../types/map.js";
+import {
+  DEED_CARD_TYPE_SPELL,
+  DEED_CARD_TYPE_ADVANCED_ACTION,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import { getCard } from "../validActions/cards/index.js";
+import { isAdventureSite } from "../../data/siteProperties.js";
+import { UNITS } from "@mage-knight/shared";
+import {
+  CARD_WOUND,
+  POINTS_PER_SPELL,
+  POINTS_PER_ADVANCED_ACTION,
+  POINTS_PER_ARTIFACT,
+  CRYSTALS_PER_POINT,
+  POINTS_PER_FORTIFIED_SHIELD,
+  POINTS_PER_ADVENTURE_SHIELD,
+  POINTS_PER_WOUND,
+} from "@mage-knight/shared";
+import { SiteType } from "../../types/map.js";
+
+/**
+ * Get all cards in a player's deed deck (hand + deck + discard).
+ * Excludes removed cards (destroyed artifacts, etc.).
+ */
+function getAllPlayerCards(player: Player): readonly string[] {
+  return [...player.hand, ...player.deck, ...player.discard];
+}
+
+/**
+ * Count cards of a specific type in the player's deck.
+ */
+function countCardsByType(
+  player: Player,
+  cardType:
+    | typeof DEED_CARD_TYPE_SPELL
+    | typeof DEED_CARD_TYPE_ADVANCED_ACTION
+    | typeof DEED_CARD_TYPE_ARTIFACT
+): number {
+  const allCards = getAllPlayerCards(player);
+  let count = 0;
+
+  for (const cardId of allCards) {
+    const card = getCard(cardId);
+    if (card && card.cardType === cardType) {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Calculate Greatest Knowledge score.
+ * +2 Fame per Spell, +1 Fame per Advanced Action in deck.
+ */
+export function calculateGreatestKnowledge(player: Player): number {
+  const spellCount = countCardsByType(player, DEED_CARD_TYPE_SPELL);
+  const advancedActionCount = countCardsByType(
+    player,
+    DEED_CARD_TYPE_ADVANCED_ACTION
+  );
+
+  return spellCount * POINTS_PER_SPELL + advancedActionCount * POINTS_PER_ADVANCED_ACTION;
+}
+
+/**
+ * Calculate Greatest Loot score.
+ * +2 Fame per Artifact in deck or on Units, +1 Fame per 2 crystals (floor).
+ *
+ * Note: The rulebook says "in their deck or on their Units". Units can have
+ * artifacts attached (e.g., banner artifacts). We count both.
+ */
+export function calculateGreatestLoot(player: Player): number {
+  // Count artifacts in deed deck
+  const artifactsInDeck = countCardsByType(player, DEED_CARD_TYPE_ARTIFACT);
+
+  // TODO: Count artifacts on units (banners) when that feature is implemented
+  // For now, this is 0 since units don't have artifact attachment yet
+  const artifactsOnUnits = 0;
+
+  // Count total crystals (all 4 colors)
+  const totalCrystals =
+    player.crystals.red +
+    player.crystals.blue +
+    player.crystals.green +
+    player.crystals.white;
+
+  // Calculate score
+  const artifactPoints = (artifactsInDeck + artifactsOnUnits) * POINTS_PER_ARTIFACT;
+  const crystalPoints = Math.floor(totalCrystals / CRYSTALS_PER_POINT);
+
+  return artifactPoints + crystalPoints;
+}
+
+/**
+ * Calculate Greatest Leader score.
+ * +1 Fame per unit level. Wounded units count as half level (floor).
+ */
+export function calculateGreatestLeader(player: Player): number {
+  let totalScore = 0;
+
+  for (const unit of player.units) {
+    const unitDef = UNITS[unit.unitId];
+    if (!unitDef) continue;
+
+    if (unit.wounded) {
+      // Wounded units count as half level, rounded down
+      totalScore += Math.floor(unitDef.level / 2);
+    } else {
+      totalScore += unitDef.level;
+    }
+  }
+
+  return totalScore;
+}
+
+/**
+ * Get shield counts for a player on different site types.
+ */
+function getPlayerShieldCounts(
+  state: GameState,
+  playerId: string
+): { fortified: number; adventure: number } {
+  let fortifiedCount = 0;
+  let adventureCount = 0;
+
+  // Iterate through all hexes on the map
+  for (const hex of Object.values(state.map.hexes) as HexState[]) {
+    // Check if player has a shield on this hex
+    if (!hex.shieldTokens.includes(playerId)) {
+      continue;
+    }
+
+    // Check the site type (if any)
+    if (!hex.site) {
+      continue;
+    }
+
+    const siteType = hex.site.type;
+
+    // Conqueror sites: Keep, Mage Tower, Monastery (not City per rulebook)
+    // Note: The rulebook says "keep, mage tower or monastery" - not cities
+    if (
+      siteType === SiteType.Keep ||
+      siteType === SiteType.MageTower ||
+      siteType === SiteType.Monastery
+    ) {
+      // Count each shield (usually 1 per site, but count the actual shields)
+      fortifiedCount += hex.shieldTokens.filter((id) => id === playerId).length;
+    }
+
+    // Adventure sites
+    if (isAdventureSite(siteType)) {
+      adventureCount += hex.shieldTokens.filter((id) => id === playerId).length;
+    }
+  }
+
+  return { fortified: fortifiedCount, adventure: adventureCount };
+}
+
+/**
+ * Calculate Greatest Conqueror score.
+ * +2 Fame per shield token on a keep, mage tower, or monastery.
+ */
+export function calculateGreatestConqueror(
+  player: Player,
+  state: GameState
+): number {
+  const { fortified } = getPlayerShieldCounts(state, player.id);
+  return fortified * POINTS_PER_FORTIFIED_SHIELD;
+}
+
+/**
+ * Calculate Greatest Adventurer score.
+ * +2 Fame per shield token on an adventure site.
+ */
+export function calculateGreatestAdventurer(
+  player: Player,
+  state: GameState
+): number {
+  const { adventure } = getPlayerShieldCounts(state, player.id);
+  return adventure * POINTS_PER_ADVENTURE_SHIELD;
+}
+
+/**
+ * Count wounds in a player's deed deck (not on units).
+ */
+function countWoundsInDeck(player: Player): number {
+  const allCards = getAllPlayerCards(player);
+  return allCards.filter((cardId) => cardId === CARD_WOUND).length;
+}
+
+/**
+ * Calculate Greatest Beating score.
+ * -2 Fame per wound card in deck (not on units).
+ * This is a negative score (penalty).
+ */
+export function calculateGreatestBeating(player: Player): number {
+  const woundCount = countWoundsInDeck(player);
+  if (woundCount === 0) {
+    return 0; // Avoid JavaScript -0 edge case
+  }
+  return woundCount * POINTS_PER_WOUND; // POINTS_PER_WOUND is already negative
+}
+
+/**
+ * All achievement calculators mapped by category.
+ */
+export const ACHIEVEMENT_CALCULATORS = {
+  greatest_knowledge: (player: Player, _state: GameState) =>
+    calculateGreatestKnowledge(player),
+  greatest_loot: (player: Player, _state: GameState) =>
+    calculateGreatestLoot(player),
+  greatest_leader: (player: Player, _state: GameState) =>
+    calculateGreatestLeader(player),
+  greatest_conqueror: (player: Player, state: GameState) =>
+    calculateGreatestConqueror(player, state),
+  greatest_adventurer: (player: Player, state: GameState) =>
+    calculateGreatestAdventurer(player, state),
+  greatest_beating: (player: Player, _state: GameState) =>
+    calculateGreatestBeating(player),
+} as const;

--- a/packages/core/src/engine/scoring/index.ts
+++ b/packages/core/src/engine/scoring/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Scoring System for Mage Knight
+ *
+ * This module provides the complete scoring implementation for end-game scoring.
+ * It includes:
+ * - Achievement calculators for the 6 standard categories
+ * - Title bonus/penalty logic for competitive multiplayer
+ * - Final score calculation combining base fame + achievements
+ *
+ * @module scoring
+ */
+
+// Achievement calculators
+export {
+  calculateGreatestKnowledge,
+  calculateGreatestLoot,
+  calculateGreatestLeader,
+  calculateGreatestConqueror,
+  calculateGreatestAdventurer,
+  calculateGreatestBeating,
+  ACHIEVEMENT_CALCULATORS,
+} from "./achievementCalculators.js";
+
+// Standard achievements scoring
+export {
+  calculateAchievementResults,
+  calculateFinalScores,
+  createDefaultScoringConfig,
+} from "./standardAchievements.js";

--- a/packages/core/src/engine/scoring/standardAchievements.ts
+++ b/packages/core/src/engine/scoring/standardAchievements.ts
@@ -1,0 +1,372 @@
+/**
+ * Standard Achievements Scoring System
+ *
+ * Implements the title bonus/penalty logic for competitive multiplayer:
+ * - Winner of each category gets +3 Fame (or -3 for Greatest Beating)
+ * - Tied players each get +1 Fame (or -1 for Greatest Beating)
+ * - Special case: No bonus if tied at 0 for Greatest Knowledge
+ * - Special case: No penalty if tied at 0 wounds for Greatest Beating
+ *
+ * For solo mode, only base scores are calculated (no titles).
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  AchievementCategory,
+  AchievementCategoryScore,
+  AchievementScoreResult,
+  AchievementsConfig,
+  PlayerScoreResult,
+  FinalScoreResult,
+  ScenarioScoringConfig,
+} from "@mage-knight/shared";
+import {
+  ACHIEVEMENT_GREATEST_KNOWLEDGE,
+  ACHIEVEMENT_GREATEST_LOOT,
+  ACHIEVEMENT_GREATEST_LEADER,
+  ACHIEVEMENT_GREATEST_CONQUEROR,
+  ACHIEVEMENT_GREATEST_ADVENTURER,
+  ACHIEVEMENT_GREATEST_BEATING,
+  ALL_ACHIEVEMENT_CATEGORIES,
+  TITLE_BONUS_WINNER,
+  TITLE_BONUS_TIED,
+  TITLE_PENALTY_MOST_WOUNDS,
+  TITLE_PENALTY_MOST_WOUNDS_TIED,
+  ACHIEVEMENT_MODE_COMPETITIVE,
+  ACHIEVEMENT_MODE_SOLO,
+  BASE_SCORE_INDIVIDUAL_FAME,
+} from "@mage-knight/shared";
+import { ACHIEVEMENT_CALCULATORS } from "./achievementCalculators.js";
+
+/**
+ * Configuration for an achievement category's title logic.
+ */
+interface CategoryTitleConfig {
+  /** Bonus for sole winner */
+  readonly winnerBonus: number;
+  /** Bonus when tied */
+  readonly tiedBonus: number;
+  /** If true, no bonus/penalty when tied at score of 0 */
+  readonly zeroTieException: boolean;
+  /** If true, "winner" is the player with the lowest (most negative) score */
+  readonly isNegative: boolean;
+}
+
+/**
+ * Title configuration for each achievement category.
+ */
+const CATEGORY_TITLE_CONFIG: Record<AchievementCategory, CategoryTitleConfig> = {
+  [ACHIEVEMENT_GREATEST_KNOWLEDGE]: {
+    winnerBonus: TITLE_BONUS_WINNER,
+    tiedBonus: TITLE_BONUS_TIED,
+    zeroTieException: true, // No bonus if tied at 0
+    isNegative: false,
+  },
+  [ACHIEVEMENT_GREATEST_LOOT]: {
+    winnerBonus: TITLE_BONUS_WINNER,
+    tiedBonus: TITLE_BONUS_TIED,
+    zeroTieException: false,
+    isNegative: false,
+  },
+  [ACHIEVEMENT_GREATEST_LEADER]: {
+    winnerBonus: TITLE_BONUS_WINNER,
+    tiedBonus: TITLE_BONUS_TIED,
+    zeroTieException: false,
+    isNegative: false,
+  },
+  [ACHIEVEMENT_GREATEST_CONQUEROR]: {
+    winnerBonus: TITLE_BONUS_WINNER,
+    tiedBonus: TITLE_BONUS_TIED,
+    zeroTieException: false,
+    isNegative: false,
+  },
+  [ACHIEVEMENT_GREATEST_ADVENTURER]: {
+    winnerBonus: TITLE_BONUS_WINNER,
+    tiedBonus: TITLE_BONUS_TIED,
+    zeroTieException: false,
+    isNegative: false,
+  },
+  [ACHIEVEMENT_GREATEST_BEATING]: {
+    winnerBonus: TITLE_PENALTY_MOST_WOUNDS, // -3 (penalty)
+    tiedBonus: TITLE_PENALTY_MOST_WOUNDS_TIED, // -1 (penalty)
+    zeroTieException: true, // No penalty if tied at 0 wounds
+    isNegative: true, // "Winner" is the one with most wounds (lowest/most negative score)
+  },
+};
+
+/**
+ * Calculate base scores for all players for a single category.
+ */
+function calculateCategoryBaseScores(
+  category: AchievementCategory,
+  players: readonly Player[],
+  state: GameState
+): Map<string, number> {
+  const scores = new Map<string, number>();
+  const calculator = ACHIEVEMENT_CALCULATORS[category];
+
+  for (const player of players) {
+    scores.set(player.id, calculator(player, state));
+  }
+
+  return scores;
+}
+
+/**
+ * Determine title winners for a category.
+ * Returns the player IDs who won/tied, and the bonus each gets.
+ */
+function determineCategoryWinners(
+  category: AchievementCategory,
+  baseScores: Map<string, number>,
+  config?: AchievementsConfig
+): { winners: string[]; bonuses: Map<string, number> } {
+  const titleConfig = CATEGORY_TITLE_CONFIG[category];
+  const bonuses = new Map<string, number>();
+
+  // Convert to array for sorting
+  const entries = Array.from(baseScores.entries());
+
+  if (entries.length === 0) {
+    return { winners: [], bonuses };
+  }
+
+  // Sort by score
+  // For negative categories (Greatest Beating), "winner" is the one with lowest score
+  if (titleConfig.isNegative) {
+    // Sort ascending (most negative first = most wounds)
+    entries.sort((a, b) => a[1] - b[1]);
+  } else {
+    // Sort descending (highest first)
+    entries.sort((a, b) => b[1] - a[1]);
+  }
+
+  const firstEntry = entries[0];
+  if (!firstEntry) {
+    return { winners: [], bonuses };
+  }
+  const bestScore = firstEntry[1];
+
+  // Find all players with the best score (potential ties)
+  const winners = entries
+    .filter(([, score]) => score === bestScore)
+    .map(([playerId]) => playerId);
+
+  const isTied = winners.length > 1;
+
+  // Check for zero-tie exception
+  // For Greatest Knowledge: no bonus if everyone tied at 0
+  // For Greatest Beating: no penalty if everyone tied at 0 wounds (score = 0)
+  // Only applies to ties - a sole winner with 0 score still gets the bonus
+  if (titleConfig.zeroTieException && isTied && bestScore === 0) {
+    return { winners: [], bonuses };
+  }
+
+  // Apply overrides from scenario config if provided
+  let winnerBonus = titleConfig.winnerBonus;
+  let tiedBonus = titleConfig.tiedBonus;
+
+  if (config?.overrides?.[category]) {
+    const override = config.overrides[category];
+    if (override.titleBonus !== undefined) {
+      winnerBonus = override.titleBonus;
+    }
+    if (override.titleTiedBonus !== undefined) {
+      tiedBonus = override.titleTiedBonus;
+    }
+  }
+
+  // Award bonuses
+  for (const winnerId of winners) {
+    bonuses.set(winnerId, isTied ? tiedBonus : winnerBonus);
+  }
+
+  return { winners, bonuses };
+}
+
+/**
+ * Calculate achievement scores for a single category across all players.
+ */
+function calculateCategoryScores(
+  category: AchievementCategory,
+  players: readonly Player[],
+  state: GameState,
+  config: AchievementsConfig
+): Map<string, AchievementCategoryScore> {
+  const result = new Map<string, AchievementCategoryScore>();
+
+  // Calculate base scores for all players
+  const baseScores = calculateCategoryBaseScores(category, players, state);
+
+  // Determine winners (only for competitive mode)
+  let winners: string[] = [];
+  let bonuses = new Map<string, number>();
+
+  if (config.mode === ACHIEVEMENT_MODE_COMPETITIVE && players.length > 1) {
+    const winnerResult = determineCategoryWinners(category, baseScores, config);
+    winners = winnerResult.winners;
+    bonuses = winnerResult.bonuses;
+  }
+
+  // Build result for each player
+  for (const player of players) {
+    const basePoints = baseScores.get(player.id) ?? 0;
+    const titleBonus = bonuses.get(player.id) ?? 0;
+    const hasTitle = winners.includes(player.id);
+    const isTied = hasTitle && winners.length > 1;
+
+    result.set(player.id, {
+      category,
+      basePoints,
+      titleBonus,
+      totalPoints: basePoints + titleBonus,
+      hasTitle,
+      isTied,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Calculate full achievement results for all players.
+ */
+export function calculateAchievementResults(
+  players: readonly Player[],
+  state: GameState,
+  config: AchievementsConfig
+): Map<string, AchievementScoreResult> {
+  const results = new Map<string, AchievementScoreResult>();
+
+  // Initialize results for each player
+  for (const player of players) {
+    results.set(player.id, {
+      categoryScores: [],
+      totalAchievementPoints: 0,
+    });
+  }
+
+  // Calculate each category
+  for (const category of ALL_ACHIEVEMENT_CATEGORIES) {
+    const categoryResults = calculateCategoryScores(
+      category,
+      players,
+      state,
+      config
+    );
+
+    // Add category results to each player's achievement result
+    for (const player of players) {
+      const playerResult = results.get(player.id);
+      const categoryScore = categoryResults.get(player.id);
+
+      if (playerResult && categoryScore) {
+        results.set(player.id, {
+          categoryScores: [...playerResult.categoryScores, categoryScore],
+          totalAchievementPoints:
+            playerResult.totalAchievementPoints + categoryScore.totalPoints,
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Calculate complete final scores for all players.
+ */
+export function calculateFinalScores(
+  state: GameState,
+  scoringConfig: ScenarioScoringConfig
+): FinalScoreResult {
+  const players = state.players;
+  const playerResults: PlayerScoreResult[] = [];
+
+  // Calculate achievement results if enabled
+  let achievementResults: Map<string, AchievementScoreResult> | null = null;
+  if (scoringConfig.achievements.enabled) {
+    achievementResults = calculateAchievementResults(
+      players,
+      state,
+      scoringConfig.achievements
+    );
+  }
+
+  // Build player results
+  for (const player of players) {
+    // Base score (Fame)
+    let baseScore = 0;
+    if (scoringConfig.baseScoreMode === BASE_SCORE_INDIVIDUAL_FAME) {
+      baseScore = player.fame;
+    }
+    // TODO: Handle other base score modes (lowest_fame, victory_points, none)
+
+    // Achievement points
+    const achievements = achievementResults?.get(player.id);
+    const achievementPoints = achievements?.totalAchievementPoints ?? 0;
+
+    // Module points (to be implemented for other scoring modules)
+    const moduleResults: PlayerScoreResult["moduleResults"] = [];
+
+    // Total score
+    const totalScore = baseScore + achievementPoints;
+
+    const playerResult: PlayerScoreResult = {
+      playerId: player.id,
+      baseScore,
+      moduleResults,
+      totalScore,
+    };
+
+    // Only add achievements if they were calculated
+    if (achievements) {
+      playerResults.push({
+        ...playerResult,
+        achievements,
+      });
+    } else {
+      playerResults.push(playerResult);
+    }
+  }
+
+  // Sort by total score descending to determine rankings
+  const sortedResults = [...playerResults].sort(
+    (a, b) => b.totalScore - a.totalScore
+  );
+  const rankings = sortedResults.map((r) => r.playerId);
+
+  // Check for tie
+  const firstResult = sortedResults[0];
+  const secondResult = sortedResults[1];
+  const isTied =
+    sortedResults.length > 1 &&
+    firstResult !== undefined &&
+    secondResult !== undefined &&
+    firstResult.totalScore === secondResult.totalScore;
+
+  return {
+    config: scoringConfig,
+    playerResults,
+    rankings,
+    isTied,
+  };
+}
+
+/**
+ * Create a default scoring config for standard achievements.
+ * Used when scenarios don't specify a custom scoring config.
+ */
+export function createDefaultScoringConfig(
+  isSolo: boolean
+): ScenarioScoringConfig {
+  return {
+    baseScoreMode: BASE_SCORE_INDIVIDUAL_FAME,
+    achievements: {
+      enabled: true,
+      mode: isSolo ? ACHIEVEMENT_MODE_SOLO : ACHIEVEMENT_MODE_COMPETITIVE,
+    },
+    modules: [],
+  };
+}

--- a/packages/core/src/state/GameState.ts
+++ b/packages/core/src/state/GameState.ts
@@ -2,7 +2,7 @@
  * Game state types and management
  */
 
-import type { GamePhase, TimeOfDay, ScenarioId, ScenarioConfig, RoundPhase, TacticId } from "@mage-knight/shared";
+import type { GamePhase, TimeOfDay, ScenarioId, ScenarioConfig, RoundPhase, TacticId, FinalScoreResult } from "@mage-knight/shared";
 import { GAME_PHASE_SETUP, TIME_OF_DAY_DAY, SCENARIO_FIRST_RECONNAISSANCE, ROUND_PHASE_PLAYER_TURNS } from "@mage-knight/shared";
 import { getScenario } from "../data/scenarios/index.js";
 import type { Player } from "../types/player.js";
@@ -106,6 +106,9 @@ export interface GameState {
   readonly finalTurnsRemaining: number | null; // null = not in final turns, number = turns left
   readonly gameEnded: boolean;
   readonly winningPlayerId: string | null; // For competitive scenarios
+
+  // Final scoring results (populated when game ends)
+  readonly finalScoreResult: FinalScoreResult | null;
 }
 
 export function createInitialGameState(
@@ -149,5 +152,6 @@ export function createInitialGameState(
     finalTurnsRemaining: null,
     gameEnded: false,
     winningPlayerId: null,
+    finalScoreResult: null,
   };
 }


### PR DESCRIPTION
## Summary

Implements the Standard Achievements Scoring system for end-game scoring as specified in the Mage Knight rulebook.

### Achievement Categories
- **Greatest Knowledge**: +2 Fame per Spell, +1 per Advanced Action
- **Greatest Loot**: +2 Fame per Artifact, +1 per 2 crystals
- **Greatest Leader**: +1 Fame per unit level (wounded = half, rounded down)
- **Greatest Conqueror**: +2 Fame per shield on keep/mage tower/monastery
- **Greatest Adventurer**: +2 Fame per shield on adventure site
- **Greatest Beating**: -2 Fame per wound in deck (penalty)

### Title Bonuses (Competitive Mode)
- Winner: +3 Fame (+1 if tied)
- Greatest Beating: -3 penalty (-1 if tied)
- Zero-tie exception: no bonus/penalty when tied at 0 for Knowledge/Beating

### Implementation
- New `packages/core/src/engine/scoring/` module with:
  - `achievementCalculators.ts` - Individual category score functions
  - `standardAchievements.ts` - Title bonus logic and orchestration
- Added `finalScoreResult` field to `GameState` for storing complete scoring breakdown
- Integrated into `endRoundCommand.ts` game end flow

### Tests
- 31 new unit tests covering all calculators, title bonuses, ties, and edge cases

Closes #440