### PR TITLE
refactor: split atomicEffects.ts into focused modules

### DIFF
--- a/packages/core/src/engine/effects/atomicCardEffects.ts
+++ b/packages/core/src/engine/effects/atomicCardEffects.ts
@@ -1,0 +1,153 @@
+/**
+ * Atomic card effect handlers
+ *
+ * Handles effects that modify the player's cards:
+ * - DrawCards (draw from deck to hand)
+ * - GainHealing (remove wounds from hand)
+ * - TakeWound (add wounds to hand as a cost)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { CardId } from "@mage-knight/shared";
+import type { EffectResolutionResult } from "./types.js";
+import { CARD_WOUND } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Apply a DrawCards effect - draws cards from deck to hand.
+ *
+ * Per the rulebook, there is no mid-round reshuffle. If the deck
+ * is empty, no cards are drawn.
+ */
+export function applyDrawCards(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  const availableInDeck = player.deck.length;
+  const actualDraw = Math.min(amount, availableInDeck);
+
+  if (actualDraw === 0) {
+    return { state, description: "No cards to draw" };
+  }
+
+  // Draw from top of deck to hand (no mid-round reshuffle per rulebook)
+  const drawnCards = player.deck.slice(0, actualDraw);
+  const newDeck = player.deck.slice(actualDraw);
+  const newHand = [...player.hand, ...drawnCards];
+
+  const updatedPlayer: Player = {
+    ...player,
+    deck: newDeck,
+    hand: newHand,
+  };
+
+  const description =
+    actualDraw === 1 ? "Drew 1 card" : `Drew ${actualDraw} cards`;
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description,
+  };
+}
+
+/**
+ * Apply a GainHealing effect - removes wounds from hand.
+ *
+ * Each healing point removes one wound card from hand.
+ * Wounds are returned to the wound pile.
+ */
+export function applyGainHealing(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  // Count wounds in hand
+  const woundsInHand = player.hand.filter((c) => c === CARD_WOUND).length;
+
+  if (woundsInHand === 0) {
+    // No wounds to heal (shouldn't normally happen since isEffectResolvable checks this)
+    return { state, description: "No wounds to heal" };
+  }
+
+  // Heal up to 'amount' wounds (each healing point removes one wound)
+  const woundsToHeal = Math.min(amount, woundsInHand);
+
+  // Remove wound cards from hand
+  const newHand = [...player.hand];
+  for (let i = 0; i < woundsToHeal; i++) {
+    const woundIndex = newHand.indexOf(CARD_WOUND);
+    if (woundIndex !== -1) {
+      newHand.splice(woundIndex, 1);
+    }
+  }
+
+  const updatedPlayer: Player = {
+    ...player,
+    hand: newHand,
+  };
+
+  // Return wounds to the wound pile (unlimited => stay null)
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : state.woundPileCount + woundsToHeal;
+
+  const updatedState = {
+    ...updatePlayer(state, playerIndex, updatedPlayer),
+    woundPileCount: newWoundPileCount,
+  };
+
+  const description =
+    woundsToHeal === 1
+      ? "Healed 1 wound"
+      : `Healed ${woundsToHeal} wounds`;
+
+  return {
+    state: updatedState,
+    description,
+  };
+}
+
+/**
+ * Apply a TakeWound effect - adds wound cards directly to hand.
+ *
+ * This is a COST, not combat damage - it bypasses armor.
+ * Used by Fireball powered, Snowstorm powered, etc.
+ */
+export function applyTakeWound(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  // Create wound cards to add to hand
+  const woundsToAdd: CardId[] = Array(amount).fill(CARD_WOUND);
+
+  const updatedPlayer: Player = {
+    ...player,
+    hand: [...player.hand, ...woundsToAdd],
+  };
+
+  // Decrement wound pile (if tracked)
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : Math.max(0, state.woundPileCount - amount);
+
+  const updatedState = {
+    ...updatePlayer(state, playerIndex, updatedPlayer),
+    woundPileCount: newWoundPileCount,
+  };
+
+  const description =
+    amount === 1 ? "Took 1 wound" : `Took ${amount} wounds`;
+
+  return {
+    state: updatedState,
+    description,
+  };
+}

