### PR TITLE
feat: implement Cumbersome enemy ability

### DIFF
--- a/packages/core/src/engine/combat/cumbersomeHelpers.ts
+++ b/packages/core/src/engine/combat/cumbersomeHelpers.ts
@@ -1,0 +1,118 @@
+/**
+ * Cumbersome ability helper functions
+ *
+ * Cumbersome: In the Block phase, you may spend Move points; for each Move point
+ * spent, the attack is reduced by 1 for the rest of the turn. An attack reduced
+ * to 0 is considered successfully blocked.
+ *
+ * CRITICAL: Reduction applies BEFORE Swift doubling.
+ *
+ * @module engine/combat/cumbersomeHelpers
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { CombatEnemy } from "../../types/combat.js";
+import type { EnemyAbilityType } from "@mage-knight/shared";
+import { ABILITY_CUMBERSOME } from "@mage-knight/shared";
+import { isAbilityNullified } from "../modifiers/index.js";
+
+/**
+ * Check if an enemy has a specific ability.
+ */
+function hasAbility(enemy: CombatEnemy, abilityType: EnemyAbilityType): boolean {
+  return enemy.definition.abilities.includes(abilityType);
+}
+
+/**
+ * Check if enemy's Cumbersome ability is active (not nullified).
+ *
+ * @param state - Game state
+ * @param playerId - Player facing the enemy
+ * @param enemy - Combat enemy instance
+ * @returns True if enemy has Cumbersome and it's not nullified
+ */
+export function isCumbersomeActive(
+  state: GameState,
+  playerId: string,
+  enemy: CombatEnemy
+): boolean {
+  if (!hasAbility(enemy, ABILITY_CUMBERSOME)) return false;
+  return !isAbilityNullified(state, playerId, enemy.instanceId, ABILITY_CUMBERSOME);
+}
+
+/**
+ * Get the attack value for a Cumbersome enemy after move point reduction.
+ * Returns base attack minus spent move points (minimum 0).
+ *
+ * IMPORTANT: This reduction happens BEFORE Swift doubling and BEFORE Brutal doubling.
+ * Call this function first, then apply Swift/Brutal multipliers separately.
+ *
+ * @param state - Game state
+ * @param playerId - Player facing the enemy
+ * @param enemy - Combat enemy instance
+ * @param baseAttack - Base attack value (before any reductions)
+ * @returns Reduced attack value (baseAttack - cumbersomeReduction, min 0)
+ */
+export function getCumbersomeReducedAttack(
+  state: GameState,
+  playerId: string,
+  enemy: CombatEnemy,
+  baseAttack: number
+): number {
+  // Only apply if Cumbersome is active (not nullified)
+  if (!isCumbersomeActive(state, playerId, enemy)) {
+    return baseAttack;
+  }
+
+  // No combat = no reductions
+  if (!state.combat) {
+    return baseAttack;
+  }
+
+  // Get the reduction amount from combat state
+  const reduction = state.combat.cumbersomeReductions[enemy.instanceId] ?? 0;
+
+  // Reduce attack (minimum 0)
+  return Math.max(0, baseAttack - reduction);
+}
+
+/**
+ * Check if a Cumbersome enemy's attack has been reduced to 0.
+ * Per rules: "An attack reduced to 0 is considered successfully blocked."
+ * This triggers Elusive's lower armor value.
+ *
+ * @param state - Game state
+ * @param playerId - Player facing the enemy
+ * @param enemy - Combat enemy instance
+ * @param baseAttack - Base attack value (before any reductions)
+ * @returns True if attack has been reduced to 0
+ */
+export function isCumbersomeAttackReducedToZero(
+  state: GameState,
+  playerId: string,
+  enemy: CombatEnemy,
+  baseAttack: number
+): boolean {
+  // Only applies if Cumbersome is active
+  if (!isCumbersomeActive(state, playerId, enemy)) {
+    return false;
+  }
+
+  const reducedAttack = getCumbersomeReducedAttack(state, playerId, enemy, baseAttack);
+  return reducedAttack === 0;
+}
+
+/**
+ * Get the current cumbersome reduction for an enemy.
+ *
+ * @param state - Game state
+ * @param enemyInstanceId - Enemy instance ID
+ * @returns Number of move points spent (reduction amount)
+ */
+export function getCumbersomeReduction(
+  state: GameState,
+  enemyInstanceId: string
+): number {
+  if (!state.combat) return 0;
+  return state.combat.cumbersomeReductions[enemyInstanceId] ?? 0;
+}

