### PR TITLE
feat: implement Motivation skill system (#308)

### DIFF
--- a/packages/core/src/data/effectHelpers.ts
+++ b/packages/core/src/data/effectHelpers.ts
@@ -60,6 +60,7 @@ import {
   CONDITION_ENEMY_DEFEATED_THIS_COMBAT,
   CONDITION_MANA_USED_THIS_TURN,
   CONDITION_HAS_WOUNDS_IN_HAND,
+  CONDITION_HAS_LOWEST_FAME_OR_SOLO,
 } from "../types/conditions.js";
 
 // === Basic Effect Helpers ===
@@ -325,6 +326,23 @@ export function ifHasWoundsInHand(
 ): ConditionalEffect {
   return conditional(
     { type: CONDITION_HAS_WOUNDS_IN_HAND },
+    thenEffect,
+    elseEffect
+  );
+}
+
+/**
+ * Effect that applies only when the player has the lowest fame (or in solo game).
+ * Used by Motivation skills.
+ * Note: "Lowest" means strictly lower than all other players (ties don't count).
+ * In solo games, the player always qualifies (FAQ S1).
+ */
+export function ifLowestFameOrSolo(
+  thenEffect: CardEffect,
+  elseEffect?: CardEffect
+): ConditionalEffect {
+  return conditional(
+    { type: CONDITION_HAS_LOWEST_FAME_OR_SOLO },
     thenEffect,
     elseEffect
   );

--- a/packages/core/src/engine/__tests__/skillMotivation.test.ts
+++ b/packages/core/src/engine/__tests__/skillMotivation.test.ts
@@ -1,0 +1,666 @@
+/**
+ * Tests for Motivation skill functionality
+ *
+ * Motivation is a flip skill that:
+ * - Draws 2 cards
+ * - Grants mana if player has lowest fame (or in solo)
+ * - Can be used on any player's turn
+ * - Can be used during combat
+ * - Has lockout until end of next turn
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+import { createUseSkillCommand } from "../commands/useSkillCommand.js";
+import { createResetPlayer } from "../commands/endTurn/playerReset.js";
+import {
+  validateSkillCooldown,
+  validateSkillTurnRestriction,
+  validateSkillNotDuringTactics,
+  validateSkillCombatRestriction,
+} from "../validators/skillValidators.js";
+import { getSkillOptions, getOutOfTurnSkillOptions } from "../validActions/skills.js";
+import { evaluateCondition } from "../effects/conditionEvaluator.js";
+import {
+  SKILL_TOVAK_MOTIVATION,
+  SKILL_WOLFHAWK_MOTIVATION,
+} from "../../data/skills/index.js";
+import {
+  CONDITION_HAS_LOWEST_FAME_OR_SOLO,
+} from "../../types/conditions.js";
+import {
+  CARD_MARCH,
+  ROUND_PHASE_TACTICS_SELECTION,
+  ROUND_PHASE_PLAYER_TURNS,
+  USE_SKILL_ACTION,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+
+describe("Motivation Skill", () => {
+  describe("Effect: Draws 2 cards", () => {
+    it("should draw 2 cards when skill is used", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        hand: [CARD_MARCH],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH, "card3" as typeof CARD_MARCH],
+        fame: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+
+      // Player should have drawn 2 cards
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.hand.length).toBe(3); // 1 original + 2 drawn
+      expect(updatedPlayer?.deck.length).toBe(1); // 3 - 2 = 1
+    });
+
+    it("should not reshuffle if deck is empty", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        hand: [CARD_MARCH],
+        deck: ["card1" as typeof CARD_MARCH], // Only 1 card in deck
+        discard: ["discard1" as typeof CARD_MARCH, "discard2" as typeof CARD_MARCH],
+        fame: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+
+      // Player should only have drawn 1 card (no reshuffle)
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.hand.length).toBe(2); // 1 original + 1 drawn
+      expect(updatedPlayer?.deck.length).toBe(0);
+      expect(updatedPlayer?.discard.length).toBe(2); // Discard unchanged
+    });
+  });
+
+  describe("Effect: Lowest fame bonus", () => {
+    it("should grant mana if player has strictly lowest fame in multiplayer", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        fame: 0, // Lowest fame
+        hand: [],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH],
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        fame: 10, // Higher fame
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+      // Tovak should get blue mana
+      expect(updatedPlayer?.pureMana.some((t) => t.color === "blue")).toBe(true);
+    });
+
+    it("should NOT grant mana if fame is tied with another player", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        fame: 5, // Tied fame
+        hand: [],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH],
+        pureMana: [],
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        fame: 5, // Tied fame
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+      // No mana should be granted (tied is not "lowest")
+      expect(updatedPlayer?.pureMana.filter((t) => t.color === "blue").length).toBe(0);
+    });
+
+    it("should always grant mana in solo game", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        fame: 100, // High fame doesn't matter in solo
+        hand: [],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH],
+        pureMana: [],
+      });
+
+      const state = createTestGameState({
+        players: [player], // Solo game
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+      // Solo always gets mana
+      expect(updatedPlayer?.pureMana.some((t) => t.color === "blue")).toBe(true);
+    });
+
+    it("should grant fame instead of mana for Wolfhawk", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_MOTIVATION],
+        fame: 0,
+        hand: [],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH],
+        pureMana: [],
+      });
+
+      const state = createTestGameState({
+        players: [player], // Solo game
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_WOLFHAWK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+      // Wolfhawk gets +1 fame instead of mana
+      expect(updatedPlayer?.fame).toBe(1);
+      expect(updatedPlayer?.pureMana.length).toBe(0);
+    });
+  });
+
+  describe("Condition: HasLowestFameOrSolo", () => {
+    it("should return true in solo game", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        fame: 100,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      const result = evaluateCondition(
+        state,
+        "player1",
+        { type: CONDITION_HAS_LOWEST_FAME_OR_SOLO }
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("should return true when player has strictly lowest fame", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        fame: 5,
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        fame: 10,
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const result = evaluateCondition(
+        state,
+        "player1",
+        { type: CONDITION_HAS_LOWEST_FAME_OR_SOLO }
+      );
+
+      expect(result).toBe(true);
+    });
+
+    it("should return false when fame is tied", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        fame: 10,
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        fame: 10,
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+      });
+
+      const result = evaluateCondition(
+        state,
+        "player1",
+        { type: CONDITION_HAS_LOWEST_FAME_OR_SOLO }
+      );
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("Timing: Cannot use during tactics selection", () => {
+    it("should fail validation during tactics phase", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        roundPhase: ROUND_PHASE_TACTICS_SELECTION,
+        availableTactics: [],
+        tacticsSelectionOrder: ["player1"],
+        currentTacticSelector: "player1",
+      });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      } as const;
+
+      const result = validateSkillNotDuringTactics(state, "player1", action);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe("SKILL_NOT_USABLE_DURING_TACTICS");
+      }
+    });
+
+    it("should not show skills in validActions during tactics phase", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        roundPhase: ROUND_PHASE_TACTICS_SELECTION,
+      });
+
+      const options = getSkillOptions(state, player, false);
+
+      expect(options).toBeUndefined();
+    });
+  });
+
+  describe("Timing: Can use during combat", () => {
+    it("should pass combat restriction validation", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: {
+          enemies: [],
+          phase: "RANGED_SIEGE",
+          woundsThisCombat: 0,
+          attacksThisPhase: 0,
+          fameGained: 0,
+          isAtFortifiedSite: false,
+          unitsAllowed: true,
+          nightManaRules: false,
+          assaultOrigin: null,
+          combatHexCoord: null,
+          allDamageBlockedThisPhase: false,
+          discardEnemiesOnFailure: false,
+          pendingDamage: {},
+          pendingBlock: {},
+        },
+      });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      } as const;
+
+      const result = validateSkillCombatRestriction(state, "player1", action);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should show Motivation in skill options during combat", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: {
+          enemies: [],
+          phase: "RANGED_SIEGE",
+          woundsThisCombat: 0,
+          attacksThisPhase: 0,
+          fameGained: 0,
+          isAtFortifiedSite: false,
+          unitsAllowed: true,
+          nightManaRules: false,
+          assaultOrigin: null,
+          combatHexCoord: null,
+          allDamageBlockedThisPhase: false,
+          discardEnemiesOnFailure: false,
+          pendingDamage: {},
+          pendingBlock: {},
+        },
+      });
+
+      const options = getSkillOptions(state, player, true);
+
+      expect(options?.usableSkills.some((s) => s.skillId === SKILL_TOVAK_MOTIVATION)).toBe(true);
+    });
+  });
+
+  describe("Timing: Can use on other players' turns", () => {
+    it("should pass turn restriction validation when not player's turn", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 1, // Player 2's turn
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      } as const;
+
+      // Player 1 tries to use Motivation on Player 2's turn
+      const result = validateSkillTurnRestriction(state, "player1", action);
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should return out-of-turn skill options for player not on their turn", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+      });
+
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 1, // Player 2's turn
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      // Player 1 should have out-of-turn skill options
+      const options = getOutOfTurnSkillOptions(state, player1, false);
+
+      expect(options?.usableSkills.some((s) => s.skillId === SKILL_TOVAK_MOTIVATION)).toBe(true);
+    });
+  });
+
+  describe("Cooldown: Lockout until end of next turn", () => {
+    it("should add skill to activeUntilNextTurn when used", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        hand: [],
+        deck: ["card1" as typeof CARD_MARCH, "card2" as typeof CARD_MARCH],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+      expect(updatedPlayer?.skillCooldowns.usedThisRound).toContain(SKILL_TOVAK_MOTIVATION);
+      expect(updatedPlayer?.skillCooldowns.usedThisTurn).toContain(SKILL_TOVAK_MOTIVATION);
+      expect(updatedPlayer?.skillCooldowns.activeUntilNextTurn).toContain(SKILL_TOVAK_MOTIVATION);
+    });
+
+    it("should fail validation when skill is in activeUntilNextTurn", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [SKILL_TOVAK_MOTIVATION], // Locked
+        },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      } as const;
+
+      const result = validateSkillCooldown(state, "player1", action);
+
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe("SKILL_LOCKED_UNTIL_NEXT_TURN");
+      }
+    });
+
+    it("should keep skill locked after current turn ends (used this turn)", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_TOVAK_MOTIVATION],
+          usedThisTurn: [SKILL_TOVAK_MOTIVATION], // Used this turn
+          usedThisCombat: [],
+          activeUntilNextTurn: [SKILL_TOVAK_MOTIVATION],
+        },
+        hand: [],
+        deck: [],
+        discard: [],
+        playArea: [],
+      });
+
+      const cardFlow = {
+        playArea: [] as typeof CARD_MARCH[],
+        hand: [] as typeof CARD_MARCH[],
+        deck: [] as typeof CARD_MARCH[],
+        discard: [] as typeof CARD_MARCH[],
+      };
+
+      const resetPlayer = createResetPlayer(player, cardFlow);
+
+      // Skill should still be in activeUntilNextTurn (lockout persists)
+      expect(resetPlayer.skillCooldowns.activeUntilNextTurn).toContain(SKILL_TOVAK_MOTIVATION);
+      // But usedThisTurn should be cleared
+      expect(resetPlayer.skillCooldowns.usedThisTurn).not.toContain(SKILL_TOVAK_MOTIVATION);
+    });
+
+    it("should unlock skill after next turn ends (not used that turn)", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [], // New round, this was cleared
+          usedThisTurn: [], // NOT used this turn (next turn)
+          usedThisCombat: [],
+          activeUntilNextTurn: [SKILL_TOVAK_MOTIVATION], // Still locked from previous turn
+        },
+        hand: [],
+        deck: [],
+        discard: [],
+        playArea: [],
+      });
+
+      const cardFlow = {
+        playArea: [] as typeof CARD_MARCH[],
+        hand: [] as typeof CARD_MARCH[],
+        deck: [] as typeof CARD_MARCH[],
+        discard: [] as typeof CARD_MARCH[],
+      };
+
+      const resetPlayer = createResetPlayer(player, cardFlow);
+
+      // Skill should be cleared from activeUntilNextTurn (lockout expired)
+      expect(resetPlayer.skillCooldowns.activeUntilNextTurn).not.toContain(SKILL_TOVAK_MOTIVATION);
+    });
+  });
+
+  describe("ValidActions integration", () => {
+    it("should not show skill in options when on cooldown", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_TOVAK_MOTIVATION],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [SKILL_TOVAK_MOTIVATION],
+        },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const options = getSkillOptions(state, player, false);
+
+      // Skill should not be in usable skills
+      expect(options?.usableSkills.some((s) => s.skillId === SKILL_TOVAK_MOTIVATION)).toBeFalsy();
+    });
+
+    it("should show skill in options when available", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        turnOrder: ["player1"],
+        currentPlayerIndex: 0,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+      });
+
+      const options = getSkillOptions(state, player, false);
+
+      expect(options?.usableSkills.some((s) => s.skillId === SKILL_TOVAK_MOTIVATION)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -54,6 +54,9 @@ export const BURN_MONASTERY_COMMAND = "BURN_MONASTERY" as const;
 // Plunder village command
 export const PLUNDER_VILLAGE_COMMAND = "PLUNDER_VILLAGE" as const;
 
+// Skill usage command
+export const USE_SKILL_COMMAND = "USE_SKILL" as const;
+
 // Reserved / upcoming command types used by undo checkpointing.
 export const DRAW_ENEMY_COMMAND = "DRAW_ENEMY" as const;
 export const DRAW_CARD_COMMAND = "DRAW_CARD" as const;

--- a/packages/core/src/engine/commands/endTurn/playerReset.ts
+++ b/packages/core/src/engine/commands/endTurn/playerReset.ts
@@ -48,5 +48,18 @@ export function createResetPlayer(
       manaStealUsedThisTurn: false,
       manaSearchUsedThisTurn: false,
     },
+    // Skill cooldown resets
+    // - usedThisTurn: cleared so once-per-turn skills can be used next turn
+    // - activeUntilNextTurn: only clear skills NOT used this turn (lockout expired)
+    //   Skills used THIS turn stay locked until end of NEXT turn
+    skillCooldowns: {
+      ...player.skillCooldowns,
+      usedThisTurn: [],
+      // Only clear skills from activeUntilNextTurn that were NOT used this turn
+      // Skills used this turn have their lockout persist until next turn ends
+      activeUntilNextTurn: player.skillCooldowns.activeUntilNextTurn.filter(
+        (skillId) => player.skillCooldowns.usedThisTurn.includes(skillId)
+      ),
+    },
   };
 }

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -57,6 +57,7 @@ import {
   DEBUG_TRIGGER_LEVEL_UP_ACTION,
   BURN_MONASTERY_ACTION,
   PLUNDER_VILLAGE_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -136,6 +137,9 @@ export {
   createDebugTriggerLevelUpCommandFromAction,
 } from "./debug.js";
 
+// Skill factories
+export { createUseSkillCommandFromAction } from "./skills.js";
+
 // Import all factories for the registry
 import {
   createMoveCommandFromAction,
@@ -202,6 +206,8 @@ import {
   createDebugTriggerLevelUpCommandFromAction,
 } from "./debug.js";
 
+import { createUseSkillCommandFromAction } from "./skills.js";
+
 import type { CommandFactory } from "./types.js";
 
 /**
@@ -250,4 +256,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [DEBUG_TRIGGER_LEVEL_UP_ACTION]: createDebugTriggerLevelUpCommandFromAction,
   [BURN_MONASTERY_ACTION]: createBurnMonasteryCommandFromAction,
   [PLUNDER_VILLAGE_ACTION]: createPlunderVillageCommandFromAction,
+  // Skill actions
+  [USE_SKILL_ACTION]: createUseSkillCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/skills.ts
+++ b/packages/core/src/engine/commands/factories/skills.ts
@@ -1,0 +1,44 @@
+/**
+ * Skill Command Factories
+ *
+ * Factory functions that translate skill-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/skills
+ *
+ * @remarks Factories in this module:
+ * - createUseSkillCommandFromAction - Activate a skill
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { PlayerAction, SkillId } from "@mage-knight/shared";
+import { USE_SKILL_ACTION } from "@mage-knight/shared";
+import { createUseSkillCommand } from "../useSkillCommand.js";
+
+/**
+ * Helper to get skill id from use skill action.
+ */
+function getSkillIdFromAction(action: PlayerAction): SkillId | null {
+  if (action.type === USE_SKILL_ACTION && "skillId" in action) {
+    return action.skillId;
+  }
+  return null;
+}
+
+/**
+ * Use skill command factory.
+ * Creates a command to activate a skill.
+ */
+export const createUseSkillCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) return null;
+
+  return createUseSkillCommand({
+    playerId,
+    skillId,
+  });
+};

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -1,0 +1,145 @@
+/**
+ * Use skill command - handles activating a skill with undo support
+ *
+ * Skills are activated differently from cards:
+ * - No mana required (effects are self-contained)
+ * - Cooldown tracking (usedThisRound, usedThisTurn, activeUntilNextTurn)
+ * - Some skills can be used on other players' turns (canUseOutOfTurn)
+ */
+
+import type { Command, CommandResult } from "../commands.js";
+import type { GameState } from "../../state/GameState.js";
+import type { SkillCooldowns } from "../../types/player.js";
+import type { SkillId, GameEvent } from "@mage-knight/shared";
+import { createSkillUsedEvent } from "@mage-knight/shared";
+import { resolveEffect } from "../effects/index.js";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_ONCE_PER_ROUND,
+} from "../../data/skills/index.js";
+import { USE_SKILL_COMMAND } from "./commandTypes.js";
+
+export { USE_SKILL_COMMAND };
+
+export interface UseSkillCommandParams {
+  readonly playerId: string;
+  readonly skillId: SkillId;
+}
+
+/**
+ * Create a use skill command.
+ *
+ * Executes the skill's effect and updates cooldown tracking.
+ */
+export function createUseSkillCommand(params: UseSkillCommandParams): Command {
+  // Store the previous cooldown state for undo
+  let previousCooldowns: SkillCooldowns | null = null;
+
+  return {
+    type: USE_SKILL_COMMAND,
+    playerId: params.playerId,
+    isReversible: true, // Can undo skill usage (before irreversible action)
+
+    execute(state: GameState): CommandResult {
+      const skill = getSkillDefinition(params.skillId);
+      if (!skill) {
+        throw new Error(`Skill not found: ${params.skillId}`);
+      }
+
+      if (!skill.effect) {
+        throw new Error(`Skill has no effect: ${params.skillId}`);
+      }
+
+      const playerIndex = state.players.findIndex((p) => p.id === params.playerId);
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error(`Player not found at index: ${playerIndex}`);
+      }
+
+      // Store for undo
+      previousCooldowns = player.skillCooldowns;
+
+      // Resolve skill effect
+      const effectResult = resolveEffect(state, params.playerId, skill.effect, undefined);
+      let newState = effectResult.state;
+
+      // Update skill cooldowns based on usage type
+      const players = [...newState.players];
+      const updatedPlayerState = players[playerIndex];
+      if (!updatedPlayerState) {
+        throw new Error(`Player not found after effect resolution: ${params.playerId}`);
+      }
+
+      // For once-per-round skills like Motivation:
+      // - Add to usedThisRound (prevents use for rest of round)
+      // - Add to activeUntilNextTurn (provides lockout until next turn ends)
+      // - Add to usedThisTurn (tracks that skill was used THIS turn, for lockout expiry logic)
+      // For once-per-turn skills:
+      // - Add to usedThisTurn only
+      const newCooldowns: SkillCooldowns = {
+        ...updatedPlayerState.skillCooldowns,
+        usedThisRound:
+          skill.usageType === SKILL_USAGE_ONCE_PER_ROUND
+            ? [...updatedPlayerState.skillCooldowns.usedThisRound, params.skillId]
+            : updatedPlayerState.skillCooldowns.usedThisRound,
+        // Always add to usedThisTurn for lockout tracking purposes
+        usedThisTurn: [...updatedPlayerState.skillCooldowns.usedThisTurn, params.skillId],
+        // For once-per-round skills, also add to activeUntilNextTurn for the lockout
+        activeUntilNextTurn:
+          skill.usageType === SKILL_USAGE_ONCE_PER_ROUND
+            ? [...updatedPlayerState.skillCooldowns.activeUntilNextTurn, params.skillId]
+            : updatedPlayerState.skillCooldowns.activeUntilNextTurn,
+        usedThisCombat: updatedPlayerState.skillCooldowns.usedThisCombat,
+      };
+
+      players[playerIndex] = {
+        ...updatedPlayerState,
+        skillCooldowns: newCooldowns,
+      };
+
+      newState = { ...newState, players };
+
+      // Build events
+      const events: GameEvent[] = [
+        createSkillUsedEvent(params.playerId, params.skillId),
+        // Include any events from the effect resolution
+        // Note: effectResult doesn't return events, effects emit via state changes
+        // The effect description is available in effectResult.description
+      ];
+
+      return {
+        state: newState,
+        events,
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      // Restore previous cooldown state
+      if (!previousCooldowns) {
+        return { state, events: [] };
+      }
+
+      const playerIndex = state.players.findIndex((p) => p.id === params.playerId);
+      if (playerIndex === -1) {
+        return { state, events: [] };
+      }
+
+      const players = [...state.players];
+      const player = players[playerIndex];
+      if (!player) {
+        return { state, events: [] };
+      }
+
+      players[playerIndex] = {
+        ...player,
+        skillCooldowns: previousCooldowns,
+      };
+
+      return { state: { ...state, players }, events: [] };
+    },
+  };
+}

