### PR TITLE
feat: implement Dark Fire Magic skill activation (#314)

### DIFF
--- a/packages/core/src/data/skills/index.ts
+++ b/packages/core/src/data/skills/index.ts
@@ -13,7 +13,7 @@
  */
 
 import type { SkillId } from "@mage-knight/shared";
-import type { Category } from "../../types/cards.js";
+import type { Category, CardEffect } from "../../types/cards.js";
 import {
   CATEGORY_MOVEMENT,
   CATEGORY_COMBAT,
@@ -21,6 +21,13 @@ import {
   CATEGORY_HEALING,
   CATEGORY_SPECIAL,
 } from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_CHOICE,
+  EFFECT_GAIN_MANA,
+} from "../../types/effectTypes.js";
+import { MANA_RED, MANA_BLACK } from "@mage-knight/shared";
 
 // ============================================================================
 // Hero ID type (to avoid circular dependency with hero.ts)
@@ -68,7 +75,8 @@ export interface SkillDefinition {
   readonly usageType: SkillUsageType;
   /** Categories for this skill (movement, combat, influence, healing, special) */
   readonly categories: readonly Category[];
-  // Note: effect implementation will be added when skills are fully implemented
+  /** Card-like effect to execute when skill is activated (for active skills) */
+  readonly effect?: CardEffect;
 }
 
 // ============================================================================
@@ -208,6 +216,19 @@ export const SKILLS: Record<SkillId, SkillDefinition> = {
     description: "Flip to gain 1 red crystal and 1 red or black mana token",
     usageType: SKILL_USAGE_ONCE_PER_ROUND,
     categories: [CATEGORY_SPECIAL],
+    effect: {
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_RED },
+        {
+          type: EFFECT_CHOICE,
+          options: [
+            { type: EFFECT_GAIN_MANA, color: MANA_RED },
+            { type: EFFECT_GAIN_MANA, color: MANA_BLACK },
+          ],
+        },
+      ],
+    },
   },
   [SKILL_ARYTHEA_POWER_OF_PAIN]: {
     id: SKILL_ARYTHEA_POWER_OF_PAIN,

--- a/packages/core/src/engine/__tests__/darkFireMagic.test.ts
+++ b/packages/core/src/engine/__tests__/darkFireMagic.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for Dark Fire Magic skill (Arythea)
+ *
+ * Dark Fire Magic: Flip to gain 1 red crystal and 1 red or black mana token
+ * - Once per round (flip skill)
+ * - Grants 1 red crystal to inventory
+ * - Player chooses red or black mana token
+ * - Black mana follows normal day/night usage rules
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  MANA_RED,
+  MANA_BLACK,
+  SKILL_USED,
+  CHOICE_REQUIRED,
+  INVALID_ACTION,
+  USE_SKILL_ACTION,
+} from "@mage-knight/shared";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { createUseSkillCommand } from "../commands/useSkillCommand.js";
+import { createResolveChoiceCommand } from "../commands/resolveChoiceCommand.js";
+import { SKILL_ARYTHEA_DARK_FIRE_MAGIC } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import { validateAction } from "../validators/index.js";
+import { EFFECT_GAIN_MANA } from "../../types/effectTypes.js";
+
+describe("Dark Fire Magic Skill", () => {
+  describe("Skill Activation", () => {
+    it("grants 1 red crystal when activated", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      });
+      const result = command.execute(state);
+
+      // Check for SKILL_USED event
+      const skillUsedEvent = result.events.find((e) => e.type === SKILL_USED);
+      expect(skillUsedEvent).toBeDefined();
+      if (skillUsedEvent?.type === SKILL_USED) {
+        expect(skillUsedEvent.playerId).toBe("player1");
+        expect(skillUsedEvent.skillId).toBe(SKILL_ARYTHEA_DARK_FIRE_MAGIC);
+      }
+
+      // Player should have 1 red crystal (effect updates state directly)
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.crystals.red).toBe(1);
+    });
+
+    it("creates a pending choice for red or black mana", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      });
+      const result = command.execute(state);
+
+      // Check for CHOICE_REQUIRED event
+      const choiceEvent = result.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      // Player should have a pending choice
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.pendingChoice).not.toBeNull();
+      expect(updatedPlayer?.pendingChoice?.options).toHaveLength(2);
+
+      // Check the pending choice has skillId, not cardId
+      expect(updatedPlayer?.pendingChoice?.sourceSkillId).toBe(SKILL_ARYTHEA_DARK_FIRE_MAGIC);
+
+      // Check the options are mana gain effects
+      const options = updatedPlayer?.pendingChoice?.options;
+      expect(options?.[0]).toMatchObject({ type: EFFECT_GAIN_MANA, color: MANA_RED });
+      expect(options?.[1]).toMatchObject({ type: EFFECT_GAIN_MANA, color: MANA_BLACK });
+    });
+
+    it("adds skill to round cooldown", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      });
+      const result = command.execute(state);
+
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.skillCooldowns.usedThisRound).toContain(
+        SKILL_ARYTHEA_DARK_FIRE_MAGIC
+      );
+    });
+  });
+
+  describe("Choice Resolution", () => {
+    it("resolving choice with red mana grants red mana token", () => {
+      // Set up player with pending choice (simulating post-skill-activation state)
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        pendingChoice: {
+          sourceSkillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+          options: [
+            { type: EFFECT_GAIN_MANA, color: MANA_RED },
+            { type: EFFECT_GAIN_MANA, color: MANA_BLACK },
+          ],
+        },
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveChoiceCommand({
+        playerId: "player1",
+        choiceIndex: 0, // Red mana
+      });
+      const result = command.execute(state);
+
+      // Player should have red mana token (state change, not event)
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.pureMana).toHaveLength(1);
+      expect(updatedPlayer?.pureMana[0]?.color).toBe(MANA_RED);
+
+      // Pending choice should be cleared
+      expect(updatedPlayer?.pendingChoice).toBeNull();
+    });
+
+    it("resolving choice with black mana grants black mana token", () => {
+      // Set up player with pending choice
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        pendingChoice: {
+          sourceSkillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+          options: [
+            { type: EFFECT_GAIN_MANA, color: MANA_RED },
+            { type: EFFECT_GAIN_MANA, color: MANA_BLACK },
+          ],
+        },
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveChoiceCommand({
+        playerId: "player1",
+        choiceIndex: 1, // Black mana
+      });
+      const result = command.execute(state);
+
+      // Player should have black mana token
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.pureMana).toHaveLength(1);
+      expect(updatedPlayer?.pureMana[0]?.color).toBe(MANA_BLACK);
+
+      // Pending choice should be cleared
+      expect(updatedPlayer?.pendingChoice).toBeNull();
+    });
+  });
+
+  describe("Cooldown Validation", () => {
+    it("cannot activate skill if already used this round", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        skillCooldowns: {
+          usedThisRound: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      });
+      const result = command.execute(state);
+
+      // Should emit invalid action event
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent?.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("used this round");
+      }
+    });
+  });
+
+  describe("Ownership Validation", () => {
+    it("cannot activate skill player does not own", () => {
+      const player = createTestPlayer({
+        skills: [], // Player has no skills
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createUseSkillCommand({
+        playerId: "player1",
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      });
+      const result = command.execute(state);
+
+      // Should emit invalid action event
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent?.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("do not own");
+      }
+    });
+  });
+
+  describe("ValidActions Integration", () => {
+    it("shows skill as activatable when owned and not on cooldown", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      expect(validActions.skillEffects).toBeDefined();
+      expect(validActions.skillEffects?.activatableSkills).toHaveLength(1);
+      expect(validActions.skillEffects?.activatableSkills[0].skillId).toBe(
+        SKILL_ARYTHEA_DARK_FIRE_MAGIC
+      );
+    });
+
+    it("does not show skill as activatable when on cooldown", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        skillCooldowns: {
+          usedThisRound: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      // skillEffects should be undefined or have empty activatableSkills
+      if (validActions.skillEffects) {
+        expect(validActions.skillEffects.activatableSkills).not.toContainEqual(
+          expect.objectContaining({ skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC })
+        );
+      }
+    });
+
+    it("does not show skill when player does not own it", () => {
+      const player = createTestPlayer({
+        skills: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      // skillEffects should be undefined when no skills available
+      expect(validActions.skillEffects).toBeUndefined();
+    });
+  });
+
+  describe("Validator Integration", () => {
+    it("validates USE_SKILL_ACTION correctly", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      };
+
+      const result = validateAction(state, "player1", action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects USE_SKILL_ACTION for skill not owned", () => {
+      const player = createTestPlayer({
+        skills: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      };
+
+      const result = validateAction(state, "player1", action);
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects USE_SKILL_ACTION when on cooldown", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+        skillCooldowns: {
+          usedThisRound: [SKILL_ARYTHEA_DARK_FIRE_MAGIC],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const action = {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_DARK_FIRE_MAGIC,
+      };
+
+      const result = validateAction(state, "player1", action);
+      expect(result.valid).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -30,6 +30,9 @@ export const ACTIVATE_TACTIC_COMMAND = "ACTIVATE_TACTIC" as const;
 export const RESOLVE_TACTIC_DECISION_COMMAND = "RESOLVE_TACTIC_DECISION" as const;
 export const REROLL_SOURCE_DICE_COMMAND = "REROLL_SOURCE_DICE" as const;
 
+// Skill activation command
+export const USE_SKILL_COMMAND = "USE_SKILL" as const;
+
 // Conquest commands
 export const CONQUER_SITE_COMMAND = "CONQUER_SITE" as const;
 

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -14,6 +14,7 @@
  * | Sites | `sites.ts` | Interact, EnterSite, ResolveGladeWound, ResolveDeepMine |
  * | Tactics | `tactics.ts` | SelectTactic, ActivateTactic, ResolveTacticDecision, RerollSourceDice |
  * | Offers | `offers.ts` | BuySpell, LearnAdvancedAction, SelectReward |
+ * | Skills | `skills.ts` | UseSkill |
  *
  * @module commands/factories
  */
@@ -60,6 +61,7 @@ import {
   PROPOSE_COOPERATIVE_ASSAULT_ACTION,
   RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION,
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -146,6 +148,9 @@ export {
   createCancelProposalCommandFromAction,
 } from "./cooperativeAssault.js";
 
+// Skill factories
+export { createUseSkillCommandFromAction } from "./skills.js";
+
 // Import all factories for the registry
 import {
   createMoveCommandFromAction,
@@ -218,6 +223,8 @@ import {
   createCancelProposalCommandFromAction,
 } from "./cooperativeAssault.js";
 
+import { createUseSkillCommandFromAction } from "./skills.js";
+
 import type { CommandFactory } from "./types.js";
 
 /**
@@ -270,4 +277,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [PROPOSE_COOPERATIVE_ASSAULT_ACTION]: createProposeCooperativeAssaultCommandFromAction,
   [RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION]: createRespondToProposalCommandFromAction,
   [CANCEL_COOPERATIVE_PROPOSAL_ACTION]: createCancelProposalCommandFromAction,
+  // Skill actions
+  [USE_SKILL_ACTION]: createUseSkillCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/skills.ts
+++ b/packages/core/src/engine/commands/factories/skills.ts
@@ -1,0 +1,40 @@
+/**
+ * Skills Command Factories
+ *
+ * Factory functions that translate skill-related PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/skills
+ *
+ * @remarks Factories in this module:
+ * - createUseSkillCommandFromAction - Activate a skill's effect
+ */
+
+import type { CommandFactory } from "./types.js";
+import type { PlayerAction, SkillId } from "@mage-knight/shared";
+import { USE_SKILL_ACTION } from "@mage-knight/shared";
+import { createUseSkillCommand } from "../useSkillCommand.js";
+
+/**
+ * Helper to get skill id from action.
+ */
+function getSkillIdFromAction(action: PlayerAction): SkillId | null {
+  if (action.type === USE_SKILL_ACTION && "skillId" in action) {
+    return action.skillId;
+  }
+  return null;
+}
+
+/**
+ * Use skill command factory.
+ * Creates a command to activate a skill's effect.
+ */
+export const createUseSkillCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) return null;
+  return createUseSkillCommand({ playerId, skillId });
+};

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -1,0 +1,213 @@
+/**
+ * Use Skill Command - handles activating a player's skill
+ *
+ * This command handles skill activation for "flip-to-use" skills:
+ * - Dark Fire Magic (Arythea): Gain 1 red crystal and 1 red or black mana token
+ * - And other once-per-round skills
+ *
+ * Skills use the same effect system as cards, but are triggered via USE_SKILL_ACTION.
+ */
+
+import type { Command, CommandResult } from "../commands.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { GameEvent, SkillId } from "@mage-knight/shared";
+import { INVALID_ACTION, SKILL_USED } from "@mage-knight/shared";
+import { createChoiceRequiredEvent } from "@mage-knight/shared";
+import { describeEffect } from "../effects/index.js";
+import { USE_SKILL_COMMAND } from "./commandTypes.js";
+import {
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_USAGE_ONCE_PER_TURN,
+  SKILL_USAGE_PASSIVE,
+  getSkillDefinition,
+} from "../../data/skills/index.js";
+import { resolveEffect } from "../effects/index.js";
+import type { CardEffect } from "../../types/cards.js";
+
+export { USE_SKILL_COMMAND };
+
+export interface UseSkillCommandArgs {
+  readonly playerId: string;
+  readonly skillId: SkillId;
+}
+
+/**
+ * Validate skill activation
+ */
+function validateSkillActivation(
+  state: GameState,
+  playerId: string,
+  skillId: SkillId
+): string | null {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return "Player not found";
+  }
+
+  // Must own the skill
+  if (!player.skills.includes(skillId)) {
+    return `You do not own the skill ${skillId}`;
+  }
+
+  // Get skill definition
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return `Unknown skill: ${skillId}`;
+  }
+
+  // Passive skills cannot be activated
+  if (skillDef.usageType === SKILL_USAGE_PASSIVE) {
+    return "Passive skills cannot be activated";
+  }
+
+  // Must have an effect defined
+  if (!skillDef.effect) {
+    return `Skill ${skillId} has no effect implemented`;
+  }
+
+  // Check cooldowns based on usage type
+  if (skillDef.usageType === SKILL_USAGE_ONCE_PER_ROUND) {
+    if (player.skillCooldowns.usedThisRound.includes(skillId)) {
+      return "Skill has already been used this round";
+    }
+  } else if (skillDef.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+    if (player.skillCooldowns.usedThisTurn.includes(skillId)) {
+      return "Skill has already been used this turn";
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a use skill command.
+ */
+export function createUseSkillCommand(args: UseSkillCommandArgs): Command {
+  const { playerId, skillId } = args;
+
+  return {
+    type: USE_SKILL_COMMAND,
+    playerId,
+    isReversible: false, // Skill activation is not reversible (it's like flipping a tactic)
+
+    execute(state: GameState): CommandResult {
+      const events: GameEvent[] = [];
+
+      // Validate
+      const error = validateSkillActivation(state, playerId, skillId);
+      if (error) {
+        events.push({
+          type: INVALID_ACTION,
+          playerId,
+          actionType: USE_SKILL_COMMAND,
+          reason: error,
+        });
+        return { state, events };
+      }
+
+      // Find the player
+      const player = state.players.find((p) => p.id === playerId);
+      if (!player) {
+        return { state, events };
+      }
+
+      // Get skill definition
+      const skillDef = getSkillDefinition(skillId);
+      if (!skillDef || !skillDef.effect) {
+        return { state, events };
+      }
+
+      // Update cooldowns based on usage type
+      let updatedCooldowns = player.skillCooldowns;
+      if (skillDef.usageType === SKILL_USAGE_ONCE_PER_ROUND) {
+        updatedCooldowns = {
+          ...updatedCooldowns,
+          usedThisRound: [...updatedCooldowns.usedThisRound, skillId],
+        };
+      } else if (skillDef.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+        updatedCooldowns = {
+          ...updatedCooldowns,
+          usedThisTurn: [...updatedCooldowns.usedThisTurn, skillId],
+        };
+      }
+
+      // Update player with cooldowns first
+      const playerWithCooldowns: Player = {
+        ...player,
+        skillCooldowns: updatedCooldowns,
+      };
+
+      // Update state with cooldowns
+      let updatedState: GameState = {
+        ...state,
+        players: state.players.map((p) =>
+          p.id === playerId ? playerWithCooldowns : p
+        ),
+      };
+
+      // Emit skill used event
+      events.push({
+        type: SKILL_USED,
+        playerId,
+        skillId,
+      });
+
+      // Resolve the skill's effect
+      const effectResult = resolveEffect(
+        updatedState,
+        playerId,
+        skillDef.effect,
+        undefined // No source card for skills
+      );
+
+      updatedState = effectResult.state;
+
+      // If the effect requires a choice, set up pending choice on the player
+      if (effectResult.requiresChoice) {
+        const currentPlayer = updatedState.players.find(
+          (p) => p.id === playerId
+        );
+        if (currentPlayer) {
+          // Use dynamic options if available, otherwise use the effect's options
+          const choiceOptions =
+            effectResult.dynamicChoiceOptions ??
+            (skillDef.effect.type === "choice"
+              ? (skillDef.effect as { options: readonly CardEffect[] }).options
+              : []);
+
+          const updatedPlayer: Player = {
+            ...currentPlayer,
+            pendingChoice: {
+              description: effectResult.description,
+              options: choiceOptions,
+              sourceSkillId: skillId,
+            },
+          };
+
+          updatedState = {
+            ...updatedState,
+            players: updatedState.players.map((p) =>
+              p.id === playerId ? updatedPlayer : p
+            ),
+          };
+
+          // Emit choice required event
+          events.push(
+            createChoiceRequiredEvent(
+              playerId,
+              choiceOptions.map((opt) => describeEffect(opt)),
+              { skillId }
+            )
+          );
+        }
+      }
+
+      return { state: updatedState, events };
+    },
+
+    undo(_state: GameState): CommandResult {
+      throw new Error("Cannot undo USE_SKILL");
+    },
+  };
+}

--- a/packages/core/src/engine/effects/choice.ts
+++ b/packages/core/src/engine/effects/choice.ts
@@ -74,7 +74,7 @@ import type { EffectResolutionResult } from "./types.js";
 export function resolveChoiceEffect(
   state: GameState,
   _playerId: string,
-  _effect: ChoiceEffectType
+  effect: ChoiceEffectType
 ): EffectResolutionResult {
   // Choice effects pause resolution until player selects an option.
   // The command layer will:
@@ -86,5 +86,6 @@ export function resolveChoiceEffect(
     state,
     description: "Choice required",
     requiresChoice: true,
+    dynamicChoiceOptions: effect.options,
   };
 }

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -38,6 +38,7 @@ import { getTacticsOptions, getTacticEffectsOptions, getPendingTacticDecision } 
 import { getGladeWoundOptions, getDeepMineOptions } from "./pending.js";
 import { getChallengeOptions } from "./challenge.js";
 import { getCooperativeAssaultOptions } from "./cooperativeAssault.js";
+import { getSkillEffectsOptions } from "./skills.js";
 
 // Re-export helpers for use in other modules
 export {
@@ -92,6 +93,7 @@ export function getValidActions(
       deepMine: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
+      skillEffects: undefined,
     };
   }
 
@@ -121,6 +123,7 @@ export function getValidActions(
         deepMine: undefined,
         levelUpRewards: undefined,
         cooperativeAssault: undefined,
+        skillEffects: undefined,
       };
     }
 
@@ -143,6 +146,7 @@ export function getValidActions(
       deepMine: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
+      skillEffects: undefined,
     };
   }
 
@@ -177,6 +181,7 @@ export function getValidActions(
       deepMine: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
+      skillEffects: undefined,
     };
   }
 
@@ -211,6 +216,7 @@ export function getValidActions(
       deepMine: deepMineOptions,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
+      skillEffects: undefined,
     };
   }
 
@@ -251,6 +257,7 @@ export function getValidActions(
           availableAAs: state.offers.advancedActions.cards,
         },
         cooperativeAssault: undefined,
+        skillEffects: undefined,
       };
     }
   }
