### PR TITLE
refactor: co-locate effect registrations with resolvers

### DIFF
--- a/packages/core/src/engine/effects/atomicEffects.ts
+++ b/packages/core/src/engine/effects/atomicEffects.ts
@@ -74,3 +74,118 @@ export {
 export {
   applyModifierEffect,
 } from "./atomicModifierEffects.js";
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+import type {
+  GainMoveEffect,
+  GainInfluenceEffect,
+  GainAttackEffect,
+  GainBlockEffect,
+  GainHealingEffect,
+  GainManaEffect,
+  DrawCardsEffect,
+  ChangeReputationEffect,
+  GainFameEffect,
+  GainCrystalEffect,
+  TakeWoundEffect,
+  ApplyModifierEffect,
+} from "../../types/cards.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_GAIN_MOVE,
+  EFFECT_GAIN_INFLUENCE,
+  EFFECT_GAIN_ATTACK,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_GAIN_HEALING,
+  EFFECT_GAIN_MANA,
+  EFFECT_DRAW_CARDS,
+  EFFECT_APPLY_MODIFIER,
+  EFFECT_CHANGE_REPUTATION,
+  EFFECT_GAIN_FAME,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_TAKE_WOUND,
+  MANA_ANY,
+} from "../../types/effectTypes.js";
+import { applyGainMove, applyGainInfluence, applyGainMana, applyGainCrystal } from "./atomicResourceEffects.js";
+import { applyGainAttack, applyGainBlock } from "./atomicCombatEffects.js";
+import { applyChangeReputation, applyGainFame } from "./atomicProgressionEffects.js";
+import { applyDrawCards, applyGainHealing, applyTakeWound } from "./atomicCardEffects.js";
+import { applyModifierEffect } from "./atomicModifierEffects.js";
+
+/**
+ * Register all atomic effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerAtomicEffects(): void {
+  registerEffect(EFFECT_GAIN_MOVE, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainMove(state, playerIndex, player, (effect as GainMoveEffect).amount);
+  });
+
+  registerEffect(EFFECT_GAIN_INFLUENCE, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainInfluence(state, playerIndex, player, (effect as GainInfluenceEffect).amount);
+  });
+
+  registerEffect(EFFECT_GAIN_ATTACK, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainAttack(state, playerIndex, player, effect as GainAttackEffect);
+  });
+
+  registerEffect(EFFECT_GAIN_BLOCK, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainBlock(state, playerIndex, player, effect as GainBlockEffect);
+  });
+
+  registerEffect(EFFECT_GAIN_HEALING, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainHealing(state, playerIndex, player, (effect as GainHealingEffect).amount);
+  });
+
+  registerEffect(EFFECT_TAKE_WOUND, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyTakeWound(state, playerIndex, player, (effect as TakeWoundEffect).amount);
+  });
+
+  registerEffect(EFFECT_DRAW_CARDS, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyDrawCards(state, playerIndex, player, (effect as DrawCardsEffect).amount);
+  });
+
+  registerEffect(EFFECT_GAIN_MANA, (state, playerId, effect) => {
+    const manaEffect = effect as GainManaEffect;
+    if (manaEffect.color === MANA_ANY) {
+      // MANA_ANY should be resolved via player choice, not passed directly
+      return {
+        state,
+        description: "Mana color choice required",
+        requiresChoice: true,
+      };
+    }
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainMana(state, playerIndex, player, manaEffect.color);
+  });
+
+  registerEffect(EFFECT_CHANGE_REPUTATION, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyChangeReputation(state, playerIndex, player, (effect as ChangeReputationEffect).amount);
+  });
+
+  registerEffect(EFFECT_GAIN_FAME, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainFame(state, playerIndex, player, (effect as GainFameEffect).amount);
+  });
+
+  registerEffect(EFFECT_GAIN_CRYSTAL, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyGainCrystal(state, playerIndex, player, (effect as GainCrystalEffect).color);
+  });
+
+  registerEffect(EFFECT_APPLY_MODIFIER, (state, playerId, effect, sourceCardId) => {
+    return applyModifierEffect(state, playerId, effect as ApplyModifierEffect, sourceCardId);
+  });
+}

--- a/packages/core/src/engine/effects/cardBoostResolvers.ts
+++ b/packages/core/src/engine/effects/cardBoostResolvers.ts
@@ -41,6 +41,9 @@ import {
   generateBoostChoiceOptions,
   addBonusToEffect,
 } from "./cardBoostEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_CARD_BOOST, EFFECT_RESOLVE_BOOST_TARGET } from "../../types/effectTypes.js";
 
 // ============================================================================
 // CARD BOOST (Entry Point)
@@ -156,4 +159,33 @@ export function resolveBoostTargetEffect(
     ...result,
     description: `Boosted ${targetCard.name}: ${result.description}`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all card boost effect handlers with the effect registry.
+ * Called during effect system initialization.
+ *
+ * @param resolver - The main resolveEffect function for recursive resolution
+ */
+export function registerCardBoostEffects(resolver: EffectResolver): void {
+  registerEffect(EFFECT_CARD_BOOST, (state, playerId, effect) => {
+    const { player } = getPlayerContext(state, playerId);
+    return resolveCardBoostEffect(state, player, effect as CardBoostEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_BOOST_TARGET, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return resolveBoostTargetEffect(
+      state,
+      playerId,
+      playerIndex,
+      player,
+      effect as ResolveBoostTargetEffect,
+      resolver
+    );
+  });
 }

--- a/packages/core/src/engine/effects/choice.ts
+++ b/packages/core/src/engine/effects/choice.ts
@@ -23,6 +23,8 @@
 import type { GameState } from "../../state/GameState.js";
 import type { ChoiceEffect as ChoiceEffectType } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
+import { registerEffect } from "./effectRegistry.js";
+import { EFFECT_CHOICE } from "../../types/effectTypes.js";
 
 // ============================================================================
 // CHOICE EFFECT
@@ -87,4 +89,18 @@ export function resolveChoiceEffect(
     description: "Choice required",
     requiresChoice: true,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all choice effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerChoiceEffects(): void {
+  registerEffect(EFFECT_CHOICE, (state, playerId, effect) => {
+    return resolveChoiceEffect(state, playerId, effect as ChoiceEffectType);
+  });
 }

--- a/packages/core/src/engine/effects/combatEffects.ts
+++ b/packages/core/src/engine/effects/combatEffects.ts
@@ -33,7 +33,8 @@ import type {
   ResolveCombatEnemyTargetEffect,
 } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
-import { EFFECT_RESOLVE_COMBAT_ENEMY_TARGET } from "../../types/effectTypes.js";
+import { EFFECT_SELECT_COMBAT_ENEMY, EFFECT_RESOLVE_COMBAT_ENEMY_TARGET } from "../../types/effectTypes.js";
+import { registerEffect } from "./effectRegistry.js";
 import { addModifier } from "../modifiers/index.js";
 import {
   DURATION_COMBAT,
@@ -232,4 +233,27 @@ export function resolveCombatEnemyTarget(
     state: currentState,
     description: descriptions.join("; ") || `Targeted ${effect.enemyName}`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all combat enemy targeting effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerCombatEffects(): void {
+  registerEffect(EFFECT_SELECT_COMBAT_ENEMY, (state, _playerId, effect) => {
+    return resolveSelectCombatEnemy(state, effect as SelectCombatEnemyEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_COMBAT_ENEMY_TARGET, (state, playerId, effect, sourceCardId) => {
+    return resolveCombatEnemyTarget(
+      state,
+      playerId,
+      effect as ResolveCombatEnemyTargetEffect,
+      sourceCardId
+    );
+  });
 }

--- a/packages/core/src/engine/effects/compound.ts
+++ b/packages/core/src/engine/effects/compound.ts
@@ -42,6 +42,12 @@ import type {
 import type { EffectResolutionResult } from "./types.js";
 import { evaluateCondition } from "./conditionEvaluator.js";
 import { evaluateScalingFactor } from "./scalingEvaluator.js";
+import { registerEffect } from "./effectRegistry.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_CONDITIONAL,
+  EFFECT_SCALING,
+} from "../../types/effectTypes.js";
 
 // ============================================================================
 // RESOLVER TYPE
@@ -258,4 +264,46 @@ export function resolveScalingEffect(
     description: `${result.description} (scaled by ${scalingCount})`,
     containsScaling: true,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all compound effect handlers with the effect registry.
+ * Called during effect system initialization.
+ *
+ * @param resolver - The main resolveEffect function for recursive resolution
+ */
+export function registerCompoundEffects(resolver: EffectResolver): void {
+  registerEffect(EFFECT_COMPOUND, (state, playerId, effect, sourceCardId) => {
+    return resolveCompoundEffectList(
+      state,
+      playerId,
+      (effect as CompoundEffectType).effects,
+      sourceCardId,
+      resolver
+    );
+  });
+
+  registerEffect(EFFECT_CONDITIONAL, (state, playerId, effect, sourceCardId) => {
+    return resolveConditionalEffect(
+      state,
+      playerId,
+      effect as ConditionalEffectType,
+      sourceCardId,
+      resolver
+    );
+  });
+
+  registerEffect(EFFECT_SCALING, (state, playerId, effect, sourceCardId) => {
+    return resolveScalingEffect(
+      state,
+      playerId,
+      effect as ScalingEffectType,
+      sourceCardId,
+      resolver
+    );
+  });
 }

--- a/packages/core/src/engine/effects/crystallize.ts
+++ b/packages/core/src/engine/effects/crystallize.ts
@@ -30,8 +30,10 @@ import type {
 } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import type { EffectResolver } from "./compound.js";
-import { EFFECT_CRYSTALLIZE_COLOR } from "../../types/effectTypes.js";
+import { EFFECT_CRYSTALLIZE_COLOR, EFFECT_CONVERT_MANA_TO_CRYSTAL } from "../../types/effectTypes.js";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
 
 // ============================================================================
 // CONVERT MANA TO CRYSTAL (Entry Point)
@@ -170,4 +172,33 @@ export function resolveCrystallizeColor(
     state: updatePlayer(state, playerIndex, updatedPlayer),
     description: `Converted ${effect.color} mana to ${effect.color} crystal`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all crystallize effect handlers with the effect registry.
+ * Called during effect system initialization.
+ *
+ * @param resolver - The main resolveEffect function for recursive resolution
+ */
+export function registerCrystallizeEffects(resolver: EffectResolver): void {
+  registerEffect(EFFECT_CONVERT_MANA_TO_CRYSTAL, (state, playerId, effect, sourceCardId) => {
+    const { player } = getPlayerContext(state, playerId);
+    return resolveConvertManaToCrystal(
+      state,
+      playerId,
+      player,
+      effect as ConvertManaToCrystalEffect,
+      sourceCardId,
+      resolver
+    );
+  });
+
+  registerEffect(EFFECT_CRYSTALLIZE_COLOR, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return resolveCrystallizeColor(state, playerIndex, player, effect as CrystallizeColorEffect);
+  });
 }

--- a/packages/core/src/engine/effects/discardEffects.ts
+++ b/packages/core/src/engine/effects/discardEffects.ts
@@ -17,6 +17,9 @@ import {
   DISCARD_FILTER_ANY,
 } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_DISCARD_CARD } from "../../types/effectTypes.js";
 
 /**
  * Get cards in hand that match the filter criteria.
@@ -133,4 +136,19 @@ export function applyDiscardCard(
     state: updatedState,
     description,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all discard effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerDiscardEffects(): void {
+  registerEffect(EFFECT_DISCARD_CARD, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleDiscardCard(state, playerIndex, player, effect as DiscardCardEffect);
+  });
 }

--- a/packages/core/src/engine/effects/effectHelpers.ts
+++ b/packages/core/src/engine/effects/effectHelpers.ts
@@ -1,0 +1,32 @@
+/**
+ * Effect Helper Functions
+ *
+ * Shared utilities for effect resolution modules.
+ *
+ * @module effects/effectHelpers
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
+
+/**
+ * Get player index and player object from state and playerId.
+ * Helper to bridge between registry signature and internal function signatures.
+ *
+ * @param state - Current game state
+ * @param playerId - ID of the player
+ * @returns Object containing playerIndex and player object
+ * @throws Error if player not found
+ */
+export function getPlayerContext(
+  state: GameState,
+  playerId: string
+): { playerIndex: number; player: Player } {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+  return { playerIndex, player };
+}

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -1,185 +1,36 @@
 /**
- * Effect Registrations
+ * Effect Registrations Coordinator
  *
- * Registers all effect handlers with the central registry.
- * Import this module to initialize the effect dispatch system.
+ * Coordinates registration of all effect handlers with the central registry.
+ * Each effect module provides its own registration function.
  *
  * @module effects/effectRegistrations
  *
  * @remarks
- * This module acts as the central point where all effect handlers are registered.
- * Each effect type maps to a handler function that processes that effect.
- * The handlers wrap the existing resolution functions to match the registry signature.
+ * This module acts as the central point where all effect registrations are triggered.
+ * The actual handler implementations live in their respective modules.
  */
 
-import type { GameState } from "../../state/GameState.js";
-import type {
-  GainMoveEffect,
-  GainInfluenceEffect,
-  GainAttackEffect,
-  GainBlockEffect,
-  GainHealingEffect,
-  GainManaEffect,
-  DrawCardsEffect,
-  ApplyModifierEffect,
-  ChangeReputationEffect,
-  GainFameEffect,
-  GainCrystalEffect,
-  TakeWoundEffect,
-  ConvertManaToCrystalEffect,
-  CrystallizeColorEffect,
-  ChoiceEffect,
-  CardBoostEffect,
-  ResolveBoostTargetEffect,
-  ReadyUnitEffect,
-  ManaDrawPoweredEffect,
-  ManaDrawPickDieEffect,
-  ManaDrawSetColorEffect,
-  SelectCombatEnemyEffect,
-  ResolveCombatEnemyTargetEffect,
-  HealUnitEffect,
-  DiscardCardEffect,
-  RevealTilesEffect,
-  PayManaCostEffect,
-  TerrainBasedBlockEffect,
-  CompoundEffect,
-  ConditionalEffect,
-  ScalingEffect,
-} from "../../types/cards.js";
-import { registerEffect, type EffectHandler } from "./effectRegistry.js";
-import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
+import type { EffectHandler } from "./effectRegistry.js";
 
-// Effect type constants
-import {
-  EFFECT_GAIN_MOVE,
-  EFFECT_GAIN_INFLUENCE,
-  EFFECT_GAIN_ATTACK,
-  EFFECT_GAIN_BLOCK,
-  EFFECT_GAIN_HEALING,
-  EFFECT_GAIN_MANA,
-  EFFECT_DRAW_CARDS,
-  EFFECT_APPLY_MODIFIER,
-  EFFECT_CHANGE_REPUTATION,
-  EFFECT_GAIN_FAME,
-  EFFECT_GAIN_CRYSTAL,
-  EFFECT_TAKE_WOUND,
-  EFFECT_CONVERT_MANA_TO_CRYSTAL,
-  EFFECT_CRYSTALLIZE_COLOR,
-  EFFECT_CHOICE,
-  EFFECT_CARD_BOOST,
-  EFFECT_RESOLVE_BOOST_TARGET,
-  EFFECT_READY_UNIT,
-  EFFECT_MANA_DRAW_POWERED,
-  EFFECT_MANA_DRAW_PICK_DIE,
-  EFFECT_MANA_DRAW_SET_COLOR,
-  EFFECT_SELECT_COMBAT_ENEMY,
-  EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
-  EFFECT_HEAL_UNIT,
-  EFFECT_DISCARD_CARD,
-  EFFECT_REVEAL_TILES,
-  EFFECT_PAY_MANA,
-  EFFECT_TERRAIN_BASED_BLOCK,
-  EFFECT_COMPOUND,
-  EFFECT_CONDITIONAL,
-  EFFECT_SCALING,
-  MANA_ANY,
-} from "../../types/effectTypes.js";
-
-// Atomic effects
-import {
-  applyGainMove,
-  applyGainInfluence,
-  applyGainMana,
-  applyGainAttack,
-  applyGainBlock,
-  applyGainHealing,
-  applyDrawCards,
-  applyChangeReputation,
-  applyGainFame,
-  applyGainCrystal,
-  applyTakeWound,
-  applyModifierEffect,
-} from "./atomicEffects.js";
-
-// Choice effects
-import { resolveChoiceEffect } from "./choice.js";
-
-// Crystallize effects
-import {
-  resolveConvertManaToCrystal,
-  resolveCrystallizeColor,
-} from "./crystallize.js";
-
-// Card boost effects
-import {
-  resolveCardBoostEffect,
-  resolveBoostTargetEffect,
-} from "./cardBoostResolvers.js";
-
-// Combat effects
-import {
-  resolveSelectCombatEnemy,
-  resolveCombatEnemyTarget,
-} from "./combatEffects.js";
-
-// Mana draw effects
-import {
-  handleManaDrawPowered,
-  handleManaDrawPickDie,
-  applyManaDrawSetColor,
-} from "./manaDrawEffects.js";
-
-// Unit effects
-import { handleReadyUnit } from "./unitEffects.js";
-
-// Heal unit effects
-import { handleHealUnit } from "./healUnitEffects.js";
-
-// Discard effects
-import { handleDiscardCard } from "./discardEffects.js";
-
-// Map effects
-import { handleRevealTiles } from "./mapEffects.js";
-
-// Mana payment effects
-import { handlePayMana } from "./manaPaymentEffects.js";
-
-// Terrain-based effects
-import { resolveTerrainBasedBlock } from "./terrainEffects.js";
-
-// Compound effects (need special handling for recursive resolution)
-import {
-  resolveCompoundEffectList,
-  resolveConditionalEffect,
-  resolveScalingEffect,
-} from "./compound.js";
+// Registration functions from each module
+import { registerAtomicEffects } from "./atomicEffects.js";
+import { registerCompoundEffects } from "./compound.js";
+import { registerChoiceEffects } from "./choice.js";
+import { registerCrystallizeEffects } from "./crystallize.js";
+import { registerCardBoostEffects } from "./cardBoostResolvers.js";
+import { registerCombatEffects } from "./combatEffects.js";
+import { registerManaDrawEffects } from "./manaDrawEffects.js";
+import { registerUnitEffects } from "./unitEffects.js";
+import { registerHealUnitEffects } from "./healUnitEffects.js";
+import { registerDiscardEffects } from "./discardEffects.js";
+import { registerMapEffects } from "./mapEffects.js";
+import { registerManaPaymentEffects } from "./manaPaymentEffects.js";
+import { registerTerrainEffects } from "./terrainEffects.js";
 
 // ============================================================================
-// HELPER
+// INITIALIZATION
 // ============================================================================
-
-/**
- * Get player index and player object from state and playerId.
- * Helper to bridge between registry signature and internal function signatures.
- */
-function getPlayerContext(state: GameState, playerId: string) {
-  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
-  const player = state.players[playerIndex];
-  if (!player) {
-    throw new Error(`Player not found at index: ${playerIndex}`);
-  }
-  return { playerIndex, player };
-}
-
-// ============================================================================
-// MAIN RESOLVER REFERENCE
-// ============================================================================
-
-/**
- * Reference to the main resolveEffect function.
- * Set by initializeRegistry() to break circular dependency.
- */
-let mainResolver: EffectHandler | null = null;
 
 /**
  * Initialize the registry with a reference to the main resolver.
@@ -188,256 +39,55 @@ let mainResolver: EffectHandler | null = null;
  * @param resolver - The main resolveEffect function
  */
 export function initializeRegistry(resolver: EffectHandler): void {
-  mainResolver = resolver;
-}
-
-/**
- * Get the main resolver, throwing if not initialized.
- */
-function getResolver(): EffectHandler {
-  if (!mainResolver) {
-    throw new Error("Effect registry not initialized - call initializeRegistry first");
-  }
-  return mainResolver;
+  registerAllEffects(resolver);
 }
 
 // ============================================================================
-// REGISTRATIONS
+// REGISTRATION COORDINATOR
 // ============================================================================
 
 /**
- * Register all effect handlers.
- * Called once during module initialization.
+ * Register all effect handlers by calling each module's registration function.
+ *
+ * @param resolver - The main resolveEffect function for recursive resolution
  */
-function registerAllEffects(): void {
-  // ========================================================================
-  // ATOMIC EFFECTS
-  // ========================================================================
+function registerAllEffects(resolver: EffectHandler): void {
+  // Atomic effects (GainMove, GainAttack, GainBlock, etc.)
+  registerAtomicEffects();
 
-  registerEffect(EFFECT_GAIN_MOVE, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainMove(state, playerIndex, player, (effect as GainMoveEffect).amount);
-  });
+  // Compound effects (Compound, Conditional, Scaling)
+  registerCompoundEffects(resolver);
 
-  registerEffect(EFFECT_GAIN_INFLUENCE, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainInfluence(state, playerIndex, player, (effect as GainInfluenceEffect).amount);
-  });
+  // Choice effects
+  registerChoiceEffects();
 
-  registerEffect(EFFECT_GAIN_ATTACK, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainAttack(state, playerIndex, player, effect as GainAttackEffect);
-  });
+  // Crystallize effects (ConvertManaToCrystal, CrystallizeColor)
+  registerCrystallizeEffects(resolver);
 
-  registerEffect(EFFECT_GAIN_BLOCK, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainBlock(state, playerIndex, player, effect as GainBlockEffect);
-  });
+  // Card boost effects (CardBoost, ResolveBoostTarget)
+  registerCardBoostEffects(resolver);
 
-  registerEffect(EFFECT_GAIN_HEALING, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainHealing(state, playerIndex, player, (effect as GainHealingEffect).amount);
-  });
+  // Combat enemy targeting effects
+  registerCombatEffects();
 
-  registerEffect(EFFECT_TAKE_WOUND, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyTakeWound(state, playerIndex, player, (effect as TakeWoundEffect).amount);
-  });
+  // Mana draw effects (ManaDrawPowered, ManaDrawPickDie, ManaDrawSetColor)
+  registerManaDrawEffects();
 
-  registerEffect(EFFECT_DRAW_CARDS, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyDrawCards(state, playerIndex, player, (effect as DrawCardsEffect).amount);
-  });
+  // Unit effects (ReadyUnit)
+  registerUnitEffects();
 
-  registerEffect(EFFECT_GAIN_MANA, (state, playerId, effect) => {
-    const manaEffect = effect as GainManaEffect;
-    if (manaEffect.color === MANA_ANY) {
-      // MANA_ANY should be resolved via player choice, not passed directly
-      return {
-        state,
-        description: "Mana color choice required",
-        requiresChoice: true,
-      };
-    }
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainMana(state, playerIndex, player, manaEffect.color);
-  });
+  // Heal unit effects
+  registerHealUnitEffects();
 
-  registerEffect(EFFECT_CHANGE_REPUTATION, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyChangeReputation(state, playerIndex, player, (effect as ChangeReputationEffect).amount);
-  });
+  // Discard effects
+  registerDiscardEffects();
 