--- a/packages/core/src/engine/effects/atomicCombatEffects.ts
+++ b/packages/core/src/engine/effects/atomicCombatEffects.ts
@@ -1,0 +1,161 @@
+/**
+ * Atomic combat effect handlers
+ *
+ * Handles effects that modify the combat accumulator:
+ * - GainAttack (normal, ranged, siege with optional element)
+ * - GainBlock (with optional element)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, AccumulatedAttack } from "../../types/player.js";
+import type { Element, BlockSource, CombatType } from "@mage-knight/shared";
+import type { GainAttackEffect, GainBlockEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { ELEMENT_PHYSICAL, COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE } from "@mage-knight/shared";
+import { updatePlayer, updateElementalValue } from "./atomicHelpers.js";
+
+// ============================================================================
+// ATTACK HELPERS
+// ============================================================================
+
+/**
+ * Get the display name for an attack type based on combat type and element.
+ */
+function getAttackTypeName(
+  combatType: CombatType | undefined,
+  element: Element | undefined
+): string {
+  const elementPrefix = element ? `${element} ` : "";
+
+  switch (combatType) {
+    case COMBAT_TYPE_RANGED:
+      return `${elementPrefix}Ranged Attack`;
+    case COMBAT_TYPE_SIEGE:
+      return `${elementPrefix}Siege Attack`;
+    default:
+      return `${elementPrefix}Attack`;
+  }
+}
+
+/**
+ * Update attack values for a specific combat type and element.
+ */
+function updateAttackForType(
+  currentAttack: AccumulatedAttack,
+  combatType: CombatType | undefined,
+  element: Element | undefined,
+  amount: number
+): AccumulatedAttack {
+  switch (combatType) {
+    case COMBAT_TYPE_RANGED:
+      if (element) {
+        return {
+          ...currentAttack,
+          rangedElements: updateElementalValue(currentAttack.rangedElements, element, amount),
+        };
+      }
+      return { ...currentAttack, ranged: currentAttack.ranged + amount };
+
+    case COMBAT_TYPE_SIEGE:
+      if (element) {
+        return {
+          ...currentAttack,
+          siegeElements: updateElementalValue(currentAttack.siegeElements, element, amount),
+        };
+      }
+      return { ...currentAttack, siege: currentAttack.siege + amount };
+
+    default:
+      if (element) {
+        return {
+          ...currentAttack,
+          normalElements: updateElementalValue(currentAttack.normalElements, element, amount),
+        };
+      }
+      return { ...currentAttack, normal: currentAttack.normal + amount };
+  }
+}
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Apply a GainAttack effect to the combat accumulator.
+ *
+ * Supports all combinations of:
+ * - Combat type: normal, ranged, siege
+ * - Element: physical (default), fire, ice, cold_fire
+ */
+export function applyGainAttack(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: GainAttackEffect
+): EffectResolutionResult {
+  const { amount, combatType, element } = effect;
+  const currentAttack = player.combatAccumulator.attack;
+
+  const updatedAttack = updateAttackForType(currentAttack, combatType, element, amount);
+  const attackTypeName = getAttackTypeName(combatType, element);
+
+  const updatedPlayer: Player = {
+    ...player,
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      attack: updatedAttack,
+    },
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${amount} ${attackTypeName}`,
+  };
+}
+
+/**
+ * Apply a GainBlock effect to the combat accumulator.
+ *
+ * Updates both the block total and element-specific tracking for
+ * elemental efficiency calculations.
+ */
+export function applyGainBlock(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: GainBlockEffect
+): EffectResolutionResult {
+  const { amount, element } = effect;
+  const effectiveElement = element ?? ELEMENT_PHYSICAL;
+
+  // Create a block source for tracking (for elemental efficiency calculations)
+  const blockSource: BlockSource = {
+    element: effectiveElement,
+    value: amount,
+  };
+
+  // Always update both block total and blockElements for consistency with:
+  // 1. activateUnitCommand (which updates both for all block types)
+  // 2. UI which checks acc.block to determine if accumulator should render
+  // 3. Valid actions computation which reads from blockElements
+  const updatedPlayer: Player = {
+    ...player,
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      block: player.combatAccumulator.block + amount,
+      blockElements: updateElementalValue(
+        player.combatAccumulator.blockElements,
+        effectiveElement,
+        amount
+      ),
+      blockSources: [...player.combatAccumulator.blockSources, blockSource],
+    },
+  };
+
+  const blockTypeName = element ? `${element} Block` : "Block";
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${amount} ${blockTypeName}`,
+  };
+}