@@ -286,6 +293,7 @@ export function getValidActions(
       deepMine: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
+      skillEffects: undefined,
     };
   }
 
@@ -324,6 +332,7 @@ export function getValidActions(
         deepMine: undefined,
         levelUpRewards: undefined,
         cooperativeAssault: undefined,
+        skillEffects: undefined,
       };
     }
   }
@@ -351,5 +360,6 @@ export function getValidActions(
     deepMine: undefined,
     levelUpRewards: undefined,
     cooperativeAssault: getCooperativeAssaultOptions(state, player),
+    skillEffects: getSkillEffectsOptions(state, player),
   };
 }

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -1,0 +1,68 @@
+/**
+ * Skills options computation.
+ *
+ * Handles skill-related valid actions:
+ * - Skill activation during player turns (for skills with effects)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { SkillEffectsOptions, ActivatableSkill } from "@mage-knight/shared";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_PASSIVE,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_USAGE_ONCE_PER_TURN,
+} from "../../data/skills/index.js";
+
+/**
+ * Get skill effects options during player turns.
+ * Returns undefined if no skill effects are available.
+ */
+export function getSkillEffectsOptions(
+  _state: GameState,
+  player: Player
+): SkillEffectsOptions | undefined {
+  const activatableSkills = getActivatableSkills(player);
+
+  if (activatableSkills.length === 0) {
+    return undefined;
+  }
+
+  return {
+    activatableSkills,
+  };
+}
+
+/**
+ * Get skills that the player can activate this turn.
+ */
+function getActivatableSkills(player: Player): ActivatableSkill[] {
+  const result: ActivatableSkill[] = [];
+
+  for (const skillId of player.skills) {
+    const skillDef = getSkillDefinition(skillId);
+    if (!skillDef) continue;
+
+    // Skip passive skills
+    if (skillDef.usageType === SKILL_USAGE_PASSIVE) continue;
+
+    // Skip skills without effects
+    if (!skillDef.effect) continue;
+
+    // Check cooldowns based on usage type
+    if (skillDef.usageType === SKILL_USAGE_ONCE_PER_ROUND) {
+      if (player.skillCooldowns.usedThisRound.includes(skillId)) continue;
+    } else if (skillDef.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+      if (player.skillCooldowns.usedThisTurn.includes(skillId)) continue;
+    }
+
+    result.push({
+      skillId,
+      name: skillDef.name,
+      description: skillDef.description,
+    });
+  }
+
+  return result;
+}