-  registerEffect(EFFECT_GAIN_FAME, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainFame(state, playerIndex, player, (effect as GainFameEffect).amount);
-  });
+  // Map effects (RevealTiles)
+  registerMapEffects();
 
-  registerEffect(EFFECT_GAIN_CRYSTAL, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyGainCrystal(state, playerIndex, player, (effect as GainCrystalEffect).color);
-  });
+  // Mana payment effects
+  registerManaPaymentEffects();
 
-  registerEffect(EFFECT_APPLY_MODIFIER, (state, playerId, effect, sourceCardId) => {
-    return applyModifierEffect(state, playerId, effect as ApplyModifierEffect, sourceCardId);
-  });
-
-  // ========================================================================
-  // CRYSTALLIZE EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_CONVERT_MANA_TO_CRYSTAL, (state, playerId, effect, sourceCardId) => {
-    const { player } = getPlayerContext(state, playerId);
-    return resolveConvertManaToCrystal(
-      state,
-      playerId,
-      player,
-      effect as ConvertManaToCrystalEffect,
-      sourceCardId,
-      getResolver()
-    );
-  });
-
-  registerEffect(EFFECT_CRYSTALLIZE_COLOR, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return resolveCrystallizeColor(state, playerIndex, player, effect as CrystallizeColorEffect);
-  });
-
-  // ========================================================================
-  // COMPOUND EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_COMPOUND, (state, playerId, effect, sourceCardId) => {
-    return resolveCompoundEffectList(
-      state,
-      playerId,
-      (effect as CompoundEffect).effects,
-      sourceCardId,
-      getResolver()
-    );
-  });
-
-  registerEffect(EFFECT_CHOICE, (state, playerId, effect) => {
-    return resolveChoiceEffect(state, playerId, effect as ChoiceEffect);
-  });
-
-  registerEffect(EFFECT_CONDITIONAL, (state, playerId, effect, sourceCardId) => {
-    return resolveConditionalEffect(
-      state,
-      playerId,
-      effect as ConditionalEffect,
-      sourceCardId,
-      getResolver()
-    );
-  });
-
-  registerEffect(EFFECT_SCALING, (state, playerId, effect, sourceCardId) => {
-    return resolveScalingEffect(
-      state,
-      playerId,
-      effect as ScalingEffect,
-      sourceCardId,
-      getResolver()
-    );
-  });
-
-  // ========================================================================
-  // CARD BOOST EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_CARD_BOOST, (state, playerId, effect) => {
-    const { player } = getPlayerContext(state, playerId);
-    return resolveCardBoostEffect(state, player, effect as CardBoostEffect);
-  });
-
-  registerEffect(EFFECT_RESOLVE_BOOST_TARGET, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return resolveBoostTargetEffect(
-      state,
-      playerId,
-      playerIndex,
-      player,
-      effect as ResolveBoostTargetEffect,
-      getResolver()
-    );
-  });
-
-  // ========================================================================
-  // UNIT EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_READY_UNIT, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return handleReadyUnit(state, playerIndex, player, effect as ReadyUnitEffect);
-  });
-
-  // ========================================================================
-  // MANA DRAW EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_MANA_DRAW_POWERED, (state, _playerId, effect) => {
-    return handleManaDrawPowered(state, effect as ManaDrawPoweredEffect);
-  });
-
-  registerEffect(EFFECT_MANA_DRAW_PICK_DIE, (state, _playerId, effect) => {
-    return handleManaDrawPickDie(state, effect as ManaDrawPickDieEffect);
-  });
-
-  registerEffect(EFFECT_MANA_DRAW_SET_COLOR, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return applyManaDrawSetColor(state, playerIndex, player, effect as ManaDrawSetColorEffect);
-  });
-
-  // ========================================================================
-  // COMBAT ENEMY TARGETING EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_SELECT_COMBAT_ENEMY, (state, _playerId, effect) => {
-    return resolveSelectCombatEnemy(state, effect as SelectCombatEnemyEffect);
-  });
-
-  registerEffect(EFFECT_RESOLVE_COMBAT_ENEMY_TARGET, (state, playerId, effect, sourceCardId) => {
-    return resolveCombatEnemyTarget(
-      state,
-      playerId,
-      effect as ResolveCombatEnemyTargetEffect,
-      sourceCardId
-    );
-  });
-
-  // ========================================================================
-  // SKILL-RELATED EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_HEAL_UNIT, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return handleHealUnit(state, playerIndex, player, effect as HealUnitEffect);
-  });
-
-  registerEffect(EFFECT_DISCARD_CARD, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return handleDiscardCard(state, playerIndex, player, effect as DiscardCardEffect);
-  });
-
-  registerEffect(EFFECT_REVEAL_TILES, (state, playerId, effect) => {
-    const { player } = getPlayerContext(state, playerId);
-    return handleRevealTiles(state, player, effect as RevealTilesEffect);
-  });
-
-  registerEffect(EFFECT_PAY_MANA, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return handlePayMana(state, playerIndex, player, effect as PayManaCostEffect);
-  });
-
-  // ========================================================================
-  // TERRAIN-BASED EFFECTS
-  // ========================================================================
-
-  registerEffect(EFFECT_TERRAIN_BASED_BLOCK, (state, playerId, effect) => {
-    const { playerIndex, player } = getPlayerContext(state, playerId);
-    return resolveTerrainBasedBlock(state, playerIndex, player, effect as TerrainBasedBlockEffect);
-  });
+  // Terrain-based effects
+  registerTerrainEffects();
 }
