### PR TITLE
refactor: split cooperativeAssaultValidators into focused modules

### DIFF
--- a/packages/core/src/engine/validators/cooperativeAssaultValidators/cancelValidators.ts
+++ b/packages/core/src/engine/validators/cooperativeAssaultValidators/cancelValidators.ts
@@ -1,0 +1,61 @@
+/**
+ * Cancel cooperative proposal validators
+ *
+ * Validates the cancel action for cooperative assault proposals.
+ * Only the initiator can cancel a proposal:
+ * - A pending proposal must exist
+ * - The cancelling player must be the initiator
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import type { ValidationResult } from "../types.js";
+import { valid, invalid } from "../types.js";
+import { CANCEL_COOPERATIVE_PROPOSAL_ACTION } from "@mage-knight/shared";
+import {
+  NO_PENDING_PROPOSAL,
+  NOT_PROPOSAL_INITIATOR,
+} from "../validationCodes.js";
+
+/**
+ * There must be a pending proposal to cancel.
+ */
+export function validateProposalExistsForCancel(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== CANCEL_COOPERATIVE_PROPOSAL_ACTION) return valid();
+
+  if (!state.pendingCooperativeAssault) {
+    return invalid(
+      NO_PENDING_PROPOSAL,
+      "There is no pending cooperative assault proposal to cancel"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * The cancelling player must be the initiator.
+ */
+export function validatePlayerIsInitiator(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== CANCEL_COOPERATIVE_PROPOSAL_ACTION) return valid();
+
+  const proposal = state.pendingCooperativeAssault;
+  if (!proposal) return valid(); // Handled by validateProposalExistsForCancel
+
+  if (proposal.initiatorId !== playerId) {
+    return invalid(
+      NOT_PROPOSAL_INITIATOR,
+      "Only the initiator can cancel the proposal"
+    );
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/cooperativeAssaultValidators/helpers.ts
+++ b/packages/core/src/engine/validators/cooperativeAssaultValidators/helpers.ts
@@ -1,0 +1,54 @@
+/**
+ * Cooperative assault validator helpers
+ *
+ * Shared helper functions used by proposal, response, and cancel validators.
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { CityColor as CoreCityColor } from "../../../types/map.js";
+import { SiteType } from "../../../types/map.js";
+import { CARD_WOUND, getAllNeighbors } from "@mage-knight/shared";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
+
+/**
+ * Find the hex coordinate of a city with the given color.
+ */
+export function findCityHex(
+  state: GameState,
+  cityColor: CoreCityColor
+): { q: number; r: number } | null {
+  for (const [, hex] of Object.entries(state.map.hexes)) {
+    if (
+      hex.site?.type === SiteType.City &&
+      hex.site.cityColor === cityColor
+    ) {
+      return hex.coord;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a position is adjacent to a city of the given color.
+ */
+export function isAdjacentToCity(
+  state: GameState,
+  position: { q: number; r: number },
+  cityColor: CoreCityColor
+): boolean {
+  const cityHex = findCityHex(state, cityColor);
+  if (!cityHex) return false;
+
+  const neighbors = getAllNeighbors(position);
+  return neighbors.some((n) => n.q === cityHex.q && n.r === cityHex.r);
+}
+
+/**
+ * Check if a player has at least one non-wound card in hand.
+ */
+export function hasNonWoundCard(state: GameState, playerId: string): boolean {
+  const player = getPlayerById(state, playerId);
+  if (!player) return false;
+
+  return player.hand.some((cardId) => cardId !== CARD_WOUND);
+}

--- a/packages/core/src/engine/validators/cooperativeAssaultValidators/index.ts
+++ b/packages/core/src/engine/validators/cooperativeAssaultValidators/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Cooperative assault validators - validates cooperative assault actions
+ *
+ * Split into focused modules:
+ * - proposeValidators: Initiator, game state, invitee, and distribution validation
+ * - responseValidators: Response to proposal validation
+ * - cancelValidators: Cancel proposal validation
+ * - helpers: Shared helper functions (city adjacency, non-wound cards)
+ */
+
+// Propose validators - initiator state
+export {
+  validateInitiatorAdjacentToCity,
+  validateInitiatorNotActed,
+  validateInitiatorTokenNotFlipped,
+  validateNoOtherPlayerOnSpace,
+} from "./proposeValidators.js";
+
+// Propose validators - game state
+export {
+  validateEndOfRoundNotAnnounced,
+  validateScenarioNotFulfilled,
+} from "./proposeValidators.js";
+
+// Propose validators - invitees
+export {
+  validateInviteesAdjacentToCity,
+  validateInviteesTokensNotFlipped,
+  validateInviteesHaveCards,
+} from "./proposeValidators.js";
+
+// Propose validators - distribution
+export {
+  validateAtLeastOneInvitee,
+  validateEnemyDistribution,
+} from "./proposeValidators.js";
+
+// Response validators
+export {
+  validateProposalExists,
+  validatePlayerIsInvitee,
+  validatePlayerNotResponded,
+} from "./responseValidators.js";
+
+// Cancel validators
+export {
+  validateProposalExistsForCancel,
+  validatePlayerIsInitiator,
+} from "./cancelValidators.js";

--- a/packages/core/src/engine/validators/cooperativeAssaultValidators/responseValidators.ts
+++ b/packages/core/src/engine/validators/cooperativeAssaultValidators/responseValidators.ts
@@ -1,0 +1,83 @@
+/**
+ * Respond to cooperative proposal validators
+ *
+ * Validates the response action for cooperative assault proposals.
+ * Players can respond to proposals when:
+ * - A pending proposal exists
+ * - They are an invited player
+ * - They have not already responded
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import type { ValidationResult } from "../types.js";
+import { valid, invalid } from "../types.js";
+import { RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION } from "@mage-knight/shared";
+import {
+  NO_PENDING_PROPOSAL,
+  NOT_AN_INVITEE,
+  ALREADY_RESPONDED,
+} from "../validationCodes.js";
+
+/**
+ * There must be a pending cooperative assault proposal.
+ */
+export function validateProposalExists(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION) return valid();
+
+  if (!state.pendingCooperativeAssault) {
+    return invalid(
+      NO_PENDING_PROPOSAL,
+      "There is no pending cooperative assault proposal"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * The responding player must be an invitee.
+ */
+export function validatePlayerIsInvitee(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION) return valid();
+
+  const proposal = state.pendingCooperativeAssault;
+  if (!proposal) return valid(); // Handled by validateProposalExists
+
+  if (!proposal.invitedPlayerIds.includes(playerId)) {
+    return invalid(NOT_AN_INVITEE, "You are not invited to this proposal");
+  }
+
+  return valid();
+}
+
+/**
+ * The responding player must not have already responded.
+ */
+export function validatePlayerNotResponded(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION) return valid();
+
+  const proposal = state.pendingCooperativeAssault;
+  if (!proposal) return valid(); // Handled by validateProposalExists
+
+  if (proposal.acceptedPlayerIds.includes(playerId)) {
+    return invalid(
+      ALREADY_RESPONDED,
+      "You have already responded to this proposal"
+    );
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/registry/cooperativeRegistry.ts
+++ b/packages/core/src/engine/validators/registry/cooperativeRegistry.ts
@@ -38,7 +38,7 @@ import {
   validatePlayerNotResponded,
   validateProposalExistsForCancel,
   validatePlayerIsInitiator,
-} from "../cooperativeAssaultValidators.js";
+} from "../cooperativeAssaultValidators/index.js";
 
 export const cooperativeRegistry: Record<string, Validator[]> = {
   [PROPOSE_COOPERATIVE_ASSAULT_ACTION]: [

--- a/packages/core/src/engine/validators/routing/cooperative.ts
+++ b/packages/core/src/engine/validators/routing/cooperative.ts
@@ -36,7 +36,7 @@ import {
   validatePlayerNotResponded,
   validateProposalExistsForCancel,
   validatePlayerIsInitiator,
-} from "../cooperativeAssaultValidators.js";
+} from "../cooperativeAssaultValidators/index.js";
 
 export const cooperativeValidatorRegistry: ValidatorRegistry = {
   [PROPOSE_COOPERATIVE_ASSAULT_ACTION]: [


### PR DESCRIPTION
## Summary
- Split monolithic `cooperativeAssaultValidators.ts` (528 lines) into modular subdirectory
- Follows established pattern from `combatValidators/` directory structure
- Improves maintainability by grouping validators by action type

## Changes
New structure under `validators/cooperativeAssaultValidators/`:
- `helpers.ts` - Shared functions (`findCityHex`, `isAdjacentToCity`, `hasNonWoundCard`)
- `proposeValidators.ts` - 11 validators for `PROPOSE_COOPERATIVE_ASSAULT_ACTION`
- `responseValidators.ts` - 3 validators for `RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION`
- `cancelValidators.ts` - 2 validators for `CANCEL_COOPERATIVE_PROPOSAL_ACTION`
- `index.ts` - Re-exports all validators

## Test plan
- [x] All existing tests pass (1225 tests)
- [x] Build succeeds
- [x] Lint passes