--- a/packages/core/src/engine/validators/index.ts
+++ b/packages/core/src/engine/validators/index.ts
@@ -44,6 +44,7 @@ import {
   PROPOSE_COOPERATIVE_ASSAULT_ACTION,
   RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION,
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
+  USE_SKILL_ACTION,
 } from "@mage-knight/shared";
 import { valid } from "./types.js";
 
@@ -289,6 +290,15 @@ import {
   validateProposalExistsForCancel,
   validatePlayerIsInitiator,
 } from "./cooperativeAssaultValidators.js";
+
+// Skill validators
+import {
+  validateSkillOwned,
+  validateSkillExists,
+  validateSkillNotPassive,
+  validateSkillHasEffect,
+  validateSkillNotOnCooldown,
+} from "./skillValidators.js";
 
 // TODO: RULES LIMITATION - Immediate Choice Resolution
 // =====================================================
@@ -677,6 +687,17 @@ const validatorRegistry: Record<string, Validator[]> = {
     // Note: Initiator can cancel regardless of whose turn it is
     validateProposalExistsForCancel,
     validatePlayerIsInitiator,
+  ],
+  [USE_SKILL_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateMustAnnounceEndOfRound,
+    validateSkillExists,
+    validateSkillOwned,
+    validateSkillNotPassive,
+    validateSkillHasEffect,
+    validateSkillNotOnCooldown,
   ],
 };
 

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -1,0 +1,169 @@
+/**
+ * Validators for USE_SKILL_ACTION
+ *
+ * Validates skill activation for skills like Dark Fire Magic (Arythea).
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction, SkillId, UseSkillAction } from "@mage-knight/shared";
+import { USE_SKILL_ACTION } from "@mage-knight/shared";
+import type { ValidationResult } from "./types.js";
+import { valid, invalid } from "./types.js";
+import {
+  SKILL_NOT_OWNED,
+  SKILL_ON_COOLDOWN,
+  SKILL_IS_PASSIVE,
+  SKILL_NO_EFFECT,
+  SKILL_NOT_FOUND,
+  PLAYER_NOT_FOUND,
+  INVALID_ACTION_CODE,
+} from "./validationCodes.js";
+import {
+  getSkillDefinition,
+  SKILL_USAGE_PASSIVE,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_USAGE_ONCE_PER_TURN,
+} from "../../data/skills/index.js";
+
+/**
+ * Type guard to extract skill ID from action.
+ */
+function getSkillIdFromAction(action: PlayerAction): SkillId | null {
+  if (action.type === USE_SKILL_ACTION && "skillId" in action) {
+    return (action as UseSkillAction).skillId;
+  }
+  return null;
+}
+
+/**
+ * Validates that the player owns the skill.
+ */
+export function validateSkillOwned(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  if (!player.skills.includes(skillId)) {
+    return invalid(SKILL_NOT_OWNED, "Player does not own this skill");
+  }
+
+  return valid();
+}
+
+/**
+ * Validates that the skill exists.
+ */
+export function validateSkillExists(
+  _state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  return valid();
+}
+
+/**
+ * Validates that the skill is not passive (passive skills cannot be activated).
+ */
+export function validateSkillNotPassive(
+  _state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  if (skillDef.usageType === SKILL_USAGE_PASSIVE) {
+    return invalid(SKILL_IS_PASSIVE, "Passive skills cannot be activated");
+  }
+
+  return valid();
+}
+
+/**
+ * Validates that the skill has an effect implemented.
+ */
+export function validateSkillHasEffect(
+  _state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  if (!skillDef.effect) {
+    return invalid(SKILL_NO_EFFECT, "Skill has no effect implemented");
+  }
+
+  return valid();
+}
+
+/**
+ * Validates that the skill is not on cooldown.
+ */
+export function validateSkillNotOnCooldown(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const skillId = getSkillIdFromAction(action);
+  if (!skillId) {
+    return invalid(INVALID_ACTION_CODE, "Invalid skill action");
+  }
+
+  const skillDef = getSkillDefinition(skillId);
+  if (!skillDef) {
+    return invalid(SKILL_NOT_FOUND, "Skill not found");
+  }
+
+  // Check cooldowns based on usage type
+  if (skillDef.usageType === SKILL_USAGE_ONCE_PER_ROUND) {
+    if (player.skillCooldowns.usedThisRound.includes(skillId)) {
+      return invalid(SKILL_ON_COOLDOWN, "Skill is on cooldown (used this round)");
+    }
+  } else if (skillDef.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+    if (player.skillCooldowns.usedThisTurn.includes(skillId)) {
+      return invalid(SKILL_ON_COOLDOWN, "Skill is on cooldown (used this turn)");
+    }
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -196,6 +196,13 @@ export const INVALID_LEVEL_UP_LEVEL = "INVALID_LEVEL_UP_LEVEL" as const;
 export const SKILL_NOT_AVAILABLE = "SKILL_NOT_AVAILABLE" as const;
 export const SKILL_ALREADY_OWNED = "SKILL_ALREADY_OWNED" as const;
 
+// Skill validation codes
+export const SKILL_NOT_OWNED = "SKILL_NOT_OWNED" as const;
+export const SKILL_ON_COOLDOWN = "SKILL_ON_COOLDOWN" as const;
+export const SKILL_IS_PASSIVE = "SKILL_IS_PASSIVE" as const;
+export const SKILL_NO_EFFECT = "SKILL_NO_EFFECT" as const;
+export const SKILL_NOT_FOUND = "SKILL_NOT_FOUND" as const;
+
 // Debug validation codes
 export const DEV_MODE_REQUIRED = "DEV_MODE_REQUIRED" as const;
 export const NO_PENDING_LEVEL_UPS = "NO_PENDING_LEVEL_UPS" as const;
@@ -373,6 +380,12 @@ export type ValidationErrorCode =
   | typeof INVALID_LEVEL_UP_LEVEL
   | typeof SKILL_NOT_AVAILABLE
   | typeof SKILL_ALREADY_OWNED
+  // Skill activation validation
+  | typeof SKILL_NOT_OWNED
+  | typeof SKILL_ON_COOLDOWN
+  | typeof SKILL_IS_PASSIVE
+  | typeof SKILL_NO_EFFECT
+  | typeof SKILL_NOT_FOUND
   // Debug validation
   | typeof DEV_MODE_REQUIRED
   | typeof NO_PENDING_LEVEL_UPS

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -147,9 +147,15 @@ export function getTotalBlock(accumulator: CombatAccumulator): number {
   return accumulator.block;
 }
 
-// Pending choice - when a card requires player selection
+// Pending choice - when a card or skill requires player selection
 export interface PendingChoice {
-  readonly cardId: CardId;
+  /** The card that created this choice (for card effects) */
+  readonly cardId?: CardId;
+  /** The skill that created this choice (for skill effects) */
+  readonly sourceSkillId?: SkillId;
+  /** Description of the choice for UI display */
+  readonly description?: string;
+  /** Available options to choose from */
   readonly options: readonly CardEffect[];
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -283,13 +283,23 @@ function toClientPlayer(player: Player, forPlayerId: string): ClientPlayer {
 function toClientPendingChoice(
   choice: NonNullable<Player["pendingChoice"]>
 ): ClientPendingChoice {
-  return {
-    cardId: choice.cardId,
+  const base: ClientPendingChoice = {
     options: choice.options.map((effect) => ({
       type: effect.type,
       description: describeEffect(effect),
     })),
   };
+  if (choice.cardId) {
+    return { ...base, cardId: choice.cardId };
+  }
+  if (choice.sourceSkillId) {
+    const withSkill = { ...base, skillId: choice.sourceSkillId };
+    if (choice.description) {
+      return { ...withSkill, description: choice.description };
+    }
+    return withSkill;
+  }
+  return base;
 }
 
 /**

--- a/packages/shared/src/events/choice.ts
+++ b/packages/shared/src/events/choice.ts
@@ -24,7 +24,7 @@
  * ```
  */
 
-import type { CardId } from "../ids.js";
+import type { CardId, SkillId } from "../ids.js";
 
 // ============================================================================
 // CHOICE_REQUIRED
@@ -59,8 +59,10 @@ export interface ChoiceRequiredEvent {
   readonly type: typeof CHOICE_REQUIRED;
   /** ID of the player who must choose */
   readonly playerId: string;
-  /** ID of the card that triggered the choice */
-  readonly cardId: CardId;
+  /** ID of the card that triggered the choice (if from a card) */
+  readonly cardId?: CardId;
+  /** ID of the skill that triggered the choice (if from a skill) */
+  readonly skillId?: SkillId;
   /** Human-readable option descriptions */
   readonly options: readonly string[];
 }
@@ -69,21 +71,27 @@ export interface ChoiceRequiredEvent {
  * Creates a ChoiceRequiredEvent.
  *
  * @param playerId - ID of the player
- * @param cardId - ID of the triggering card
  * @param options - Array of option descriptions
+ * @param source - Object specifying cardId or skillId
  * @returns A new ChoiceRequiredEvent
  */
 export function createChoiceRequiredEvent(
   playerId: string,
-  cardId: CardId,
-  options: readonly string[]
+  options: readonly string[],
+  source?: { cardId?: CardId; skillId?: SkillId }
 ): ChoiceRequiredEvent {
-  return {
+  const event: ChoiceRequiredEvent = {
     type: CHOICE_REQUIRED,
     playerId,
-    cardId,
     options,
   };
+  if (source?.cardId) {
+    return { ...event, cardId: source.cardId };
+  }
+  if (source?.skillId) {
+    return { ...event, skillId: source.skillId };
+  }
+  return event;
 }
 
 // ============================================================================
@@ -120,8 +128,10 @@ export interface ChoiceResolvedEvent {
   readonly type: typeof CHOICE_RESOLVED;
   /** ID of the player who made the choice */
   readonly playerId: string;
-  /** ID of the card the choice was for */
-  readonly cardId: CardId;
+  /** ID of the card the choice was for (if from a card) */
+  readonly cardId?: CardId;
+  /** ID of the skill the choice was for (if from a skill) */
+  readonly skillId?: SkillId;
   /** Index of the chosen option (0-indexed) */
   readonly chosenIndex: number;
   /** Human-readable description of what happened */
@@ -132,24 +142,30 @@ export interface ChoiceResolvedEvent {
  * Creates a ChoiceResolvedEvent.
  *
  * @param playerId - ID of the player
- * @param cardId - ID of the card
  * @param chosenIndex - Index of selected option
  * @param effect - Description of result
+ * @param source - Object specifying cardId or skillId
  * @returns A new ChoiceResolvedEvent
  */
 export function createChoiceResolvedEvent(
   playerId: string,
-  cardId: CardId,
   chosenIndex: number,
-  effect: string
+  effect: string,
+  source?: { cardId?: CardId; skillId?: SkillId }
 ): ChoiceResolvedEvent {
-  return {
+  const event: ChoiceResolvedEvent = {
     type: CHOICE_RESOLVED,
     playerId,
-    cardId,
     chosenIndex,
     effect,
   };
+  if (source?.cardId) {
+    return { ...event, cardId: source.cardId };
+  }
+  if (source?.skillId) {
+    return { ...event, skillId: source.skillId };
+  }
+  return event;
 }
 
 // ============================================================================

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -237,6 +237,9 @@ export type {
   // Cooperative assault options
   CooperativeAssaultOptions,
   EligibleInvitee,
+  // Skill effects
+  SkillEffectsOptions,
+  ActivatableSkill,
 } from "./types/validActions.js";
 
 // Shared value constants (sub-unions)

--- a/packages/shared/src/types/clientState.ts
+++ b/packages/shared/src/types/clientState.ts
@@ -31,9 +31,15 @@ export interface ClientPendingLevelUpReward {
   readonly drawnSkills: readonly SkillId[];
 }
 
-// Pending choice - when a card requires player selection
+// Pending choice - when a card or skill requires player selection
 export interface ClientPendingChoice {
-  readonly cardId: CardId;
+  /** ID of the card that triggered the choice (if from a card) */
+  readonly cardId?: CardId;
+  /** ID of the skill that triggered the choice (if from a skill) */
+  readonly skillId?: SkillId;
+  /** Description of the choice (if any) */
+  readonly description?: string;
+  /** Available options */
   readonly options: readonly {
     readonly type: string;
     readonly description: string;

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -81,6 +81,9 @@ export interface ValidActions {
 
   /** Cooperative assault options (propose, respond, or cancel) */
   readonly cooperativeAssault: CooperativeAssaultOptions | undefined;
+
+  /** Skill effect options (activatable skills during player turns) */
+  readonly skillEffects: SkillEffectsOptions | undefined;
 }
 
 // ============================================================================
@@ -729,4 +732,29 @@ export interface CooperativeAssaultOptions {
     /** Enemy count assigned to this player in the proposal */
     readonly assignedEnemyCount: number;
   };
+}
+
+// ============================================================================
+// Skill Effects
+// ============================================================================
+
+/**
+ * Options for activating skills during player turns.
+ * Present when the player has skills that can be activated.
+ */
+export interface SkillEffectsOptions {
+  /** Skills that can be activated (not on cooldown, have effects) */
+  readonly activatableSkills: readonly ActivatableSkill[];
+}
+
+/**
+ * A skill that can be activated by the player.
+ */
+export interface ActivatableSkill {
+  /** The skill identifier */
+  readonly skillId: SkillId;
+  /** Human-readable skill name */
+  readonly name: string;
+  /** Skill description/effect text */
+  readonly description: string;
 }


### PR DESCRIPTION
## Summary
- Add skill effect system infrastructure for activatable "flip-to-use" skills
- Implement Dark Fire Magic (Arythea): Once per round, gain 1 red crystal + choice of red or black mana token
- Create useSkillCommand for skill activation with cooldown tracking
- Add skill validators, command factory, and validActions integration
- Support sourceSkillId in PendingChoice for skill-triggered choices

Closes #314

## Test plan
- [x] Skill activation grants red crystal immediately
- [x] Skill creates pending choice for red/black mana
- [x] Resolving choice grants correct mana token
- [x] Skill adds to round cooldown after use
- [x] Cannot activate skill when on cooldown
- [x] Cannot activate skill player doesn't own
- [x] ValidActions shows skill when available
- [x] ValidActions hides skill when on cooldown
- [x] Validators correctly accept/reject USE_SKILL_ACTION