### PR TITLE
feat: implement Power of Pain skill (Arythea)

### DIFF
--- a/packages/core/src/engine/__tests__/powerOfPain.test.ts
+++ b/packages/core/src/engine/__tests__/powerOfPain.test.ts
@@ -1,0 +1,568 @@
+/**
+ * Tests for Power of Pain skill (Arythea)
+ *
+ * Power of Pain allows playing one Wound sideways for +2 instead of +1 once per turn.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  PLAY_CARD_SIDEWAYS_ACTION,
+  PLAY_SIDEWAYS_AS_MOVE,
+  PLAY_SIDEWAYS_AS_INFLUENCE,
+  PLAY_SIDEWAYS_AS_ATTACK,
+  PLAY_SIDEWAYS_AS_BLOCK,
+  CARD_PLAYED,
+  CARD_WOUND,
+  CARD_MARCH,
+  INVALID_ACTION,
+  SKILL_USED,
+} from "@mage-knight/shared";
+import { SKILL_ARYTHEA_POWER_OF_PAIN } from "../../data/skills/index.js";
+import { isRuleActive, getEffectiveSidewaysValue } from "../modifiers.js";
+import { RULE_WOUNDS_PLAYABLE_SIDEWAYS } from "../modifierConstants.js";
+import { getPlayableCardsForNormalTurn } from "../validActions/cards/normalTurn.js";
+import { getPlayableCardsForCombat } from "../validActions/cards/combat.js";
+import { COMBAT_PHASE_BLOCK, COMBAT_PHASE_ATTACK, COMBAT_PHASE_RANGED_SIEGE } from "../../types/combat.js";
+
+describe("Power of Pain skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("skill activation", () => {
+    it("should activate successfully when player owns skill and has wound in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+        })
+      );
+    });
+
+    it("should create rule override modifier for wounds playable sideways", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(isRuleActive(result.state, "player1", RULE_WOUNDS_PLAYABLE_SIDEWAYS)).toBe(true);
+    });
+
+    it("should create sideways value modifier for wounds with +2 value", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // For wounds, should return 2
+      const woundValue = getEffectiveSidewaysValue(
+        result.state,
+        "player1",
+        true, // isWound
+        false, // usedManaFromSource
+        undefined
+      );
+      expect(woundValue).toBe(2);
+
+      // For non-wounds, should still be 1
+      const normalValue = getEffectiveSidewaysValue(
+        result.state,
+        "player1",
+        false, // isWound
+        false,
+        undefined
+      );
+      expect(normalValue).toBe(1);
+    });
+
+    it("should fail if player does not own the skill", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [], // No skills
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "You do not own this skill",
+        })
+      );
+    });
+
+    it("should fail if player has no wound in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH], // No wounds
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Power of Pain requires at least one Wound in hand",
+        })
+      );
+    });
+
+    it("should fail if skill already used this turn", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND], // Two wounds
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate first time
+      const afterFirst = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(afterFirst.events).toContainEqual(
+        expect.objectContaining({ type: SKILL_USED })
+      );
+
+      // Try to activate again
+      const afterSecond = engine.processAction(afterFirst.state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(afterSecond.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Skill already used this turn",
+        })
+      );
+    });
+
+    it("should track skill in usedThisTurn cooldowns", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      expect(result.state.players[0].skillCooldowns.usedThisTurn).toContain(
+        SKILL_ARYTHEA_POWER_OF_PAIN
+      );
+    });
+  });
+
+  describe("playing wounds sideways after activation", () => {
+    it("should allow playing wound sideways for +2 Move", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play wound sideways for move
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.state.players[0].movePoints).toBe(2);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_PLAYED,
+          cardId: CARD_WOUND,
+          sideways: true,
+          effect: "Gained 2 Move (sideways)",
+        })
+      );
+    });
+
+    it("should allow playing wound sideways for +2 Influence", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+        influencePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play wound sideways for influence
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_INFLUENCE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(2);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_PLAYED,
+          cardId: CARD_WOUND,
+          sideways: true,
+          effect: "Gained 2 Influence (sideways)",
+        })
+      );
+    });
+
+    it("should allow playing wound sideways for +2 Attack", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play wound sideways for attack
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_ATTACK,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(2);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_PLAYED,
+          cardId: CARD_WOUND,
+          sideways: true,
+          effect: "Gained 2 Attack (sideways)",
+        })
+      );
+    });
+
+    it("should allow playing wound sideways for +2 Block", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play wound sideways for block
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_BLOCK,
+      });
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(2);
+      expect(result.state.players[0].combatAccumulator.blockElements.physical).toBe(2);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_PLAYED,
+          cardId: CARD_WOUND,
+          sideways: true,
+          effect: "Gained 2 Block (sideways)",
+        })
+      );
+    });
+
+    it("should move wound to play area when played sideways", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play wound sideways
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.state.players[0].hand).not.toContain(CARD_WOUND);
+      expect(result.state.players[0].playArea).toContain(CARD_WOUND);
+    });
+  });
+
+  describe("valid actions integration", () => {
+    it("should include wound in playable cards for normal turn after activation", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Before activation - wound should not be playable
+      const beforeCards = getPlayableCardsForNormalTurn(state, state.players[0]);
+      expect(beforeCards.cards.find((c) => c.cardId === CARD_WOUND)).toBeUndefined();
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // After activation - wound should be playable sideways
+      const afterCards = getPlayableCardsForNormalTurn(
+        afterSkill.state,
+        afterSkill.state.players[0]
+      );
+      const woundCard = afterCards.cards.find((c) => c.cardId === CARD_WOUND);
+      expect(woundCard).toBeDefined();
+      expect(woundCard?.canPlaySideways).toBe(true);
+      expect(woundCard?.canPlayBasic).toBe(false);
+      expect(woundCard?.canPlayPowered).toBe(false);
+    });
+
+    it("should show +2 sideways options for wound after activation", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      const playableCards = getPlayableCardsForNormalTurn(
+        afterSkill.state,
+        afterSkill.state.players[0]
+      );
+      const woundCard = playableCards.cards.find((c) => c.cardId === CARD_WOUND);
+
+      expect(woundCard?.sidewaysOptions).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ as: PLAY_SIDEWAYS_AS_MOVE, value: 2 }),
+          expect.objectContaining({ as: PLAY_SIDEWAYS_AS_INFLUENCE, value: 2 }),
+        ])
+      );
+    });
+
+    it("should include wound in combat block phase after activation", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_BLOCK);
+      const state = createTestGameState({ players: [player] });
+
+      // Before activation - wound should not be playable
+      const beforeCards = getPlayableCardsForCombat(state, state.players[0], combat);
+      expect(beforeCards.cards.find((c) => c.cardId === CARD_WOUND)).toBeUndefined();
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // After activation - wound should be playable in block phase
+      const afterCards = getPlayableCardsForCombat(
+        afterSkill.state,
+        afterSkill.state.players[0],
+        combat
+      );
+      const woundCard = afterCards.cards.find((c) => c.cardId === CARD_WOUND);
+      expect(woundCard).toBeDefined();
+      expect(woundCard?.canPlaySideways).toBe(true);
+      expect(woundCard?.sidewaysOptions).toEqual([
+        expect.objectContaining({ as: PLAY_SIDEWAYS_AS_BLOCK, value: 2 }),
+      ]);
+    });
+
+    it("should include wound in combat attack phase after activation", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_ATTACK);
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // After activation - wound should be playable in attack phase
+      const afterCards = getPlayableCardsForCombat(
+        afterSkill.state,
+        afterSkill.state.players[0],
+        combat
+      );
+      const woundCard = afterCards.cards.find((c) => c.cardId === CARD_WOUND);
+      expect(woundCard).toBeDefined();
+      expect(woundCard?.sidewaysOptions).toEqual([
+        expect.objectContaining({ as: PLAY_SIDEWAYS_AS_ATTACK, value: 2 }),
+      ]);
+    });
+
+    it("should NOT include wound in ranged/siege phase (per FAQ)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_RANGED_SIEGE);
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Wound should not be playable in ranged/siege phase per FAQ
+      const afterCards = getPlayableCardsForCombat(
+        afterSkill.state,
+        afterSkill.state.players[0],
+        combat
+      );
+      const woundCard = afterCards.cards.find((c) => c.cardId === CARD_WOUND);
+      expect(woundCard).toBeUndefined();
+    });
+  });
+
+  describe("without skill activation", () => {
+    it("should still reject wounds sideways without skill", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [], // No skills
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Wound cards cannot be played sideways",
+        })
+      );
+    });
+
+    it("should still reject wounds sideways with skill but not activated", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN], // Has skill but not activated
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Try to play wound without activating skill first
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_WOUND,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Wound cards cannot be played sideways",
+        })
+      );
+    });
+  });
+
+  describe("normal cards still work normally", () => {
+    it("should not affect normal card sideways value after skill activation", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        skills: [SKILL_ARYTHEA_POWER_OF_PAIN],
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_POWER_OF_PAIN,
+      });
+
+      // Play March sideways - should still be +1
+      const result = engine.processAction(afterSkill.state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_MARCH,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.state.players[0].movePoints).toBe(1);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_PLAYED,
+          cardId: CARD_MARCH,
+          sideways: true,
+          effect: "Gained 1 Move (sideways)",
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -60,6 +60,7 @@ import {
   PROPOSE_COOPERATIVE_ASSAULT_ACTION,
   RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION,
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -146,6 +147,9 @@ export {
   createCancelProposalCommandFromAction,
 } from "./cooperativeAssault.js";
 
+// Skill factories
+export { createUseSkillCommandFromAction } from "./skills.js";
+
 // Import all factories for the registry
 import {
   createMoveCommandFromAction,
@@ -218,6 +222,8 @@ import {
   createCancelProposalCommandFromAction,
 } from "./cooperativeAssault.js";
 
+import { createUseSkillCommandFromAction } from "./skills.js";
+
 import type { CommandFactory } from "./types.js";
 
 /**
@@ -270,4 +276,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [PROPOSE_COOPERATIVE_ASSAULT_ACTION]: createProposeCooperativeAssaultCommandFromAction,
   [RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION]: createRespondToProposalCommandFromAction,
   [CANCEL_COOPERATIVE_PROPOSAL_ACTION]: createCancelProposalCommandFromAction,
+  // Skill actions
+  [USE_SKILL_ACTION]: createUseSkillCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/skills.ts
+++ b/packages/core/src/engine/commands/factories/skills.ts
@@ -1,0 +1,31 @@
+/**
+ * Skill Command Factories
+ *
+ * Factory functions for creating skill-related commands from player actions.
+ *
+ * @module commands/factories/skills
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction, UseSkillAction } from "@mage-knight/shared";
+import type { Command } from "../../commands.js";
+import { USE_SKILL_ACTION } from "@mage-knight/shared";
+import { createUseSkillCommand } from "../skills/useSkillCommand.js";
+
+/**
+ * Create a UseSkillCommand from a player action.
+ */
+export function createUseSkillCommandFromAction(
+  _state: GameState,
+  playerId: string,
+  action: PlayerAction
+): Command | null {
+  if (action.type !== USE_SKILL_ACTION) return null;
+
+  const skillAction = action as UseSkillAction;
+
+  return createUseSkillCommand({
+    playerId,
+    skillId: skillAction.skillId,
+  });
+}