--- a/packages/core/src/engine/effects/atomicEffects.ts
+++ b/packages/core/src/engine/effects/atomicEffects.ts
@@ -1,440 +1,76 @@
 /**
- * Atomic effect handlers - pure leaf functions that don't recurse back into resolveEffect.
+ * Atomic Effect Handlers
  *
- * These handle direct state transformations:
- * - Gain move/influence/attack/block/healing/mana
- * - Draw cards
- * - Change reputation
- * - Gain crystals
- * - Apply modifiers
+ * This module provides pure leaf functions that directly transform game state
+ * without recursing back into resolveEffect. These handle direct state changes:
+ *
+ * | Module | Effects |
+ * |--------|---------|
+ * | `atomicCombatEffects.ts` | GainAttack, GainBlock |
+ * | `atomicResourceEffects.ts` | GainMove, GainInfluence, GainMana, GainCrystal |
+ * | `atomicProgressionEffects.ts` | GainFame, ChangeReputation |
+ * | `atomicCardEffects.ts` | DrawCards, GainHealing, TakeWound |
+ * | `atomicModifierEffects.ts` | ApplyModifier |
+ * | `atomicHelpers.ts` | Shared utilities (updatePlayer, updateElementalValue) |
+ *
+ * @module effects/atomicEffects
  */
 
-import type { GameState } from "../../state/GameState.js";
-import type { Player, AccumulatedAttack, ElementalAttackValues } from "../../types/player.js";
-import type { CardId, Element, BlockSource, ManaColor, BasicManaColor } from "@mage-knight/shared";
-import type { GainAttackEffect, GainBlockEffect, ApplyModifierEffect } from "../../types/cards.js";
-import type { EffectResolutionResult } from "./types.js";
-import { CARD_WOUND, MANA_TOKEN_SOURCE_CARD, MIN_REPUTATION, MAX_REPUTATION, getLevelsCrossed } from "@mage-knight/shared";
-import { ELEMENT_FIRE, ELEMENT_ICE, ELEMENT_COLD_FIRE, ELEMENT_PHYSICAL } from "@mage-knight/shared";
-import { COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE } from "../../types/effectTypes.js";
-import { addModifier } from "../modifiers/index.js";
-import { SOURCE_CARD, SCOPE_SELF } from "../modifierConstants.js";
+// ============================================================================
+// SHARED HELPERS
+// ============================================================================
 
-// === Shared helpers ===
+export {
+  updatePlayer,
+  updateElementalValue,
+  elementToPropertyKey,
+} from "./atomicHelpers.js";
 
-export function updatePlayer(
-  state: GameState,
-  playerIndex: number,
-  updatedPlayer: Player
-): GameState {
-  const players = [...state.players];
-  players[playerIndex] = updatedPlayer;
-  return { ...state, players };
-}
+// ============================================================================
+// COMBAT EFFECTS
+// ============================================================================
 
-/**
- * Helper to update elemental values
- */
-export function updateElementalValue(
-  values: ElementalAttackValues,
-  element: Element | undefined,
-  amount: number
-): ElementalAttackValues {
-  if (!element) {
-    return { ...values, physical: values.physical + amount };
-  }
-  switch (element) {
-    case ELEMENT_FIRE:
-      return { ...values, fire: values.fire + amount };
-    case ELEMENT_ICE:
-      return { ...values, ice: values.ice + amount };
-    case ELEMENT_COLD_FIRE:
-      return { ...values, coldFire: values.coldFire + amount };
-    default:
-      return { ...values, physical: values.physical + amount };
-  }
-}
+export {
+  applyGainAttack,
+  applyGainBlock,
+} from "./atomicCombatEffects.js";
 
-// Re-export for reverseEffect (imported from @mage-knight/shared)
-export { MIN_REPUTATION, MAX_REPUTATION };
+// ============================================================================
+// RESOURCE EFFECTS
+// ============================================================================
 
-// === Atomic effect handlers ===
+export {
+  applyGainMove,
+  applyGainInfluence,
+  applyGainMana,
+  applyGainCrystal,
+} from "./atomicResourceEffects.js";
 
-export function applyGainMove(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  const updatedPlayer: Player = {
-    ...player,
-    movePoints: player.movePoints + amount,
-  };
+// ============================================================================
+// PROGRESSION EFFECTS
+// ============================================================================
 
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${amount} Move`,
-  };
-}
+export {
+  applyChangeReputation,
+  applyGainFame,
+  MIN_REPUTATION,
+  MAX_REPUTATION,
+} from "./atomicProgressionEffects.js";
 
-export function applyGainInfluence(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  const updatedPlayer: Player = {
-    ...player,
-    influencePoints: player.influencePoints + amount,
-  };
+// ============================================================================
+// CARD EFFECTS
+// ============================================================================
 
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${amount} Influence`,
-  };
-}
+export {
+  applyDrawCards,
+  applyGainHealing,
+  applyTakeWound,
+} from "./atomicCardEffects.js";
 
