### PR TITLE
feat(units): implement mana-powered unit abilities

### DIFF
--- a/packages/core/src/engine/commands/factories/units.ts
+++ b/packages/core/src/engine/commands/factories/units.ts
@@ -49,5 +49,6 @@ export const createActivateUnitCommandFromAction: CommandFactory = (
     playerId,
     unitInstanceId: action.unitInstanceId,
     abilityIndex: action.abilityIndex,
+    ...(action.manaSource && { manaSource: action.manaSource }),
   });
 };

--- a/packages/core/src/engine/validActions/units/activation.ts
+++ b/packages/core/src/engine/validActions/units/activation.ts
@@ -29,7 +29,9 @@ import {
   UNIT_ABILITY_PARALYZE,
   CARD_WOUND,
   type UnitAbilityType,
+  type ManaColor,
 } from "@mage-knight/shared";
+import { canPayForMana } from "../mana.js";
 import {
   COMBAT_PHASE_RANGED_SIEGE,
   COMBAT_PHASE_BLOCK,
@@ -260,14 +262,27 @@ export function getActivatableUnits(
               reason = "Cannot use influence in combat";
             }
           }
+          // Check mana cost availability (if ability has mana cost)
+          if (canActivate && ability.manaCost) {
+            if (!canPayForMana(state, player, ability.manaCost)) {
+              canActivate = false;
+              reason = `Requires ${ability.manaCost} mana (unavailable)`;
+            }
+          }
         }
       }
 
+      // Build the activatable ability with optional mana cost
       const activatableAbility: ActivatableAbility = {
         index: i,
         name: formatAbilityType(ability.type),
         canActivate,
       };