--- a/packages/core/src/engine/commands/index.ts
+++ b/packages/core/src/engine/commands/index.ts
@@ -217,3 +217,6 @@ export {
   type BurnMonasteryCommandParams,
   BURN_MONASTERY_COMMAND,
 } from "./burnMonasteryCommand.js";
+
+// Skill commands
+export * from "./skills/index.js";

--- a/packages/core/src/engine/commands/playCardSidewaysCommand.ts
+++ b/packages/core/src/engine/commands/playCardSidewaysCommand.ts
@@ -16,6 +16,7 @@ import {
   PLAY_SIDEWAYS_AS_ATTACK,
   PLAY_SIDEWAYS_AS_BLOCK,
   ELEMENT_PHYSICAL,
+  CARD_WOUND,
   createCardPlayUndoneEvent,
 } from "@mage-knight/shared";
 import { getEffectiveSidewaysValue } from "../modifiers.js";
@@ -195,11 +196,15 @@ export function createPlayCardSidewaysCommand(
         throw new Error(`Player not found at index: ${playerIndex}`);
       }
 
+      // Check if the card being played is a wound
+      const isWound = params.cardId === CARD_WOUND;
+
       // Calculate effective sideways value (usually 1, can be modified)
+      // For wounds with Power of Pain, this will return 2
       appliedValue = getEffectiveSidewaysValue(
         state,
         params.playerId,
-        false, // not a wound
+        isWound,
         player.usedManaFromSource,
         undefined // manaColorMatchesCard not applicable for sideways
       );

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Skill Commands Module
+ *
+ * Commands for activating and using skills.
+ *
+ * @module commands/skills
+ */
+
+export {
+  createUseSkillCommand,
+  type UseSkillCommandParams,
+  USE_SKILL_COMMAND,
+} from "./useSkillCommand.js";
+
+export {
+  applyPowerOfPain,
+  canActivatePowerOfPain,
+  isPowerOfPainSkill,
+} from "./powerOfPain.js";

