### PR TITLE
feat(cards): implement terrain-based block for One with the Land

### DIFF
--- a/packages/core/src/data/basicActions/blue.ts
+++ b/packages/core/src/data/basicActions/blue.ts
@@ -13,7 +13,7 @@ import {
 } from "@mage-knight/shared";
 import {
   move, heal, attack, attackWithElement, block, blockWithElement, choice,
-  gainCrystal, convertManaToCrystal,
+  gainCrystal, convertManaToCrystal, terrainBasedBlock,
 } from "./helpers.js";
 
 // === Shared Blue Cards ===
@@ -68,7 +68,7 @@ export const BRAEVALAR_ONE_WITH_THE_LAND: DeedCard = {
   id: CARD_BRAEVALAR_ONE_WITH_THE_LAND, name: "One with the Land", cardType: DEED_CARD_TYPE_BASIC_ACTION,
   poweredBy: [MANA_BLUE], categories: [CATEGORY_MOVEMENT, CATEGORY_HEALING, CATEGORY_COMBAT],
   basicEffect: choice(move(2), heal(1), block(2)),
-  poweredEffect: choice(move(4), heal(2), block(4)), sidewaysValue: 1,
+  poweredEffect: choice(move(4), heal(2), terrainBasedBlock()), sidewaysValue: 1,
 };
 
 /** All blue-powered basic action cards */

--- a/packages/core/src/data/basicActions/helpers.ts
+++ b/packages/core/src/data/basicActions/helpers.ts
@@ -5,7 +5,8 @@ import {
   EFFECT_GAIN_HEALING, EFFECT_GAIN_MANA, EFFECT_DRAW_CARDS, EFFECT_APPLY_MODIFIER,
   EFFECT_CHOICE, EFFECT_COMPOUND, EFFECT_CHANGE_REPUTATION, EFFECT_GAIN_CRYSTAL,
   EFFECT_CONVERT_MANA_TO_CRYSTAL, EFFECT_CARD_BOOST, EFFECT_READY_UNIT,
-  EFFECT_MANA_DRAW_POWERED, COMBAT_TYPE_MELEE, COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE,
+  EFFECT_MANA_DRAW_POWERED, EFFECT_TERRAIN_BASED_BLOCK,
+  COMBAT_TYPE_MELEE, COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
 import { MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE, type BasicManaColor } from "@mage-knight/shared";
 import {
@@ -118,4 +119,14 @@ export function grantExtraSourceDieWithBlackAsAnyColor(): CardEffect {
       },
     ],
   };
+}
+
+/**
+ * Terrain-based block effect.
+ * Block value equals the unmodified movement cost of the hex the player is on.
+ * Element: Fire during day, Ice at night or in dungeon/tomb (per FAQ S1).
+ * Used by Braevalar's "One with the Land" card.
+ */
+export function terrainBasedBlock(): CardEffect {
+  return { type: EFFECT_TERRAIN_BASED_BLOCK };
 }