+
+      // Add mana cost if present
+      if (ability.manaCost) {
+        (activatableAbility as { manaCost?: ManaColor }).manaCost = ability.manaCost;
+      }
 
       // Only add reason if can't activate
       if (!canActivate && reason) {

--- a/packages/core/src/engine/validators/registry/unitRegistry.ts
+++ b/packages/core/src/engine/validators/registry/unitRegistry.ts
@@ -28,6 +28,7 @@ import {
   validateSiegeRequirement,
   validateCombatRequiredForAbility,
   validateUnitsAllowedInCombat,
+  validateUnitAbilityManaCost,
 } from "../units/index.js";
 
 export const unitRegistry: Record<string, Validator[]> = {
@@ -53,5 +54,6 @@ export const unitRegistry: Record<string, Validator[]> = {
     validateUnitsAllowedInCombat, // Dungeon/Tomb: units cannot be used
     validateAbilityMatchesPhase, // Ability type must match combat phase
     validateSiegeRequirement, // Ranged can't hit fortified in ranged phase
+    validateUnitAbilityManaCost, // Validate mana source if ability has mana cost
   ],
 };

--- a/packages/core/src/engine/validators/units/index.ts
+++ b/packages/core/src/engine/validators/units/index.ts
@@ -22,4 +22,5 @@ export {
   validateSiegeRequirement,
   validateCombatRequiredForAbility,
   validateUnitsAllowedInCombat,
+  validateUnitAbilityManaCost,
 } from "./activationValidators.js";

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -121,6 +121,8 @@ export const WRONG_PHASE_FOR_ABILITY = "WRONG_PHASE_FOR_ABILITY" as const;
 export const NON_COMBAT_ABILITY = "NON_COMBAT_ABILITY" as const;
 export const PASSIVE_ABILITY = "PASSIVE_ABILITY" as const;
 export const SIEGE_REQUIRED = "SIEGE_REQUIRED" as const;
+export const UNIT_ABILITY_REQUIRES_MANA = "UNIT_ABILITY_REQUIRES_MANA" as const;
+export const UNIT_ABILITY_MANA_UNAVAILABLE = "UNIT_ABILITY_MANA_UNAVAILABLE" as const;
 
 // Site interaction validation codes
 export const NO_SITE = "NO_SITE" as const;
@@ -320,6 +322,8 @@ export type ValidationErrorCode =
   | typeof NON_COMBAT_ABILITY
   | typeof PASSIVE_ABILITY
   | typeof SIEGE_REQUIRED
+  | typeof UNIT_ABILITY_REQUIRES_MANA
+  | typeof UNIT_ABILITY_MANA_UNAVAILABLE
   // Site interaction validation
   | typeof NO_SITE
   | typeof NOT_INHABITED

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -208,7 +208,11 @@ export interface ActivateUnitAction {
   readonly type: typeof ACTIVATE_UNIT_ACTION;
   readonly unitInstanceId: string;
   readonly abilityIndex: number;
-  readonly manaPaid?: ManaColor;
+  /**
+   * Mana source used to pay for abilities with manaCost.
+   * Required when the ability has a manaCost defined.
+   */
+  readonly manaSource?: ManaSourceInfo;
 }
 
 // Skill usage

--- a/packages/shared/src/units/elite.ts
+++ b/packages/shared/src/units/elite.ts
@@ -10,6 +10,7 @@ import {
   ELEMENT_FIRE,
   ELEMENT_ICE,
 } from "../elements.js";
+import { MANA_RED, MANA_BLUE } from "../ids.js";
 import { RESIST_PHYSICAL, RESIST_FIRE, RESIST_ICE } from "../enemies/index.js";
 import type { UnitDefinition } from "./types.js";
 import {
@@ -104,8 +105,12 @@ export const ELITE_UNITS: Record<EliteUnitId, UnitDefinition> = {
     resistances: [RESIST_PHYSICAL, RESIST_FIRE],
     recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_MAGE_TOWER],
     abilities: [
+      // Base abilities (free)
       { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_FIRE },
       { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_FIRE },
+      // Powered abilities (require red mana)
+      { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_FIRE, manaCost: MANA_RED },
+      { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_FIRE, manaCost: MANA_RED },
     ],
     copies: 2,
   },
@@ -119,8 +124,13 @@ export const ELITE_UNITS: Record<EliteUnitId, UnitDefinition> = {
     resistances: [RESIST_PHYSICAL, RESIST_ICE],
     recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_MAGE_TOWER],
     abilities: [
+      // Base abilities (free)
       { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_ICE },
       { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_ICE },
+      // Powered abilities (require blue mana)
+      { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_ICE, manaCost: MANA_BLUE },
+      { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_ICE, manaCost: MANA_BLUE },
+      // Passive
       { type: UNIT_ABILITY_PARALYZE },
     ],
     copies: 2,

--- a/packages/shared/src/units/types.ts
+++ b/packages/shared/src/units/types.ts
@@ -6,6 +6,7 @@ import { type Element } from "../elements.js";
 import { type EnemyResistances } from "../enemies/index.js";
 import { type Terrain } from "../terrain.js";
 import { type UnitId } from "./ids.js";
+import { type ManaColor } from "../ids.js";
 
 // =============================================================================
 // TYPE ALIASES
@@ -74,6 +75,11 @@ export interface UnitAbility {
    * Modifiers last until the end of the current turn.
    */
   readonly terrainModifiers?: readonly UnitTerrainModifier[];
+  /**
+   * Mana cost to activate this ability.
+   * If undefined, the ability is free to use.
+   */
+  readonly manaCost?: ManaColor;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional `manaCost` field to `UnitAbility` interface for abilities that require mana
- Update `ActivateUnitAction` to include `manaSource` for specifying how to pay mana costs
- Add validator to check mana availability and validate mana source when activating powered abilities
- Update `validActions` to filter abilities based on mana availability and expose `manaCost` to UI
- Implement mana consumption in `activateUnitCommand` with proper undo support
- Add powered abilities to Fire Golems (red mana) and Ice Golems (blue mana)

## Test plan
- [x] Free abilities (no mana cost) work without mana source
- [x] Powered abilities reject activation without mana source
- [x] Powered abilities work with mana token
- [x] Powered abilities work with mana crystal
- [x] Powered abilities work with mana die
- [x] Validator rejects wrong mana color
- [x] Validator rejects when no mana is available
- [x] Mana used is tracked in `manaUsedThisTurn`
- [x] All 1203 existing tests pass
- [x] Build and lint pass

Closes #238