-
-// Register all effects when this module is imported
-registerAllEffects();

--- a/packages/core/src/engine/effects/healUnitEffects.ts
+++ b/packages/core/src/engine/effects/healUnitEffects.ts
@@ -12,6 +12,9 @@ import type { HealUnitEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import { UNITS } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_HEAL_UNIT } from "../../types/effectTypes.js";
 
 /**
  * Get wounded units that are at or below a given level.
@@ -122,4 +125,19 @@ export function applyHealUnit(
     state: updatePlayer(state, playerIndex, updatedPlayer),
     description: `Healed ${unitName}`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all heal unit effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerHealUnitEffects(): void {
+  registerEffect(EFFECT_HEAL_UNIT, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleHealUnit(state, playerIndex, player, effect as HealUnitEffect);
+  });
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -111,6 +111,7 @@ export {
   applyModifierEffect,
   MIN_REPUTATION,
   MAX_REPUTATION,
+  registerAtomicEffects,
 } from "./atomicEffects.js";
 
 // Compound effect resolution
@@ -119,22 +120,25 @@ export {
   resolveCompoundEffectList,
   resolveConditionalEffect,
   resolveScalingEffect,
+  registerCompoundEffects,
   type EffectResolver,
 } from "./compound.js";
 
 // Choice effect resolution
-export { resolveChoiceEffect } from "./choice.js";
+export { resolveChoiceEffect, registerChoiceEffects } from "./choice.js";
 
 // Crystallize effects
 export {
   resolveConvertManaToCrystal,
   resolveCrystallizeColor,
+  registerCrystallizeEffects,
 } from "./crystallize.js";
 
 // Card boost effects
 export {
   resolveCardBoostEffect,
   resolveBoostTargetEffect,
+  registerCardBoostEffects,
 } from "./cardBoostResolvers.js";
 export { addBonusToEffect } from "./cardBoostEffects.js";
 
@@ -142,6 +146,7 @@ export { addBonusToEffect } from "./cardBoostEffects.js";
 export {
   resolveSelectCombatEnemy,
   resolveCombatEnemyTarget,
+  registerCombatEffects,
 } from "./combatEffects.js";
 
 // Mana draw effects
@@ -149,12 +154,14 @@ export {
   handleManaDrawPowered,
   handleManaDrawPickDie,
   applyManaDrawSetColor,
+  registerManaDrawEffects,
 } from "./manaDrawEffects.js";
 
 // Unit effects
 export {
   handleReadyUnit,
   getSpentUnitsAtOrBelowLevel,
+  registerUnitEffects,
 } from "./unitEffects.js";
 
 // Heal unit effects
@@ -162,6 +169,7 @@ export {
   handleHealUnit,
   getWoundedUnitsAtOrBelowLevel,
   applyHealUnit,
+  registerHealUnitEffects,
 } from "./healUnitEffects.js";
 
 // Discard effects
@@ -169,20 +177,25 @@ export {
   handleDiscardCard,
   getDiscardableCards,
   applyDiscardCard,
+  registerDiscardEffects,
 } from "./discardEffects.js";
 
 // Map effects
-export { handleRevealTiles } from "./mapEffects.js";
+export { handleRevealTiles, registerMapEffects } from "./mapEffects.js";
 
 // Mana payment effects
 export {
   handlePayMana,
   getPayableManaColors,
   applyPayMana,
+  registerManaPaymentEffects,
 } from "./manaPaymentEffects.js";
 
 // Terrain-based effects
-export { resolveTerrainBasedBlock } from "./terrainEffects.js";
+export { resolveTerrainBasedBlock, registerTerrainEffects } from "./terrainEffects.js";
+
+// Effect helpers
+export { getPlayerContext } from "./effectHelpers.js";
 
 // Effect reversal (for undo)
 export { reverseEffect } from "./reverse.js";

--- a/packages/core/src/engine/effects/manaDrawEffects.ts
+++ b/packages/core/src/engine/effects/manaDrawEffects.ts
@@ -27,8 +27,10 @@ import type { BasicManaColor } from "@mage-knight/shared";
 import type { ManaDrawPoweredEffect, ManaDrawPickDieEffect, ManaDrawSetColorEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import { MANA_TOKEN_SOURCE_CARD, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
-import { EFFECT_MANA_DRAW_PICK_DIE, EFFECT_MANA_DRAW_SET_COLOR } from "../../types/effectTypes.js";
+import { EFFECT_MANA_DRAW_POWERED, EFFECT_MANA_DRAW_PICK_DIE, EFFECT_MANA_DRAW_SET_COLOR } from "../../types/effectTypes.js";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
 
 /**
  * Entry point for Mana Draw/Mana Pull powered effect.
@@ -279,4 +281,27 @@ function chainToNextDieSelection(
     requiresChoice: true,
     dynamicChoiceOptions: dieOptions,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all mana draw effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerManaDrawEffects(): void {
+  registerEffect(EFFECT_MANA_DRAW_POWERED, (state, _playerId, effect) => {
+    return handleManaDrawPowered(state, effect as ManaDrawPoweredEffect);
+  });
+
+  registerEffect(EFFECT_MANA_DRAW_PICK_DIE, (state, _playerId, effect) => {
+    return handleManaDrawPickDie(state, effect as ManaDrawPickDieEffect);
+  });
+
+  registerEffect(EFFECT_MANA_DRAW_SET_COLOR, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return applyManaDrawSetColor(state, playerIndex, player, effect as ManaDrawSetColorEffect);
+  });
 }

--- a/packages/core/src/engine/effects/manaPaymentEffects.ts
+++ b/packages/core/src/engine/effects/manaPaymentEffects.ts
@@ -11,6 +11,9 @@ import type { PayManaCostEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import type { ManaColor } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_PAY_MANA } from "../../types/effectTypes.js";
 
 /**
  * Get available mana tokens that match the allowed colors.
@@ -120,4 +123,19 @@ export function applyPayMana(
     state: updatePlayer(state, playerIndex, updatedPlayer),
     description: `Paid ${amount} ${color} mana`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all mana payment effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerManaPaymentEffects(): void {
+  registerEffect(EFFECT_PAY_MANA, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handlePayMana(state, playerIndex, player, effect as PayManaCostEffect);
+  });
 }

--- a/packages/core/src/engine/effects/mapEffects.ts
+++ b/packages/core/src/engine/effects/mapEffects.ts
@@ -17,6 +17,9 @@ import {
   REVEAL_TILE_TYPE_GARRISON,
   REVEAL_TILE_TYPE_ALL,
 } from "@mage-knight/shared";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_REVEAL_TILES } from "../../types/effectTypes.js";
 
 /**
  * Calculate the distance between two hexes using axial coordinates.
@@ -122,4 +125,19 @@ export function handleRevealTiles(
     state: { ...state, map: updatedMap },
     description: `Revealed ${revealedCount} enemy token(s)`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all map effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerMapEffects(): void {
+  registerEffect(EFFECT_REVEAL_TILES, (state, playerId, effect) => {
+    const { player } = getPlayerContext(state, playerId);
+    return handleRevealTiles(state, player, effect as RevealTilesEffect);
+  });
 }

--- a/packages/core/src/engine/effects/terrainEffects.ts
+++ b/packages/core/src/engine/effects/terrainEffects.ts
@@ -21,7 +21,9 @@ import {
   TERRAIN_MOUNTAIN,
   TERRAIN_OCEAN,
 } from "@mage-knight/shared";
-import { EFFECT_GAIN_BLOCK } from "../../types/effectTypes.js";
+import { EFFECT_GAIN_BLOCK, EFFECT_TERRAIN_BASED_BLOCK } from "../../types/effectTypes.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
 
 /**
  * Get the unmodified movement cost for the terrain at the player's position.
@@ -107,4 +109,19 @@ export function resolveTerrainBasedBlock(
     ...result,
     description: `Gained ${blockAmount} ${element} Block (terrain cost)`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all terrain-based effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerTerrainEffects(): void {
+  registerEffect(EFFECT_TERRAIN_BASED_BLOCK, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return resolveTerrainBasedBlock(state, playerIndex, player, effect as TerrainBasedBlockEffect);
+  });
 }

--- a/packages/core/src/engine/effects/unitEffects.ts
+++ b/packages/core/src/engine/effects/unitEffects.ts
@@ -12,6 +12,9 @@ import type { ReadyUnitEffect } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import { UNITS, UNIT_STATE_READY, UNIT_STATE_SPENT } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_READY_UNIT } from "../../types/effectTypes.js";
 
 /**
  * Get spent units that are at or below a given level.
@@ -125,4 +128,19 @@ export function applyReadyUnit(
     state: updatePlayer(state, playerIndex, updatedPlayer),
     description: `Readied ${unitName}`,
   };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all unit effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerUnitEffects(): void {
+  registerEffect(EFFECT_READY_UNIT, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleReadyUnit(state, playerIndex, player, effect as ReadyUnitEffect);
+  });
 }


### PR DESCRIPTION
## Summary

- Move effect handler registrations from centralized `effectRegistrations.ts` into their respective module files
- Each module now has a `registerXxxEffects()` function that registers its own handlers
- Simplify `effectRegistrations.ts` from 443 lines to ~75 lines as a coordinator

## Changes

- Create `effectHelpers.ts` with shared `getPlayerContext()` helper
- Add registration functions to 13 modules (31 total handlers)
- Update `effectRegistrations.ts` to call module registration functions
- Export new functions from `index.ts`

## Benefits

- **Co-location**: Registration logic lives with resolution logic
- **Self-contained modules**: Each module manages its own effect handlers
- **Easier maintenance**: Adding new effects only requires modifying one file
- **Better discoverability**: Clear ownership of effect handlers

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes  
- [x] `pnpm test` passes (1285 tests)