--- a/packages/core/src/engine/commands/combat/__tests__/cumbersome.test.ts
+++ b/packages/core/src/engine/commands/combat/__tests__/cumbersome.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Tests for Cumbersome enemy ability
+ *
+ * Cumbersome: In the Block phase, you may spend Move points; for each Move point
+ * spent, the attack is reduced by 1 for the rest of the turn. An attack reduced
+ * to 0 is considered successfully blocked.
+ *
+ * CRITICAL: Reduction applies BEFORE Swift doubling and BEFORE Brutal damage doubling.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, MageKnightEngine } from "../../../MageKnightEngine.js";
+import { createTestGameState } from "../../../__tests__/testHelpers.js";
+import {
+  SPEND_MOVE_ON_CUMBERSOME_ACTION,
+  DECLARE_BLOCK_ACTION,
+  UNDO_ACTION,
+  INVALID_ACTION,
+  MOVE_SPENT_ON_CUMBERSOME,
+  ENEMY_BLOCKED,
+  BLOCK_FAILED,
+  type EnemyId,
+} from "@mage-knight/shared";
+import {
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_RANGED_SIEGE,
+} from "../../../../types/combat.js";
+import type { GameState } from "../../../../state/GameState.js";
+import type { CombatEnemy } from "../../../../types/combat.js";
+import type { EnemyDefinition } from "@mage-knight/shared";
+import { ELEMENT_PHYSICAL } from "@mage-knight/shared";
+
+// Mock enemy with Cumbersome ability for testing
+const CUMBERSOME_ENEMY_DEF: EnemyDefinition = {
+  id: "test_cumbersome" as EnemyId,
+  name: "Cumbersome Test Enemy",
+  color: "green",
+  attack: 5,
+  armor: 4,
+  fame: 3,
+  attackElement: ELEMENT_PHYSICAL,
+  abilities: ["cumbersome"],
+  resistances: {},
+};
+
+// Mock enemy with Cumbersome + Swift for testing interaction
+const CUMBERSOME_SWIFT_ENEMY_DEF: EnemyDefinition = {
+  id: "test_cumbersome_swift" as EnemyId,
+  name: "Cumbersome Swift Enemy",
+  color: "green",
+  attack: 4,
+  armor: 3,
+  fame: 4,
+  attackElement: ELEMENT_PHYSICAL,
+  abilities: ["cumbersome", "swift"],
+  resistances: {},
+};
+
+/**
+ * Helper to set up a combat state with a custom enemy for testing Cumbersome.
+ */
+function setupCumbersomeCombat(
+  state: GameState,
+  enemyDef: EnemyDefinition,
+  playerMovePoints: number = 5
+): GameState {
+  const combatEnemy: CombatEnemy = {
+    instanceId: "enemy_cumbersome_0",
+    definition: enemyDef,
+    isDefeated: false,
+    isBlocked: false,
+    attacksBlocked: undefined,
+    isSummonerHidden: false,
+    summonedByInstanceId: undefined,
+  };
+
+  // Update player with move points
+  const playerIndex = state.players.findIndex((p) => p.id === "player1");
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = {
+    ...updatedPlayers[playerIndex],
+    movePoints: playerMovePoints,
+    hasCombattedThisTurn: true,
+  };
+
+  return {
+    ...state,
+    players: updatedPlayers,
+    combat: {
+      enemies: [combatEnemy],
+      phase: COMBAT_PHASE_BLOCK,
+      initiatorId: "player1",
+      isCooperative: false,
+      fortificationLevel: 0,
+      pendingDamage: {},
+      pendingBlock: {},
+      cumbersomeReductions: {},
+    },
+  };
+}
+
+/**
+ * Helper to give player block for testing.
+ */
+function withPlayerBlock(state: GameState, physicalBlock: number): GameState {
+  const playerIndex = state.players.findIndex((p) => p.id === "player1");
+  const player = state.players[playerIndex];
+
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = {
+    ...player,
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      block: physicalBlock,
+      blockElements: {
+        ...player.combatAccumulator.blockElements,
+        physical: physicalBlock,
+      },
+    },
+  };
+
+  return { ...state, players: updatedPlayers };
+}
+
+describe("Cumbersome Ability", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("SPEND_MOVE_ON_CUMBERSOME", () => {
+    it("should reduce enemy attack by move points spent", () => {
+      let state = createTestGameState();
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+
+      // Spend 3 move points on Cumbersome enemy
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 3,
+      });
+
+      // Should emit MOVE_SPENT_ON_CUMBERSOME event
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: MOVE_SPENT_ON_CUMBERSOME,
+          enemyInstanceId: "enemy_cumbersome_0",
+          movePointsSpent: 3,
+          totalReduction: 3,
+        })
+      );
+
+      // Move points should be deducted
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.movePoints).toBe(2);
+
+      // Reduction should be tracked
+      expect(
+        result.state.combat?.cumbersomeReductions["enemy_cumbersome_0"]
+      ).toBe(3);
+    });
+
+    it("should allow spending multiple times on same enemy", () => {
+      let state = createTestGameState();
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 10);
+
+      // Spend 2 move points
+      let result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 2,
+      });
+
+      // Spend 3 more
+      result = engine.processAction(result.state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 3,
+      });
+
+      // Total reduction should be 5
+      expect(
+        result.state.combat?.cumbersomeReductions["enemy_cumbersome_0"]
+      ).toBe(5);
+
+      // Player should have 5 move points left
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.movePoints).toBe(5);
+    });
+
+    it("should fail when player has no move points", () => {
+      let state = createTestGameState();
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 0);
+
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 1,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should fail when enemy does not have Cumbersome", () => {
+      let state = createTestGameState();
+      // Use a regular enemy without Cumbersome
+      const regularEnemy: CombatEnemy = {
+        instanceId: "enemy_regular_0",
+        definition: {
+          id: "test_regular" as EnemyId,
+          name: "Regular Enemy",
+          color: "green",
+          attack: 3,
+          armor: 2,
+          fame: 2,
+          attackElement: ELEMENT_PHYSICAL,
+          abilities: [],
+          resistances: {},
+        },
+        isDefeated: false,
+        isBlocked: false,
+        attacksBlocked: undefined,
+        isSummonerHidden: false,
+        summonedByInstanceId: undefined,
+      };
+
+      state = {
+        ...state,
+        players: state.players.map((p) =>
+          p.id === "player1"
+            ? { ...p, movePoints: 5, hasCombattedThisTurn: true }
+            : p
+        ),
+        combat: {
+          enemies: [regularEnemy],
+          phase: COMBAT_PHASE_BLOCK,
+          initiatorId: "player1",
+          isCooperative: false,
+          fortificationLevel: 0,
+          pendingDamage: {},
+          pendingBlock: {},
+          cumbersomeReductions: {},
+        },
+      };
+
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_regular_0",
+        movePointsToSpend: 1,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should fail when not in Block phase", () => {
+      let state = createTestGameState();
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+
+      // Change to ranged phase
+      state = {
+        ...state,
+        combat: state.combat
+          ? { ...state.combat, phase: COMBAT_PHASE_RANGED_SIEGE }
+          : null,
+      };
+
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 1,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should be reversible via undo", () => {
+      let state = createTestGameState();
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+
+      // Spend 3 move points
+      const spendResult = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 3,
+      });
+
+      expect(spendResult.state.combat?.cumbersomeReductions["enemy_cumbersome_0"]).toBe(3);
+
+      // Undo
+      const undoResult = engine.processAction(spendResult.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Reduction should be removed
+      expect(
+        undoResult.state.combat?.cumbersomeReductions["enemy_cumbersome_0"]
+      ).toBeUndefined();
+
+      // Move points should be restored
+      const player = undoResult.state.players.find((p) => p.id === "player1");
+      expect(player?.movePoints).toBe(5);
+    });
+  });
+
+  describe("blocking interaction", () => {
+    it("should reduce block requirement based on Cumbersome reduction", () => {
+      let state = createTestGameState();
+      // Enemy has attack 5, we'll reduce by 3 (need 2 block)
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+      state = withPlayerBlock(state, 2);
+
+      // Spend 3 move points to reduce attack from 5 to 2
+      let result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 3,
+      });
+
+      // Assign 2 block to the enemy
+      result = {
+        ...result,
+        state: {
+          ...result.state,
+          combat: result.state.combat
+            ? {
+                ...result.state.combat,
+                pendingBlock: {
+                  ["enemy_cumbersome_0"]: {
+                    physical: 2,
+                    fire: 0,
+                    ice: 0,
+                    coldFire: 0,
+                  },
+                },
+              }
+            : null,
+        },
+      };
+
+      // Mark assigned block in player accumulator
+      const playerIndex = result.state.players.findIndex((p) => p.id === "player1");
+      const updatedPlayers = [...result.state.players];
+      updatedPlayers[playerIndex] = {
+        ...updatedPlayers[playerIndex],
+        combatAccumulator: {
+          ...updatedPlayers[playerIndex].combatAccumulator,
+          assignedBlock: 2,
+          assignedBlockElements: { physical: 2, fire: 0, ice: 0, coldFire: 0 },
+        },
+      };
+      result = { ...result, state: { ...result.state, players: updatedPlayers } };
+
+      // Declare block - should succeed because 2 block >= 2 reduced attack
+      const blockResult = engine.processAction(result.state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_cumbersome_0",
+      });
+
+      expect(blockResult.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_cumbersome_0",
+        })
+      );
+    });
+
+    it("should fail block if insufficient after Cumbersome reduction", () => {
+      let state = createTestGameState();
+      // Enemy has attack 5, we'll reduce by 2 (need 3 block, but we only have 2)
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+      state = withPlayerBlock(state, 2);
+
+      // Spend 2 move points to reduce attack from 5 to 3
+      let result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 2,
+      });
+
+      // Assign 2 block
+      result = {
+        ...result,
+        state: {
+          ...result.state,
+          combat: result.state.combat
+            ? {
+                ...result.state.combat,
+                pendingBlock: {
+                  ["enemy_cumbersome_0"]: {
+                    physical: 2,
+                    fire: 0,
+                    ice: 0,
+                    coldFire: 0,
+                  },
+                },
+              }
+            : null,
+        },
+      };
+
+      const playerIndex = result.state.players.findIndex((p) => p.id === "player1");
+      const updatedPlayers = [...result.state.players];
+      updatedPlayers[playerIndex] = {
+        ...updatedPlayers[playerIndex],
+        combatAccumulator: {
+          ...updatedPlayers[playerIndex].combatAccumulator,
+          assignedBlock: 2,
+          assignedBlockElements: { physical: 2, fire: 0, ice: 0, coldFire: 0 },
+        },
+      };
+      result = { ...result, state: { ...result.state, players: updatedPlayers } };
+
+      // Declare block - should fail because 2 block < 3 reduced attack
+      const blockResult = engine.processAction(result.state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_cumbersome_0",
+      });
+
+      expect(blockResult.events).toContainEqual(
+        expect.objectContaining({
+          type: BLOCK_FAILED,
+          enemyInstanceId: "enemy_cumbersome_0",
+        })
+      );
+    });
+
+    it("should count attack reduced to 0 as blocked", () => {
+      let state = createTestGameState();
+      // Enemy has attack 5, we'll reduce by 5 (0 block needed)
+      state = setupCumbersomeCombat(state, CUMBERSOME_ENEMY_DEF, 5);
+      state = withPlayerBlock(state, 0); // No block needed
+
+      // Spend 5 move points to reduce attack from 5 to 0
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 5,
+      });
+
+      // No pending block needed since attack is 0
+      // Declare block with 0 block should succeed
+      const blockResult = engine.processAction(result.state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_cumbersome_0",
+      });
+
+      expect(blockResult.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_cumbersome_0",
+        })
+      );
+    });
+  });
+
+  describe("Swift interaction (CRITICAL order of operations)", () => {
+    it("should apply Cumbersome BEFORE Swift doubling", () => {
+      let state = createTestGameState();
+      // Enemy has attack 4 with Cumbersome + Swift
+      // Without reduction: need 8 block (4 * 2)
+      // With 2 reduction: need 4 block ((4-2) * 2)
+      state = setupCumbersomeCombat(state, CUMBERSOME_SWIFT_ENEMY_DEF, 5);
+      state = withPlayerBlock(state, 4);
+
+      // Spend 2 move points to reduce attack from 4 to 2
+      let result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 2,
+      });
+
+      // Assign 4 block
+      result = {
+        ...result,
+        state: {
+          ...result.state,
+          combat: result.state.combat
+            ? {
+                ...result.state.combat,
+                pendingBlock: {
+                  ["enemy_cumbersome_0"]: {
+                    physical: 4,
+                    fire: 0,
+                    ice: 0,
+                    coldFire: 0,
+                  },
+                },
+              }
+            : null,
+        },
+      };
+
+      const playerIndex = result.state.players.findIndex((p) => p.id === "player1");
+      const updatedPlayers = [...result.state.players];
+      updatedPlayers[playerIndex] = {
+        ...updatedPlayers[playerIndex],
+        combatAccumulator: {
+          ...updatedPlayers[playerIndex].combatAccumulator,
+          assignedBlock: 4,
+          assignedBlockElements: { physical: 4, fire: 0, ice: 0, coldFire: 0 },
+        },
+      };
+      result = { ...result, state: { ...result.state, players: updatedPlayers } };
+
+      // Declare block - should succeed
+      // Reduced attack = 4 - 2 = 2
+      // Swift doubles: 2 * 2 = 4
+      // Block 4 >= 4 required
+      const blockResult = engine.processAction(result.state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_cumbersome_0",
+      });
+
+      expect(blockResult.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_cumbersome_0",
+        })
+      );
+    });
+
+    it("should reduce Swift enemy attack to 0 and count as blocked", () => {
+      let state = createTestGameState();
+      // Enemy has attack 4 with Cumbersome + Swift
+      // Reduce attack to 0: need 0 block (0 * 2 = 0)
+      state = setupCumbersomeCombat(state, CUMBERSOME_SWIFT_ENEMY_DEF, 5);
+      state = withPlayerBlock(state, 0);
+
+      // Spend 4 move points to reduce attack from 4 to 0
+      const result = engine.processAction(state, "player1", {
+        type: SPEND_MOVE_ON_CUMBERSOME_ACTION,
+        enemyInstanceId: "enemy_cumbersome_0",
+        movePointsToSpend: 4,
+      });
+
+      // Declare block - should succeed with 0 block
+      const blockResult = engine.processAction(result.state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_cumbersome_0",
+      });
+
+      expect(blockResult.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_cumbersome_0",
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/engine/commands/combat/abilityHelpers.ts
+++ b/packages/core/src/engine/commands/combat/abilityHelpers.ts
@@ -15,6 +15,7 @@ import {
 } from "@mage-knight/shared";
 import { isAbilityNullified } from "../../modifiers/index.js";
 import { getEnemyAttacks } from "../../combat/enemyAttackHelpers.js";
+import { getCumbersomeReducedAttack } from "../../combat/cumbersomeHelpers.js";
 
 /**
  * Check if an enemy has a specific ability.
@@ -74,7 +75,10 @@ export function isParalyzeActive(
 
 /**
  * Get effective damage from a specific attack.
- * Brutal: doubles the damage.
+ *
+ * Order of operations (CRITICAL):
+ * 1. Apply Cumbersome reduction (move points spent)
+ * 2. Apply Brutal doubling (if active)
  *
  * @param enemy - Combat enemy instance
  * @param attackIndex - Which attack's damage to calculate (0-indexed)
@@ -97,7 +101,10 @@ export function getEffectiveDamage(
 
   let damage = attack.damage;
 
-  // Brutal doubles the damage
+  // FIRST: Apply Cumbersome reduction (BEFORE Brutal)
+  damage = getCumbersomeReducedAttack(state, playerId, enemy, damage);
+
+  // SECOND: Brutal doubles the damage
   if (isBrutalActive(state, playerId, enemy)) {
     damage *= 2;
   }

--- a/packages/core/src/engine/commands/combat/declareBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareBlockCommand.ts
@@ -33,6 +33,7 @@ import {
   getEnemyAttackCount,
   isAttackBlocked,
 } from "../../combat/enemyAttackHelpers.js";
+import { getCumbersomeReducedAttack } from "../../combat/cumbersomeHelpers.js";
 
 export const DECLARE_BLOCK_COMMAND = "DECLARE_BLOCK" as const;
 
@@ -91,7 +92,10 @@ function isSwiftActive(
 
 /**
  * Get effective enemy attack value for blocking purposes
- * Swift: doubles the attack value (player must assign double block)
+ *
+ * Order of operations (CRITICAL):
+ * 1. Apply Cumbersome reduction (move points spent)
+ * 2. Apply Swift doubling (if active)
  *
  * Note: Swift does NOT affect attack timing or phases - only block requirements
  *
@@ -116,7 +120,10 @@ function getEffectiveEnemyAttackForBlocking(
 
   let attackValue = attack.damage;
 
-  // Swift: doubles attack value for blocking purposes
+  // FIRST: Apply Cumbersome reduction (BEFORE Swift)
+  attackValue = getCumbersomeReducedAttack(state, playerId, enemy, attackValue);
+
+  // SECOND: Swift doubles attack value for blocking purposes
   if (isSwiftActive(state, playerId, enemy)) {
     attackValue *= 2;
   }

--- a/packages/core/src/engine/commands/combat/index.ts
+++ b/packages/core/src/engine/commands/combat/index.ts
@@ -61,3 +61,9 @@ export {
   CHALLENGE_RAMPAGING_COMMAND,
   type ChallengeRampagingCommandParams,
 } from "./challengeRampagingCommand.js";
+
+export {
+  createSpendMoveOnCumbersomeCommand,
+  SPEND_MOVE_ON_CUMBERSOME_COMMAND,
+  type SpendMoveOnCumbersomeCommandParams,
+} from "./spendMoveOnCumbersomeCommand.js";

--- a/packages/core/src/engine/commands/combat/spendMoveOnCumbersomeCommand.ts
+++ b/packages/core/src/engine/commands/combat/spendMoveOnCumbersomeCommand.ts
@@ -1,0 +1,150 @@
+/**
+ * Spend Move on Cumbersome Command
+ *
+ * Allows player to spend accumulated move points during the BLOCK phase
+ * to reduce a Cumbersome enemy's attack value. Each move point spent
+ * reduces the attack by 1 for the rest of the turn (persists through
+ * Assign Damage phase).
+ *
+ * IMPORTANT: This reduction applies BEFORE Swift doubling and BEFORE Brutal doubling.
+ * REVERSIBLE: Can be undone until DECLARE_BLOCK commits the block.
+ *
+ * @module engine/commands/combat/spendMoveOnCumbersomeCommand
+ */
+
+import type { Command, CommandResult } from "../../commands.js";
+import type { GameState } from "../../../state/GameState.js";
+import { MOVE_SPENT_ON_CUMBERSOME } from "@mage-knight/shared";
+import { isCumbersomeActive } from "../../combat/cumbersomeHelpers.js";
+
+export const SPEND_MOVE_ON_CUMBERSOME_COMMAND = "SPEND_MOVE_ON_CUMBERSOME" as const;
+
+export interface SpendMoveOnCumbersomeCommandParams {
+  readonly playerId: string;
+  readonly enemyInstanceId: string;
+  readonly movePointsToSpend: number;
+}
+
+export function createSpendMoveOnCumbersomeCommand(
+  params: SpendMoveOnCumbersomeCommandParams
+): Command {
+  // Capture state for undo
+  let previousMovePoints = 0;
+  let previousReduction = 0;
+
+  return {
+    type: SPEND_MOVE_ON_CUMBERSOME_COMMAND,
+    playerId: params.playerId,
+    isReversible: true, // Can undo until block is committed
+
+    execute(state: GameState): CommandResult {
+      if (!state.combat) {
+        throw new Error("Not in combat");
+      }
+
+      const player = state.players.find((p) => p.id === params.playerId);
+      if (!player) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+      const playerIndex = state.players.indexOf(player);
+
+      const enemy = state.combat.enemies.find(
+        (e) => e.instanceId === params.enemyInstanceId
+      );
+      if (!enemy) {
+        throw new Error(`Enemy not found: ${params.enemyInstanceId}`);
+      }
+
+      // Verify Cumbersome is active
+      if (!isCumbersomeActive(state, params.playerId, enemy)) {
+        throw new Error("Enemy does not have active Cumbersome ability");
+      }
+
+      // Verify player has enough move points
+      if (player.movePoints < params.movePointsToSpend) {
+        throw new Error(
+          `Insufficient move points (has ${player.movePoints}, needs ${params.movePointsToSpend})`
+        );
+      }
+
+      // Validate positive amount
+      if (params.movePointsToSpend <= 0) {
+        throw new Error("Must spend at least 1 move point");
+      }
+
+      // Capture for undo
+      previousMovePoints = player.movePoints;
+      previousReduction = state.combat.cumbersomeReductions[params.enemyInstanceId] ?? 0;
+
+      // Deduct move points from player
+      const updatedPlayers = state.players.map((p, i) =>
+        i === playerIndex
+          ? { ...p, movePoints: p.movePoints - params.movePointsToSpend }
+          : p
+      );
+
+      // Add to cumbersome reductions
+      const updatedReductions = {
+        ...state.combat.cumbersomeReductions,
+        [params.enemyInstanceId]: previousReduction + params.movePointsToSpend,
+      };
+
+      const updatedCombat = {
+        ...state.combat,
+        cumbersomeReductions: updatedReductions,
+      };
+
+      return {
+        state: { ...state, players: updatedPlayers, combat: updatedCombat },
+        events: [
+          {
+            type: MOVE_SPENT_ON_CUMBERSOME,
+            enemyInstanceId: params.enemyInstanceId,
+            movePointsSpent: params.movePointsToSpend,
+            totalReduction: previousReduction + params.movePointsToSpend,
+          },
+        ],
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      if (!state.combat) {
+        throw new Error("Not in combat (undo)");
+      }
+
+      const playerIndex = state.players.findIndex((p) => p.id === params.playerId);
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      // Restore player's move points
+      const updatedPlayers = state.players.map((p, i) =>
+        i === playerIndex ? { ...p, movePoints: previousMovePoints } : p
+      );
+
+      // Restore previous reduction (or remove entry if was 0)
+      let updatedReductions: { readonly [enemyInstanceId: string]: number };
+      if (previousReduction === 0) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { [params.enemyInstanceId]: _removed, ...remaining } =
+          state.combat.cumbersomeReductions;
+        updatedReductions = remaining;
+      } else {
+        updatedReductions = {
+          ...state.combat.cumbersomeReductions,
+          [params.enemyInstanceId]: previousReduction,
+        };
+      }
+
+      const updatedCombat = {
+        ...state.combat,
+        cumbersomeReductions: updatedReductions,
+      };
+
+      return {
+        state: { ...state, players: updatedPlayers, combat: updatedCombat },
+        events: [],
+      };
+    },
+  };
+}

--- a/packages/core/src/engine/commands/factories/combat.ts
+++ b/packages/core/src/engine/commands/factories/combat.ts
@@ -30,6 +30,7 @@ import {
   UNASSIGN_ATTACK_ACTION,
   ASSIGN_BLOCK_ACTION,
   UNASSIGN_BLOCK_ACTION,
+  SPEND_MOVE_ON_CUMBERSOME_ACTION,
 } from "@mage-knight/shared";
 import {
   createEnterCombatCommand,
@@ -42,6 +43,7 @@ import {
   createUnassignAttackCommand,
   createAssignBlockCommand,
   createUnassignBlockCommand,
+  createSpendMoveOnCumbersomeCommand,
 } from "../combat/index.js";
 
 /**
@@ -247,5 +249,24 @@ export const createUnassignBlockCommandFromAction: CommandFactory = (
     enemyInstanceId: action.enemyInstanceId,
     element: action.element,
     amount: action.amount,
+  });
+};
+
+/**
+ * Spend move on cumbersome command factory.
+ * Creates a command to spend move points to reduce a Cumbersome enemy's attack.
+ *
+ * Part of the Cumbersome ability system.
+ */
+export const createSpendMoveOnCumbersomeCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== SPEND_MOVE_ON_CUMBERSOME_ACTION) return null;
+  return createSpendMoveOnCumbersomeCommand({
+    playerId,
+    enemyInstanceId: action.enemyInstanceId,
+    movePointsToSpend: action.movePointsToSpend,
   });
 };

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -61,6 +61,7 @@ import {
   RESPOND_TO_COOPERATIVE_PROPOSAL_ACTION,
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
   USE_SKILL_ACTION,
+  SPEND_MOVE_ON_CUMBERSOME_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -91,6 +92,7 @@ export {
   createUnassignAttackCommandFromAction,
   createAssignBlockCommandFromAction,
   createUnassignBlockCommandFromAction,
+  createSpendMoveOnCumbersomeCommandFromAction,
 } from "./combat.js";
 
 // Unit factories
@@ -173,6 +175,7 @@ import {
   createUnassignAttackCommandFromAction,
   createAssignBlockCommandFromAction,
   createUnassignBlockCommandFromAction,
+  createSpendMoveOnCumbersomeCommandFromAction,
 } from "./combat.js";
 
 import {
@@ -278,4 +281,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [CANCEL_COOPERATIVE_PROPOSAL_ACTION]: createCancelProposalCommandFromAction,
   // Skill actions
   [USE_SKILL_ACTION]: createUseSkillCommandFromAction,
+  // Cumbersome ability actions
+  [SPEND_MOVE_ON_CUMBERSOME_ACTION]: createSpendMoveOnCumbersomeCommandFromAction,
 };

--- a/packages/core/src/engine/validators/combatValidators/cumbersomeValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/cumbersomeValidators.ts
@@ -1,0 +1,119 @@
+/**
+ * Cumbersome ability validators
+ *
+ * Validators for the SPEND_MOVE_ON_CUMBERSOME action.
+ * Players can spend Move points during the Block phase to reduce
+ * the attack of enemies with the Cumbersome ability.
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import type { ValidationResult } from "../types.js";
+import { valid, invalid } from "../types.js";
+import { SPEND_MOVE_ON_CUMBERSOME_ACTION } from "@mage-knight/shared";
+import { COMBAT_PHASE_BLOCK } from "../../../types/combat.js";
+import {
+  NOT_IN_COMBAT,
+  WRONG_COMBAT_PHASE,
+  ENEMY_NOT_FOUND,
+  NOT_ENOUGH_MOVE_POINTS,
+  CUMBERSOME_NOT_ACTIVE,
+  CUMBERSOME_INVALID_AMOUNT,
+} from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
+import { isCumbersomeActive } from "../../combat/cumbersomeHelpers.js";
+
+/**
+ * Validate that spend move on cumbersome action is during combat
+ */
+export function validateSpendCumbersomeInCombat(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== SPEND_MOVE_ON_CUMBERSOME_ACTION) return valid();
+
+  if (state.combat === null) {
+    return invalid(NOT_IN_COMBAT, "Not in combat");
+  }
+
+  return valid();
+}
+
+/**
+ * Validate that spend move on cumbersome action is in Block phase
+ */
+export function validateSpendCumbersomePhase(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== SPEND_MOVE_ON_CUMBERSOME_ACTION) return valid();
+
+  if (state.combat?.phase !== COMBAT_PHASE_BLOCK) {
+    return invalid(
+      WRONG_COMBAT_PHASE,
+      "Can only spend move points on Cumbersome enemies during Block phase"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * Validate that the target enemy exists and has active Cumbersome ability
+ */
+export function validateCumbersomeEnemy(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== SPEND_MOVE_ON_CUMBERSOME_ACTION) return valid();
+
+  const enemy = state.combat?.enemies.find(
+    (e) => e.instanceId === action.enemyInstanceId
+  );
+
+  if (!enemy) {
+    return invalid(ENEMY_NOT_FOUND, "Target enemy not found");
+  }
+
+  if (!isCumbersomeActive(state, playerId, enemy)) {
+    return invalid(
+      CUMBERSOME_NOT_ACTIVE,
+      "Target enemy does not have active Cumbersome ability"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * Validate that player has enough move points to spend
+ */
+export function validateHasMovePointsForCumbersome(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== SPEND_MOVE_ON_CUMBERSOME_ACTION) return valid();
+
+  const player = getPlayerById(state, playerId);
+  if (!player) return valid();
+
+  if (action.movePointsToSpend <= 0) {
+    return invalid(
+      CUMBERSOME_INVALID_AMOUNT,
+      "Must spend at least 1 move point"
+    );
+  }
+
+  if (action.movePointsToSpend > player.movePoints) {
+    return invalid(
+      NOT_ENOUGH_MOVE_POINTS,
+      `Insufficient move points: need ${action.movePointsToSpend}, have ${player.movePoints}`
+    );
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/combatValidators/index.ts
+++ b/packages/core/src/engine/validators/combatValidators/index.ts
@@ -62,3 +62,11 @@ export {
   validateHasAvailableBlock,
   validateHasAssignedBlockToUnassign,
 } from "./blockAssignmentValidators.js";
+
+// Cumbersome ability validators
+export {
+  validateSpendCumbersomeInCombat,
+  validateSpendCumbersomePhase,
+  validateCumbersomeEnemy,
+  validateHasMovePointsForCumbersome,
+} from "./cumbersomeValidators.js";

--- a/packages/core/src/engine/validators/registry/combatRegistry.ts
+++ b/packages/core/src/engine/validators/registry/combatRegistry.ts
@@ -21,6 +21,7 @@ import {
   UNASSIGN_ATTACK_ACTION,
   ASSIGN_BLOCK_ACTION,
   UNASSIGN_BLOCK_ACTION,
+  SPEND_MOVE_ON_CUMBERSOME_ACTION,
 } from "@mage-knight/shared";
 
 // Turn validators
@@ -73,6 +74,11 @@ import {
   validateUnassignBlockTargetEnemy,
   validateHasAvailableBlock,
   validateHasAssignedBlockToUnassign,
+  // Cumbersome ability validators
+  validateSpendCumbersomeInCombat,
+  validateSpendCumbersomePhase,
+  validateCumbersomeEnemy,
+  validateHasMovePointsForCumbersome,
 } from "../combatValidators/index.js";
 
 // Challenge rampaging validators
@@ -169,5 +175,13 @@ export const combatRegistry: Record<string, Validator[]> = {
     validateAssignBlockPhase,
     validateUnassignBlockTargetEnemy,
     validateHasAssignedBlockToUnassign,
+  ],
+  // Cumbersome ability action
+  [SPEND_MOVE_ON_CUMBERSOME_ACTION]: [
+    validateIsPlayersTurn,
+    validateSpendCumbersomeInCombat,
+    validateSpendCumbersomePhase,
+    validateCumbersomeEnemy,
+    validateHasMovePointsForCumbersome,
   ],
 };

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -107,6 +107,9 @@ export const ASSASSINATION_REQUIRES_HERO_TARGET = "ASSASSINATION_REQUIRES_HERO_T
 export const INVALID_ATTACK_INDEX = "INVALID_ATTACK_INDEX" as const;
 export const ATTACK_ALREADY_BLOCKED = "ATTACK_ALREADY_BLOCKED" as const;
 export const ATTACK_DAMAGE_ALREADY_ASSIGNED = "ATTACK_DAMAGE_ALREADY_ASSIGNED" as const;
+// Cumbersome ability validation codes
+export const CUMBERSOME_NOT_ACTIVE = "CUMBERSOME_NOT_ACTIVE" as const;
+export const CUMBERSOME_INVALID_AMOUNT = "CUMBERSOME_INVALID_AMOUNT" as const;
 
 // Unit validation codes
 export const NO_COMMAND_SLOTS = "NO_COMMAND_SLOTS" as const;
@@ -309,6 +312,8 @@ export type ValidationErrorCode =
   | typeof INVALID_ATTACK_INDEX
   | typeof ATTACK_ALREADY_BLOCKED
   | typeof ATTACK_DAMAGE_ALREADY_ASSIGNED
+  | typeof CUMBERSOME_NOT_ACTIVE
+  | typeof CUMBERSOME_INVALID_AMOUNT
   // Unit validation
   | typeof NO_COMMAND_SLOTS
   | typeof INSUFFICIENT_INFLUENCE

--- a/packages/core/src/types/combat.ts
+++ b/packages/core/src/types/combat.ts
@@ -135,6 +135,21 @@ export interface CombatState {
    * Undefined for standard single-player combat.
    */
   readonly enemyAssignments?: EnemyAssignments;
+  /**
+   * Move points spent on Cumbersome enemies to reduce their attack values.
+   * Maps enemy instance ID to the number of move points spent.
+   * Each move point reduces attack by 1 for the rest of the turn.
+   * Reduction applies BEFORE Swift doubling and persists through Assign Damage phase.
+   */
+  readonly cumbersomeReductions: CumbersomeReductionMap;
+}
+
+/**
+ * Map of enemy instance IDs to move points spent on them via Cumbersome ability.
+ * Each move point reduces the enemy's attack by 1.
+ */
+export type CumbersomeReductionMap = {
+  readonly [enemyInstanceId: string]: number;
 }
 
 // Options for special combat rules
@@ -196,6 +211,7 @@ export function createCombatState(
     pendingDamage: {},
     pendingBlock: {},
     combatContext: options?.combatContext ?? COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
   };
 
   // Only include enemyAssignments if provided (avoids exactOptionalPropertyTypes issues)

--- a/packages/core/src/types/enemy.ts
+++ b/packages/core/src/types/enemy.ts
@@ -5,6 +5,7 @@
 import {
   ENEMY_ABILITY_ASSASSINATION,
   ENEMY_ABILITY_BRUTAL,
+  ENEMY_ABILITY_CUMBERSOME,
   ENEMY_ABILITY_FORTIFIED,
   ENEMY_ABILITY_PARALYZE,
   ENEMY_ABILITY_POISON,
@@ -54,6 +55,7 @@ export type EnemyAbility =
   | { readonly type: typeof ENEMY_ABILITY_POISON }
   | { readonly type: typeof ENEMY_ABILITY_PARALYZE }
   | { readonly type: typeof ENEMY_ABILITY_ASSASSINATION }
+  | { readonly type: typeof ENEMY_ABILITY_CUMBERSOME }
   | { readonly type: typeof ENEMY_ABILITY_SUMMON; readonly pool: EnemyColor }
   | { readonly type: typeof ENEMY_ABILITY_SUMMON_GREEN; readonly pool: EnemyColor }
   | {

--- a/packages/core/src/types/enemyConstants.ts
+++ b/packages/core/src/types/enemyConstants.ts
@@ -20,3 +20,4 @@ export const ENEMY_ABILITY_SUMMON = "summon" as const;
 export const ENEMY_ABILITY_SUMMON_GREEN = "summon_green" as const;
 export const ENEMY_ABILITY_RESISTANCE = "resistance" as const;
 export const ENEMY_ABILITY_ASSASSINATION = "assassination" as const;
+export const ENEMY_ABILITY_CUMBERSOME = "cumbersome" as const;

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -371,6 +371,9 @@ export const UNASSIGN_ATTACK_ACTION = "UNASSIGN_ATTACK" as const;
 export const ASSIGN_BLOCK_ACTION = "ASSIGN_BLOCK" as const;
 export const UNASSIGN_BLOCK_ACTION = "UNASSIGN_BLOCK" as const;
 
+// Cumbersome ability - spend move points to reduce enemy attack
+export const SPEND_MOVE_ON_CUMBERSOME_ACTION = "SPEND_MOVE_ON_CUMBERSOME" as const;
+
 // Debug actions (dev-only)
 export const DEBUG_ADD_FAME_ACTION = "DEBUG_ADD_FAME" as const;
 export interface DebugAddFameAction {
@@ -519,6 +522,13 @@ export interface UnassignBlockAction {
   readonly amount: number;
 }
 
+// Spend move points to reduce Cumbersome enemy attack (for Cumbersome ability)
+export interface SpendMoveOnCumbersomeAction {
+  readonly type: typeof SPEND_MOVE_ON_CUMBERSOME_ACTION;
+  readonly enemyInstanceId: string;
+  readonly movePointsToSpend: number;
+}
+
 export type PlayerAction =
   // Movement
   | MoveAction
@@ -580,6 +590,8 @@ export type PlayerAction =
   // Incremental block assignment
   | AssignBlockAction
   | UnassignBlockAction
+  // Cumbersome ability
+  | SpendMoveOnCumbersomeAction
   // Debug actions (dev-only)
   | DebugAddFameAction
   | DebugTriggerLevelUpAction

--- a/packages/shared/src/events/combat/blocking.ts
+++ b/packages/shared/src/events/combat/blocking.ts
@@ -203,3 +203,67 @@ export interface BlockUnassignedEvent {
 export function isBlockUnassignedEvent(event: { type: string }): event is BlockUnassignedEvent {
   return event.type === BLOCK_UNASSIGNED;
 }
+
+// ============================================================================
+// MOVE_SPENT_ON_CUMBERSOME (Cumbersome ability)
+// ============================================================================
+
+/**
+ * Event type constant for spending move on Cumbersome enemy.
+ * @see MoveSpentOnCumbersomeEvent
+ */
+export const MOVE_SPENT_ON_CUMBERSOME = "MOVE_SPENT_ON_CUMBERSOME" as const;
+
+/**
+ * Emitted when move points are spent to reduce a Cumbersome enemy's attack.
+ *
+ * Each move point spent reduces the enemy's attack by 1 for the rest of
+ * the turn. An attack reduced to 0 is considered successfully blocked.
+ *
+ * @remarks
+ * - Only valid during BLOCK phase
+ * - Target enemy must have Cumbersome ability
+ * - Reduction applies BEFORE Swift doubling
+ * - Reduction persists through Assign Damage phase
+ *
+ * @example
+ * ```typescript
+ * if (event.type === MOVE_SPENT_ON_CUMBERSOME) {
+ *   updateEnemyAttackDisplay(event.enemyInstanceId, event.totalReduction);
+ * }
+ * ```
+ */
+export interface MoveSpentOnCumbersomeEvent {
+  readonly type: typeof MOVE_SPENT_ON_CUMBERSOME;
+  /** Instance ID of the enemy with Cumbersome ability */
+  readonly enemyInstanceId: string;
+  /** Move points spent in this action */
+  readonly movePointsSpent: number;
+  /** Total reduction applied to this enemy (cumulative) */
+  readonly totalReduction: number;
+}
+
+/**
+ * Creates a MoveSpentOnCumbersomeEvent.
+ */
+export function createMoveSpentOnCumbersomeEvent(
+  enemyInstanceId: string,
+  movePointsSpent: number,
+  totalReduction: number
+): MoveSpentOnCumbersomeEvent {
+  return {
+    type: MOVE_SPENT_ON_CUMBERSOME,
+    enemyInstanceId,
+    movePointsSpent,
+    totalReduction,
+  };
+}
+
+/**
+ * Type guard for MoveSpentOnCumbersomeEvent.
+ */
+export function isMoveSpentOnCumbersomeEvent(
+  event: { type: string }
+): event is MoveSpentOnCumbersomeEvent {
+  return event.type === MOVE_SPENT_ON_CUMBERSOME;
+}

--- a/packages/shared/src/events/combat/index.ts
+++ b/packages/shared/src/events/combat/index.ts
@@ -45,7 +45,7 @@ export * from "./resolution.js";
 // Import constants for the isCombatEvent guard
 import { COMBAT_TRIGGERED, COMBAT_STARTED, ENEMY_SUMMONED, SUMMONED_ENEMY_DISCARDED } from "./initiation.js";
 import { COMBAT_PHASE_CHANGED } from "./phases.js";
-import { ENEMY_BLOCKED, BLOCK_FAILED, BLOCK_ASSIGNED, BLOCK_UNASSIGNED } from "./blocking.js";
+import { ENEMY_BLOCKED, BLOCK_FAILED, BLOCK_ASSIGNED, BLOCK_UNASSIGNED, MOVE_SPENT_ON_CUMBERSOME } from "./blocking.js";
 import { ENEMY_DEFEATED, ATTACK_FAILED, ATTACK_ASSIGNED, ATTACK_UNASSIGNED } from "./attacks.js";
 import {
   DAMAGE_ASSIGNED,
@@ -80,5 +80,6 @@ export function isCombatEvent(event: { type: string }): boolean {
     PLAYER_WITHDREW,
     ENEMY_SUMMONED,
     SUMMONED_ENEMY_DISCARDED,
+    MOVE_SPENT_ON_CUMBERSOME,
   ].includes(event.type as typeof COMBAT_STARTED);
 }

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -171,6 +171,7 @@ import type {
   BlockFailedEvent,
   BlockAssignedEvent,
   BlockUnassignedEvent,
+  MoveSpentOnCumbersomeEvent,
   EnemyDefeatedEvent,
   AttackFailedEvent,
   AttackAssignedEvent,
@@ -343,6 +344,7 @@ export type GameEvent =
   | BlockFailedEvent
   | BlockAssignedEvent
   | BlockUnassignedEvent
+  | MoveSpentOnCumbersomeEvent
   | EnemyDefeatedEvent
   | AttackFailedEvent
   | AttackAssignedEvent

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -240,6 +240,8 @@ export type {
   // Skill options
   SkillOptions,
   ActivatableSkill,
+  // Cumbersome ability options
+  CumbersomeOption,
 } from "./types/validActions.js";
 
 // Shared value constants (sub-unions)

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -211,6 +211,14 @@ export interface CombatOptions {
 
   /** Valid block unassignment actions */
   readonly unassignableBlocks?: readonly UnassignBlockOption[];
+
+  // ---- Cumbersome options (BLOCK phase) ----
+
+  /** Cumbersome enemies that can have move points spent on them */
+  readonly cumbersomeOptions?: readonly CumbersomeOption[];
+
+  /** Available move points for Cumbersome reduction */
+  readonly availableMovePoints?: number;
 }
 
 export interface BlockOption {
@@ -394,6 +402,29 @@ export interface UnassignBlockOption {
   readonly enemyInstanceId: string;
   readonly element: AttackElement;
   readonly amount: number;
+}
+
+// ============================================================================
+// Cumbersome Ability (BLOCK phase)
+// ============================================================================
+
+/**
+ * Information about a Cumbersome enemy that can have move points spent on it.
+ * Present during BLOCK phase when there are Cumbersome enemies.
+ */
+export interface CumbersomeOption {
+  /** Instance ID of the enemy with Cumbersome ability */
+  readonly enemyInstanceId: string;
+  /** Enemy display name */
+  readonly enemyName: string;
+  /** Base attack value (before any reductions) */
+  readonly baseAttack: number;
+  /** Move points already spent on this enemy */
+  readonly currentReduction: number;
+  /** Current attack value after reduction (baseAttack - currentReduction) */
+  readonly reducedAttack: number;
+  /** Maximum additional move points that can be spent (min of playerMovePoints, reducedAttack) */
+  readonly maxAdditionalReduction: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Implements the **Cumbersome** enemy ability (#243) that allows players to spend Move points during the Block phase to reduce an enemy's attack
- Each Move point spent reduces the attack by 1; an attack reduced to 0 counts as successfully blocked
- Ensures correct order of operations: Cumbersome reduction applies **BEFORE** Swift doubling (blocking) and **BEFORE** Brutal doubling (damage)

## Implementation Details

### New Files
- `packages/core/src/engine/combat/cumbersomeHelpers.ts` - Core helper functions for Cumbersome logic
- `packages/core/src/engine/commands/combat/spendMoveOnCumbersomeCommand.ts` - Command with execute/undo
- `packages/core/src/engine/validators/combatValidators/cumbersomeValidators.ts` - Action validators
- `packages/core/src/engine/commands/combat/__tests__/cumbersome.test.ts` - Comprehensive tests (11 test cases)

### Key Changes
- `CombatState` now includes `cumbersomeReductions` map to track reductions per enemy
- `SPEND_MOVE_ON_CUMBERSOME_ACTION` registered in validator registry and command factory
- `validActions` returns `CumbersomeOption[]` during Block phase for eligible enemies
- `getEffectiveDamage()` applies Cumbersome reduction before Brutal doubling
- `getEffectiveBlockRequired()` applies Cumbersome reduction before Swift doubling
- Supports ability nullification via existing modifier system

## Test Plan
- [x] Spending Move points reduces enemy attack and deducts from player's movePoints
- [x] Cumbersome reduction tracked in CombatState persists through damage assignment
- [x] Multiple spends on same enemy accumulate correctly
- [x] Action fails when player has no Move points
- [x] Action fails when enemy doesn't have Cumbersome ability
- [x] Action fails when not in Block phase
- [x] Undo restores move points and removes reduction
- [x] Attack reduced to 0 counts as blocked with 0 block
- [x] Swift interaction: reduction applies BEFORE doubling (4-2=2, then 2*2=4 block needed)
- [x] Swift enemy with attack reduced to 0 counts as blocked
- [x] Partial reduction still requires remaining block

Closes #243