--- a/packages/core/src/engine/commands/skills/powerOfPain.ts
+++ b/packages/core/src/engine/commands/skills/powerOfPain.ts
@@ -1,0 +1,104 @@
+/**
+ * Power of Pain Skill Handler
+ *
+ * Arythea's skill: Once per turn, play one Wound sideways for +2 instead of +1.
+ * The Wound goes to discard pile at end of turn (already default behavior).
+ *
+ * @module commands/skills/powerOfPain
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { SkillId } from "@mage-knight/shared";
+import type { ActiveModifier, SidewaysValueModifier, RuleOverrideModifier } from "../../../types/modifiers.js";
+import { addModifier } from "../../modifiers.js";
+import {
+  DURATION_TURN,
+  EFFECT_RULE_OVERRIDE,
+  EFFECT_SIDEWAYS_VALUE,
+  RULE_WOUNDS_PLAYABLE_SIDEWAYS,
+  SCOPE_SELF,
+  SOURCE_SKILL,
+} from "../../modifierConstants.js";
+import { SKILL_ARYTHEA_POWER_OF_PAIN } from "../../../data/skills/index.js";
+import { CARD_WOUND } from "@mage-knight/shared";
+
+/**
+ * Check if Power of Pain can be activated.
+ *
+ * Preconditions:
+ * - Player has at least one Wound in hand
+ *
+ * @param state - Current game state
+ * @param playerId - Player attempting to use the skill
+ * @returns true if skill can be activated
+ */
+export function canActivatePowerOfPain(
+  state: GameState,
+  playerId: string
+): boolean {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return false;
+
+  // Check if player has a wound in hand
+  return player.hand.some((cardId) => cardId === CARD_WOUND);
+}
+
+/**
+ * Apply Power of Pain modifiers to game state.
+ *
+ * Creates two modifiers:
+ * 1. RuleOverrideModifier: RULE_WOUNDS_PLAYABLE_SIDEWAYS - allows wounds to be played sideways
+ * 2. SidewaysValueModifier: forWounds=true, newValue=2 - gives +2 value for wounds
+ *
+ * @param state - Current game state
+ * @param playerId - Player using the skill
+ * @param skillId - The skill being used (for tracking)
+ * @returns New state with modifiers applied
+ */
+export function applyPowerOfPain(
+  state: GameState,
+  playerId: string,
+  skillId: SkillId
+): GameState {
+  const currentRound = state.round;
+
+  // Modifier 1: Allow wounds to be played sideways
+  const ruleModifier: Omit<ActiveModifier, "id"> = {
+    source: { type: SOURCE_SKILL, skillId, playerId },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_RULE_OVERRIDE,
+      rule: RULE_WOUNDS_PLAYABLE_SIDEWAYS,
+    } as RuleOverrideModifier,
+    createdAtRound: currentRound,
+    createdByPlayerId: playerId,
+  };
+
+  let newState = addModifier(state, ruleModifier);
+
+  // Modifier 2: Set sideways value to 2 for wounds
+  const valueModifier: Omit<ActiveModifier, "id"> = {
+    source: { type: SOURCE_SKILL, skillId, playerId },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_SIDEWAYS_VALUE,
+      newValue: 2,
+      forWounds: true,
+    } as SidewaysValueModifier,
+    createdAtRound: currentRound,
+    createdByPlayerId: playerId,
+  };
+
+  newState = addModifier(newState, valueModifier);
+
+  return newState;
+}
+
+/**
+ * Check if a skill is Power of Pain.
+ */
+export function isPowerOfPainSkill(skillId: SkillId): boolean {
+  return skillId === SKILL_ARYTHEA_POWER_OF_PAIN;
+}