-export function applyGainMana(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  color: ManaColor
-): EffectResolutionResult {
-  const newToken = {
-    color,
-    source: MANA_TOKEN_SOURCE_CARD,
-  };
+// ============================================================================
+// MODIFIER EFFECTS
+// ============================================================================
 
-  const updatedPlayer: Player = {
-    ...player,
-    pureMana: [...player.pureMana, newToken],
-  };
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${color} mana token`,
-  };
-}
-
-export function applyChangeReputation(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  // Clamp to -7 to +7 range
-  const newReputation = Math.max(
-    MIN_REPUTATION,
-    Math.min(MAX_REPUTATION, player.reputation + amount)
-  );
-
-  const updatedPlayer: Player = {
-    ...player,
-    reputation: newReputation,
-  };
-
-  const direction = amount >= 0 ? "Gained" : "Lost";
-  const absAmount = Math.abs(amount);
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `${direction} ${absAmount} Reputation`,
-  };
-}
-
-export function applyGainFame(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  const newFame = player.fame + amount;
-  const levelsCrossed = getLevelsCrossed(player.fame, newFame);
-
-  const updatedPlayer: Player = {
-    ...player,
-    fame: newFame,
-    pendingLevelUps: [...player.pendingLevelUps, ...levelsCrossed],
-  };
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${amount} Fame`,
-  };
-}
-
-export function applyGainCrystal(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  color: BasicManaColor
-): EffectResolutionResult {
-  const updatedCrystals = {
-    ...player.crystals,
-    [color]: player.crystals[color] + 1,
-  };
-
-  const updatedPlayer: Player = {
-    ...player,
-    crystals: updatedCrystals,
-  };
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${color} crystal`,
-  };
-}
-
-export function applyGainAttack(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  effect: GainAttackEffect
-): EffectResolutionResult {
-  const { amount, combatType, element } = effect;
-  const currentAttack = player.combatAccumulator.attack;
-  let updatedAttack: AccumulatedAttack;
-  let attackTypeName: string;
-
-  // If there's an element, track it in the elemental values
-  // Otherwise, track in the main value
-  switch (combatType) {
-    case COMBAT_TYPE_RANGED:
-      if (element) {
-        updatedAttack = {
-          ...currentAttack,
-          rangedElements: updateElementalValue(currentAttack.rangedElements, element, amount),
-        };
-        attackTypeName = `${element} Ranged Attack`;
-      } else {
-        updatedAttack = { ...currentAttack, ranged: currentAttack.ranged + amount };
-        attackTypeName = "Ranged Attack";
-      }
-      break;
-    case COMBAT_TYPE_SIEGE:
-      if (element) {
-        updatedAttack = {
-          ...currentAttack,
-          siegeElements: updateElementalValue(currentAttack.siegeElements, element, amount),
-        };
-        attackTypeName = `${element} Siege Attack`;
-      } else {
-        updatedAttack = { ...currentAttack, siege: currentAttack.siege + amount };
-        attackTypeName = "Siege Attack";
-      }
-      break;
-    default:
-      if (element) {
-        updatedAttack = {
-          ...currentAttack,
-          normalElements: updateElementalValue(currentAttack.normalElements, element, amount),
-        };
-        attackTypeName = `${element} Attack`;
-      } else {
-        updatedAttack = { ...currentAttack, normal: currentAttack.normal + amount };
-        attackTypeName = "Attack";
-      }
-      break;
-  }
-
-  const updatedPlayer: Player = {
-    ...player,
-    combatAccumulator: {
-      ...player.combatAccumulator,
-      attack: updatedAttack,
-    },
-  };
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${amount} ${attackTypeName}`,
-  };
-}
-
-export function applyGainBlock(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  effect: GainBlockEffect
-): EffectResolutionResult {
-  const { amount, element } = effect;
-
-  // Create a block source for tracking (for elemental efficiency calculations)
-  const blockSource: BlockSource = {
-    element: element ?? ELEMENT_PHYSICAL,
-    value: amount,
-  };
-
-  // Always update both block total and blockElements for consistency with:
-  // 1. activateUnitCommand (which updates both for all block types)
-  // 2. UI which checks acc.block to determine if accumulator should render
-  // 3. Valid actions computation which reads from blockElements
-  const updatedPlayer: Player = {
-    ...player,
-    combatAccumulator: {
-      ...player.combatAccumulator,
-      block: player.combatAccumulator.block + amount,
-      blockElements: updateElementalValue(
-        player.combatAccumulator.blockElements,
-        element ?? ELEMENT_PHYSICAL,
-        amount
-      ),
-      blockSources: [...player.combatAccumulator.blockSources, blockSource],
-    },
-  };
-  const blockTypeName = element ? `${element} Block` : "Block";
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${amount} ${blockTypeName}`,
-  };
-}
-
-export function applyGainHealing(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  // Count wounds in hand
-  const woundsInHand = player.hand.filter((c) => c === CARD_WOUND).length;
-
-  if (woundsInHand === 0) {
-    // No wounds to heal (shouldn't normally happen since isEffectResolvable checks this)
-    return { state, description: "No wounds to heal" };
-  }
-
-  // Heal up to 'amount' wounds (each healing point removes one wound)
-  const woundsToHeal = Math.min(amount, woundsInHand);
-
-  // Remove wound cards from hand
-  const newHand = [...player.hand];
-  for (let i = 0; i < woundsToHeal; i++) {
-    const woundIndex = newHand.indexOf(CARD_WOUND);
-    if (woundIndex !== -1) {
-      newHand.splice(woundIndex, 1);
-    }
-  }
-
-  const updatedPlayer: Player = {
-    ...player,
-    hand: newHand,
-  };
-
-  // Return wounds to the wound pile (unlimited => stay null)
-  const newWoundPileCount =
-    state.woundPileCount === null ? null : state.woundPileCount + woundsToHeal;
-
-  const updatedState = {
-    ...updatePlayer(state, playerIndex, updatedPlayer),
-    woundPileCount: newWoundPileCount,
-  };
-
-  const description =
-    woundsToHeal === 1
-      ? "Healed 1 wound"
-      : `Healed ${woundsToHeal} wounds`;
-
-  return {
-    state: updatedState,
-    description,
-  };
-}
-
-export function applyDrawCards(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  const availableInDeck = player.deck.length;
-  const actualDraw = Math.min(amount, availableInDeck);
-
-  if (actualDraw === 0) {
-    return { state, description: "No cards to draw" };
-  }
-
-  // Draw from top of deck to hand (no mid-round reshuffle per rulebook)
-  const drawnCards = player.deck.slice(0, actualDraw);
-  const newDeck = player.deck.slice(actualDraw);
-  const newHand = [...player.hand, ...drawnCards];
-
-  const updatedPlayer: Player = {
-    ...player,
-    deck: newDeck,
-    hand: newHand,
-  };
-
-  const description =
-    actualDraw === 1 ? "Drew 1 card" : `Drew ${actualDraw} cards`;
-
-  return {
-    state: updatePlayer(state, playerIndex, updatedPlayer),
-    description,
-  };
-}
-
-/**
- * Apply "take wound" effect - adds wound cards directly to hand.
- * This is a COST, not combat damage - it bypasses armor.
- * Used by Fireball powered, Snowstorm powered, etc.
- */
-export function applyTakeWound(
-  state: GameState,
-  playerIndex: number,
-  player: Player,
-  amount: number
-): EffectResolutionResult {
-  // Create wound cards to add to hand
-  const woundsToAdd: CardId[] = Array(amount).fill(CARD_WOUND);
-
-  const updatedPlayer: Player = {
-    ...player,
-    hand: [...player.hand, ...woundsToAdd],
-  };
-
-  // Decrement wound pile (if tracked)
-  const newWoundPileCount =
-    state.woundPileCount === null ? null : Math.max(0, state.woundPileCount - amount);
-
-  const updatedState = {
-    ...updatePlayer(state, playerIndex, updatedPlayer),
-    woundPileCount: newWoundPileCount,
-  };
-
-  const description =
-    amount === 1 ? "Took 1 wound" : `Took ${amount} wounds`;
-
-  return {
-    state: updatedState,
-    description,
-  };
-}
-
-export function applyModifierEffect(
-  state: GameState,
-  playerId: string,
-  effect: ApplyModifierEffect,
-  sourceCardId?: string
-): EffectResolutionResult {
-  // Use scope from effect if provided, otherwise default to SCOPE_SELF
-  const scope = effect.scope ?? { type: SCOPE_SELF };
-
-  const newState = addModifier(state, {
-    source: {
-      type: SOURCE_CARD,
-      cardId: (sourceCardId ?? "unknown") as CardId,
-      playerId,
-    },
-    duration: effect.duration,
-    scope,
-    effect: effect.modifier,
-    createdAtRound: state.round,
-    createdByPlayerId: playerId,
-  });
-
-  return {
-    state: newState,
-    description: effect.description ?? "Applied modifier",
-  };
-}
+export {
+  applyModifierEffect,
+} from "./atomicModifierEffects.js";

--- a/packages/core/src/engine/effects/atomicHelpers.ts
+++ b/packages/core/src/engine/effects/atomicHelpers.ts
@@ -1,0 +1,96 @@
+/**
+ * Shared helpers for atomic effect handlers
+ *
+ * These utilities are used across multiple atomic effect modules
+ * for common operations like updating player state and elemental values.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, ElementalAttackValues } from "../../types/player.js";
+import type { Element } from "@mage-knight/shared";
+import { ELEMENT_FIRE, ELEMENT_ICE, ELEMENT_COLD_FIRE } from "@mage-knight/shared";
+
+// ============================================================================
+// PLAYER STATE HELPERS
+// ============================================================================
+
+/**
+ * Update a player in the game state immutably.
+ *
+ * @param state - Current game state
+ * @param playerIndex - Index of player to update
+ * @param updatedPlayer - New player object
+ * @returns New game state with updated player
+ */
+export function updatePlayer(
+  state: GameState,
+  playerIndex: number,
+  updatedPlayer: Player
+): GameState {
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+  return { ...state, players };
+}
+
+// ============================================================================
+// ELEMENTAL VALUE HELPERS
+// ============================================================================
+
+/**
+ * Update an elemental value (attack or block) for a specific element.
+ *
+ * Maps element types to their corresponding property in ElementalAttackValues:
+ * - undefined or physical → physical
+ * - fire → fire
+ * - ice → ice
+ * - cold_fire → coldFire
+ *
+ * @param values - Current elemental values
+ * @param element - Element to update (undefined defaults to physical)
+ * @param amount - Amount to add
+ * @returns New elemental values with updated amount
+ */
+export function updateElementalValue(
+  values: ElementalAttackValues,
+  element: Element | undefined,
+  amount: number
+): ElementalAttackValues {
+  if (!element) {
+    return { ...values, physical: values.physical + amount };
+  }
+  switch (element) {
+    case ELEMENT_FIRE:
+      return { ...values, fire: values.fire + amount };
+    case ELEMENT_ICE:
+      return { ...values, ice: values.ice + amount };
+    case ELEMENT_COLD_FIRE:
+      return { ...values, coldFire: values.coldFire + amount };
+    default:
+      return { ...values, physical: values.physical + amount };
+  }
+}
+
+/**
+ * Map an Element type to its property key in ElementalAttackValues.
+ *
+ * Used by reverseEffect and other places that need to access
+ * elemental values by element type.
+ *
+ * @param element - Element type (undefined defaults to physical)
+ * @returns Property key for ElementalAttackValues
+ */
+export function elementToPropertyKey(
+  element: Element | undefined
+): keyof ElementalAttackValues {
+  if (!element) return "physical";
+  switch (element) {
+    case ELEMENT_FIRE:
+      return "fire";
+    case ELEMENT_ICE:
+      return "ice";
+    case ELEMENT_COLD_FIRE:
+      return "coldFire";
+    default:
+      return "physical";
+  }
+}

--- a/packages/core/src/engine/effects/atomicModifierEffects.ts
+++ b/packages/core/src/engine/effects/atomicModifierEffects.ts
@@ -1,0 +1,56 @@
+/**
+ * Atomic modifier effect handlers
+ *
+ * Handles effects that apply modifiers to game state:
+ * - ApplyModifier (terrain cost reduction, sideways value changes, etc.)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { CardId } from "@mage-knight/shared";
+import type { ApplyModifierEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { addModifier } from "../modifiers/index.js";
+import { SOURCE_CARD, SCOPE_SELF } from "../modifierConstants.js";
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Apply an ApplyModifier effect - adds a modifier to the game state.
+ *
+ * Modifiers have:
+ * - Duration: turn, combat, round, permanent
+ * - Scope: self, all players, etc.
+ * - Effect: the actual modification (terrain cost, sideways value, rules)
+ *
+ * Used by cards that provide ongoing effects like reduced terrain costs
+ * or increased sideways values for certain card types.
+ */
+export function applyModifierEffect(
+  state: GameState,
+  playerId: string,
+  effect: ApplyModifierEffect,
+  sourceCardId?: string
+): EffectResolutionResult {
+  // Use scope from effect if provided, otherwise default to SCOPE_SELF
+  const scope = effect.scope ?? { type: SCOPE_SELF };
+
+  const newState = addModifier(state, {
+    source: {
+      type: SOURCE_CARD,
+      cardId: (sourceCardId ?? "unknown") as CardId,
+      playerId,
+    },
+    duration: effect.duration,
+    scope,
+    effect: effect.modifier,
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  return {
+    state: newState,
+    description: effect.description ?? "Applied modifier",
+  };
+}

--- a/packages/core/src/engine/effects/atomicProgressionEffects.ts
+++ b/packages/core/src/engine/effects/atomicProgressionEffects.ts
@@ -1,0 +1,79 @@
+/**
+ * Atomic progression effect handlers
+ *
+ * Handles effects that modify player progression:
+ * - ChangeReputation (reputation track, -7 to +7)
+ * - GainFame (fame points, triggers level ups)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { EffectResolutionResult } from "./types.js";
+import { MIN_REPUTATION, MAX_REPUTATION, getLevelsCrossed } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+
+// Re-export reputation bounds for use in reverseEffect
+export { MIN_REPUTATION, MAX_REPUTATION };
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Apply a ChangeReputation effect - modifies reputation on the track.
+ *
+ * Reputation is clamped to the valid range (-7 to +7).
+ * Reputation affects influence costs when interacting with locals.
+ */
+export function applyChangeReputation(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  // Clamp to -7 to +7 range
+  const newReputation = Math.max(
+    MIN_REPUTATION,
+    Math.min(MAX_REPUTATION, player.reputation + amount)
+  );
+
+  const updatedPlayer: Player = {
+    ...player,
+    reputation: newReputation,
+  };
+
+  const direction = amount >= 0 ? "Gained" : "Lost";
+  const absAmount = Math.abs(amount);
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `${direction} ${absAmount} Reputation`,
+  };
+}
+
+/**
+ * Apply a GainFame effect - adds fame points and queues level ups.
+ *
+ * When fame crosses level thresholds, pending level ups are queued
+ * for the player to resolve (choosing skills or advanced actions).
+ */
+export function applyGainFame(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  const newFame = player.fame + amount;
+  const levelsCrossed = getLevelsCrossed(player.fame, newFame);
+
+  const updatedPlayer: Player = {
+    ...player,
+    fame: newFame,
+    pendingLevelUps: [...player.pendingLevelUps, ...levelsCrossed],
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${amount} Fame`,
+  };
+}

