### PR TITLE
Extract player lookup helpers into dedicated utility module

### DIFF
--- a/packages/core/src/engine/commands/combat/damageResolution.ts
+++ b/packages/core/src/engine/commands/combat/damageResolution.ts
@@ -26,6 +26,7 @@ import {
   createEmptyElementalValues,
 } from "../../../types/player.js";
 import { isAttackResisted, type Resistances } from "../../combat/elementalCalc.js";
+import { getPlayerIndexById } from "../../helpers/playerHelpers.js";
 
 /**
  * Get enemy resistances from their definition.
@@ -163,7 +164,7 @@ export function clearPendingAndAssigned(
     : null;
 
   // Clear player's assigned attack
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  const playerIndex = getPlayerIndexById(state, playerId);
   if (playerIndex === -1) {
     return { ...state, combat: updatedCombat };
   }
@@ -207,7 +208,7 @@ export function clearPendingBlock(state: GameState, playerId: string): GameState
     : null;
 
   // Clear player's assigned block tracking
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  const playerIndex = getPlayerIndexById(state, playerId);
   if (playerIndex === -1) {
     return { ...state, combat: updatedCombat };
   }
@@ -251,7 +252,7 @@ export function applyFameToPlayer(
     return state;
   }
 
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  const playerIndex = getPlayerIndexById(state, playerId);
   if (playerIndex === -1) {
     return state;
   }
@@ -307,7 +308,7 @@ export function applyReputationChange(
     return { state, events: [] };
   }
 
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  const playerIndex = getPlayerIndexById(state, playerId);
   if (playerIndex === -1) {
     return { state, events: [] };
   }

--- a/packages/core/src/engine/commands/debug/debugAddFameCommand.ts
+++ b/packages/core/src/engine/commands/debug/debugAddFameCommand.ts
@@ -9,6 +9,7 @@ import type { Command, CommandResult } from "../../commands.js";
 import type { GameState } from "../../../state/GameState.js";
 import type { GameEvent } from "@mage-knight/shared";
 import { getLevelsCrossed, createFameGainedEvent } from "@mage-knight/shared";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 export const DEBUG_ADD_FAME_COMMAND = "DEBUG_ADD_FAME" as const;
 
@@ -32,7 +33,7 @@ export function createDebugAddFameCommand(
     isReversible: true, // Can undo this
 
     execute(state: GameState): CommandResult {
-      const player = state.players.find((p) => p.id === playerId);
+      const player = getPlayerById(state, playerId);
       if (!player) {
         return { state, events: [] };
       }
@@ -74,7 +75,7 @@ export function createDebugAddFameCommand(
         return { state, events: [] };
       }
 
-      const player = state.players.find((p) => p.id === playerId);
+      const player = getPlayerById(state, playerId);
       if (!player) {
         return { state, events: [] };
       }

--- a/packages/core/src/engine/commands/debug/debugTriggerLevelUpCommand.ts
+++ b/packages/core/src/engine/commands/debug/debugTriggerLevelUpCommand.ts
@@ -10,6 +10,7 @@
 import type { Command, CommandResult } from "../../commands.js";
 import type { GameState } from "../../../state/GameState.js";
 import { processLevelUps } from "../endTurn/levelUp.js";
+import { getPlayerIndexById } from "../../helpers/playerHelpers.js";
 
 export const DEBUG_TRIGGER_LEVEL_UP_COMMAND = "DEBUG_TRIGGER_LEVEL_UP" as const;
 
@@ -28,10 +29,12 @@ export function createDebugTriggerLevelUpCommand(
     isReversible: false, // Uses RNG for skill drawing
 
     execute(state: GameState): CommandResult {
-      const playerIndex = state.players.findIndex((p) => p.id === playerId);
+      const playerIndex = getPlayerIndexById(state, playerId);
+      if (playerIndex === -1) {
+        return { state, events: [] };
+      }
       const player = state.players[playerIndex];
-
-      if (playerIndex === -1 || !player) {
+      if (!player) {
         return { state, events: [] };
       }
 

--- a/packages/core/src/engine/commands/endTurn/turnAdvancement.ts
+++ b/packages/core/src/engine/commands/endTurn/turnAdvancement.ts
@@ -22,6 +22,7 @@ import {
 } from "@mage-knight/shared";
 import { SiteType } from "../../../types/map.js";
 import type { NextPlayerResult, NextPlayerSetupResult } from "./types.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Determine what happens after the current player's turn ends.
@@ -53,7 +54,7 @@ export function determineNextPlayer(
   }
 
   // Check for extra turn (The Right Moment tactic)
-  const currentPlayer = state.players.find((p) => p.id === playerId);
+  const currentPlayer = getPlayerById(state, playerId);
   const hasExtraTurnPending = currentPlayer?.tacticState?.extraTurnPending === true;
 
   let nextPlayerId: string | null = null;

--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -31,6 +31,7 @@ import { getCard } from "../../validActions/cards/index.js";
 import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
 import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
 import type { Player } from "../../../types/player.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Helper to get card id from play card action.
@@ -135,7 +136,7 @@ export const createPlayCardCommandFromAction: CommandFactory = (
   const details = getPlayCardDetails(action);
   if (!details) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return null;
 
   const handIndex = player.hand.indexOf(cardId);
@@ -207,7 +208,7 @@ export const createPlayCardSidewaysCommandFromAction: CommandFactory = (
   const sidewaysChoice = getSidewaysChoice(action);
   if (!sidewaysChoice) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return null;
 
   const handIndex = player.hand.indexOf(cardId);
@@ -234,7 +235,7 @@ export const createResolveChoiceCommandFromAction: CommandFactory = (
   const choiceIndex = getChoiceIndexFromAction(action);
   if (choiceIndex === null) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.pendingChoice) return null;
 
   return createResolveChoiceCommand({

--- a/packages/core/src/engine/commands/factories/movement.ts
+++ b/packages/core/src/engine/commands/factories/movement.ts
@@ -25,6 +25,7 @@ import { SITE_PROPERTIES } from "../../../data/siteProperties.js";
 import { createMoveCommand } from "../moveCommand.js";
 import { createExploreCommand } from "../exploreCommand.js";
 import { getEffectiveTerrainCost } from "../../modifiers.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Helper to get move target from action.
@@ -82,7 +83,7 @@ export const createMoveCommandFromAction: CommandFactory = (
   playerId,
   action
 ) => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   const target = getMoveTarget(action);
 
   if (!player?.position || !target) return null;
@@ -123,7 +124,7 @@ export const createExploreCommandFromAction: CommandFactory = (
   const { direction, fromTileCoord } = action;
   if (!direction || !fromTileCoord) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) return null;
 
   // Draw a tile (SIMPLE: take first from countryside, then core)

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -29,6 +29,7 @@ import { createResolveGladeWoundCommand } from "../resolveGladeWoundCommand.js";
 import { createResolveDeepMineChoiceCommand } from "../resolveDeepMineChoiceCommand.js";
 import { createBurnMonasteryCommand } from "../burnMonasteryCommand.js";
 import { createPlunderVillageCommand } from "../plunderVillageCommand.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Helper to get glade wound choice from action.
@@ -65,7 +66,7 @@ export const createInteractCommandFromAction: CommandFactory = (
 ) => {
   if (action.type !== INTERACT_ACTION) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return null;
 
   // For now, influence must be calculated from player's influencePoints

--- a/packages/core/src/engine/commands/factories/turn.ts
+++ b/packages/core/src/engine/commands/factories/turn.ts
@@ -31,6 +31,7 @@ import { createCompleteRestCommand } from "../completeRestCommand.js";
 import { createAnnounceEndOfRoundCommand } from "../announceEndOfRoundCommand.js";
 import { getBasicActionCard } from "../../../data/basicActions/index.js";
 import { DEED_CARD_TYPE_WOUND } from "../../../types/cards.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Helper to check if a card is a wound
@@ -67,7 +68,7 @@ export const createRestCommandFromAction: CommandFactory = (
 ) => {
   if (action.type !== REST_ACTION) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return null;
 
   return createRestCommand({
@@ -119,7 +120,7 @@ export const createCompleteRestCommandFromAction: CommandFactory = (
 ) => {
   if (action.type !== COMPLETE_REST_ACTION) return null;
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return null;
 
   // Determine rest type based on current hand state

--- a/packages/core/src/engine/commands/rerollSourceDiceCommand.ts
+++ b/packages/core/src/engine/commands/rerollSourceDiceCommand.ts
@@ -22,6 +22,7 @@ import {
 } from "@mage-knight/shared";
 import { rerollDie } from "../mana/manaSource.js";
 import { REROLL_SOURCE_DICE_COMMAND } from "./commandTypes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 export { REROLL_SOURCE_DICE_COMMAND };
 
@@ -38,7 +39,7 @@ function validateReroll(
   playerId: string,
   dieIds: readonly string[]
 ): string | null {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return "Player not found";
   }
@@ -124,7 +125,7 @@ export function createRerollSourceDiceCommand(
       }
 
       // Find the player
-      const player = state.players.find((p) => p.id === playerId);
+      const player = getPlayerById(state, playerId);
       if (!player) {
         return { state, events };
       }

--- a/packages/core/src/engine/commands/resolveTacticDecisionCommand.ts
+++ b/packages/core/src/engine/commands/resolveTacticDecisionCommand.ts
@@ -36,6 +36,7 @@ import {
 import { RESOLVE_TACTIC_DECISION_COMMAND } from "./commandTypes.js";
 import { shuffleWithRng } from "../../utils/rng.js";
 import { getTacticCard } from "../../data/tactics.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 export { RESOLVE_TACTIC_DECISION_COMMAND };
 
@@ -52,7 +53,7 @@ function validateResolution(
   playerId: string,
   decision: ResolveTacticDecisionPayload
 ): string | null {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return "Player not found";
   }
@@ -183,7 +184,7 @@ export function createResolveTacticDecisionCommand(
       }
 
       // Find the player
-      const player = state.players.find((p) => p.id === playerId);
+      const player = getPlayerById(state, playerId);
       if (!player) {
         return { state, events };
       }

--- a/packages/core/src/engine/commands/selectTacticCommand.ts
+++ b/packages/core/src/engine/commands/selectTacticCommand.ts
@@ -35,6 +35,7 @@ import {
 import { getTacticCard } from "../../data/tactics.js";
 import { SELECT_TACTIC_COMMAND } from "./commandTypes.js";
 import { randomElement, type RngState } from "../../utils/rng.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 export { SELECT_TACTIC_COMMAND };
 
@@ -62,7 +63,7 @@ function validateSelection(
   }
 
   // Must not have a pending tactic decision to resolve
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (player?.pendingTacticDecision) {
     return "Must resolve pending tactic decision first";
   }
@@ -130,7 +131,7 @@ export function createSelectTacticCommand(
       const tacticCard = getTacticCard(tacticId);
 
       // Find the player for on-pick effect processing
-      const player = state.players.find(p => p.id === playerId);
+      const player = getPlayerById(state, playerId);
       if (!player) {
         events.push({
           type: INVALID_ACTION,

--- a/packages/core/src/engine/commands/skills/shieldMasteryEffect.ts
+++ b/packages/core/src/engine/commands/skills/shieldMasteryEffect.ts
@@ -21,6 +21,7 @@ import {
   fireBlock,
   iceBlock,
 } from "../../../data/effectHelpers.js";
+import { getPlayerIndexByIdOrThrow } from "../../helpers/playerHelpers.js";
 
 /**
  * Apply the Shield Mastery skill effect.
@@ -36,11 +37,7 @@ export function applyShieldMasteryEffect(
   state: GameState,
   playerId: string
 ): GameState {
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
-  if (playerIndex === -1) {
-    throw new Error(`Player not found: ${playerId}`);
-  }
-
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
   const player = state.players[playerIndex];
   if (!player) {
     throw new Error(`Player not found at index: ${playerIndex}`);
@@ -77,11 +74,7 @@ export function removeShieldMasteryEffect(
   state: GameState,
   playerId: string
 ): GameState {
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
-  if (playerIndex === -1) {
-    throw new Error(`Player not found: ${playerId}`);
-  }
-
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
   const player = state.players[playerIndex];
   if (!player) {
     throw new Error(`Player not found at index: ${playerIndex}`);

--- a/packages/core/src/engine/commands/skills/whoNeedsMagicEffect.ts
+++ b/packages/core/src/engine/commands/skills/whoNeedsMagicEffect.ts
@@ -22,6 +22,7 @@ import {
   SIDEWAYS_CONDITION_NO_MANA_USED,
   SOURCE_SKILL,
 } from "../../modifierConstants.js";
+import { getPlayerByIdOrThrow } from "../../helpers/playerHelpers.js";
 
 /**
  * Apply the Who Needs Magic? skill effect.
@@ -38,10 +39,7 @@ export function applyWhoNeedsMagicEffect(
   state: GameState,
   playerId: string
 ): GameState {
-  const player = state.players.find((p) => p.id === playerId);
-  if (!player) {
-    throw new Error(`Player not found: ${playerId}`);
-  }
+  const player = getPlayerByIdOrThrow(state, playerId);
 
   // Add +2 modifier (unconditional - always applies as baseline)
   state = addModifier(state, {

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -29,6 +29,7 @@ import {
   applyIFeelNoPainEffect,
   removeIFeelNoPainEffect,
 } from "./skills/index.js";
+import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
 
 export { USE_SKILL_COMMAND };
 
@@ -149,11 +150,7 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
         throw new Error(`Skill not found: ${skillId}`);
       }
 
-      const playerIndex = state.players.findIndex((p) => p.id === playerId);
-      if (playerIndex === -1) {
-        throw new Error(`Player not found: ${playerId}`);
-      }
-
+      const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
       const player = state.players[playerIndex];
       if (!player) {
         throw new Error(`Player not found at index: ${playerIndex}`);
@@ -192,11 +189,7 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
         throw new Error(`Skill not found: ${skillId}`);
       }
 
-      const playerIndex = state.players.findIndex((p) => p.id === playerId);
-      if (playerIndex === -1) {
-        throw new Error(`Player not found: ${playerId}`);
-      }
-
+      const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
       const player = state.players[playerIndex];
       if (!player) {
         throw new Error(`Player not found at index: ${playerIndex}`);

--- a/packages/core/src/engine/effects/conditionEvaluator.ts
+++ b/packages/core/src/engine/effects/conditionEvaluator.ts
@@ -21,6 +21,7 @@ import {
   CONDITION_IS_NIGHT_OR_UNDERGROUND,
 } from "../../types/conditions.js";
 import { CARD_WOUND, hexKey, TIME_OF_DAY_NIGHT } from "@mage-knight/shared";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Evaluates a condition against the current game state for a specific player.
@@ -35,7 +36,7 @@ export function evaluateCondition(
   playerId: string,
   condition: EffectCondition
 ): boolean {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return false;
 
   switch (condition.type) {

--- a/packages/core/src/engine/effects/effectUndoContext.ts
+++ b/packages/core/src/engine/effects/effectUndoContext.ts
@@ -20,6 +20,7 @@ import { EFFECT_MANA_DRAW_SET_COLOR, EFFECT_RESOLVE_BOOST_TARGET } from "../../t
 import { getCard } from "../validActions/cards/index.js";
 import { addBonusToEffect } from "./cardBoostEffects.js";
 import { reverseEffect } from "./reverse.js";
+import { getPlayerIndexById } from "../helpers/playerHelpers.js";
 
 // === Undo Context Types (Discriminated Union) ===
 
@@ -146,7 +147,7 @@ export function applyUndoContext(
       );
 
       // Remove the mana tokens that were gained
-      const playerIndex = state.players.findIndex((p) => p.id === playerId);
+      const playerIndex = getPlayerIndexById(state, playerId);
       if (playerIndex === -1) {
         return { ...state, source: { ...state.source, dice: updatedDice } };
       }
@@ -189,7 +190,7 @@ export function applyUndoContext(
 
     case EFFECT_RESOLVE_BOOST_TARGET: {
       // 1. Reverse the boosted effect (removes move points, attack, etc.)
-      const playerIndex = state.players.findIndex((p) => p.id === playerId);
+      const playerIndex = getPlayerIndexById(state, playerId);
       if (playerIndex === -1) {
         return state;
       }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -280,6 +280,9 @@ import { handlePayMana } from "./manaPaymentEffects.js";
 // Terrain-based effects
 import { resolveTerrainBasedBlock } from "./terrainEffects.js";
 
+// Player helpers
+import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
+
 // ============================================================================
 // MAIN EFFECT RESOLVER
 // ============================================================================
@@ -313,11 +316,7 @@ export function resolveEffect(
   effect: CardEffect,
   sourceCardId?: string
 ): EffectResolutionResult {
-  const playerIndex = state.players.findIndex((p) => p.id === playerId);
-  if (playerIndex === -1) {
-    throw new Error(`Player not found: ${playerId}`);
-  }
-
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
   const player = state.players[playerIndex];
   if (!player) {
     throw new Error(`Player not found at index: ${playerIndex}`);

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -32,6 +32,7 @@ import {
   MANA_WHITE,
 } from "@mage-knight/shared";
 import { getCard } from "../validActions/cards/index.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 import {
   EFFECT_GAIN_MOVE,
   EFFECT_GAIN_INFLUENCE,
@@ -94,7 +95,7 @@ export function isEffectResolvable(
   playerId: string,
   effect: CardEffect
 ): boolean {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return false;
 
   switch (effect.type) {

--- a/packages/core/src/engine/effects/scalingEvaluator.ts
+++ b/packages/core/src/engine/effects/scalingEvaluator.ts
@@ -14,6 +14,7 @@ import {
 import type { UnitFilter } from "../../types/scaling.js";
 import type { PlayerUnit } from "../../types/unit.js";
 import { CARD_WOUND, UNIT_STATE_READY, UNIT_STATE_SPENT } from "@mage-knight/shared";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Evaluates a scaling factor and returns the count to multiply by.
@@ -28,7 +29,7 @@ export function evaluateScalingFactor(
   playerId: string,
   factor: ScalingFactor
 ): number {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return 0;
 
   switch (factor.type) {

--- a/packages/core/src/engine/helpers/handLimitHelpers.ts
+++ b/packages/core/src/engine/helpers/handLimitHelpers.ts
@@ -8,6 +8,7 @@
 import type { GameState } from "../../state/GameState.js";
 import { SiteType } from "../../types/map.js";
 import { STARTING_HAND_LIMIT, hexKey, getAllNeighbors, TACTIC_PLANNING } from "@mage-knight/shared";
+import { getPlayerById } from "./playerHelpers.js";
 
 const PLANNING_MIN_HAND_SIZE_BEFORE_DRAW_FOR_BONUS = 2;
 const PLANNING_HAND_LIMIT_BONUS = 1;
@@ -31,7 +32,7 @@ export function countOwnedKeeps(state: GameState, playerId: string): number {
  * Check if player is on or adjacent to any keep they own.
  */
 export function isNearOwnedKeep(state: GameState, playerId: string): boolean {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) return false;
 
   // Check current hex
