### PR TITLE
feat: add Hot Swordsmanship skill effect

### DIFF
--- a/packages/core/src/data/__tests__/skills.test.ts
+++ b/packages/core/src/data/__tests__/skills.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Skill definitions tests
+ *
+ * Tests for skill effects and categories.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  SKILLS,
+  SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+  SKILL_TOVAK_COLD_SWORDSMANSHIP,
+} from "../skills/index.js";
+import {
+  EFFECT_CHOICE,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_MELEE,
+} from "../../types/effectTypes.js";
+import { CARD_CATEGORY_COMBAT } from "../../types/cards.js";
+import { ELEMENT_FIRE } from "@mage-knight/shared";
+import type { ChoiceEffect, GainAttackEffect } from "../../types/cards.js";
+
+describe("Hot Swordsmanship (Arythea)", () => {
+  const skill = SKILLS[SKILL_ARYTHEA_HOT_SWORDSMANSHIP];
+
+  it("should have the correct metadata", () => {
+    expect(skill.id).toBe(SKILL_ARYTHEA_HOT_SWORDSMANSHIP);
+    expect(skill.name).toBe("Hot Swordsmanship");
+    expect(skill.heroId).toBe("arythea");
+    expect(skill.description).toBe("Attack 2 or Fire Attack 2");
+    expect(skill.usageType).toBe("once_per_turn");
+  });
+
+  it("should have Combat category", () => {
+    expect(skill.categories).toBeDefined();
+    expect(skill.categories).toContain(CARD_CATEGORY_COMBAT);
+  });
+
+  it("should have a choice effect", () => {
+    expect(skill.effect).toBeDefined();
+    expect(skill.effect?.type).toBe(EFFECT_CHOICE);
+  });
+
+  it("should offer two attack options", () => {
+    const effect = skill.effect as ChoiceEffect;
+    expect(effect.options).toHaveLength(2);
+  });
+
+  it("should have Attack 2 (physical melee) as first option", () => {
+    const effect = skill.effect as ChoiceEffect;
+    const firstOption = effect.options[0] as GainAttackEffect;
+
+    expect(firstOption.type).toBe(EFFECT_GAIN_ATTACK);
+    expect(firstOption.amount).toBe(2);
+    expect(firstOption.combatType).toBe(COMBAT_TYPE_MELEE);
+    expect(firstOption.element).toBeUndefined(); // Physical attack has no element
+  });
+
+  it("should have Fire Attack 2 as second option", () => {
+    const effect = skill.effect as ChoiceEffect;
+    const secondOption = effect.options[1] as GainAttackEffect;
+
+    expect(secondOption.type).toBe(EFFECT_GAIN_ATTACK);
+    expect(secondOption.amount).toBe(2);
+    expect(secondOption.combatType).toBe(COMBAT_TYPE_MELEE);
+    expect(secondOption.element).toBe(ELEMENT_FIRE);
+  });
+});
+
+describe("Cold Swordsmanship (Tovak) - reference comparison", () => {
+  const skill = SKILLS[SKILL_TOVAK_COLD_SWORDSMANSHIP];
+
+  it("should have the correct metadata", () => {
+    expect(skill.id).toBe(SKILL_TOVAK_COLD_SWORDSMANSHIP);
+    expect(skill.name).toBe("Cold Swordsmanship");
+    expect(skill.heroId).toBe("tovak");
+    expect(skill.description).toBe("Attack 2 or Ice Attack 2");
+    expect(skill.usageType).toBe("once_per_turn");
+  });
+
+  it("should not have effect yet (not implemented)", () => {
+    // Cold Swordsmanship is the equivalent skill for Tovak
+    // but has not been implemented yet - effect should be undefined
+    expect(skill.effect).toBeUndefined();
+  });
+});

--- a/packages/core/src/data/skills/index.ts
+++ b/packages/core/src/data/skills/index.ts
@@ -13,6 +13,9 @@
  */
 
 import type { SkillId } from "@mage-knight/shared";
+import type { CardEffect, CardCategory } from "../../types/cards.js";
+import { CARD_CATEGORY_COMBAT } from "../../types/cards.js";
+import { attack, fireAttack, choice } from "../effectHelpers.js";
 
 // ============================================================================
 // Hero ID type (to avoid circular dependency with hero.ts)
@@ -58,7 +61,10 @@ export interface SkillDefinition {
   readonly description: string;
   /** How often the skill can be used */
   readonly usageType: SkillUsageType;
-  // Note: effect implementation will be added when skills are fully implemented
+  /** The effect to resolve when the skill is used (optional - not all skills are implemented yet) */
+  readonly effect?: CardEffect;
+  /** Skill categories for grouping (e.g., Combat skills can only be used during combat attack phase) */
+  readonly categories?: readonly CardCategory[];
 }
 
 // ============================================================================
@@ -179,6 +185,8 @@ export const SKILLS: Record<SkillId, SkillDefinition> = {
     heroId: "arythea",
     description: "Attack 2 or Fire Attack 2",
     usageType: SKILL_USAGE_ONCE_PER_TURN,
+    effect: choice([attack(2), fireAttack(2)]),
+    categories: [CARD_CATEGORY_COMBAT],
   },
   [SKILL_ARYTHEA_DARK_NEGOTIATION]: {
     id: SKILL_ARYTHEA_DARK_NEGOTIATION,


### PR DESCRIPTION
## Summary
- Implement Arythea's Hot Swordsmanship skill effect: choice between Attack 2 or Fire Attack 2
- Add `effect` and `categories` properties to `SkillDefinition` interface
- Add test coverage for the skill effect structure

## Changes
- **packages/core/src/data/skills/index.ts**: 
  - Import effect helpers (`attack`, `fireAttack`, `choice`) and card types
  - Add optional `effect` and `categories` properties to `SkillDefinition` interface
  - Add effect definition to Hot Swordsmanship: `choice([attack(2), fireAttack(2)])`
  - Set Combat category for attack-phase restriction

- **packages/core/src/data/__tests__/skills.test.ts** (new):
  - Test skill metadata (name, heroId, description, usageType)
  - Test effect is a choice with 2 options
  - Test first option is Attack 2 (physical melee)
  - Test second option is Fire Attack 2 (fire melee)
  - Test skill has Combat category

## Test Plan
- [x] All existing tests pass (1092 tests)
- [x] New skill tests pass (8 tests)
- [x] Build passes
- [x] Lint passes

Closes #312