### PR TITLE
refactor: split AA card IDs into per-color modules

### DIFF
--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -4,13 +4,11 @@
  * Each constant is a branded CardId compatible value.
  */
 
-import type { CardId } from "./ids.js";
+// Import the cardId helper for local use
+import { cardId } from "./cardIds/helpers.js";
 
-// === Helper to create CardId constants ===
-// This ensures type safety while allowing the value to be used as a CardId
-function cardId<T extends string>(id: T): T & CardId {
-  return id as T & CardId;
-}
+// Re-export advanced action card IDs from modular structure
+export * from "./cardIds/advancedActions/index.js";
 
 // === Shared Basic Action Card IDs (14 cards in every starting deck) ===
 
@@ -59,63 +57,6 @@ export const CARD_BRAEVALAR_ONE_WITH_THE_LAND = cardId("braevalar_one_with_the_l
 
 // === Wound Card ===
 export const CARD_WOUND = cardId("wound");
-
-// === Advanced Action Card IDs ===
-// Bolt cards (gain crystal basic / ranged attack powered)
-export const CARD_FIRE_BOLT = cardId("fire_bolt");
-export const CARD_ICE_BOLT = cardId("ice_bolt");
-export const CARD_SWIFT_BOLT = cardId("swift_bolt");
-export const CARD_CRUSHING_BOLT = cardId("crushing_bolt");
-
-// Red advanced actions
-export const CARD_BLOOD_RAGE = cardId("blood_rage");
-export const CARD_INTIMIDATE = cardId("intimidate");
-export const CARD_BLOOD_RITUAL = cardId("blood_ritual");
-export const CARD_INTO_THE_HEAT = cardId("into_the_heat");
-export const CARD_DECOMPOSE = cardId("decompose");
-export const CARD_MAXIMAL_EFFECT = cardId("maximal_effect");
-export const CARD_COUNTERATTACK = cardId("counterattack");
-export const CARD_RITUAL_ATTACK = cardId("ritual_attack");
-export const CARD_BLOOD_OF_ANCIENTS = cardId("blood_of_ancients");
-export const CARD_EXPLOSIVE_BOLT = cardId("explosive_bolt");
-
-// Blue advanced actions
-export const CARD_ICE_SHIELD = cardId("ice_shield");
-export const CARD_FROST_BRIDGE = cardId("frost_bridge");
-export const CARD_PURE_MAGIC = cardId("pure_magic");
-export const CARD_STEADY_TEMPO = cardId("steady_tempo");
-export const CARD_CRYSTAL_MASTERY = cardId("crystal_mastery");
-export const CARD_MAGIC_TALENT = cardId("magic_talent");
-export const CARD_SHIELD_BASH = cardId("shield_bash");
-export const CARD_TEMPORAL_PORTAL = cardId("temporal_portal");
-export const CARD_SPELL_FORGE = cardId("spell_forge");
-
-// White advanced actions
-export const CARD_AGILITY = cardId("agility");
-export const CARD_SONG_OF_WIND = cardId("song_of_wind");
-export const CARD_HEROIC_TALE = cardId("heroic_tale");
-export const CARD_DIPLOMACY = cardId("diplomacy");
-export const CARD_MANA_STORM = cardId("mana_storm");
-export const CARD_LEARNING = cardId("learning");
-export const CARD_CHIVALRY = cardId("chivalry");
-export const CARD_PEACEFUL_MOMENT = cardId("peaceful_moment");
-export const CARD_DODGE_AND_WEAVE = cardId("dodge_and_weave");
-
-// Green advanced actions
-export const CARD_REFRESHING_WALK = cardId("refreshing_walk");
-export const CARD_PATH_FINDING = cardId("path_finding");
-export const CARD_REGENERATION = cardId("regeneration");
-export const CARD_IN_NEED = cardId("in_need");
-export const CARD_AMBUSH = cardId("ambush");
-export const CARD_TRAINING = cardId("training");
-export const CARD_STOUT_RESOLVE = cardId("stout_resolve");
-export const CARD_FORCE_OF_NATURE = cardId("force_of_nature");
-export const CARD_MOUNTAIN_LORE = cardId("mountain_lore");
-export const CARD_POWER_OF_CRYSTALS = cardId("power_of_crystals");
-
-// Dual-color advanced actions
-export const CARD_RUSH_OF_ADRENALINE = cardId("rush_of_adrenaline"); // green+red
-export const CARD_CHILLING_STARE = cardId("chilling_stare"); // blue+white
 
 // === Artifact Card IDs ===
 export const CARD_ENDLESS_BAG_OF_GOLD = cardId("endless_bag_of_gold");
@@ -173,58 +114,6 @@ export type BasicActionCardId =
   | SharedBasicActionCardId
   | HeroSpecificCardId
   | typeof CARD_WOUND;
-
-export type AdvancedActionCardId =
-  // Bolt cards
-  | typeof CARD_FIRE_BOLT
-  | typeof CARD_ICE_BOLT
-  | typeof CARD_SWIFT_BOLT
-  | typeof CARD_CRUSHING_BOLT
-  // Red advanced actions
-  | typeof CARD_BLOOD_RAGE
-  | typeof CARD_INTIMIDATE
-  | typeof CARD_BLOOD_RITUAL
-  | typeof CARD_INTO_THE_HEAT
-  | typeof CARD_DECOMPOSE
-  | typeof CARD_MAXIMAL_EFFECT
-  | typeof CARD_COUNTERATTACK
-  | typeof CARD_RITUAL_ATTACK
-  | typeof CARD_BLOOD_OF_ANCIENTS
-  | typeof CARD_EXPLOSIVE_BOLT
-  // Blue advanced actions
-  | typeof CARD_ICE_SHIELD
-  | typeof CARD_FROST_BRIDGE
-  | typeof CARD_PURE_MAGIC
-  | typeof CARD_STEADY_TEMPO
-  | typeof CARD_CRYSTAL_MASTERY
-  | typeof CARD_MAGIC_TALENT
-  | typeof CARD_SHIELD_BASH
-  | typeof CARD_TEMPORAL_PORTAL
-  | typeof CARD_SPELL_FORGE
-  // White advanced actions
-  | typeof CARD_AGILITY
-  | typeof CARD_SONG_OF_WIND
-  | typeof CARD_HEROIC_TALE
-  | typeof CARD_DIPLOMACY
-  | typeof CARD_MANA_STORM
-  | typeof CARD_LEARNING
-  | typeof CARD_CHIVALRY
-  | typeof CARD_PEACEFUL_MOMENT
-  | typeof CARD_DODGE_AND_WEAVE
-  // Green advanced actions
-  | typeof CARD_REFRESHING_WALK
-  | typeof CARD_PATH_FINDING
-  | typeof CARD_REGENERATION
-  | typeof CARD_IN_NEED
-  | typeof CARD_AMBUSH
-  | typeof CARD_TRAINING
-  | typeof CARD_STOUT_RESOLVE
-  | typeof CARD_FORCE_OF_NATURE
-  | typeof CARD_MOUNTAIN_LORE
-  | typeof CARD_POWER_OF_CRYSTALS
-  // Dual-color advanced actions
-  | typeof CARD_RUSH_OF_ADRENALINE
-  | typeof CARD_CHILLING_STARE;
 
 export type SpellCardId =
   // Red spells

--- a/packages/shared/src/cardIds/advancedActions/blue/crystalMastery.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/crystalMastery.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_CRYSTAL_MASTERY = cardId("crystal_mastery");

--- a/packages/shared/src/cardIds/advancedActions/blue/frostBridge.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/frostBridge.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_FROST_BRIDGE = cardId("frost_bridge");

--- a/packages/shared/src/cardIds/advancedActions/blue/iceShield.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/iceShield.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_ICE_SHIELD = cardId("ice_shield");

--- a/packages/shared/src/cardIds/advancedActions/blue/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Blue advanced action card IDs
+ */
+
+export { CARD_ICE_SHIELD } from "./iceShield.js";
+export { CARD_FROST_BRIDGE } from "./frostBridge.js";
+export { CARD_PURE_MAGIC } from "./pureMagic.js";
+export { CARD_STEADY_TEMPO } from "./steadyTempo.js";
+export { CARD_CRYSTAL_MASTERY } from "./crystalMastery.js";
+export { CARD_MAGIC_TALENT } from "./magicTalent.js";
+export { CARD_SHIELD_BASH } from "./shieldBash.js";
+export { CARD_TEMPORAL_PORTAL } from "./temporalPortal.js";
+export { CARD_SPELL_FORGE } from "./spellForge.js";
+
+import { CARD_ICE_SHIELD } from "./iceShield.js";
+import { CARD_FROST_BRIDGE } from "./frostBridge.js";
+import { CARD_PURE_MAGIC } from "./pureMagic.js";
+import { CARD_STEADY_TEMPO } from "./steadyTempo.js";
+import { CARD_CRYSTAL_MASTERY } from "./crystalMastery.js";
+import { CARD_MAGIC_TALENT } from "./magicTalent.js";
+import { CARD_SHIELD_BASH } from "./shieldBash.js";
+import { CARD_TEMPORAL_PORTAL } from "./temporalPortal.js";
+import { CARD_SPELL_FORGE } from "./spellForge.js";
+
+export const BLUE_AA_IDS = [
+  CARD_ICE_SHIELD,
+  CARD_FROST_BRIDGE,
+  CARD_PURE_MAGIC,
+  CARD_STEADY_TEMPO,
+  CARD_CRYSTAL_MASTERY,
+  CARD_MAGIC_TALENT,
+  CARD_SHIELD_BASH,
+  CARD_TEMPORAL_PORTAL,
+  CARD_SPELL_FORGE,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/blue/magicTalent.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/magicTalent.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_MAGIC_TALENT = cardId("magic_talent");

--- a/packages/shared/src/cardIds/advancedActions/blue/pureMagic.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/pureMagic.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_PURE_MAGIC = cardId("pure_magic");

--- a/packages/shared/src/cardIds/advancedActions/blue/shieldBash.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/shieldBash.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_SHIELD_BASH = cardId("shield_bash");

--- a/packages/shared/src/cardIds/advancedActions/blue/spellForge.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/spellForge.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_SPELL_FORGE = cardId("spell_forge");

--- a/packages/shared/src/cardIds/advancedActions/blue/steadyTempo.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/steadyTempo.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_STEADY_TEMPO = cardId("steady_tempo");

--- a/packages/shared/src/cardIds/advancedActions/blue/temporalPortal.ts
+++ b/packages/shared/src/cardIds/advancedActions/blue/temporalPortal.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_TEMPORAL_PORTAL = cardId("temporal_portal");

--- a/packages/shared/src/cardIds/advancedActions/bolts/crushingBolt.ts
+++ b/packages/shared/src/cardIds/advancedActions/bolts/crushingBolt.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_CRUSHING_BOLT = cardId("crushing_bolt");

--- a/packages/shared/src/cardIds/advancedActions/bolts/fireBolt.ts
+++ b/packages/shared/src/cardIds/advancedActions/bolts/fireBolt.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_FIRE_BOLT = cardId("fire_bolt");

--- a/packages/shared/src/cardIds/advancedActions/bolts/iceBolt.ts
+++ b/packages/shared/src/cardIds/advancedActions/bolts/iceBolt.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_ICE_BOLT = cardId("ice_bolt");

--- a/packages/shared/src/cardIds/advancedActions/bolts/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/bolts/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Bolt advanced action card IDs
+ * These cards gain crystal (basic) / ranged attack (powered)
+ */
+
+export { CARD_FIRE_BOLT } from "./fireBolt.js";
+export { CARD_ICE_BOLT } from "./iceBolt.js";
+export { CARD_SWIFT_BOLT } from "./swiftBolt.js";
+export { CARD_CRUSHING_BOLT } from "./crushingBolt.js";
+
+import { CARD_FIRE_BOLT } from "./fireBolt.js";
+import { CARD_ICE_BOLT } from "./iceBolt.js";
+import { CARD_SWIFT_BOLT } from "./swiftBolt.js";
+import { CARD_CRUSHING_BOLT } from "./crushingBolt.js";
+
+export const BOLT_IDS = [
+  CARD_FIRE_BOLT,
+  CARD_ICE_BOLT,
+  CARD_SWIFT_BOLT,
+  CARD_CRUSHING_BOLT,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/bolts/swiftBolt.ts
+++ b/packages/shared/src/cardIds/advancedActions/bolts/swiftBolt.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_SWIFT_BOLT = cardId("swift_bolt");

--- a/packages/shared/src/cardIds/advancedActions/dual/chillingStare.ts
+++ b/packages/shared/src/cardIds/advancedActions/dual/chillingStare.ts
@@ -1,0 +1,4 @@
+import { cardId } from "../../helpers.js";
+
+/** Blue + White dual-color advanced action */
+export const CARD_CHILLING_STARE = cardId("chilling_stare");

--- a/packages/shared/src/cardIds/advancedActions/dual/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/dual/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Dual-color advanced action card IDs
+ */
+
+export { CARD_RUSH_OF_ADRENALINE } from "./rushOfAdrenaline.js";
+export { CARD_CHILLING_STARE } from "./chillingStare.js";
+
+import { CARD_RUSH_OF_ADRENALINE } from "./rushOfAdrenaline.js";
+import { CARD_CHILLING_STARE } from "./chillingStare.js";
+
+export const DUAL_AA_IDS = [
+  CARD_RUSH_OF_ADRENALINE,
+  CARD_CHILLING_STARE,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/dual/rushOfAdrenaline.ts
+++ b/packages/shared/src/cardIds/advancedActions/dual/rushOfAdrenaline.ts
@@ -1,0 +1,4 @@
+import { cardId } from "../../helpers.js";
+
+/** Green + Red dual-color advanced action */
+export const CARD_RUSH_OF_ADRENALINE = cardId("rush_of_adrenaline");

--- a/packages/shared/src/cardIds/advancedActions/green/ambush.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/ambush.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_AMBUSH = cardId("ambush");

--- a/packages/shared/src/cardIds/advancedActions/green/forceOfNature.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/forceOfNature.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_FORCE_OF_NATURE = cardId("force_of_nature");

--- a/packages/shared/src/cardIds/advancedActions/green/inNeed.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/inNeed.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_IN_NEED = cardId("in_need");

--- a/packages/shared/src/cardIds/advancedActions/green/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Green advanced action card IDs
+ */
+
+export { CARD_REFRESHING_WALK } from "./refreshingWalk.js";
+export { CARD_PATH_FINDING } from "./pathFinding.js";
+export { CARD_REGENERATION } from "./regeneration.js";
+export { CARD_IN_NEED } from "./inNeed.js";
+export { CARD_AMBUSH } from "./ambush.js";
+export { CARD_TRAINING } from "./training.js";
+export { CARD_STOUT_RESOLVE } from "./stoutResolve.js";
+export { CARD_FORCE_OF_NATURE } from "./forceOfNature.js";
+export { CARD_MOUNTAIN_LORE } from "./mountainLore.js";
+export { CARD_POWER_OF_CRYSTALS } from "./powerOfCrystals.js";
+
+import { CARD_REFRESHING_WALK } from "./refreshingWalk.js";
+import { CARD_PATH_FINDING } from "./pathFinding.js";
+import { CARD_REGENERATION } from "./regeneration.js";
+import { CARD_IN_NEED } from "./inNeed.js";
+import { CARD_AMBUSH } from "./ambush.js";
+import { CARD_TRAINING } from "./training.js";
+import { CARD_STOUT_RESOLVE } from "./stoutResolve.js";
+import { CARD_FORCE_OF_NATURE } from "./forceOfNature.js";
+import { CARD_MOUNTAIN_LORE } from "./mountainLore.js";
+import { CARD_POWER_OF_CRYSTALS } from "./powerOfCrystals.js";
+
+export const GREEN_AA_IDS = [
+  CARD_REFRESHING_WALK,
+  CARD_PATH_FINDING,
+  CARD_REGENERATION,
+  CARD_IN_NEED,
+  CARD_AMBUSH,
+  CARD_TRAINING,
+  CARD_STOUT_RESOLVE,
+  CARD_FORCE_OF_NATURE,
+  CARD_MOUNTAIN_LORE,
+  CARD_POWER_OF_CRYSTALS,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/green/mountainLore.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/mountainLore.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_MOUNTAIN_LORE = cardId("mountain_lore");

--- a/packages/shared/src/cardIds/advancedActions/green/pathFinding.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/pathFinding.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_PATH_FINDING = cardId("path_finding");

--- a/packages/shared/src/cardIds/advancedActions/green/powerOfCrystals.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/powerOfCrystals.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_POWER_OF_CRYSTALS = cardId("power_of_crystals");

--- a/packages/shared/src/cardIds/advancedActions/green/refreshingWalk.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/refreshingWalk.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_REFRESHING_WALK = cardId("refreshing_walk");

--- a/packages/shared/src/cardIds/advancedActions/green/regeneration.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/regeneration.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_REGENERATION = cardId("regeneration");

--- a/packages/shared/src/cardIds/advancedActions/green/stoutResolve.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/stoutResolve.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_STOUT_RESOLVE = cardId("stout_resolve");

--- a/packages/shared/src/cardIds/advancedActions/green/training.ts
+++ b/packages/shared/src/cardIds/advancedActions/green/training.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_TRAINING = cardId("training");

--- a/packages/shared/src/cardIds/advancedActions/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/index.ts
@@ -1,0 +1,41 @@
+/**
+ * Advanced Action Card IDs - Aggregator
+ *
+ * This module re-exports all advanced action card IDs organized by color,
+ * and provides the AdvancedActionCardId type derived from the exported arrays.
+ */
+
+// Re-export all card IDs from per-color modules
+export * from "./bolts/index.js";
+export * from "./red/index.js";
+export * from "./blue/index.js";
+export * from "./white/index.js";
+export * from "./green/index.js";
+export * from "./dual/index.js";
+
+// Import arrays for type derivation
+import { BOLT_IDS } from "./bolts/index.js";
+import { RED_AA_IDS } from "./red/index.js";
+import { BLUE_AA_IDS } from "./blue/index.js";
+import { WHITE_AA_IDS } from "./white/index.js";
+import { GREEN_AA_IDS } from "./green/index.js";
+import { DUAL_AA_IDS } from "./dual/index.js";
+
+/**
+ * All advanced action card IDs combined.
+ * Used to derive the AdvancedActionCardId type.
+ */
+export const ALL_ADVANCED_ACTION_IDS = [
+  ...BOLT_IDS,
+  ...RED_AA_IDS,
+  ...BLUE_AA_IDS,
+  ...WHITE_AA_IDS,
+  ...GREEN_AA_IDS,
+  ...DUAL_AA_IDS,
+] as const;
+
+/**
+ * Union type of all advanced action card IDs.
+ * Auto-derived from the card ID arrays to prevent manual maintenance.
+ */
+export type AdvancedActionCardId = (typeof ALL_ADVANCED_ACTION_IDS)[number];

--- a/packages/shared/src/cardIds/advancedActions/red/bloodOfAncients.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/bloodOfAncients.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_BLOOD_OF_ANCIENTS = cardId("blood_of_ancients");

--- a/packages/shared/src/cardIds/advancedActions/red/bloodRage.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/bloodRage.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_BLOOD_RAGE = cardId("blood_rage");

--- a/packages/shared/src/cardIds/advancedActions/red/bloodRitual.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/bloodRitual.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_BLOOD_RITUAL = cardId("blood_ritual");

--- a/packages/shared/src/cardIds/advancedActions/red/counterattack.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/counterattack.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_COUNTERATTACK = cardId("counterattack");

--- a/packages/shared/src/cardIds/advancedActions/red/decompose.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/decompose.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_DECOMPOSE = cardId("decompose");

--- a/packages/shared/src/cardIds/advancedActions/red/explosiveBolt.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/explosiveBolt.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_EXPLOSIVE_BOLT = cardId("explosive_bolt");

--- a/packages/shared/src/cardIds/advancedActions/red/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/index.ts
@@ -1,0 +1,38 @@
+/**
+ * Red advanced action card IDs
+ */
+
+export { CARD_BLOOD_RAGE } from "./bloodRage.js";
+export { CARD_INTIMIDATE } from "./intimidate.js";
+export { CARD_BLOOD_RITUAL } from "./bloodRitual.js";
+export { CARD_INTO_THE_HEAT } from "./intoTheHeat.js";
+export { CARD_DECOMPOSE } from "./decompose.js";
+export { CARD_MAXIMAL_EFFECT } from "./maximalEffect.js";
+export { CARD_COUNTERATTACK } from "./counterattack.js";
+export { CARD_RITUAL_ATTACK } from "./ritualAttack.js";
+export { CARD_BLOOD_OF_ANCIENTS } from "./bloodOfAncients.js";
+export { CARD_EXPLOSIVE_BOLT } from "./explosiveBolt.js";
+
+import { CARD_BLOOD_RAGE } from "./bloodRage.js";
+import { CARD_INTIMIDATE } from "./intimidate.js";
+import { CARD_BLOOD_RITUAL } from "./bloodRitual.js";
+import { CARD_INTO_THE_HEAT } from "./intoTheHeat.js";
+import { CARD_DECOMPOSE } from "./decompose.js";
+import { CARD_MAXIMAL_EFFECT } from "./maximalEffect.js";
+import { CARD_COUNTERATTACK } from "./counterattack.js";
+import { CARD_RITUAL_ATTACK } from "./ritualAttack.js";
+import { CARD_BLOOD_OF_ANCIENTS } from "./bloodOfAncients.js";
+import { CARD_EXPLOSIVE_BOLT } from "./explosiveBolt.js";
+
+export const RED_AA_IDS = [
+  CARD_BLOOD_RAGE,
+  CARD_INTIMIDATE,
+  CARD_BLOOD_RITUAL,
+  CARD_INTO_THE_HEAT,
+  CARD_DECOMPOSE,
+  CARD_MAXIMAL_EFFECT,
+  CARD_COUNTERATTACK,
+  CARD_RITUAL_ATTACK,
+  CARD_BLOOD_OF_ANCIENTS,
+  CARD_EXPLOSIVE_BOLT,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/red/intimidate.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/intimidate.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_INTIMIDATE = cardId("intimidate");

--- a/packages/shared/src/cardIds/advancedActions/red/intoTheHeat.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/intoTheHeat.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_INTO_THE_HEAT = cardId("into_the_heat");

--- a/packages/shared/src/cardIds/advancedActions/red/maximalEffect.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/maximalEffect.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_MAXIMAL_EFFECT = cardId("maximal_effect");

--- a/packages/shared/src/cardIds/advancedActions/red/ritualAttack.ts
+++ b/packages/shared/src/cardIds/advancedActions/red/ritualAttack.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_RITUAL_ATTACK = cardId("ritual_attack");

--- a/packages/shared/src/cardIds/advancedActions/white/agility.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/agility.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_AGILITY = cardId("agility");

--- a/packages/shared/src/cardIds/advancedActions/white/chivalry.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/chivalry.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_CHIVALRY = cardId("chivalry");

--- a/packages/shared/src/cardIds/advancedActions/white/diplomacy.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/diplomacy.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_DIPLOMACY = cardId("diplomacy");

--- a/packages/shared/src/cardIds/advancedActions/white/dodgeAndWeave.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/dodgeAndWeave.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_DODGE_AND_WEAVE = cardId("dodge_and_weave");

--- a/packages/shared/src/cardIds/advancedActions/white/heroicTale.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/heroicTale.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_HEROIC_TALE = cardId("heroic_tale");

--- a/packages/shared/src/cardIds/advancedActions/white/index.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/index.ts
@@ -1,0 +1,35 @@
+/**
+ * White advanced action card IDs
+ */
+
+export { CARD_AGILITY } from "./agility.js";
+export { CARD_SONG_OF_WIND } from "./songOfWind.js";
+export { CARD_HEROIC_TALE } from "./heroicTale.js";
+export { CARD_DIPLOMACY } from "./diplomacy.js";
+export { CARD_MANA_STORM } from "./manaStorm.js";
+export { CARD_LEARNING } from "./learning.js";
+export { CARD_CHIVALRY } from "./chivalry.js";
+export { CARD_PEACEFUL_MOMENT } from "./peacefulMoment.js";
+export { CARD_DODGE_AND_WEAVE } from "./dodgeAndWeave.js";
+
+import { CARD_AGILITY } from "./agility.js";
+import { CARD_SONG_OF_WIND } from "./songOfWind.js";
+import { CARD_HEROIC_TALE } from "./heroicTale.js";
+import { CARD_DIPLOMACY } from "./diplomacy.js";
+import { CARD_MANA_STORM } from "./manaStorm.js";
+import { CARD_LEARNING } from "./learning.js";
+import { CARD_CHIVALRY } from "./chivalry.js";
+import { CARD_PEACEFUL_MOMENT } from "./peacefulMoment.js";
+import { CARD_DODGE_AND_WEAVE } from "./dodgeAndWeave.js";
+
+export const WHITE_AA_IDS = [
+  CARD_AGILITY,
+  CARD_SONG_OF_WIND,
+  CARD_HEROIC_TALE,
+  CARD_DIPLOMACY,
+  CARD_MANA_STORM,
+  CARD_LEARNING,
+  CARD_CHIVALRY,
+  CARD_PEACEFUL_MOMENT,
+  CARD_DODGE_AND_WEAVE,
+] as const;

--- a/packages/shared/src/cardIds/advancedActions/white/learning.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/learning.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_LEARNING = cardId("learning");

--- a/packages/shared/src/cardIds/advancedActions/white/manaStorm.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/manaStorm.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_MANA_STORM = cardId("mana_storm");

--- a/packages/shared/src/cardIds/advancedActions/white/peacefulMoment.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/peacefulMoment.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_PEACEFUL_MOMENT = cardId("peaceful_moment");

--- a/packages/shared/src/cardIds/advancedActions/white/songOfWind.ts
+++ b/packages/shared/src/cardIds/advancedActions/white/songOfWind.ts
@@ -1,0 +1,3 @@
+import { cardId } from "../../helpers.js";
+
+export const CARD_SONG_OF_WIND = cardId("song_of_wind");

--- a/packages/shared/src/cardIds/helpers.ts
+++ b/packages/shared/src/cardIds/helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Helper function to create branded CardId constants
+ */
+
+import type { CardId } from "../ids.js";
+
+/**
+ * Creates a branded CardId constant.
+ * This ensures type safety while allowing the value to be used as a CardId.
+ */
+export function cardId<T extends string>(id: T): T & CardId {
+  return id as T & CardId;
+}


### PR DESCRIPTION
## Summary
- Split advanced action card IDs into individual files per card (44 card files)
- Each color gets its own directory with individual card files + index.ts
- Auto-derive `AdvancedActionCardId` type from arrays to eliminate manual maintenance

## New Structure
```
shared/src/cardIds/
├── helpers.ts                           # cardId() helper
└── advancedActions/
    ├── index.ts                         # Aggregator + type
    ├── bolts/
    │   ├── index.ts                     # Re-exports + BOLT_IDS array
    │   ├── fireBolt.ts                  # CARD_FIRE_BOLT
    │   ├── iceBolt.ts
    │   ├── swiftBolt.ts
    │   └── crushingBolt.ts
    ├── red/
    │   ├── index.ts                     # Re-exports + RED_AA_IDS array
    │   ├── bloodRage.ts                 # CARD_BLOOD_RAGE
    │   └── ... (10 files)
    ├── blue/  (9 files)
    ├── white/ (9 files)
    ├── green/ (10 files)
    └── dual/  (2 files)
```

## Conflict Analysis

| Scenario | Before | After |
|----------|--------|-------|
| Add cards to different colors | Conflict on cardIds.ts | No conflict |
| Add cards to same color | Conflict on cardIds.ts | 2 lines in color/index.ts |

## Adding a New Card

1. Create `red/newCard.ts`:
   ```typescript
   import { cardId } from "../../helpers.js";
   export const CARD_NEW_CARD = cardId("new_card");
   ```

2. Update `red/index.ts`:
   ```typescript
   export { CARD_NEW_CARD } from "./newCard.js";
   // ... and add to RED_AA_IDS array
   ```

That's it. The type is auto-generated.

## Test plan
- [x] `pnpm build` - all packages compile
- [x] `pnpm test` - all 1289 tests pass
- [x] `pnpm lint` - no errors
- [x] All existing imports work (re-exports preserve API compatibility)