--- a/packages/core/src/engine/effects/atomicResourceEffects.ts
+++ b/packages/core/src/engine/effects/atomicResourceEffects.ts
@@ -1,0 +1,116 @@
+/**
+ * Atomic resource effect handlers
+ *
+ * Handles effects that modify player resources:
+ * - GainMove (movement points)
+ * - GainInfluence (influence points)
+ * - GainMana (mana tokens)
+ * - GainCrystal (permanent mana crystals)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { ManaColor, BasicManaColor } from "@mage-knight/shared";
+import type { EffectResolutionResult } from "./types.js";
+import { MANA_TOKEN_SOURCE_CARD } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Apply a GainMove effect - adds movement points to the player.
+ */
+export function applyGainMove(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  const updatedPlayer: Player = {
+    ...player,
+    movePoints: player.movePoints + amount,
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${amount} Move`,
+  };
+}
+
+/**
+ * Apply a GainInfluence effect - adds influence points to the player.
+ */
+export function applyGainInfluence(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  amount: number
+): EffectResolutionResult {
+  const updatedPlayer: Player = {
+    ...player,
+    influencePoints: player.influencePoints + amount,
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${amount} Influence`,
+  };
+}
+
+/**
+ * Apply a GainMana effect - adds a mana token to the player's pool.
+ *
+ * Mana tokens are temporary and return to the source at end of turn.
+ * They are distinct from crystals, which are permanent storage.
+ */
+export function applyGainMana(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  color: ManaColor
+): EffectResolutionResult {
+  const newToken = {
+    color,
+    source: MANA_TOKEN_SOURCE_CARD,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    pureMana: [...player.pureMana, newToken],
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${color} mana token`,
+  };
+}
+
+/**
+ * Apply a GainCrystal effect - adds a permanent mana crystal to the player.
+ *
+ * Crystals are permanent storage (max 3 per color) that persist between turns.
+ * They can be converted to/from tokens.
+ */
+export function applyGainCrystal(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  color: BasicManaColor
+): EffectResolutionResult {
+  const updatedCrystals = {
+    ...player.crystals,
+    [color]: player.crystals[color] + 1,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    crystals: updatedCrystals,
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: `Gained ${color} crystal`,
+  };
+}

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -13,7 +13,13 @@
  *
  * | Module | Effects |
  * |--------|---------|
- * | `atomicEffects.ts` | GainMove, GainInfluence, GainAttack, GainBlock, GainHealing, etc. |
+ * | `atomicEffects.ts` | Re-exports from focused atomic modules (see below) |
+ * | `atomicCombatEffects.ts` | GainAttack, GainBlock |
+ * | `atomicResourceEffects.ts` | GainMove, GainInfluence, GainMana, GainCrystal |
+ * | `atomicProgressionEffects.ts` | GainFame, ChangeReputation |
+ * | `atomicCardEffects.ts` | DrawCards, GainHealing, TakeWound |
+ * | `atomicModifierEffects.ts` | ApplyModifier |
+ * | `atomicHelpers.ts` | Shared utilities (updatePlayer, updateElementalValue) |
  * | `compound.ts` | Compound, Conditional, Scaling |
  * | `choice.ts` | Choice |
  * | `crystallize.ts` | ConvertManaToCrystal, CrystallizeColor |
@@ -89,6 +95,8 @@ export * from "./resolvability.js";
 // Atomic effects (gain move, attack, etc.)
 export {
   updatePlayer,
+  updateElementalValue,
+  elementToPropertyKey,
   applyGainMove,
   applyGainInfluence,
   applyGainMana,

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -50,27 +50,8 @@ import {
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
-import { getLevelsCrossed, ELEMENT_FIRE, ELEMENT_ICE, ELEMENT_COLD_FIRE } from "@mage-knight/shared";
-import type { Element } from "@mage-knight/shared";
-import { MIN_REPUTATION, MAX_REPUTATION } from "./atomicEffects.js";
-
-/**
- * Maps Element type to the property key in ElementalAttackValues.
- * Element uses "cold_fire" but ElementalAttackValues uses "coldFire".
- */
-function elementToPropertyKey(element: Element | undefined): "physical" | "fire" | "ice" | "coldFire" {
-  if (!element) return "physical";
-  switch (element) {
-    case ELEMENT_FIRE:
-      return "fire";
-    case ELEMENT_ICE:
-      return "ice";
-    case ELEMENT_COLD_FIRE:
-      return "coldFire";
-    default:
-      return "physical";
-  }
-}
+import { getLevelsCrossed } from "@mage-knight/shared";
+import { MIN_REPUTATION, MAX_REPUTATION, elementToPropertyKey } from "./atomicEffects.js";
 
 // ============================================================================
 // REVERSE EFFECT


### PR DESCRIPTION
## Summary
- Split monolithic `atomicEffects.ts` (440 lines) into 6 focused domain modules
- Extracted shared helpers to `atomicHelpers.ts` eliminating duplication with `reverse.ts`
- Simplified `applyGainAttack` by extracting helper functions to reduce nesting

## New Module Structure

| File | Purpose |
|------|---------|
| `atomicHelpers.ts` | Shared utilities: `updatePlayer`, `updateElementalValue`, `elementToPropertyKey` |
| `atomicCombatEffects.ts` | `applyGainAttack`, `applyGainBlock` |
| `atomicResourceEffects.ts` | `applyGainMove`, `applyGainInfluence`, `applyGainMana`, `applyGainCrystal` |
| `atomicProgressionEffects.ts` | `applyChangeReputation`, `applyGainFame` |
| `atomicCardEffects.ts` | `applyDrawCards`, `applyGainHealing`, `applyTakeWound` |
| `atomicModifierEffects.ts` | `applyModifierEffect` |

## Test plan
- [x] All 1225 tests pass
- [x] Build succeeds
- [x] Lint passes
- [x] All exports remain backward compatible via barrel file