--- a/packages/core/src/engine/effects/conditionEvaluator.ts
+++ b/packages/core/src/engine/effects/conditionEvaluator.ts
@@ -16,6 +16,7 @@ import {
   CONDITION_ENEMY_DEFEATED_THIS_COMBAT,
   CONDITION_MANA_USED_THIS_TURN,
   CONDITION_HAS_WOUNDS_IN_HAND,
+  CONDITION_HAS_LOWEST_FAME_OR_SOLO,
 } from "../../types/conditions.js";
 import { CARD_WOUND, hexKey } from "@mage-knight/shared";
 
@@ -72,6 +73,20 @@ export function evaluateCondition(
 
     case CONDITION_HAS_WOUNDS_IN_HAND:
       return player.hand.some((c) => c === CARD_WOUND);
+
+    case CONDITION_HAS_LOWEST_FAME_OR_SOLO: {
+      // Solo game - always qualifies (FAQ S1)
+      if (state.players.length === 1) {
+        return true;
+      }
+
+      // Must be strictly lowest fame (not tied)
+      const otherPlayersFame = state.players
+        .filter((p) => p.id !== playerId)
+        .map((p) => p.fame);
+
+      return otherPlayersFame.every((fame) => player.fame < fame);
+    }
 
     default:
       // Exhaustive check - TypeScript ensures all cases are handled

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -1,0 +1,150 @@
+/**
+ * Skill valid actions computation.
+ *
+ * Determines which skills a player can use in the current game state.
+ * Handles both normal skill usage and out-of-turn skills (like Motivation).
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { SkillOptions, UsableSkill, SkillId } from "@mage-knight/shared";
+import {
+  GAME_PHASE_ROUND,
+  ROUND_PHASE_PLAYER_TURNS,
+  ROUND_PHASE_TACTICS_SELECTION,
+} from "@mage-knight/shared";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_USAGE_ONCE_PER_TURN,
+} from "../../data/skills/index.js";
+
+/**
+ * Check if a skill is on cooldown.
+ */
+function isSkillOnCooldown(
+  player: Player,
+  skillId: SkillId,
+  usageType: string
+): boolean {
+  const cooldowns = player.skillCooldowns;
+
+  // Check if locked until next turn (Motivation lockout)
+  if (cooldowns.activeUntilNextTurn.includes(skillId)) {
+    return true;
+  }
+
+  // Check usage-based cooldowns
+  if (usageType === SKILL_USAGE_ONCE_PER_ROUND && cooldowns.usedThisRound.includes(skillId)) {
+    return true;
+  }
+
+  if (usageType === SKILL_USAGE_ONCE_PER_TURN && cooldowns.usedThisTurn.includes(skillId)) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Get skill options for a player during their own turn.
+ * This includes all skills with effects that aren't on cooldown.
+ *
+ * @param state - Current game state
+ * @param player - The player to get skill options for
+ * @param inCombat - Whether the player is in combat
+ */
+export function getSkillOptions(
+  state: GameState,
+  player: Player,
+  inCombat: boolean
+): SkillOptions | undefined {
+  // Can't use skills during tactics selection
+  if (
+    state.phase === GAME_PHASE_ROUND &&
+    state.roundPhase === ROUND_PHASE_TACTICS_SELECTION
+  ) {
+    return undefined;
+  }
+
+  const usableSkills: UsableSkill[] = [];
+
+  for (const skillId of player.skills) {
+    const skill = getSkillDefinition(skillId);
+    if (!skill) continue;
+
+    // Skip skills without effects (passive skills)
+    if (!skill.effect) continue;
+
+    // Check combat restriction
+    if (inCombat && !skill.canUseInCombat) continue;
+
+    // Check cooldown
+    if (isSkillOnCooldown(player, skillId, skill.usageType)) continue;
+
+    usableSkills.push({
+      skillId,
+      name: skill.name,
+      description: skill.description,
+    });
+  }
+
+  if (usableSkills.length === 0) {
+    return undefined;
+  }
+
+  return { usableSkills };
+}
+
+/**
+ * Get out-of-turn skill options for a player.
+ * Only returns skills that can be used on other players' turns.
+ *
+ * @param state - Current game state
+ * @param player - The player to get skill options for
+ * @param inCombat - Whether combat is active
+ */
+export function getOutOfTurnSkillOptions(
+  state: GameState,
+  player: Player,
+  inCombat: boolean
+): SkillOptions | undefined {
+  // Can only use out-of-turn skills during player turns phase
+  if (
+    state.phase !== GAME_PHASE_ROUND ||
+    state.roundPhase !== ROUND_PHASE_PLAYER_TURNS
+  ) {
+    return undefined;
+  }
+
+  const usableSkills: UsableSkill[] = [];
+
+  for (const skillId of player.skills) {
+    const skill = getSkillDefinition(skillId);
+    if (!skill) continue;
+
+    // Skip skills without effects (passive skills)
+    if (!skill.effect) continue;
+
+    // Only include skills that can be used out of turn
+    if (!skill.canUseOutOfTurn) continue;
+
+    // Check combat restriction
+    if (inCombat && !skill.canUseInCombat) continue;
+
+    // Check cooldown
+    if (isSkillOnCooldown(player, skillId, skill.usageType)) continue;
+
+    usableSkills.push({
+      skillId,
+      name: skill.name,
+      description: skill.description,
+    });
+  }
+
+  if (usableSkills.length === 0) {
+    return undefined;
+  }
+
+  return { usableSkills };
+}

--- a/packages/core/src/engine/validators/index.ts
+++ b/packages/core/src/engine/validators/index.ts
@@ -41,6 +41,7 @@ import {
   DEBUG_TRIGGER_LEVEL_UP_ACTION,
   BURN_MONASTERY_ACTION,
   PLUNDER_VILLAGE_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 import { valid } from "./types.js";
 
@@ -266,6 +267,17 @@ import {
   validateNotAlreadyPlundered,
   validateBeforeTurnForPlunder,
 } from "./plunderVillageValidators.js";
+
+// Skill validators
+import {
+  validateSkillExists,
+  validateSkillOwned,
+  validateSkillHasEffect,
+  validateSkillCooldown,
+  validateSkillCombatRestriction,
+  validateSkillTurnRestriction,
+  validateSkillNotDuringTactics,
+} from "./skillValidators.js";
 
 // TODO: RULES LIMITATION - Immediate Choice Resolution
 // =====================================================
@@ -626,6 +638,21 @@ const validatorRegistry: Record<string, Validator[]> = {
     validateBeforeTurnForPlunder, // Must plunder before taking any action or moving
     validateAtVillage,
     validateNotAlreadyPlundered,
+  ],
+  [USE_SKILL_ACTION]: [
+    // Note: validateIsPlayersTurn is intentionally NOT included here
+    // because skills with canUseOutOfTurn=true (like Motivation) can be used on any player's turn.
+    // The turn check is handled by validateSkillTurnRestriction which considers the skill's properties.
+    validateRoundPhase,
+    validateSkillNotDuringTactics, // Cannot use before tactic cards drawn (FAQ S6)
+    validateNoChoicePending, // Must resolve pending choice first
+    validateNoPendingLevelUpRewards, // Must select level up rewards first
+    validateSkillExists,
+    validateSkillOwned,
+    validateSkillHasEffect,
+    validateSkillCooldown,
+    validateSkillTurnRestriction, // Checks turn ownership based on skill properties
+    validateSkillCombatRestriction,
   ],
 };
 

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -1,0 +1,202 @@
+/**
+ * Skill usage validators
+ *
+ * Validates USE_SKILL_ACTION against game rules:
+ * - Player must own the skill
+ * - Skill must have an executable effect
+ * - Skill must not be on cooldown
+ * - Turn/combat restrictions must be met
+ */
+
+import type { Validator } from "./types.js";
+import { invalid, valid } from "./types.js";
+import { USE_SKILL_ACTION, type UseSkillAction, ROUND_PHASE_TACTICS_SELECTION } from "@mage-knight/shared";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_USAGE_ONCE_PER_TURN,
+} from "../../data/skills/index.js";
+import {
+  PLAYER_NOT_FOUND,
+  SKILL_NOT_FOUND,
+  SKILL_NOT_OWNED,
+  SKILL_HAS_NO_EFFECT,
+  SKILL_ALREADY_USED_THIS_ROUND,
+  SKILL_ALREADY_USED_THIS_TURN,
+  SKILL_LOCKED_UNTIL_NEXT_TURN,
+  SKILL_NOT_USABLE_IN_COMBAT,
+  SKILL_NOT_USABLE_OUT_OF_TURN,
+  SKILL_NOT_USABLE_DURING_TACTICS,
+} from "./validationCodes.js";
+
+/**
+ * Validates that the skill exists in the game data.
+ */
+export const validateSkillExists: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const skillAction = action as UseSkillAction;
+  const skillDef = getSkillDefinition(skillAction.skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, `Skill ${skillAction.skillId} not found`);
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that the player owns the skill they are trying to use.
+ */
+export const validateSkillOwned: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const skillAction = action as UseSkillAction;
+  if (!player.skills.includes(skillAction.skillId)) {
+    return invalid(SKILL_NOT_OWNED, "You do not own this skill");
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that the skill has an effect to execute.
+ * Passive skills have no effect property and cannot be "used".
+ */
+export const validateSkillHasEffect: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const skillAction = action as UseSkillAction;
+  const skillDef = getSkillDefinition(skillAction.skillId);
+  if (!skillDef?.effect) {
+    return invalid(SKILL_HAS_NO_EFFECT, "This skill has no active effect");
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that the skill is not on cooldown.
+ * Checks usedThisRound, usedThisTurn, and activeUntilNextTurn.
+ */
+export const validateSkillCooldown: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const skillAction = action as UseSkillAction;
+  const skillDef = getSkillDefinition(skillAction.skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  const cooldowns = player.skillCooldowns;
+
+  // Check if skill is locked (used this round, not yet reset)
+  if (cooldowns.activeUntilNextTurn.includes(skillAction.skillId)) {
+    return invalid(
+      SKILL_LOCKED_UNTIL_NEXT_TURN,
+      "Skill is locked until the start of your next turn"
+    );
+  }
+
+  // Check usage type cooldowns
+  if (skillDef.usageType === SKILL_USAGE_ONCE_PER_ROUND) {
+    if (cooldowns.usedThisRound.includes(skillAction.skillId)) {
+      return invalid(
+        SKILL_ALREADY_USED_THIS_ROUND,
+        "Skill has already been used this round"
+      );
+    }
+  } else if (skillDef.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+    if (cooldowns.usedThisTurn.includes(skillAction.skillId)) {
+      return invalid(
+        SKILL_ALREADY_USED_THIS_TURN,
+        "Skill has already been used this turn"
+      );
+    }
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that the skill can be used in the current combat context.
+ * Skills with canUseInCombat=false cannot be used during combat.
+ */
+export const validateSkillCombatRestriction: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const skillAction = action as UseSkillAction;
+  const skillDef = getSkillDefinition(skillAction.skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  const inCombat = state.combat !== null;
+
+  if (inCombat && !skillDef.canUseInCombat) {
+    return invalid(
+      SKILL_NOT_USABLE_IN_COMBAT,
+      "This skill cannot be used during combat"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validates turn ownership for skill usage.
+ * Most skills require it to be the player's turn.
+ * Skills with canUseOutOfTurn=true (like Motivation) can be used on any player's turn.
+ */
+export const validateSkillTurnRestriction: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  const skillAction = action as UseSkillAction;
+  const skillDef = getSkillDefinition(skillAction.skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  // Get the current player from turn order
+  const currentPlayerId = state.turnOrder[state.currentPlayerIndex];
+  const isPlayersTurn = currentPlayerId === playerId;
+
+  // If it's the player's turn, always allowed
+  if (isPlayersTurn) return valid();
+
+  // If not player's turn, check if skill allows out-of-turn usage
+  if (!skillDef.canUseOutOfTurn) {
+    return invalid(
+      SKILL_NOT_USABLE_OUT_OF_TURN,
+      "This skill can only be used on your turn"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that the player is not in tactics selection phase.
+ * Skills cannot be used before tactic cards are drawn (FAQ S6).
+ */
+export const validateSkillNotDuringTactics: Validator = (state, playerId, action) => {
+  if (action.type !== USE_SKILL_ACTION) return valid();
+
+  if (state.roundPhase === ROUND_PHASE_TACTICS_SELECTION) {
+    return invalid(
+      SKILL_NOT_USABLE_DURING_TACTICS,
+      "Cannot use skills during tactics selection"
+    );
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -200,6 +200,17 @@ export const SKILL_ALREADY_OWNED = "SKILL_ALREADY_OWNED" as const;
 export const DEV_MODE_REQUIRED = "DEV_MODE_REQUIRED" as const;
 export const NO_PENDING_LEVEL_UPS = "NO_PENDING_LEVEL_UPS" as const;
 
+// Skill usage validation codes
+export const SKILL_NOT_FOUND = "SKILL_NOT_FOUND" as const;
+export const SKILL_NOT_OWNED = "SKILL_NOT_OWNED" as const;
+export const SKILL_HAS_NO_EFFECT = "SKILL_HAS_NO_EFFECT" as const;
+export const SKILL_ALREADY_USED_THIS_ROUND = "SKILL_ALREADY_USED_THIS_ROUND" as const;
+export const SKILL_ALREADY_USED_THIS_TURN = "SKILL_ALREADY_USED_THIS_TURN" as const;
+export const SKILL_LOCKED_UNTIL_NEXT_TURN = "SKILL_LOCKED_UNTIL_NEXT_TURN" as const;
+export const SKILL_NOT_USABLE_IN_COMBAT = "SKILL_NOT_USABLE_IN_COMBAT" as const;
+export const SKILL_NOT_USABLE_OUT_OF_TURN = "SKILL_NOT_USABLE_OUT_OF_TURN" as const;
+export const SKILL_NOT_USABLE_DURING_TACTICS = "SKILL_NOT_USABLE_DURING_TACTICS" as const;
+
 export type ValidationErrorCode =
   | typeof NOT_YOUR_TURN
   | typeof WRONG_PHASE
@@ -359,4 +370,14 @@ export type ValidationErrorCode =
   | typeof SKILL_ALREADY_OWNED
   // Debug validation
   | typeof DEV_MODE_REQUIRED
-  | typeof NO_PENDING_LEVEL_UPS;
+  | typeof NO_PENDING_LEVEL_UPS
+  // Skill usage validation
+  | typeof SKILL_NOT_FOUND
+  | typeof SKILL_NOT_OWNED
+  | typeof SKILL_HAS_NO_EFFECT
+  | typeof SKILL_ALREADY_USED_THIS_ROUND
+  | typeof SKILL_ALREADY_USED_THIS_TURN
+  | typeof SKILL_LOCKED_UNTIL_NEXT_TURN
+  | typeof SKILL_NOT_USABLE_IN_COMBAT
+  | typeof SKILL_NOT_USABLE_OUT_OF_TURN
+  | typeof SKILL_NOT_USABLE_DURING_TACTICS;

--- a/packages/core/src/types/conditions.ts
+++ b/packages/core/src/types/conditions.ts
@@ -17,6 +17,7 @@ export const CONDITION_BLOCKED_SUCCESSFULLY = "blocked_successfully" as const;
 export const CONDITION_ENEMY_DEFEATED_THIS_COMBAT = "enemy_defeated_this_combat" as const;
 export const CONDITION_MANA_USED_THIS_TURN = "mana_used_this_turn" as const;
 export const CONDITION_HAS_WOUNDS_IN_HAND = "has_wounds_in_hand" as const;
+export const CONDITION_HAS_LOWEST_FAME_OR_SOLO = "has_lowest_fame_or_solo" as const;
 
 // === Condition Interfaces ===
 
@@ -56,6 +57,10 @@ export interface HasWoundsInHandCondition {
   readonly type: typeof CONDITION_HAS_WOUNDS_IN_HAND;
 }
 
+export interface HasLowestFameOrSoloCondition {
+  readonly type: typeof CONDITION_HAS_LOWEST_FAME_OR_SOLO;
+}
+
 // === Union Type ===
 
 export type EffectCondition =
@@ -66,4 +71,5 @@ export type EffectCondition =
   | BlockedSuccessfullyCondition
   | EnemyDefeatedThisCombatCondition
   | ManaUsedThisTurnCondition
-  | HasWoundsInHandCondition;
+  | HasWoundsInHandCondition
+  | HasLowestFameOrSoloCondition;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -226,6 +226,9 @@ export type {
   DeepMineOptions,
   // Level up rewards options
   LevelUpRewardsOptions,
+  // Skill options
+  SkillOptions,
+  UsableSkill,
 } from "./types/validActions.js";
 
 // Shared value constants (sub-unions)

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -78,6 +78,9 @@ export interface ValidActions {
 
   /** Level up reward options (when pending level up rewards exist) */
   readonly levelUpRewards: LevelUpRewardsOptions | undefined;
+
+  /** Skill usage options */
+  readonly skills: SkillOptions | undefined;
 }
 
 // ============================================================================
@@ -682,4 +685,29 @@ export interface LevelUpRewardsOptions {
   readonly commonPoolSkills: readonly SkillId[];
   /** Available advanced action cards in the offer */
   readonly availableAAs: readonly CardId[];
+}
+
+// ============================================================================
+// Skills
+// ============================================================================
+
+/**
+ * Options for using skills.
+ * Only present when there are usable skills available.
+ */
+export interface SkillOptions {
+  /** Skills that can be used right now */
+  readonly usableSkills: readonly UsableSkill[];
+}
+
+/**
+ * Information about a skill that can be used.
+ */
+export interface UsableSkill {
+  /** The skill ID */
+  readonly skillId: SkillId;
+  /** Human-readable name */
+  readonly name: string;
+  /** Description of what the skill does */
+  readonly description: string;
 }


### PR DESCRIPTION
## Summary
Implements the Motivation skill for Tovak and all other heroes with Motivation variants. This is a flip skill (once per round) that can be used on any player's turn, including during combat.

## Changes
- Added `CONDITION_HAS_LOWEST_FAME_OR_SOLO` condition type for fame-based conditional effects
- Added condition evaluation logic to check if player has strictly lowest fame or is in solo game
- Created skill effect definitions for all 5 Motivation variants (Tovak=blue, Arythea=red, Goldyx=green, Norowas=white, Wolfhawk=+1 fame)
- Created `useSkillCommand` with execute/undo support for skill activation
- Created skill validators (7 validators for existence, ownership, cooldown, combat, turn restrictions, tactics phase)
- Created `validActions/skills.ts` with `getSkillOptions` and `getOutOfTurnSkillOptions`
- Updated `ValidActions` type in shared package to include skill options
- Updated `playerReset.ts` to handle skill cooldown expiration with proper lockout logic
- Added skill command factory and registered it in the command system

## Key Features
- **Out-of-turn usage**: Players can use Motivation on other players' turns
- **Combat usage**: Skill can be used during combat phases
- **Lockout system**: Once used, skill is locked until end of next turn (persists across turn end)
- **Fame condition**: Blue mana only granted if player has strictly lowest fame (not tied), always in solo
- **Round cooldown**: Once-per-round usage tracked separately from lockout

## Test Plan
- 21 comprehensive tests added covering:
  - Basic skill usage and cooldown
  - Fame-based mana grant scenarios (lowest, tied, highest)
  - Solo game always grants mana
  - Out-of-turn usage validation
  - Combat usage validation
  - Tactics phase restrictions
  - Undo functionality
  - Turn end lockout expiration

Closes #308