--- a/packages/core/src/engine/__tests__/terrainBasedBlock.test.ts
+++ b/packages/core/src/engine/__tests__/terrainBasedBlock.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for terrain-based block effect
+ *
+ * Used by Braevalar's "One with the Land" card.
+ * Block value = unmodified terrain movement cost
+ * Element = Fire (day) / Ice (night or underground)
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveEffect } from "../effects/index.js";
+import { createTestGameState, createTestPlayer, createTestHex } from "./testHelpers.js";
+import { EFFECT_TERRAIN_BASED_BLOCK } from "../../types/effectTypes.js";
+import {
+  hexKey,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+  TERRAIN_PLAINS,
+  TERRAIN_HILLS,
+  TERRAIN_FOREST,
+  TERRAIN_WASTELAND,
+  TERRAIN_DESERT,
+  TERRAIN_SWAMP,
+  TERRAIN_MOUNTAIN,
+  TERRAIN_LAKE,
+} from "@mage-knight/shared";
+import type { TerrainBasedBlockEffect } from "../../types/cards.js";
+import type { CombatState } from "../../types/combat.js";
+
+const terrainBasedBlockEffect: TerrainBasedBlockEffect = {
+  type: EFFECT_TERRAIN_BASED_BLOCK,
+};
+
+describe("Terrain-Based Block Effect", () => {
+  describe("Day time - Fire Block", () => {
+    it("should give Fire Block 2 on plains (day cost = 2)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(2);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(2);
+      expect(result.description).toContain("fire Block");
+    });
+
+    it("should give Fire Block 3 on hills (day cost = 3)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_HILLS),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(3);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(3);
+    });
+
+    it("should give Fire Block 3 on forest (day cost = 3, not night cost = 5)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_FOREST),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      // Uses unmodified (day) cost regardless of time of day
+      expect(result.state.players[0].combatAccumulator.block).toBe(3);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(3);
+    });
+
+    it("should give Fire Block 4 on wasteland (day cost = 4)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_WASTELAND),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(4);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(4);
+    });
+
+    it("should give Fire Block 5 on desert (day cost = 5)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_DESERT),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(5);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(5);
+    });
+
+    it("should give Fire Block 5 on swamp (day cost = 5)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_SWAMP),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(5);
+      expect(result.state.players[0].combatAccumulator.blockElements.fire).toBe(5);
+    });
+  });
+
+  describe("Night time - Ice Block", () => {
+    it("should give Ice Block 2 on plains at night", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      expect(result.state.players[0].combatAccumulator.block).toBe(2);
+      expect(result.state.players[0].combatAccumulator.blockElements.ice).toBe(2);
+      expect(result.description).toContain("ice Block");
+    });
+
+    it("should give Ice Block 3 on forest at night (still uses day cost = 3)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_FOREST),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      // Per rulebook: uses UNMODIFIED move cost (day cost), not the time-adjusted cost
+      expect(result.state.players[0].combatAccumulator.block).toBe(3);
+      expect(result.state.players[0].combatAccumulator.blockElements.ice).toBe(3);
+    });
+  });
+
+  describe("Underground combat (Dungeon/Tomb) - Ice Block per FAQ S1", () => {
+    it("should give Ice Block during day when in dungeon combat (nightManaRules)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+
+      // Create dungeon combat state (nightManaRules = true)
+      const combat: CombatState = {
+        enemies: [],
+        phase: "rangedSiege",
+        woundsThisCombat: 0,
+        attacksThisPhase: 0,
+        fameGained: 0,
+        isAtFortifiedSite: false,
+        unitsAllowed: false, // Dungeons don't allow units
+        nightManaRules: true, // This makes it "night-like" for element purposes
+        assaultOrigin: null,
+        combatHexCoord: null,
+        allDamageBlockedThisPhase: false,
+        discardEnemiesOnFailure: false,
+        pendingDamage: {},
+        pendingBlock: {},
+      };
+
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY, // Day outside, but dungeon uses night rules
+        combat,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      // Even during day, underground combat gives Ice Block
+      expect(result.state.players[0].combatAccumulator.blockElements.ice).toBe(2);
+      expect(result.description).toContain("ice Block");
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should give Block 2 on lake (fallback for impassable terrain)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_LAKE),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      // Lake is impassable (Infinity), but if you're somehow on it (boat),
+      // we use a reasonable fallback of 2
+      expect(result.state.players[0].combatAccumulator.block).toBe(2);
+    });
+
+    it("should give Block 5 on mountain (fallback for impassable terrain)", () => {
+      const player = createTestPlayer({ position: { q: 0, r: 0 } });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_MOUNTAIN),
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      const result = resolveEffect(state, player.id, terrainBasedBlockEffect);
+
+      // Mountain gets 5 as fallback (thematically appropriate for the highest terrain)
+      expect(result.state.players[0].combatAccumulator.block).toBe(5);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -25,6 +25,7 @@ import {
   EFFECT_MANA_DRAW_SET_COLOR,
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+  EFFECT_TERRAIN_BASED_BLOCK,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -140,6 +141,9 @@ export function describeEffect(effect: CardEffect): string {
         .join(", ");
       return modDescriptions || `Target ${effect.enemyName}`;
     }
+
+    case EFFECT_TERRAIN_BASED_BLOCK:
+      return "Block (terrain cost, Fire/Ice)";
 
     default:
       return "Unknown effect";

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -160,6 +160,9 @@ export {
   applyPayMana,
 } from "./manaPaymentEffects.js";
 
+// Terrain-based effects
+export { resolveTerrainBasedBlock } from "./terrainEffects.js";
+
 // Effect reversal (for undo)
 export { reverseEffect } from "./reverse.js";
 
@@ -204,6 +207,7 @@ import {
   EFFECT_DISCARD_CARD,
   EFFECT_REVEAL_TILES,
   EFFECT_PAY_MANA,
+  EFFECT_TERRAIN_BASED_BLOCK,
   MANA_ANY,
 } from "../../types/effectTypes.js";
 
@@ -272,6 +276,9 @@ import { handleRevealTiles } from "./mapEffects.js";
 
 // Mana payment effects
 import { handlePayMana } from "./manaPaymentEffects.js";
+
+// Terrain-based effects
+import { resolveTerrainBasedBlock } from "./terrainEffects.js";
 
 // ============================================================================
 // MAIN EFFECT RESOLVER
@@ -479,6 +486,13 @@ export function resolveEffect(
 
     case EFFECT_PAY_MANA:
       return handlePayMana(state, playerIndex, player, effect);
+
+    // ========================================================================
+    // TERRAIN-BASED EFFECTS
+    // ========================================================================
+
+    case EFFECT_TERRAIN_BASED_BLOCK:
+      return resolveTerrainBasedBlock(state, playerIndex, player, effect);
 
     // ========================================================================
     // UNKNOWN EFFECT TYPE

--- a/packages/core/src/engine/effects/terrainEffects.ts
+++ b/packages/core/src/engine/effects/terrainEffects.ts
@@ -1,0 +1,107 @@
+/**
+ * Terrain-based effect resolvers
+ *
+ * Handles effects that depend on the terrain the player is currently on.
+ * - TerrainBasedBlock: Block value equals terrain's unmodified movement cost,
+ *   with Fire element during day and Ice element at night/underground.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { TerrainBasedBlockEffect, GainBlockEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { applyGainBlock } from "./atomicEffects.js";
+import {
+  hexKey,
+  DEFAULT_MOVEMENT_COSTS,
+  TIME_OF_DAY_NIGHT,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+} from "@mage-knight/shared";
+import { EFFECT_GAIN_BLOCK } from "../../types/effectTypes.js";
+
+/**
+ * Get the unmodified movement cost for the terrain at the player's position.
+ * Returns the DAY cost (since "unmodified" means the base cost, not time-adjusted).
+ *
+ * Special cases:
+ * - Lake: Returns 2 (boat required to be on lake)
+ * - Mountain: Returns 5 (shouldn't normally be on mountain, but fallback)
+ * - Ocean: Returns 2 (shouldn't normally be on ocean, but fallback)
+ * - Dungeon/Tomb: Uses the site's terrain cost (usually city = 2)
+ */
+function getUnmodifiedTerrainCost(state: GameState, player: Player): number {
+  if (!player.position) {
+    return 2; // Fallback if no position
+  }
+
+  const hex = state.map.hexes[hexKey(player.position)];
+  if (!hex) {
+    return 2; // Fallback if hex not found
+  }
+
+  const terrain = hex.terrain;
+  const costs = DEFAULT_MOVEMENT_COSTS[terrain];
+
+  // For impassable terrain, use reasonable fallback values
+  // (Player shouldn't normally be on these, but handle gracefully)
+  if (costs.day === Infinity) {
+    // Lake = 2 (with boat), Mountain = 5, Ocean = 2
+    if (terrain === "lake") return 2;
+    if (terrain === "mountain") return 5;
+    if (terrain === "ocean") return 2;
+    return 2; // Generic fallback
+  }
+
+  // Use day cost as the "unmodified" base cost
+  return costs.day;
+}
+
+/**
+ * Determine if we're in "night-like" conditions for element purposes.
+ * True if:
+ * - It's night time
+ * - OR we're in underground combat (dungeon/tomb)
+ *
+ * Per FAQ S1: Dungeons and Tombs count as "night" for this effect.
+ */
+function isNightLikeConditions(state: GameState): boolean {
+  return state.timeOfDay === TIME_OF_DAY_NIGHT || (state.combat?.nightManaRules ?? false);
+}
+
+/**
+ * Resolve a terrain-based block effect.
+ *
+ * Block value = unmodified movement cost of current terrain
+ * Element = Fire (day) or Ice (night/underground)
+ *
+ * @param state - Current game state
+ * @param playerIndex - Index of the player in state.players
+ * @param player - The player resolving the effect
+ * @param _effect - The terrain-based block effect (unused, but kept for API consistency)
+ * @returns Resolution result with updated state
+ */
+export function resolveTerrainBasedBlock(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  _effect: TerrainBasedBlockEffect
+): EffectResolutionResult {
+  const blockAmount = getUnmodifiedTerrainCost(state, player);
+  const element = isNightLikeConditions(state) ? ELEMENT_ICE : ELEMENT_FIRE;
+
+  // Create a standard GainBlockEffect and delegate to the atomic resolver
+  const blockEffect: GainBlockEffect = {
+    type: EFFECT_GAIN_BLOCK,
+    amount: blockAmount,
+    element,
+  };
+
+  const result = applyGainBlock(state, playerIndex, player, blockEffect);
+
+  // Enhance description to clarify it's terrain-based
+  return {
+    ...result,
+    description: `Gained ${blockAmount} ${element} Block (terrain cost)`,
+  };
+}

--- a/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
@@ -8,6 +8,7 @@ import type { CardEffect } from "../../../../types/cards.js";
 import {
   EFFECT_GAIN_ATTACK,
   EFFECT_GAIN_BLOCK,
+  EFFECT_TERRAIN_BASED_BLOCK,
   EFFECT_CHOICE,
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
@@ -50,6 +51,7 @@ export function effectHasRangedOrSiege(effect: CardEffect): boolean {
 export function effectHasBlock(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_BLOCK:
+    case EFFECT_TERRAIN_BASED_BLOCK:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -37,6 +37,7 @@ import {
   EFFECT_DISCARD_CARD,
   EFFECT_REVEAL_TILES,
   EFFECT_PAY_MANA,
+  EFFECT_TERRAIN_BASED_BLOCK,
   MANA_ANY,
   type CombatType,
 } from "./effectTypes.js";
@@ -398,6 +399,20 @@ export interface PayManaCostEffect {
   readonly amount: number;
 }
 
+/**
+ * Terrain-based block effect.
+ * Block value equals the unmodified movement cost of the hex the player is on.
+ * Element varies by time of day:
+ * - Day: Fire Block
+ * - Night or Underground (Dungeon/Tomb): Ice Block
+ *
+ * Used by Braevalar's "One with the Land" card.
+ * Per FAQ S1: Dungeons and Tombs count as "night" for this effect.
+ */
+export interface TerrainBasedBlockEffect {
+  readonly type: typeof EFFECT_TERRAIN_BASED_BLOCK;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -429,7 +444,8 @@ export type CardEffect =
   | HealUnitEffect
   | DiscardCardEffect
   | RevealTilesEffect
-  | PayManaCostEffect;
+  | PayManaCostEffect
+  | TerrainBasedBlockEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -66,6 +66,11 @@ export type CardColor =
 // Used when an effect can produce any color of mana
 export const MANA_ANY = "any" as const;
 
+// === Terrain-Based Effects ===
+// Block with value based on terrain's unmodified movement cost
+// Element varies by time of day: Fire (day) / Ice (night or underground)
+export const EFFECT_TERRAIN_BASED_BLOCK = "terrain_based_block" as const;
+
 // === Cost Effects ===
 // Take a wound (add wound card to hand)
 export const EFFECT_TAKE_WOUND = "take_wound" as const;


### PR DESCRIPTION
## Summary

- Implement the powered block effect for Braevalar's hero-specific card "One with the Land" (#118)
- Block value equals the terrain's unmodified (day) movement cost
- Fire element during day, Ice element at night or underground (dungeon/tomb per FAQ S1)

## Changes

- Add `EFFECT_TERRAIN_BASED_BLOCK` effect type constant
- Add `TerrainBasedBlockEffect` interface to CardEffect union
- Create `terrainEffects.ts` resolver with terrain cost lookup
- Add `terrainBasedBlock()` helper function
- Update `effectHasBlock()` detection for valid actions
- Update One with the Land card definition to use new effect
- Add 11 tests covering various terrain types and day/night/underground conditions

## Test plan

- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 1162 core tests pass, including 11 new terrain-based block tests
- [ ] Manual testing: Play as Braevalar, use powered One with the Land in combat on different terrains

Closes #118