@@ -63,7 +64,7 @@ export function getEffectiveHandLimit(
   state: GameState,
   playerId: string
 ): number {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return STARTING_HAND_LIMIT; // Fallback
 
   let handLimit = player.handLimit;
@@ -95,7 +96,7 @@ export function getEndTurnDrawLimit(
   let limit = getEffectiveHandLimit(state, playerId);
 
   // Planning tactic: +1 if hand size >= 2 before drawing
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (
     player?.selectedTactic === TACTIC_PLANNING &&
     currentHandSize >= PLANNING_MIN_HAND_SIZE_BEFORE_DRAW_FOR_BONUS

--- a/packages/core/src/engine/helpers/index.ts
+++ b/packages/core/src/engine/helpers/index.ts
@@ -3,6 +3,13 @@
  */
 
 export {
+  getPlayerByIdOrThrow,
+  getPlayerIndexByIdOrThrow,
+  getPlayerById,
+  getPlayerIndexById,
+} from "./playerHelpers.js";
+
+export {
   getPlayerSite,
   isPlayerAtSiteType,
 } from "./siteHelpers.js";

--- a/packages/core/src/engine/helpers/playerHelpers.ts
+++ b/packages/core/src/engine/helpers/playerHelpers.ts
@@ -1,0 +1,58 @@
+/**
+ * Player lookup helper functions for game engine operations
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+
+/**
+ * Get a player by ID, throwing an error if not found.
+ * Use this in commands where the player must exist.
+ */
+export function getPlayerByIdOrThrow(
+  state: GameState,
+  playerId: string
+): Player {
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) {
+    throw new Error(`Player not found: ${playerId}`);
+  }
+  return player;
+}
+
+/**
+ * Get a player's index by ID, throwing an error if not found.
+ * Use this when you need to update the player in state.
+ */
+export function getPlayerIndexByIdOrThrow(
+  state: GameState,
+  playerId: string
+): number {
+  const index = state.players.findIndex((p) => p.id === playerId);
+  if (index === -1) {
+    throw new Error(`Player not found: ${playerId}`);
+  }
+  return index;
+}
+
+/**
+ * Get a player by ID, returning null if not found.
+ * Use this when the player might not exist and you need to handle that case.
+ */
+export function getPlayerById(
+  state: GameState,
+  playerId: string
+): Player | null {
+  return state.players.find((p) => p.id === playerId) ?? null;
+}
+
+/**
+ * Get a player's index by ID, returning -1 if not found.
+ * Use this when you need to check existence before proceeding.
+ */
+export function getPlayerIndexById(
+  state: GameState,
+  playerId: string
+): number {
+  return state.players.findIndex((p) => p.id === playerId);
+}

--- a/packages/core/src/engine/helpers/rewards/handlers.ts
+++ b/packages/core/src/engine/helpers/rewards/handlers.ts
@@ -25,6 +25,7 @@ import {
   MANA_BLACK,
   BasicManaColor,
 } from "@mage-knight/shared";
+import { getPlayerById } from "../playerHelpers.js";
 
 /**
  * Grant a site reward to a player.
@@ -83,7 +84,7 @@ export function grantSpellReward(
     if (!cardId) continue;
 
     // Add spell to top of player's deed deck (drawn next round)
-    const player = currentState.players.find((p) => p.id === playerId);
+    const player = getPlayerById(currentState, playerId);
     if (!player) continue;
 
     const updatedPlayer: Player = {
@@ -158,7 +159,7 @@ export function grantArtifactReward(
     if (!cardId) continue;
 
     // Add artifact to top of player's deed deck (drawn next round)
-    const player = currentState.players.find((p) => p.id === playerId);
+    const player = getPlayerById(currentState, playerId);
     if (!player) continue;
 
     const updatedPlayer: Player = {
@@ -200,7 +201,7 @@ export function grantCrystalRollReward(
   const events: GameEvent[] = [];
   let currentRng = state.rng;
 
-  const player = currentState.players.find((p) => p.id === playerId);
+  const player = getPlayerById(currentState, playerId);
   if (!player) {
     return { state, events: [] };
   }
@@ -282,7 +283,7 @@ export function grantAdvancedActionReward(
     const cardId = aaOffer[0];
     if (!cardId) continue;
 
-    const player = currentState.players.find((p) => p.id === playerId);
+    const player = getPlayerById(currentState, playerId);
     if (!player) continue;
 
     const updatedPlayer: Player = {
@@ -337,7 +338,7 @@ export function grantFameReward(
   playerId: string,
   amount: number
 ): RewardResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return { state, events: [] };
   }

--- a/packages/core/src/engine/helpers/rewards/queueing.ts
+++ b/packages/core/src/engine/helpers/rewards/queueing.ts
@@ -17,6 +17,7 @@ import {
   REWARD_QUEUED,
 } from "@mage-knight/shared";
 import { grantFameReward, grantCrystalRollReward, grantArtifactReward } from "./handlers.js";
+import { getPlayerById } from "../playerHelpers.js";
 
 /**
  * Queue a site reward for the player to select at end of turn.
@@ -63,7 +64,7 @@ export function queueSiteReward(
   }
 
   // Queue rewards that require player choice
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return { state, events: [] };
   }

--- a/packages/core/src/engine/helpers/siteHelpers.ts
+++ b/packages/core/src/engine/helpers/siteHelpers.ts
@@ -5,6 +5,7 @@
 import type { GameState } from "../../state/GameState.js";
 import type { Site, SiteType } from "../../types/map.js";
 import { hexKey } from "@mage-knight/shared";
+import { getPlayerById } from "./playerHelpers.js";
 
 /**
  * Get the site at the player's current position
@@ -14,7 +15,7 @@ export function getPlayerSite(
   state: GameState,
   playerId: string
 ): Site | null {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) return null;
 
   const hexKeyStr = hexKey(player.position);

--- a/packages/core/src/engine/validActions/helpers.ts
+++ b/packages/core/src/engine/validActions/helpers.ts
@@ -16,6 +16,7 @@ import {
   WRONG_PHASE,
   PLAYER_NOT_FOUND,
 } from "../validators/validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Check if a player can act in the current game state.
@@ -26,7 +27,7 @@ export function checkCanAct(
   playerId: string
 ): { canAct: true; player: Player } | { canAct: false; reason: string } {
   // Find the player
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return { canAct: false, reason: PLAYER_NOT_FOUND };
   }

--- a/packages/core/src/engine/validators/burnMonasteryValidators.ts
+++ b/packages/core/src/engine/validators/burnMonasteryValidators.ts
@@ -11,6 +11,7 @@ import { BURN_MONASTERY_ACTION, hexKey } from "@mage-knight/shared";
 import { valid, invalid } from "./types.js";
 import { NOT_AT_MONASTERY, MONASTERY_BURNED, ALREADY_COMBATTED } from "./validationCodes.js";
 import { SiteType } from "../../types/map.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Must be at a monastery site
@@ -22,7 +23,7 @@ export function validateAtMonastery(
 ): ValidationResult {
   if (action.type !== BURN_MONASTERY_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) {
     return invalid(NOT_AT_MONASTERY, "You are not at a monastery");
   }
@@ -45,7 +46,7 @@ export function validateMonasteryNotBurned(
 ): ValidationResult {
   if (action.type !== BURN_MONASTERY_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) return valid(); // Handled by validateAtMonastery
 
   const hex = state.map.hexes[hexKey(player.position)];
@@ -68,7 +69,7 @@ export function validateNoCombatThisTurnForBurn(
 ): ValidationResult {
   if (action.type !== BURN_MONASTERY_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   if (player.hasCombattedThisTurn) {

--- a/packages/core/src/engine/validators/challengeValidators.ts
+++ b/packages/core/src/engine/validators/challengeValidators.ts
@@ -24,6 +24,7 @@ import {
   TARGET_NOT_RAMPAGING,
   HEX_NOT_FOUND,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Type guard to extract target hex from action.
@@ -60,7 +61,7 @@ export function validateChallengePlayerOnMap(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -92,7 +93,7 @@ export function validateNoCombatThisTurn(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -110,7 +111,7 @@ export function validateAdjacentToTarget(
   playerId: string,
   action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   const target = getChallengeTarget(action);
 
   if (!player?.position || !target) {

--- a/packages/core/src/engine/validators/choiceValidators.ts
+++ b/packages/core/src/engine/validators/choiceValidators.ts
@@ -14,6 +14,7 @@ import {
   CHOICE_PENDING,
   TACTIC_DECISION_PENDING,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Validates that the player has a pending choice to resolve.
@@ -23,7 +24,7 @@ export function validateHasPendingChoice(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -47,7 +48,7 @@ export function validateChoiceIndex(
     return invalid(INVALID_CHOICE_INDEX, "Invalid resolve choice action");
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.pendingChoice) {
     return invalid(NO_PENDING_CHOICE, "No choice pending");
   }
@@ -74,7 +75,7 @@ export function validateNoChoicePending(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (player?.pendingChoice) {
     return invalid(CHOICE_PENDING, "Must resolve pending choice first");
   }
@@ -90,7 +91,7 @@ export function validateNoTacticDecisionPending(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (player?.pendingTacticDecision) {
     return invalid(TACTIC_DECISION_PENDING, "Must resolve pending tactic decision first");
   }

--- a/packages/core/src/engine/validators/combatValidators/attackAssignmentValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/attackAssignmentValidators.ts
@@ -34,6 +34,7 @@ import {
   INVALID_ASSIGNMENT_AMOUNT,
   FORTIFIED_NEEDS_SIEGE,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Get the available amount for a specific attack type and element.
@@ -200,7 +201,7 @@ export function validateHasAvailableAttack(
 ): ValidationResult {
   if (action.type !== ASSIGN_ATTACK_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   const available = getAvailableAttack(

--- a/packages/core/src/engine/validators/combatValidators/blockAssignmentValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/blockAssignmentValidators.ts
@@ -28,6 +28,7 @@ import {
   NOTHING_TO_UNASSIGN_BLOCK,
   INVALID_ASSIGNMENT_AMOUNT,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Get the available amount for a specific element of block.
@@ -162,7 +163,7 @@ export function validateHasAvailableBlock(
 ): ValidationResult {
   if (action.type !== ASSIGN_BLOCK_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   const available = getAvailableBlock(

--- a/packages/core/src/engine/validators/combatValidators/fortificationValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/fortificationValidators.ts
@@ -21,6 +21,7 @@ import {
   FORTIFIED_NEEDS_SIEGE,
   NO_SIEGE_ATTACK_ACCUMULATED,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Calculate fortification level for an enemy.
@@ -103,7 +104,7 @@ export function validateHasSiegeAttack(
   if (action.attackType !== COMBAT_TYPE_SIEGE) return valid();
 
   // Find the player
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   // Calculate total siege attack (base + elemental)

--- a/packages/core/src/engine/validators/combatValidators/stateValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/stateValidators.ts
@@ -20,6 +20,7 @@ import {
   NOT_IN_COMBAT,
   ALREADY_COMBATTED,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 // Must not already be in combat
 export function validateNotAlreadyInCombat(
@@ -68,7 +69,7 @@ export function validateOneCombatPerTurn(
 ): ValidationResult {
   if (action.type !== ENTER_COMBAT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   if (player.hasCombattedThisTurn) {

--- a/packages/core/src/engine/validators/cooperativeAssaultValidators.ts
+++ b/packages/core/src/engine/validators/cooperativeAssaultValidators.ts
@@ -50,6 +50,7 @@ import {
   MUST_INVITE_AT_LEAST_ONE,
   INITIATOR_TOKEN_FLIPPED,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Helper to find hexes adjacent to a city of a specific color.
@@ -89,7 +90,7 @@ function isAdjacentToCity(
  * Check if a player has at least one non-wound card in hand.
  */
 function hasNonWoundCard(state: GameState, playerId: string): boolean {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return false;
 
   return player.hand.some((cardId) => cardId !== CARD_WOUND);
@@ -110,7 +111,7 @@ export function validateInitiatorAdjacentToCity(
   if (action.type !== PROPOSE_COOPERATIVE_ASSAULT_ACTION) return valid();
 
   const proposeAction = action as ProposeCooperativeAssaultAction;
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
   if (!player.position) return invalid(PLAYER_NOT_FOUND, "Player is not on the map");
 
@@ -177,7 +178,7 @@ export function validateInitiatorNotActed(
 ): ValidationResult {
   if (action.type !== PROPOSE_COOPERATIVE_ASSAULT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.hasTakenActionThisTurn) {
@@ -200,7 +201,7 @@ export function validateInitiatorTokenNotFlipped(
 ): ValidationResult {
   if (action.type !== PROPOSE_COOPERATIVE_ASSAULT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.roundOrderTokenFlipped) {
@@ -223,7 +224,7 @@ export function validateNoOtherPlayerOnSpace(
 ): ValidationResult {
   if (action.type !== PROPOSE_COOPERATIVE_ASSAULT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
   if (!player.position) return invalid(PLAYER_NOT_FOUND, "Player is not on the map");
 

--- a/packages/core/src/engine/validators/debugValidators.ts
+++ b/packages/core/src/engine/validators/debugValidators.ts
@@ -8,6 +8,7 @@ import type { Validator } from "./types.js";
 import { valid, invalid } from "./types.js";
 import { DEV_MODE_REQUIRED, NO_PENDING_LEVEL_UPS } from "./validationCodes.js";
 import type { GameState } from "../../state/GameState.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 // Type declaration for Node.js-like process global
 declare const process: { env?: { NODE_ENV?: string } } | undefined;
@@ -50,7 +51,7 @@ export const validateHasPendingLevelUps: Validator = (
   playerId: string,
   _action
 ) => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid(); // Let turn validators handle this
   }

--- a/packages/core/src/engine/validators/deepMineValidators.ts
+++ b/packages/core/src/engine/validators/deepMineValidators.ts
@@ -12,6 +12,7 @@ import {
   DEEP_MINE_CHOICE_REQUIRED,
   DEEP_MINE_INVALID_COLOR,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Validate that the player has a pending deep mine choice
@@ -21,7 +22,7 @@ export const validateHasPendingDeepMineChoice: Validator = (
   playerId: string,
   _action: PlayerAction
 ): ValidationResult => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid("PLAYER_NOT_FOUND", "Player not found");
   }
@@ -45,7 +46,7 @@ export const validateDeepMineColorChoice: Validator = (
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid("PLAYER_NOT_FOUND", "Player not found");
   }

--- a/packages/core/src/engine/validators/exploreValidators.ts
+++ b/packages/core/src/engine/validators/exploreValidators.ts
@@ -26,6 +26,7 @@ import { isCoastlineSlot } from "../explore/tileGrid.js";
 import { getValidExploreOptions } from "../validActions/exploration.js";
 import { peekNextTileType } from "../../data/tileDeckSetup.js";
 import { TILE_TYPE_CORE } from "../../data/tileConstants.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Extract explore direction from action (type guard helper)
@@ -45,7 +46,7 @@ export function validatePlayerOnMapForExplore(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) {
     return invalid(NOT_ON_MAP, "Player is not on the map");
   }
@@ -61,7 +62,7 @@ export function validateOnEdgeHex(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) {
     return invalid(NOT_ON_MAP, "Player is not on the map");
   }
@@ -82,7 +83,7 @@ export function validateExploreDirection(
   playerId: string,
   action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   const direction = getExploreDirection(action);
 
   if (!player?.position || !direction) {
@@ -170,7 +171,7 @@ export function validateExploreMoveCost(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/gladeValidators.ts
+++ b/packages/core/src/engine/validators/gladeValidators.ts
@@ -17,6 +17,7 @@ import {
   GLADE_WOUND_NO_WOUNDS_IN_HAND,
   GLADE_WOUND_NO_WOUNDS_IN_DISCARD,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Validate that the player has a pending glade wound choice
@@ -26,7 +27,7 @@ export const validateHasPendingGladeChoice: Validator = (
   playerId: string,
   _action: PlayerAction
 ): ValidationResult => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid("PLAYER_NOT_FOUND", "Player not found");
   }
@@ -50,7 +51,7 @@ export const validateGladeWoundChoice: Validator = (
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid("PLAYER_NOT_FOUND", "Player not found");
   }

--- a/packages/core/src/engine/validators/levelUpValidators.ts
+++ b/packages/core/src/engine/validators/levelUpValidators.ts
@@ -18,6 +18,7 @@ import {
   LEVEL_UP_REWARDS_PENDING,
 } from "./validationCodes.js";
 import { CHOOSE_LEVEL_UP_REWARDS_ACTION, type SkillId, type CardId } from "@mage-knight/shared";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Validates that the player has pending level up rewards.
@@ -28,7 +29,7 @@ export const validateHasPendingLevelUpRewards: Validator = (
   playerId,
   _action
 ) => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid(); // Let other validators catch this
   }
@@ -55,7 +56,7 @@ export const validateLevelInPendingRewards: Validator = (
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid();
   }
@@ -82,7 +83,7 @@ export const validateSkillAvailable: Validator = (state, playerId, action) => {
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid();
   }
@@ -126,7 +127,7 @@ export const validateSkillNotAlreadyOwned: Validator = (
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid();
   }
@@ -172,7 +173,7 @@ export const validateNoPendingLevelUpRewards: Validator = (
   playerId,
   _action
 ) => {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return valid();
   }

--- a/packages/core/src/engine/validators/mana/sourceValidators.ts
+++ b/packages/core/src/engine/validators/mana/sourceValidators.ts
@@ -31,6 +31,7 @@ import {
   POWERED_WITHOUT_MANA,
   PLAYER_NOT_FOUND,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Validate that mana source is available and valid
@@ -61,7 +62,7 @@ export function validateManaAvailable(
     return valid(); // Shouldn't happen, but satisfy TypeScript
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/mana/spellValidators.ts
+++ b/packages/core/src/engine/validators/mana/spellValidators.ts
@@ -20,6 +20,7 @@ import {
   SPELL_REQUIRES_TWO_MANA,
   SPELL_BASIC_REQUIRES_MANA,
 } from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Validate that spells provide both mana sources (black + color) when powered.
@@ -90,7 +91,7 @@ export function validateSpellManaRequirement(
   }
 
   // Now validate each mana source is available
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -131,7 +132,7 @@ export function validateSpellBasicManaRequirement(
   // Only spells require mana for basic effect
   if (card.cardType !== DEED_CARD_TYPE_SPELL) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/movementValidators.ts
+++ b/packages/core/src/engine/validators/movementValidators.ts
@@ -20,6 +20,7 @@ import {
   CANNOT_ENTER_CITY,
 } from "./validationCodes.js";
 import { SiteType } from "../../types/map.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 // Helper to get target from action (type guard)
 function getMoveTarget(action: PlayerAction): HexCoord | null {
@@ -50,7 +51,7 @@ export function validatePlayerOnMap(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -66,7 +67,7 @@ export function validateTargetAdjacent(
   playerId: string,
   action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   const target = getMoveTarget(action);
 
   if (!player?.position || !target) {
@@ -128,7 +129,7 @@ export function validateEnoughMovePoints(
   playerId: string,
   action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   const target = getMoveTarget(action);
 
   if (!player || !target) {

--- a/packages/core/src/engine/validators/offerValidators.ts
+++ b/packages/core/src/engine/validators/offerValidators.ts
@@ -36,6 +36,7 @@ import {
   SPELL_PURCHASE_COST,
   MONASTERY_AA_PURCHASE_COST,
 } from "../../data/siteProperties.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 // === Spell Purchase Validators ===
 
@@ -99,7 +100,7 @@ export function validateHasInfluenceForSpell(
 ): ValidationResult {
   if (action.type !== BUY_SPELL_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -203,7 +204,7 @@ export function validateHasInfluenceForMonasteryAA(
     return valid();
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -235,7 +236,7 @@ export function validateInLevelUpContext(
   }
 
   // Regular AAs require a pending level-up reward that offers AA selection
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/playCardValidators.ts
+++ b/packages/core/src/engine/validators/playCardValidators.ts
@@ -16,6 +16,7 @@ import {
   PLAYER_NOT_FOUND,
   INVALID_ACTION_CODE,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 function getCardId(action: PlayerAction): CardId | null {
   if (action.type === PLAY_CARD_ACTION && "cardId" in action) {
@@ -35,7 +36,7 @@ export function validateCardInHand(
     return invalid(INVALID_ACTION_CODE, "Invalid play card action");
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/plunderVillageValidators.ts
+++ b/packages/core/src/engine/validators/plunderVillageValidators.ts
@@ -11,6 +11,7 @@ import { PLUNDER_VILLAGE_ACTION, hexKey } from "@mage-knight/shared";
 import { valid, invalid } from "./types.js";
 import { NOT_AT_VILLAGE, ALREADY_PLUNDERED, ALREADY_ACTED, ALREADY_MOVED } from "./validationCodes.js";
 import { SiteType } from "../../types/map.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Must be at a village site
@@ -22,7 +23,7 @@ export function validateAtVillage(
 ): ValidationResult {
   if (action.type !== PLUNDER_VILLAGE_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) {
     return invalid(NOT_AT_VILLAGE, "You are not at a village");
   }
@@ -45,7 +46,7 @@ export function validateBeforeTurnForPlunder(
 ): ValidationResult {
   if (action.type !== PLUNDER_VILLAGE_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   if (player.hasTakenActionThisTurn) {
@@ -69,7 +70,7 @@ export function validateNotAlreadyPlundered(
 ): ValidationResult {
   if (action.type !== PLUNDER_VILLAGE_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   if (player.hasPlunderedThisTurn) {

--- a/packages/core/src/engine/validators/restValidators.ts
+++ b/packages/core/src/engine/validators/restValidators.ts
@@ -45,6 +45,7 @@ import {
   SLOW_RECOVERY_NO_DISCARD_ALLOWED,
   CANNOT_REST_AFTER_MOVING,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Helper to check if a card is a wound
@@ -86,7 +87,7 @@ export function validateRestCardsInHand(
 ): ValidationResult {
   if (action.type !== REST_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   for (const cardId of action.discardCardIds) {
@@ -138,7 +139,7 @@ export function validateSlowRecovery(
   if (action.type !== REST_ACTION) return valid();
   if (action.restType !== REST_TYPE_SLOW_RECOVERY) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   // Hand must contain ONLY wounds
@@ -184,7 +185,7 @@ export function validateNotAlreadyResting(
 ): ValidationResult {
   if (action.type !== DECLARE_REST_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {
@@ -206,7 +207,7 @@ export function validateNotMovedForRest(
 ): ValidationResult {
   if (action.type !== DECLARE_REST_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.hasMovedThisTurn) {
@@ -229,7 +230,7 @@ export function validateIsResting(
 ): ValidationResult {
   if (action.type !== COMPLETE_REST_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (!player.isResting) {
@@ -253,7 +254,7 @@ export function validateCompleteRestDiscard(
 ): ValidationResult {
   if (action.type !== COMPLETE_REST_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   // Check if all cards in discard selection are in hand
@@ -324,7 +325,7 @@ export function validateNotRestingForMovement(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {
@@ -342,7 +343,7 @@ export function validateNotRestingForCombat(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {
@@ -361,7 +362,7 @@ export function validateNotRestingForInteraction(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {
@@ -379,7 +380,7 @@ export function validateNotRestingForEnterSite(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {
@@ -397,7 +398,7 @@ export function validateRestCompleted(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.isResting) {

--- a/packages/core/src/engine/validators/rewardValidators.ts
+++ b/packages/core/src/engine/validators/rewardValidators.ts
@@ -20,6 +20,7 @@ import {
   CARD_NOT_IN_OFFER,
   PENDING_REWARDS_NOT_RESOLVED,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Player must have pending rewards to select one.
@@ -31,7 +32,7 @@ export function validateHasPendingRewards(
 ): ValidationResult {
   if (action.type !== SELECT_REWARD_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.pendingRewards.length === 0) {
@@ -51,7 +52,7 @@ export function validateRewardIndex(
 ): ValidationResult {
   if (action.type !== SELECT_REWARD_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const { rewardIndex } = action;
@@ -75,7 +76,7 @@ export function validateCardInOffer(
 ): ValidationResult {
   if (action.type !== SELECT_REWARD_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const { cardId, rewardIndex } = action;
@@ -133,7 +134,7 @@ export function validateNoPendingRewards(
 ): ValidationResult {
   if (action.type !== END_TURN_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.pendingRewards.length > 0) {

--- a/packages/core/src/engine/validators/roundValidators.ts
+++ b/packages/core/src/engine/validators/roundValidators.ts
@@ -13,6 +13,7 @@ import {
   ALREADY_ANNOUNCED,
   MUST_ANNOUNCE_END_OF_ROUND,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Player must have empty deck to announce end of round.
@@ -26,7 +27,7 @@ export function validateDeckEmpty(
 ): ValidationResult {
   if (action.type !== ANNOUNCE_END_OF_ROUND_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.deck.length > 0) {
@@ -75,7 +76,7 @@ export function validateMustAnnounceEndOfRound(
   // Skip if round end already announced
   if (state.endOfRoundAnnouncedBy !== null) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   // If deck AND hand are both empty, must announce

--- a/packages/core/src/engine/validators/sidewaysValidators.ts
+++ b/packages/core/src/engine/validators/sidewaysValidators.ts
@@ -40,6 +40,7 @@ import {
   INVALID_ACTION_CODE,
   SIDEWAYS_CHOICE_REQUIRED,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 function getCardIdForSideways(action: PlayerAction): CardId | null {
   if (action.type === PLAY_CARD_SIDEWAYS_ACTION && "cardId" in action) {
@@ -59,7 +60,7 @@ export function validateSidewaysCardInHand(
     return invalid(INVALID_ACTION_CODE, "Invalid sideways play action");
   }
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/siteValidators.ts
+++ b/packages/core/src/engine/validators/siteValidators.ts
@@ -18,6 +18,7 @@ import {
 import { getPlayerSite } from "../helpers/siteHelpers.js";
 import { SITE_PROPERTIES } from "../../data/siteProperties.js";
 import { SiteType } from "../../types/map.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Must be at an adventure site
@@ -84,7 +85,7 @@ export function validateSiteHasEnemiesOrDraws(
 ): ValidationResult {
   if (action.type !== ENTER_SITE_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player?.position) return valid();
 
   const hex = state.map.hexes[hexKey(player.position)];

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -32,13 +32,14 @@ import {
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
 import { CARD_WOUND } from "@mage-knight/shared";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 /**
  * Validates that the player has learned the skill they're trying to use.
  */
 export const validateSkillLearned: Validator = (state, playerId, action) => {
   const useSkillAction = action as UseSkillAction;
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
 
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
@@ -59,7 +60,7 @@ export const validateSkillLearned: Validator = (state, playerId, action) => {
  */
 export const validateSkillCooldown: Validator = (state, playerId, action) => {
   const useSkillAction = action as UseSkillAction;
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
 
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
@@ -151,7 +152,7 @@ export const validateSkillRequirements: Validator = (
   action
 ) => {
   const useSkillAction = action as UseSkillAction;
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
 
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");

--- a/packages/core/src/engine/validators/turnValidators.ts
+++ b/packages/core/src/engine/validators/turnValidators.ts
@@ -15,6 +15,7 @@ import {
   PLAYER_NOT_FOUND,
   WRONG_PHASE,
 } from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
 
 // Check it's this player's turn
 export function validateIsPlayersTurn(
@@ -62,7 +63,7 @@ export function validateHasNotActed(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
@@ -80,7 +81,7 @@ export function validateMinimumTurnRequirement(
   playerId: string,
   _action: PlayerAction
 ): ValidationResult {
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }

--- a/packages/core/src/engine/validators/units/activationValidators.ts
+++ b/packages/core/src/engine/validators/units/activationValidators.ts
@@ -46,6 +46,7 @@ import {
   COMBAT_PHASE_BLOCK,
   COMBAT_PHASE_ATTACK,
 } from "../../../types/combat.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Check unit exists and belongs to player
@@ -57,7 +58,7 @@ export function validateUnitExists(
 ): ValidationResult {
   if (action.type !== ACTIVATE_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);
@@ -78,7 +79,7 @@ export function validateUnitCanActivate(
 ): ValidationResult {
   if (action.type !== ACTIVATE_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);
@@ -111,7 +112,7 @@ export function validateUnitCanReceiveDamage(
   // If no assignments provided, all damage goes to hero (no unit validation needed)
   if (!action.assignments) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   for (const assignment of action.assignments) {
@@ -155,7 +156,7 @@ export function validateAbilityIndex(
 ): ValidationResult {
   if (action.type !== ACTIVATE_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);
@@ -193,7 +194,7 @@ export function validateAbilityMatchesPhase(
   // (non-combat abilities like Move/Influence can be used outside combat)
   if (!state.combat) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);
@@ -270,7 +271,7 @@ export function validateSiegeRequirement(
   if (action.type !== ACTIVATE_UNIT_ACTION) return valid();
   if (!state.combat) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return valid();
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);
@@ -308,7 +309,7 @@ export function validateCombatRequiredForAbility(
 ): ValidationResult {
   if (action.type !== ACTIVATE_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unit = player.units.find((u) => u.instanceId === action.unitInstanceId);

--- a/packages/core/src/engine/validators/units/recruitmentValidators.ts
+++ b/packages/core/src/engine/validators/units/recruitmentValidators.ts
@@ -29,6 +29,7 @@ import {
   getReputationCostModifier,
   siteTypeToRecruitSite,
 } from "../../validActions/units/recruitment.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
  * Check player has enough command slots to recruit
@@ -40,7 +41,7 @@ export function validateCommandSlots(
 ): ValidationResult {
   if (action.type !== RECRUIT_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   if (player.units.length >= player.commandTokens) {
@@ -65,7 +66,7 @@ export function validateInfluenceCost(
 ): ValidationResult {
   if (action.type !== RECRUIT_UNIT_ACTION) return valid();
 
-  const player = state.players.find((p) => p.id === playerId);
+  const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
   const unitDef = getUnit(action.unitId);


### PR DESCRIPTION
## Summary
Refactored player lookup logic across the codebase by extracting repeated `state.players.find()` and `state.players.findIndex()` patterns into a dedicated helper module. This improves code maintainability, reduces duplication, and provides consistent error handling patterns.

## Key Changes

- **Created new `playerHelpers.ts` module** with four helper functions:
  - `getPlayerById()` - Returns player or null (for optional lookups)
  - `getPlayerIndexById()` - Returns index or -1 (for existence checks)
  - `getPlayerByIdOrThrow()` - Returns player or throws error (for required lookups)
  - `getPlayerIndexByIdOrThrow()` - Returns index or throws error (for required updates)

- **Updated 40+ files** to use the new helpers instead of inline `find()`/`findIndex()` calls across:
  - Combat resolution and damage calculations
  - Command factories (cards, movement, sites, turn actions)
  - Debug commands
  - Effect resolution and evaluation
  - Validators (movement, combat, choices, offers, etc.)
  - Reward handlers
  - Helper utilities

- **Exported helpers from main helpers index** for easy importing across the engine

## Implementation Details

The helpers follow a consistent naming convention:
- Functions returning nullable values use `getPlayerById` pattern
- Functions that throw use `getPlayerByIdOrThrow` pattern
- Index variants use `getPlayerIndexById` pattern

This provides clear intent at call sites - developers can immediately see whether a player lookup is expected to always succeed or might fail gracefully.

All existing logic and error handling behavior is preserved; this is purely a refactoring to reduce code duplication and improve maintainability.

https://claude.ai/code/session_01Kaumvq9ExATfbzQXAhhKc9