### PR TITLE
refactor: extract activateUnitCommand helpers to reduce merge conflicts

### DIFF
--- a/packages/core/src/engine/commands/units/helpers/combatAccumulatorHelpers.ts
+++ b/packages/core/src/engine/commands/units/helpers/combatAccumulatorHelpers.ts
@@ -1,0 +1,161 @@
+/**
+ * Combat accumulator helpers for unit ability activation
+ *
+ * Handles adding and removing unit ability values to/from
+ * the combat accumulator during combat phases.
+ */
+
+import type { Element, UnitAbilityType } from "@mage-knight/shared";
+import {
+  UNIT_ABILITY_ATTACK,
+  UNIT_ABILITY_BLOCK,
+  UNIT_ABILITY_RANGED_ATTACK,
+  UNIT_ABILITY_SIEGE_ATTACK,
+} from "@mage-knight/shared";
+import type { CombatAccumulator } from "../../../../types/player.js";
+import {
+  getElementKey,
+  addToElementalValues,
+  subtractFromElementalValues,
+} from "./elementalHelpers.js";
+
+/**
+ * Add unit ability value to combat accumulator
+ */
+export function addAbilityToAccumulator(
+  accumulator: CombatAccumulator,
+  abilityType: UnitAbilityType,
+  value: number,
+  element: Element | undefined
+): CombatAccumulator {
+  const elementKey = getElementKey(element);
+
+  switch (abilityType) {
+    case UNIT_ABILITY_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          normal: accumulator.attack.normal + value,
+          normalElements: addToElementalValues(
+            accumulator.attack.normalElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    case UNIT_ABILITY_BLOCK:
+      return {
+        ...accumulator,
+        block: accumulator.block + value,
+        blockElements: addToElementalValues(
+          accumulator.blockElements,
+          elementKey,
+          value
+        ),
+      };
+
+    case UNIT_ABILITY_RANGED_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          ranged: accumulator.attack.ranged + value,
+          rangedElements: addToElementalValues(
+            accumulator.attack.rangedElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    case UNIT_ABILITY_SIEGE_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          siege: accumulator.attack.siege + value,
+          siegeElements: addToElementalValues(
+            accumulator.attack.siegeElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    default:
+      // Non-combat abilities (move, influence, heal, etc.) don't affect accumulator
+      return accumulator;
+  }
+}
+
+/**
+ * Remove unit ability value from combat accumulator (for undo)
+ */
+export function removeAbilityFromAccumulator(
+  accumulator: CombatAccumulator,
+  abilityType: UnitAbilityType,
+  value: number,
+  element: Element | undefined
+): CombatAccumulator {
+  const elementKey = getElementKey(element);
+
+  switch (abilityType) {
+    case UNIT_ABILITY_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          normal: Math.max(0, accumulator.attack.normal - value),
+          normalElements: subtractFromElementalValues(
+            accumulator.attack.normalElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    case UNIT_ABILITY_BLOCK:
+      return {
+        ...accumulator,
+        block: Math.max(0, accumulator.block - value),
+        blockElements: subtractFromElementalValues(
+          accumulator.blockElements,
+          elementKey,
+          value
+        ),
+      };
+
+    case UNIT_ABILITY_RANGED_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          ranged: Math.max(0, accumulator.attack.ranged - value),
+          rangedElements: subtractFromElementalValues(
+            accumulator.attack.rangedElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    case UNIT_ABILITY_SIEGE_ATTACK:
+      return {
+        ...accumulator,
+        attack: {
+          ...accumulator.attack,
+          siege: Math.max(0, accumulator.attack.siege - value),
+          siegeElements: subtractFromElementalValues(
+            accumulator.attack.siegeElements,
+            elementKey,
+            value
+          ),
+        },
+      };
+
+    default:
+      return accumulator;
+  }
+}

--- a/packages/core/src/engine/commands/units/helpers/elementalHelpers.ts
+++ b/packages/core/src/engine/commands/units/helpers/elementalHelpers.ts
@@ -1,0 +1,62 @@
+/**
+ * Elemental value helpers for unit ability activation
+ *
+ * Handles mapping between Element types and ElementalAttackValues keys,
+ * and arithmetic operations on elemental value objects.
+ */
+
+import type { Element } from "@mage-knight/shared";
+import {
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  ELEMENT_PHYSICAL,
+} from "@mage-knight/shared";
+import type { ElementalAttackValues } from "../../../../types/player.js";
+
+/**
+ * Get the element key for the ElementalAttackValues interface
+ */
+export function getElementKey(
+  element: Element | undefined
+): keyof ElementalAttackValues {
+  switch (element) {
+    case ELEMENT_FIRE:
+      return "fire";
+    case ELEMENT_ICE:
+      return "ice";
+    case ELEMENT_COLD_FIRE:
+      return "coldFire";
+    case ELEMENT_PHYSICAL:
+    default:
+      return "physical";
+  }
+}
+
+/**
+ * Add value to elemental attack values
+ */
+export function addToElementalValues(
+  values: ElementalAttackValues,
+  elementKey: keyof ElementalAttackValues,
+  amount: number
+): ElementalAttackValues {
+  return {
+    ...values,
+    [elementKey]: values[elementKey] + amount,
+  };
+}
+
+/**
+ * Subtract value from elemental attack values (for undo)
+ */
+export function subtractFromElementalValues(
+  values: ElementalAttackValues,
+  elementKey: keyof ElementalAttackValues,
+  amount: number
+): ElementalAttackValues {
+  return {
+    ...values,
+    [elementKey]: Math.max(0, values[elementKey] - amount),
+  };
+}

--- a/packages/core/src/engine/commands/units/helpers/index.ts
+++ b/packages/core/src/engine/commands/units/helpers/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Unit activation helpers
+ *
+ * Re-exports all helper modules for unit ability activation.
+ */
+
+export * from "./elementalHelpers.js";
+export * from "./combatAccumulatorHelpers.js";
+export * from "./nonCombatAbilityHelpers.js";
+export * from "./terrainModifierHelpers.js";
+export * from "./manaConsumptionHelpers.js";

--- a/packages/core/src/engine/commands/units/helpers/manaConsumptionHelpers.ts
+++ b/packages/core/src/engine/commands/units/helpers/manaConsumptionHelpers.ts
@@ -1,0 +1,189 @@
+/**
+ * Mana consumption helpers for unit ability activation
+ *
+ * Handles consuming and restoring mana from various sources
+ * (dice, crystals, tokens) when activating unit abilities.
+ */
+
+import type { ManaSourceInfo, BasicManaColor } from "@mage-knight/shared";
+import {
+  MANA_SOURCE_DIE,
+  MANA_SOURCE_CRYSTAL,
+  MANA_SOURCE_TOKEN,
+} from "@mage-knight/shared";
+import type { Player, Crystals } from "../../../../types/player.js";
+import type { SourceDieId, ManaSource } from "../../../../types/mana.js";
+
+/**
+ * Result of consuming mana for an ability
+ */
+export interface ManaConsumptionResult {
+  readonly player: Player;
+  readonly source: ManaSource;
+}
+
+/**
+ * Consume mana from the specified source to pay for an ability.
+ * Updates player state and source die pool as needed.
+ */
+export function consumeManaForAbility(
+  player: Player,
+  source: ManaSource,
+  manaSourceInfo: ManaSourceInfo,
+  playerId: string
+): ManaConsumptionResult {
+  const { type: sourceType, color } = manaSourceInfo;
+  let updatedPlayer = player;
+  let updatedSource = source;
+
+  // Track mana usage for conditional effects
+  updatedPlayer = {
+    ...updatedPlayer,
+    manaUsedThisTurn: [...updatedPlayer.manaUsedThisTurn, color],
+  };
+
+  switch (sourceType) {
+    case MANA_SOURCE_DIE: {
+      const dieId = manaSourceInfo.dieId as SourceDieId;
+      if (!dieId) {
+        throw new Error("Die ID required when using mana from source");
+      }
+
+      // Check if this is the Mana Steal stored die
+      const storedDie = updatedPlayer.tacticState.storedManaDie;
+      if (storedDie && storedDie.dieId === dieId) {
+        // Using the stolen Mana Steal die
+        updatedPlayer = {
+          ...updatedPlayer,
+          tacticState: {
+            ...updatedPlayer.tacticState,
+            manaStealUsedThisTurn: true,
+          },
+        };
+      } else {
+        // Using a normal source die
+        const alreadyUsed = updatedPlayer.usedDieIds.includes(dieId);
+        updatedPlayer = {
+          ...updatedPlayer,
+          usedManaFromSource: true,
+          usedDieIds: alreadyUsed
+            ? updatedPlayer.usedDieIds
+            : [...updatedPlayer.usedDieIds, dieId],
+        };
+        // Mark the die as taken in the source
+        const updatedDice = source.dice.map((die) =>
+          die.id === dieId ? { ...die, takenByPlayerId: playerId } : die
+        );
+        updatedSource = { dice: updatedDice };
+      }
+      break;
+    }
+
+    case MANA_SOURCE_CRYSTAL: {
+      const basicColor = color as BasicManaColor;
+      const newCrystals: Crystals = {
+        ...updatedPlayer.crystals,
+        [basicColor]: updatedPlayer.crystals[basicColor] - 1,
+      };
+      updatedPlayer = { ...updatedPlayer, crystals: newCrystals };
+      break;
+    }
+
+    case MANA_SOURCE_TOKEN: {
+      const tokenIndex = updatedPlayer.pureMana.findIndex(
+        (t) => t.color === color
+      );
+      if (tokenIndex !== -1) {
+        const newPureMana = [...updatedPlayer.pureMana];
+        newPureMana.splice(tokenIndex, 1);
+        updatedPlayer = { ...updatedPlayer, pureMana: newPureMana };
+      }
+      break;
+    }
+  }
+
+  return { player: updatedPlayer, source: updatedSource };
+}
+
+/**
+ * Restore mana that was consumed for an ability (for undo).
+ * Reverses the effects of consumeManaForAbility.
+ */
+export function restoreManaForAbility(
+  player: Player,
+  source: ManaSource,
+  manaSourceInfo: ManaSourceInfo
+): ManaConsumptionResult {
+  const { type: sourceType, color } = manaSourceInfo;
+  let updatedPlayer = player;
+  let updatedSource = source;
+
+  // Remove the mana color from manaUsedThisTurn
+  const colorIndex = updatedPlayer.manaUsedThisTurn.lastIndexOf(color);
+  if (colorIndex !== -1) {
+    const newManaUsed = [...updatedPlayer.manaUsedThisTurn];
+    newManaUsed.splice(colorIndex, 1);
+    updatedPlayer = { ...updatedPlayer, manaUsedThisTurn: newManaUsed };
+  }
+
+  switch (sourceType) {
+    case MANA_SOURCE_DIE: {
+      const dieId = manaSourceInfo.dieId as SourceDieId;
+
+      // Check if this was the Mana Steal stored die
+      const storedDie = updatedPlayer.tacticState.storedManaDie;
+      if (storedDie && storedDie.dieId === dieId) {
+        // Restore Mana Steal die usage
+        updatedPlayer = {
+          ...updatedPlayer,
+          tacticState: {
+            ...updatedPlayer.tacticState,
+            manaStealUsedThisTurn: false,
+          },
+        };
+      } else {
+        // Restore normal source die
+        // Remove from usedDieIds
+        const newUsedDieIds = updatedPlayer.usedDieIds.filter(
+          (id) => id !== dieId
+        );
+        updatedPlayer = {
+          ...updatedPlayer,
+          usedManaFromSource: newUsedDieIds.length > 0,
+          usedDieIds: newUsedDieIds,
+        };
+        // Unmark the die as taken
+        const updatedDice = source.dice.map((die) =>
+          die.id === dieId ? { ...die, takenByPlayerId: null } : die
+        );
+        updatedSource = { dice: updatedDice };
+      }
+      break;
+    }
+
+    case MANA_SOURCE_CRYSTAL: {
+      const basicColor = color as BasicManaColor;
+      const newCrystals: Crystals = {
+        ...updatedPlayer.crystals,
+        [basicColor]: updatedPlayer.crystals[basicColor] + 1,
+      };
+      updatedPlayer = { ...updatedPlayer, crystals: newCrystals };
+      break;
+    }
+
+    case MANA_SOURCE_TOKEN: {
+      // Restore the mana token
+      const restoredToken = {
+        color,
+        source: "card" as const, // Simplified - actual source unknown
+      };
+      updatedPlayer = {
+        ...updatedPlayer,
+        pureMana: [...updatedPlayer.pureMana, restoredToken],
+      };
+      break;
+    }
+  }
+
+  return { player: updatedPlayer, source: updatedSource };
+}

--- a/packages/core/src/engine/commands/units/helpers/nonCombatAbilityHelpers.ts
+++ b/packages/core/src/engine/commands/units/helpers/nonCombatAbilityHelpers.ts
@@ -1,0 +1,85 @@
+/**
+ * Non-combat ability helpers for unit ability activation
+ *
+ * Handles application of heal, move, and influence abilities
+ * that don't contribute to the combat accumulator.
+ */
+
+import type { UnitAbilityType } from "@mage-knight/shared";
+import {
+  UNIT_ABILITY_HEAL,
+  UNIT_ABILITY_MOVE,
+  UNIT_ABILITY_INFLUENCE,
+  CARD_WOUND,
+} from "@mage-knight/shared";
+import type { Player } from "../../../../types/player.js";
+
+/**
+ * Result of applying a non-combat ability
+ */
+export interface NonCombatAbilityResult {
+  readonly player: Player;
+  readonly woundPileCountDelta: number;
+}
+
+/**
+ * Apply non-combat ability effects (move, influence, heal)
+ * Returns updated player and state changes
+ */
+export function applyNonCombatAbility(
+  player: Player,
+  abilityType: UnitAbilityType,
+  value: number
+): NonCombatAbilityResult {
+  switch (abilityType) {
+    case UNIT_ABILITY_HEAL: {
+      // Count wounds in hand
+      const woundsInHand = player.hand.filter((c) => c === CARD_WOUND).length;
+      const woundsToHeal = Math.min(value, woundsInHand);
+
+      if (woundsToHeal === 0) {
+        return { player, woundPileCountDelta: 0 };
+      }
+
+      // Remove wound cards from hand
+      const newHand = [...player.hand];
+      for (let i = 0; i < woundsToHeal; i++) {
+        const woundIndex = newHand.indexOf(CARD_WOUND);
+        if (woundIndex !== -1) {
+          newHand.splice(woundIndex, 1);
+        }
+      }
+
+      return {
+        player: { ...player, hand: newHand },
+        woundPileCountDelta: woundsToHeal, // Return healed wounds to pile
+      };
+    }
+
+    case UNIT_ABILITY_MOVE: {
+      // Add move points
+      return {
+        player: {
+          ...player,
+          movePoints: player.movePoints + value,
+        },
+        woundPileCountDelta: 0,
+      };
+    }
+
+    case UNIT_ABILITY_INFLUENCE: {
+      // Add influence points
+      return {
+        player: {
+          ...player,
+          influencePoints: player.influencePoints + value,
+        },
+        woundPileCountDelta: 0,
+      };
+    }
+
+    default:
+      // Combat abilities handled elsewhere
+      return { player, woundPileCountDelta: 0 };
+  }
+}

--- a/packages/core/src/engine/commands/units/helpers/terrainModifierHelpers.ts
+++ b/packages/core/src/engine/commands/units/helpers/terrainModifierHelpers.ts
@@ -1,0 +1,51 @@
+/**
+ * Terrain modifier helpers for unit ability activation
+ *
+ * Handles applying terrain cost modifiers from unit abilities
+ * (e.g., Foresters reducing forest movement cost).
+ */
+
+import type { UnitTerrainModifier } from "@mage-knight/shared";
+import type { GameState } from "../../../../state/GameState.js";
+import { addModifier } from "../../../modifiers.js";
+import {
+  DURATION_TURN,
+  EFFECT_TERRAIN_COST,
+  SCOPE_SELF,
+  SOURCE_UNIT,
+} from "../../../../types/modifierConstants.js";
+
+/**
+ * Apply terrain cost modifiers from a unit ability.
+ * Returns the updated state with modifiers added.
+ */
+export function applyTerrainModifiers(
+  state: GameState,
+  playerId: string,
+  unitIndex: number,
+  terrainModifiers: readonly UnitTerrainModifier[]
+): GameState {
+  let currentState = state;
+
+  for (const terrainMod of terrainModifiers) {
+    currentState = addModifier(currentState, {
+      source: {
+        type: SOURCE_UNIT,
+        unitIndex,
+        playerId,
+      },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: {
+        type: EFFECT_TERRAIN_COST,
+        terrain: terrainMod.terrain,
+        amount: terrainMod.amount,
+        minimum: terrainMod.minimum,
+      },
+      createdAtRound: state.round,
+      createdByPlayerId: playerId,
+    });
+  }
+
+  return currentState;
+}


### PR DESCRIPTION
## Summary

- Split `activateUnitCommand.ts` (663 lines) into 6 focused helper modules (main file now 246 lines)
- Enables parallel development on unit activation logic without merge conflicts
- Pure refactor with no behavior changes - all existing tests pass

## New File Structure

```
packages/core/src/engine/commands/units/
├── activateUnitCommand.ts           # 246 lines (was 663)
├── helpers/
│   ├── index.ts                     # Barrel export
│   ├── elementalHelpers.ts          # Element-to-key mapping, value math
│   ├── combatAccumulatorHelpers.ts  # Add/remove from combat accumulator
│   ├── nonCombatAbilityHelpers.ts   # Heal, move, influence effects
│   ├── terrainModifierHelpers.ts    # Terrain cost modifiers
│   └── manaConsumptionHelpers.ts    # Mana source handling
```

## Conflict Reduction

| Change Type | Before | After |
|-------------|--------|-------|
| New ability type | Edit 663-line file | Edit `combatAccumulatorHelpers.ts` only |
| New mana source | Edit 663-line file | Edit `manaConsumptionHelpers.ts` only |
| Terrain modifier changes | Hunt through 663 lines | Edit 51-line file |

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` passes (1225 tests, 0 failures)
- [x] No behavior changes - pure refactor