--- a/packages/core/src/engine/commands/skills/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/skills/useSkillCommand.ts
@@ -1,0 +1,162 @@
+/**
+ * Use Skill Command
+ *
+ * Handles activating skills. Each skill has its own handler that applies
+ * the appropriate modifiers or effects.
+ *
+ * @module commands/skills/useSkillCommand
+ */
+
+import type { Command, CommandResult } from "../../commands.js";
+import type { GameState } from "../../../state/GameState.js";
+import type { Player, SkillCooldowns } from "../../../types/player.js";
+import type { SkillId } from "@mage-knight/shared";
+import { createSkillUsedEvent } from "@mage-knight/shared";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_ONCE_PER_TURN,
+  SKILL_USAGE_ONCE_PER_ROUND,
+} from "../../../data/skills/index.js";
+import { applyPowerOfPain, isPowerOfPainSkill } from "./powerOfPain.js";
+import { SOURCE_SKILL } from "../../modifierConstants.js";
+
+export const USE_SKILL_COMMAND = "USE_SKILL" as const;
+
+export interface UseSkillCommandParams {
+  readonly playerId: string;
+  readonly skillId: SkillId;
+}
+
+/**
+ * Create a use skill command.
+ */
+export function createUseSkillCommand(params: UseSkillCommandParams): Command {
+  // Store the modifier IDs added during execute for undo
+  let addedModifierIds: string[] = [];
+  let previousCooldowns: SkillCooldowns | null = null;
+
+  return {
+    type: USE_SKILL_COMMAND,
+    playerId: params.playerId,
+    isReversible: true,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error(`Player not found at index: ${playerIndex}`);
+      }
+
+      // Store previous cooldowns for undo
+      previousCooldowns = player.skillCooldowns;
+
+      // Dispatch to skill-specific handler
+      let newState = state;
+      if (isPowerOfPainSkill(params.skillId)) {
+        newState = applyPowerOfPain(state, params.playerId, params.skillId);
+      }
+      // Future: add more skill handlers here
+
+      // Track which modifiers were added
+      addedModifierIds = newState.activeModifiers
+        .filter(
+          (m) =>
+            m.source.type === SOURCE_SKILL &&
+            m.source.skillId === params.skillId &&
+            m.createdByPlayerId === params.playerId &&
+            !state.activeModifiers.some((existing) => existing.id === m.id)
+        )
+        .map((m) => m.id);
+
+      // Update skill cooldowns
+      const skillDef = getSkillDefinition(params.skillId);
+      const updatedPlayer = updateSkillCooldowns(player, params.skillId, skillDef?.usageType);
+
+      const players = [...newState.players];
+      players[playerIndex] = updatedPlayer;
+
+      return {
+        state: { ...newState, players },
+        events: [createSkillUsedEvent(params.playerId, params.skillId)],
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error(`Player not found at index: ${playerIndex}`);
+      }
+
+      // Remove added modifiers
+      const remainingModifiers = state.activeModifiers.filter(
+        (m) => !addedModifierIds.includes(m.id)
+      );
+
+      // Restore previous cooldowns
+      const updatedPlayer: Player = {
+        ...player,
+        skillCooldowns: previousCooldowns ?? player.skillCooldowns,
+      };
+
+      const players = [...state.players];
+      players[playerIndex] = updatedPlayer;
+
+      return {
+        state: {
+          ...state,
+          players,
+          activeModifiers: remainingModifiers,
+        },
+        events: [], // No specific undo event needed
+      };
+    },
+  };
+}
+
+/**
+ * Update player's skill cooldowns based on skill usage type.
+ */
+function updateSkillCooldowns(
+  player: Player,
+  skillId: SkillId,
+  usageType: string | undefined
+): Player {
+  const cooldowns = player.skillCooldowns;
+
+  switch (usageType) {
+    case SKILL_USAGE_ONCE_PER_TURN:
+      return {
+        ...player,
+        skillCooldowns: {
+          ...cooldowns,
+          usedThisTurn: [...cooldowns.usedThisTurn, skillId],
+        },
+      };
+
+    case SKILL_USAGE_ONCE_PER_ROUND:
+      return {
+        ...player,
+        skillCooldowns: {
+          ...cooldowns,
+          usedThisRound: [...cooldowns.usedThisRound, skillId],
+        },
+      };
+
+    default:
+      // Passive or interactive skills don't track cooldowns here
+      return player;
+  }
+}

