### PR TITLE
refactor: eliminate magic strings with typed constants

### DIFF
--- a/packages/core/src/engine/effects/discardEffects.ts
+++ b/packages/core/src/engine/effects/discardEffects.ts
@@ -9,8 +9,13 @@ import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
 import type { DiscardCardEffect, CardEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
-import type { CardId } from "@mage-knight/shared";
-import { CARD_WOUND } from "@mage-knight/shared";
+import type { CardId, DiscardFilter } from "@mage-knight/shared";
+import {
+  CARD_WOUND,
+  DISCARD_FILTER_WOUND,
+  DISCARD_FILTER_NON_WOUND,
+  DISCARD_FILTER_ANY,
+} from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
 
 /**
@@ -18,14 +23,14 @@ import { updatePlayer } from "./atomicEffects.js";
  */
 export function getDiscardableCards(
   hand: readonly CardId[],
-  filter: "wound" | "non-wound" | "any"
+  filter: DiscardFilter
 ): CardId[] {
   switch (filter) {
-    case "wound":
+    case DISCARD_FILTER_WOUND:
       return hand.filter((cardId) => cardId === CARD_WOUND);
-    case "non-wound":
+    case DISCARD_FILTER_NON_WOUND:
       return hand.filter((cardId) => cardId !== CARD_WOUND);
-    case "any":
+    case DISCARD_FILTER_ANY:
       return [...hand];
   }
 }
@@ -45,9 +50,9 @@ export function handleDiscardCard(
   // Check if there are enough cards to discard
   if (eligibleCards.length < effect.amount) {
     const filterDesc =
-      effect.filter === "wound"
+      effect.filter === DISCARD_FILTER_WOUND
         ? "wound cards"
-        : effect.filter === "non-wound"
+        : effect.filter === DISCARD_FILTER_NON_WOUND
           ? "non-wound cards"
           : "cards";
     return {
@@ -120,7 +125,7 @@ export function applyDiscardCard(
     return {
       state: updatedState,
       description: `${description}. Follow-up effect pending.`,
-      resolvedEffect: { type: "discard_card", filter: "any", amount: cardIds.length } as DiscardCardEffect,
+      resolvedEffect: { type: "discard_card", filter: DISCARD_FILTER_ANY, amount: cardIds.length } as DiscardCardEffect,
     };
   }
 

--- a/packages/core/src/engine/effects/mapEffects.ts
+++ b/packages/core/src/engine/effects/mapEffects.ts
@@ -11,7 +11,12 @@ import type { HexState, HexEnemy } from "../../types/map.js";
 import type { RevealTilesEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import type { HexCoord } from "@mage-knight/shared";
-import { hexKey } from "@mage-knight/shared";
+import {
+  hexKey,
+  REVEAL_TILE_TYPE_ENEMY,
+  REVEAL_TILE_TYPE_GARRISON,
+  REVEAL_TILE_TYPE_ALL,
+} from "@mage-knight/shared";
 
 /**
  * Calculate the distance between two hexes using axial coordinates.
@@ -69,7 +74,7 @@ export function handleRevealTiles(
   const nearbyHexes = getHexesWithinDistance(state, player.position, effect.distance);
 
   // Determine what to reveal based on tileType
-  const tileType = effect.tileType ?? "all";
+  const tileType = effect.tileType ?? REVEAL_TILE_TYPE_ALL;
   let revealedCount = 0;
   const updatedHexes = { ...state.map.hexes };
 
@@ -78,7 +83,7 @@ export function handleRevealTiles(
     let hexUpdated = false;
 
     // Reveal enemies (garrisons)
-    if ((tileType === "enemy" || tileType === "garrison" || tileType === "all") &&
+    if ((tileType === REVEAL_TILE_TYPE_ENEMY || tileType === REVEAL_TILE_TYPE_GARRISON || tileType === REVEAL_TILE_TYPE_ALL) &&
         hasUnrevealedEnemies(hex)) {
       const revealedEnemies: HexEnemy[] = hex.enemies.map((e) => ({
         ...e,

--- a/packages/core/src/engine/effects/terrainEffects.ts
+++ b/packages/core/src/engine/effects/terrainEffects.ts
@@ -17,6 +17,9 @@ import {
   TIME_OF_DAY_NIGHT,
   ELEMENT_FIRE,
   ELEMENT_ICE,
+  TERRAIN_LAKE,
+  TERRAIN_MOUNTAIN,
+  TERRAIN_OCEAN,
 } from "@mage-knight/shared";
 import { EFFECT_GAIN_BLOCK } from "../../types/effectTypes.js";
 
@@ -47,9 +50,9 @@ function getUnmodifiedTerrainCost(state: GameState, player: Player): number {
   // (Player shouldn't normally be on these, but handle gracefully)
   if (costs.day === Infinity) {
     // Lake = 2 (with boat), Mountain = 5, Ocean = 2
-    if (terrain === "lake") return 2;
-    if (terrain === "mountain") return 5;
-    if (terrain === "ocean") return 2;
+    if (terrain === TERRAIN_LAKE) return 2;
+    if (terrain === TERRAIN_MOUNTAIN) return 5;
+    if (terrain === TERRAIN_OCEAN) return 2;
     return 2; // Generic fallback
   }
 

--- a/packages/core/src/engine/validators/units/recruitmentValidators.ts
+++ b/packages/core/src/engine/validators/units/recruitmentValidators.ts
@@ -11,7 +11,7 @@ import type { GameState } from "../../../state/GameState.js";
 import type { PlayerAction } from "@mage-knight/shared";
 import type { ValidationResult } from "../types.js";
 import { valid, invalid } from "../types.js";
-import { RECRUIT_UNIT_ACTION, getUnit } from "@mage-knight/shared";
+import { RECRUIT_UNIT_ACTION, getUnit, CITY_COLOR_WHITE } from "@mage-knight/shared";
 import {
   NO_COMMAND_SLOTS,
   INSUFFICIENT_INFLUENCE,
@@ -137,7 +137,7 @@ export function validateUnitTypeMatchesSite(
   const unitDef = getUnit(action.unitId);
 
   // White cities allow all unit types
-  if (site.type === SiteType.City && site.cityColor === "white") {
+  if (site.type === SiteType.City && site.cityColor === CITY_COLOR_WHITE) {
     return valid();
   }
 

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -2,7 +2,7 @@
  * Card definitions for Mage Knight
  */
 
-import type { CardId, ManaColor, BasicManaColor, Element } from "@mage-knight/shared";
+import type { CardId, ManaColor, BasicManaColor, Element, DiscardFilter, RevealTileType } from "@mage-knight/shared";
 import type { ModifierEffect, ModifierDuration, ModifierScope } from "./modifiers.js";
 import type { CombatPhase } from "./combat.js";
 import type { SourceDieId } from "./mana.js";
@@ -370,7 +370,7 @@ export interface HealUnitEffect {
  */
 export interface DiscardCardEffect {
   readonly type: typeof EFFECT_DISCARD_CARD;
-  readonly filter: "wound" | "non-wound" | "any";
+  readonly filter: DiscardFilter;
   readonly amount: number;
   readonly onSuccess?: CardEffect;
 }
@@ -384,7 +384,7 @@ export interface DiscardCardEffect {
 export interface RevealTilesEffect {
   readonly type: typeof EFFECT_REVEAL_TILES;
   readonly distance: number;
-  readonly tileType?: "garrison" | "enemy" | "all";
+  readonly tileType?: RevealTileType;
 }
 
 /**

--- a/packages/core/src/types/mapConstants.ts
+++ b/packages/core/src/types/mapConstants.ts
@@ -1,17 +1,39 @@
 /**
  * Map-related constants (distinct domains even if values overlap).
+ *
+ * Re-exported from @mage-knight/shared for core package convenience.
  */
 
-// City color (faction/identity)
-export const CITY_COLOR_RED = "red" as const;
-export const CITY_COLOR_BLUE = "blue" as const;
-export const CITY_COLOR_GREEN = "green" as const;
-export const CITY_COLOR_WHITE = "white" as const;
+// City colors
+export {
+  CITY_COLOR_RED,
+  CITY_COLOR_BLUE,
+  CITY_COLOR_GREEN,
+  CITY_COLOR_WHITE,
+  type CityColor,
+} from "@mage-knight/shared";
 
-// Mine color (resource-adjacent; yields basic mana crystals)
-export const MINE_COLOR_RED = "red" as const;
-export const MINE_COLOR_BLUE = "blue" as const;
-export const MINE_COLOR_GREEN = "green" as const;
-export const MINE_COLOR_WHITE = "white" as const;
+// Mine colors
+export {
+  MINE_COLOR_RED,
+  MINE_COLOR_BLUE,
+  MINE_COLOR_GREEN,
+  MINE_COLOR_WHITE,
+  type MineColor,
+} from "@mage-knight/shared";
 
+// Discard filter types
+export {
+  DISCARD_FILTER_WOUND,
+  DISCARD_FILTER_NON_WOUND,
+  DISCARD_FILTER_ANY,
+  type DiscardFilter,
+} from "@mage-knight/shared";
 
+// Reveal tile types
+export {
+  REVEAL_TILE_TYPE_ENEMY,
+  REVEAL_TILE_TYPE_GARRISON,
+  REVEAL_TILE_TYPE_ALL,
+  type RevealTileType,
+} from "@mage-knight/shared";

--- a/packages/shared/src/cooperativeAssault.ts
+++ b/packages/shared/src/cooperativeAssault.ts
@@ -5,17 +5,10 @@
  * This module defines the proposal and agreement system.
  */
 
-// City colors for targeting (matches core's CityColor)
-export const CITY_COLOR_RED = "red" as const;
-export const CITY_COLOR_BLUE = "blue" as const;
-export const CITY_COLOR_GREEN = "green" as const;
-export const CITY_COLOR_WHITE = "white" as const;
-
-export type CityColor =
-  | typeof CITY_COLOR_RED
-  | typeof CITY_COLOR_BLUE
-  | typeof CITY_COLOR_GREEN
-  | typeof CITY_COLOR_WHITE;
+// Import CityColor for local use and re-export for backwards compatibility
+// (canonical definition is in mapConstants)
+import type { CityColor } from "./mapConstants.js";
+export type { CityColor } from "./mapConstants.js";
 
 /**
  * Enemy distribution assignment for a cooperative assault.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -281,3 +281,6 @@ export * from "./hero.js";
 
 // Game configuration
 export * from "./gameConfig.js";
+
+// Map constants (city colors, mine colors, discard filters, reveal types)
+export * from "./mapConstants.js";

--- a/packages/shared/src/mapConstants.ts
+++ b/packages/shared/src/mapConstants.ts
@@ -1,0 +1,51 @@
+/**
+ * Map-related constants (distinct domains even if values overlap).
+ */
+
+// === City Colors ===
+// Faction/identity for cities on the map
+export const CITY_COLOR_RED = "red" as const;
+export const CITY_COLOR_BLUE = "blue" as const;
+export const CITY_COLOR_GREEN = "green" as const;
+export const CITY_COLOR_WHITE = "white" as const;
+
+export type CityColor =
+  | typeof CITY_COLOR_RED
+  | typeof CITY_COLOR_BLUE
+  | typeof CITY_COLOR_GREEN
+  | typeof CITY_COLOR_WHITE;
+
+// === Mine Colors ===
+// Resource-adjacent; yields basic mana crystals
+export const MINE_COLOR_RED = "red" as const;
+export const MINE_COLOR_BLUE = "blue" as const;
+export const MINE_COLOR_GREEN = "green" as const;
+export const MINE_COLOR_WHITE = "white" as const;
+
+export type MineColor =
+  | typeof MINE_COLOR_RED
+  | typeof MINE_COLOR_BLUE
+  | typeof MINE_COLOR_GREEN
+  | typeof MINE_COLOR_WHITE;
+
+// === Discard Filter Types ===
+// Used for card discard effects (e.g., "discard a wound", "discard any card")
+export const DISCARD_FILTER_WOUND = "wound" as const;
+export const DISCARD_FILTER_NON_WOUND = "non-wound" as const;
+export const DISCARD_FILTER_ANY = "any" as const;
+
+export type DiscardFilter =
+  | typeof DISCARD_FILTER_WOUND
+  | typeof DISCARD_FILTER_NON_WOUND
+  | typeof DISCARD_FILTER_ANY;
+
+// === Reveal Tile Types ===
+// Used for tile/enemy reveal effects (e.g., Scouting, Intelligence skills)
+export const REVEAL_TILE_TYPE_ENEMY = "enemy" as const;
+export const REVEAL_TILE_TYPE_GARRISON = "garrison" as const;
+export const REVEAL_TILE_TYPE_ALL = "all" as const;
+
+export type RevealTileType =
+  | typeof REVEAL_TILE_TYPE_ENEMY
+  | typeof REVEAL_TILE_TYPE_GARRISON
+  | typeof REVEAL_TILE_TYPE_ALL;


### PR DESCRIPTION
## Summary
- Create `mapConstants.ts` in shared package with typed constants for city colors, mine colors, discard filters, and reveal tile types
- Consolidate duplicate `CityColor` definitions from `cooperativeAssault.ts` into the new central location
- Update core package to re-export constants from shared for internal use
- Replace raw string literals with constants across effect resolvers and validators

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` passes (1,285 tests)