--- a/packages/core/src/engine/modifiers.ts
+++ b/packages/core/src/engine/modifiers.ts
@@ -160,8 +160,11 @@ export function getEffectiveSidewaysValue(
   let bestValue = baseValue;
 
   for (const mod of modifiers) {
-    // Check if this modifier applies
+    // Check if this modifier applies based on card type
+    // forWounds=true modifiers only apply to wounds
+    // forWounds=false modifiers only apply to non-wounds
     if (isWound && !mod.forWounds) continue;
+    if (!isWound && mod.forWounds) continue;
 
     if (mod.condition === SIDEWAYS_CONDITION_NO_MANA_USED && manaUsedThisTurn)
       continue;

--- a/packages/core/src/engine/validators/index.ts
+++ b/packages/core/src/engine/validators/index.ts
@@ -44,6 +44,7 @@ import {
   PROPOSE_COOPERATIVE_ASSAULT_ACTION,
   RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION,
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 import { valid } from "./types.js";
 
@@ -289,6 +290,13 @@ import {
   validateProposalExistsForCancel,
   validatePlayerIsInitiator,
 } from "./cooperativeAssaultValidators.js";
+
+// Skill validators
+import {
+  validateSkillOwned,
+  validateSkillNotOnCooldown,
+  validateSkillPreconditions,
+} from "./skillValidators.js";
 
 // TODO: RULES LIMITATION - Immediate Choice Resolution
 // =====================================================
@@ -677,6 +685,17 @@ const validatorRegistry: Record<string, Validator[]> = {
     // Note: Initiator can cancel regardless of whose turn it is
     validateProposalExistsForCancel,
     validatePlayerIsInitiator,
+  ],
+  // Skill actions
+  [USE_SKILL_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateNoPendingLevelUpRewards,
+    validateMustAnnounceEndOfRound,
+    validateSkillOwned,
+    validateSkillNotOnCooldown,
+    validateSkillPreconditions,
   ],
 };
 

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -1,0 +1,147 @@
+/**
+ * Skill Usage Validators
+ *
+ * Validates skill activation actions.
+ *
+ * @module validators/skillValidators
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction, SkillId } from "@mage-knight/shared";
+import type { ValidationResult } from "./types.js";
+import { valid, invalid } from "./types.js";
+import { USE_SKILL_ACTION } from "@mage-knight/shared";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_ONCE_PER_TURN,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_ARYTHEA_POWER_OF_PAIN,
+} from "../../data/skills/index.js";
+import { canActivatePowerOfPain } from "../commands/skills/powerOfPain.js";
+import {
+  SKILL_NOT_OWNED,
+  SKILL_ON_COOLDOWN,
+  SKILL_PRECONDITION_FAILED,
+  INVALID_ACTION_CODE,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+
+/**
+ * Extract skill ID from action.
+ */
+function getSkillIdFromAction(action: PlayerAction): SkillId | null {
+  if (action.type === USE_SKILL_ACTION && "skillId" in action) {
+    return action.skillId as SkillId;
+  }
+  return null;
+}
+
+/**
+ * Validate that the player owns the skill.
+ */
+export function validateSkillOwned(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.skills.includes(skillId)) {
+    return invalid(SKILL_NOT_OWNED, "You do not own this skill");
+  }
+
+  return valid();
+}
+
+/**
+ * Validate that the skill is not on cooldown.
+ */
+export function validateSkillNotOnCooldown(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return invalid(INVALID_ACTION_CODE, "Unknown skill");
+  }
+
+  const cooldowns = player.skillCooldowns;
+
+  // Check cooldown based on usage type
+  switch (skillDef.usageType) {
+    case SKILL_USAGE_ONCE_PER_TURN:
+      if (cooldowns.usedThisTurn.includes(skillId)) {
+        return invalid(SKILL_ON_COOLDOWN, "Skill already used this turn");
+      }
+      break;
+
+    case SKILL_USAGE_ONCE_PER_ROUND:
+      if (cooldowns.usedThisRound.includes(skillId)) {
+        return invalid(SKILL_ON_COOLDOWN, "Skill already used this round");
+      }
+      break;
+
+    // Passive and interactive skills have different activation patterns
+    // and are not validated here
+  }
+
+  return valid();
+}
+
+/**
+ * Validate skill-specific preconditions.
+ *
+ * Each skill may have unique preconditions (e.g., must have wound in hand).
+ */
+export function validateSkillPreconditions(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  // Dispatch to skill-specific precondition checks
+  if (skillId === SKILL_ARYTHEA_POWER_OF_PAIN) {
+    if (!canActivatePowerOfPain(state, playerId)) {
+      return invalid(
+        SKILL_PRECONDITION_FAILED,
+        "Power of Pain requires at least one Wound in hand"
+      );
+    }
+  }
+
+  // Future: add more skill-specific precondition checks here
+
+  return valid();
+}
+
+/**
+ * All skill validators.
+ */
+export const skillValidators = [
+  validateSkillOwned,
+  validateSkillNotOnCooldown,
+  validateSkillPreconditions,
+];

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -196,6 +196,11 @@ export const INVALID_LEVEL_UP_LEVEL = "INVALID_LEVEL_UP_LEVEL" as const;
 export const SKILL_NOT_AVAILABLE = "SKILL_NOT_AVAILABLE" as const;
 export const SKILL_ALREADY_OWNED = "SKILL_ALREADY_OWNED" as const;
 
+// Skill usage validation codes
+export const SKILL_NOT_OWNED = "SKILL_NOT_OWNED" as const;
+export const SKILL_ON_COOLDOWN = "SKILL_ON_COOLDOWN" as const;
+export const SKILL_PRECONDITION_FAILED = "SKILL_PRECONDITION_FAILED" as const;
+
 // Debug validation codes
 export const DEV_MODE_REQUIRED = "DEV_MODE_REQUIRED" as const;
 export const NO_PENDING_LEVEL_UPS = "NO_PENDING_LEVEL_UPS" as const;
@@ -373,6 +378,10 @@ export type ValidationErrorCode =
   | typeof INVALID_LEVEL_UP_LEVEL
   | typeof SKILL_NOT_AVAILABLE
   | typeof SKILL_ALREADY_OWNED
+  // Skill usage validation
+  | typeof SKILL_NOT_OWNED
+  | typeof SKILL_ON_COOLDOWN
+  | typeof SKILL_PRECONDITION_FAILED
   // Debug validation
   | typeof DEV_MODE_REQUIRED
   | typeof NO_PENDING_LEVEL_UPS


### PR DESCRIPTION
## Summary
- Implements Arythea's **Power of Pain** skill that allows playing one Wound sideways for +2 value instead of +1
- Adds complete USE_SKILL_ACTION infrastructure with command, validator, and factory pattern
- Fixes `getEffectiveSidewaysValue` to properly filter `forWounds` modifiers

## Changes
- **New skill command system**: `useSkillCommand.ts`, skill validators, and factory
- **Power of Pain handler**: Creates rule override and sideways value modifiers
- **Updated validators**: Sideways validators check for RULE_WOUNDS_PLAYABLE_SIDEWAYS
- **Updated validActions**: Normal turn and combat show wounds as playable when rule active
- **Per FAQ**: Wounds cannot be played sideways during Ranged/Siege combat phase

## Test plan
- [x] Skill activation creates both modifiers (rule override + sideways value)
- [x] `isRuleActive()` returns true after activation
- [x] `getEffectiveSidewaysValue(isWound=true)` returns 2
- [x] Wound appears in validActions after activation
- [x] Playing wound sideways gives +2 move/influence/attack/block
- [x] Cannot use skill twice in same turn (cooldown)
- [x] Cannot activate without owning skill
- [x] Cannot activate without wound in hand
- [x] Normal cards still give +1 after skill activation
- [x] Wound NOT playable in Ranged/Siege phase (per FAQ)

Closes #315