### PR TITLE
feat: implement discard-as-cost engine for Improvisation (#41)

### DIFF
--- a/packages/core/src/data/basicActions/helpers.ts
+++ b/packages/core/src/data/basicActions/helpers.ts
@@ -5,7 +5,7 @@ import {
   EFFECT_GAIN_HEALING, EFFECT_GAIN_MANA, EFFECT_DRAW_CARDS, EFFECT_APPLY_MODIFIER,
   EFFECT_CHOICE, EFFECT_COMPOUND, EFFECT_CHANGE_REPUTATION, EFFECT_GAIN_CRYSTAL,
   EFFECT_CONVERT_MANA_TO_CRYSTAL, EFFECT_CARD_BOOST, EFFECT_READY_UNIT,
-  EFFECT_MANA_DRAW_POWERED, EFFECT_TERRAIN_BASED_BLOCK,
+  EFFECT_MANA_DRAW_POWERED, EFFECT_TERRAIN_BASED_BLOCK, EFFECT_DISCARD_COST,
   COMBAT_TYPE_MELEE, COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
 import { MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE, type BasicManaColor } from "@mage-knight/shared";
@@ -129,4 +129,29 @@ export function grantExtraSourceDieWithBlackAsAnyColor(): CardEffect {
  */
 export function terrainBasedBlock(): CardEffect {
   return { type: EFFECT_TERRAIN_BASED_BLOCK };
+}
+
+/**
+ * Discard as cost effect.
+ * Requires discarding card(s) from hand before resolving the thenEffect.
+ * Used by Improvisation, which requires discarding a card to gain Move/Attack/etc.
+ *
+ * @param count - Number of cards to discard (usually 1)
+ * @param thenEffect - Effect to resolve after discarding
+ * @param optional - If true, player can skip discarding (and skip the effect)
+ * @param filterWounds - If true (default), wounds cannot be discarded
+ */
+export function discardCost(
+  count: number,
+  thenEffect: CardEffect,
+  optional: boolean = false,
+  filterWounds: boolean = true
+): CardEffect {
+  return {
+    type: EFFECT_DISCARD_COST,
+    count,
+    optional,
+    thenEffect,
+    filterWounds,
+  };
 }

--- a/packages/core/src/data/basicActions/red/improvisation.ts
+++ b/packages/core/src/data/basicActions/red/improvisation.ts
@@ -6,7 +6,7 @@ import {
   DEED_CARD_TYPE_BASIC_ACTION,
 } from "../../../types/cards.js";
 import { MANA_RED, CARD_IMPROVISATION } from "@mage-knight/shared";
-import { move, influence, attack, block, choice } from "../helpers.js";
+import { move, influence, attack, block, choice, discardCost } from "../helpers.js";
 
 export const IMPROVISATION: DeedCard = {
   id: CARD_IMPROVISATION,
@@ -16,8 +16,7 @@ export const IMPROVISATION: DeedCard = {
   categories: [CATEGORY_MOVEMENT, CATEGORY_COMBAT, CATEGORY_INFLUENCE],
   // Basic: Discard a card → Move 3, Influence 3, Attack 3, or Block 3
   // Powered: Discard a card → Move 5, Influence 5, Attack 5, or Block 5
-  // Note: Discard cost not modeled
-  basicEffect: choice(move(3), influence(3), attack(3), block(3)),
-  poweredEffect: choice(move(5), influence(5), attack(5), block(5)),
+  basicEffect: discardCost(1, choice(move(3), influence(3), attack(3), block(3))),
+  poweredEffect: discardCost(1, choice(move(5), influence(5), attack(5), block(5))),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -48,6 +48,9 @@ export const RESOLVE_GLADE_WOUND_COMMAND = "RESOLVE_GLADE_WOUND" as const;
 // Deep Mine command
 export const RESOLVE_DEEP_MINE_COMMAND = "RESOLVE_DEEP_MINE" as const;
 
+// Discard as cost command
+export const RESOLVE_DISCARD_COMMAND = "RESOLVE_DISCARD" as const;
+
 // Burn monastery command
 export const BURN_MONASTERY_COMMAND = "BURN_MONASTERY" as const;
 

--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -10,6 +10,7 @@
  * - createPlayCardCommandFromAction - Play a card from hand
  * - createPlayCardSidewaysCommandFromAction - Play a card sideways for move/influence/attack/block
  * - createResolveChoiceCommandFromAction - Resolve a pending choice from a card effect
+ * - createResolveDiscardCommandFromAction - Resolve a pending discard cost
  */
 
 import type { CommandFactory } from "./types.js";
@@ -19,6 +20,7 @@ import {
   PLAY_CARD_ACTION,
   PLAY_CARD_SIDEWAYS_ACTION,
   RESOLVE_CHOICE_ACTION,
+  RESOLVE_DISCARD_ACTION,
   MANA_BLACK,
 } from "@mage-knight/shared";
 import { createPlayCardCommand } from "../playCardCommand.js";
@@ -27,6 +29,7 @@ import {
   type SidewaysAs,
 } from "../playCardSidewaysCommand.js";
 import { createResolveChoiceCommand } from "../resolveChoiceCommand.js";
+import { createResolveDiscardCommand } from "../resolveDiscardCommand.js";
 import { getCard } from "../../validActions/cards/index.js";
 import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
 import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
@@ -242,5 +245,25 @@ export const createResolveChoiceCommandFromAction: CommandFactory = (
     playerId,
     choiceIndex,
     previousPendingChoice: player.pendingChoice,
+  });
+};
+
+/**
+ * Resolve discard command factory.
+ * Creates a command to resolve a pending discard cost from a card effect.
+ */
+export const createResolveDiscardCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_DISCARD_ACTION) return null;
+
+  const player = getPlayerById(state, playerId);
+  if (!player?.pendingDiscard) return null;
+
+  return createResolveDiscardCommand({
+    playerId,
+    cardIds: action.cardIds,
   });
 };

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -25,6 +25,7 @@ import {
   PLAY_CARD_ACTION,
   PLAY_CARD_SIDEWAYS_ACTION,
   RESOLVE_CHOICE_ACTION,
+  RESOLVE_DISCARD_ACTION,
   REST_ACTION,
   DECLARE_REST_ACTION,
   COMPLETE_REST_ACTION,
@@ -77,6 +78,7 @@ export {
   createPlayCardCommandFromAction,
   createPlayCardSidewaysCommandFromAction,
   createResolveChoiceCommandFromAction,
+  createResolveDiscardCommandFromAction,
 } from "./cards.js";
 
 // Combat factories
@@ -160,6 +162,7 @@ import {
   createPlayCardCommandFromAction,
   createPlayCardSidewaysCommandFromAction,
   createResolveChoiceCommandFromAction,
+  createResolveDiscardCommandFromAction,
 } from "./cards.js";
 
 import {
@@ -239,6 +242,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [PLAY_CARD_ACTION]: createPlayCardCommandFromAction,
   [PLAY_CARD_SIDEWAYS_ACTION]: createPlayCardSidewaysCommandFromAction,
   [RESOLVE_CHOICE_ACTION]: createResolveChoiceCommandFromAction,
+  [RESOLVE_DISCARD_ACTION]: createResolveDiscardCommandFromAction,
   [REST_ACTION]: createRestCommandFromAction,
   [DECLARE_REST_ACTION]: createDeclareRestCommandFromAction,
   [COMPLETE_REST_ACTION]: createCompleteRestCommandFromAction,

--- a/packages/core/src/engine/commands/resolveDiscardCommand.ts
+++ b/packages/core/src/engine/commands/resolveDiscardCommand.ts
@@ -1,0 +1,203 @@
+/**
+ * Resolve Discard Cost Command
+ *
+ * Handles player resolution of a pending discard cost (e.g., Improvisation).
+ * When a card effect requires discarding cards as a cost before gaining
+ * the benefit, this command processes the player's card selection.
+ *
+ * Flow:
+ * 1. Card played creates pendingDiscard state via EFFECT_DISCARD_COST
+ * 2. Player sends RESOLVE_DISCARD action with selected cardIds (or empty to skip if optional)
+ * 3. This command validates selection, moves cards to discard, clears pendingDiscard
+ * 4. Resolves the thenEffect to apply the card's benefit
+ *
+ * This command is reversible since it's part of normal card play flow.
+ */
+
+import type { Command, CommandResult } from "../commands.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, CardId } from "@mage-knight/shared";
+import { createCardDiscardedEvent } from "@mage-knight/shared";
+import type { Player } from "../../types/player.js";
+import { RESOLVE_DISCARD_COMMAND } from "./commandTypes.js";
+import { resolveEffect } from "../effects/index.js";
+import { getCardsEligibleForDiscardCost } from "../effects/discardEffects.js";
+
+export { RESOLVE_DISCARD_COMMAND };
+
+export interface ResolveDiscardCommandParams {
+  readonly playerId: string;
+  /** Card IDs to discard. Length must match pendingDiscard.count, or be empty if skipping (when optional). */
+  readonly cardIds: readonly CardId[];
+}
+
+export function createResolveDiscardCommand(
+  params: ResolveDiscardCommandParams
+): Command {
+  // Store previous state for undo
+  let previousPendingDiscard: Player["pendingDiscard"] = null;
+  let previousHand: readonly CardId[] = [];
+  let previousDiscard: readonly CardId[] = [];
+
+  return {
+    type: RESOLVE_DISCARD_COMMAND,
+    playerId: params.playerId,
+    isReversible: true, // Part of normal card play flow
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      if (!player.pendingDiscard) {
+        throw new Error("No pending discard cost to resolve");
+      }
+
+      const pendingDiscard = player.pendingDiscard;
+
+      // Store for undo
+      previousPendingDiscard = pendingDiscard;
+      previousHand = player.hand;
+      previousDiscard = player.discard;
+
+      const events: GameEvent[] = [];
+
+      // Check if player is skipping (empty cardIds with optional discard)
+      if (params.cardIds.length === 0) {
+        if (!pendingDiscard.optional) {
+          throw new Error(
+            "Cannot skip discard: discard is required (not optional)"
+          );
+        }
+
+        // Clear pending discard and don't resolve thenEffect (skipped the cost)
+        const updatedPlayer: Player = {
+          ...player,
+          pendingDiscard: null,
+        };
+
+        const newState: GameState = {
+          ...state,
+          players: state.players.map((p, i) =>
+            i === playerIndex ? updatedPlayer : p
+          ),
+        };
+
+        return {
+          state: newState,
+          events: [],
+        };
+      }
+
+      // Validate card count
+      if (params.cardIds.length !== pendingDiscard.count) {
+        throw new Error(
+          `Expected ${pendingDiscard.count} card(s) to discard, got ${params.cardIds.length}`
+        );
+      }
+
+      // Validate all cards are eligible
+      const eligibleCards = getCardsEligibleForDiscardCost(
+        player.hand,
+        pendingDiscard.filterWounds
+      );
+      for (const cardId of params.cardIds) {
+        if (!eligibleCards.includes(cardId)) {
+          throw new Error(
+            `Card ${cardId} is not eligible for discard (either not in hand or filtered out)`
+          );
+        }
+      }
+
+      // Move cards from hand to discard pile
+      const updatedHand = [...player.hand];
+      const discardedCards: CardId[] = [];
+
+      for (const cardId of params.cardIds) {
+        const index = updatedHand.indexOf(cardId);
+        if (index === -1) {
+          throw new Error(`Card ${cardId} not found in hand`);
+        }
+        updatedHand.splice(index, 1);
+        discardedCards.push(cardId);
+
+        // Emit discard event for each card
+        events.push(createCardDiscardedEvent(params.playerId, cardId));
+      }
+
+      const updatedDiscardPile = [...player.discard, ...discardedCards];
+
+      // Clear pending discard
+      const updatedPlayer: Player = {
+        ...player,
+        hand: updatedHand,
+        discard: updatedDiscardPile,
+        pendingDiscard: null,
+      };
+
+      let newState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? updatedPlayer : p
+        ),
+      };
+
+      // Now resolve the thenEffect since the cost was paid
+      const effectResult = resolveEffect(
+        newState,
+        params.playerId,
+        pendingDiscard.thenEffect,
+        pendingDiscard.sourceCardId
+      );
+
+      newState = effectResult.state;
+
+      return {
+        state: newState,
+        events,
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      // Restore previous state
+      const restoredPlayer: Player = {
+        ...player,
+        hand: previousHand,
+        discard: previousDiscard,
+        pendingDiscard: previousPendingDiscard,
+      };
+
+      const newState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? restoredPlayer : p
+        ),
+      };
+
+      return {
+        state: newState,
+        events: [],
+      };
+    },
+  };
+}

--- a/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
@@ -13,6 +13,7 @@ import {
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
+  EFFECT_DISCARD_COST,
 } from "../../../../types/effectTypes.js";
 import {
   COMBAT_TYPE_RANGED,
@@ -39,6 +40,9 @@ export function effectHasRangedOrSiege(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasRangedOrSiege(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasRangedOrSiege(effect.thenEffect);
 
     default:
       return false;
@@ -67,6 +71,9 @@ export function effectHasBlock(effect: CardEffect): boolean {
     case EFFECT_SCALING:
       return effectHasBlock(effect.baseEffect);
 
+    case EFFECT_DISCARD_COST:
+      return effectHasBlock(effect.thenEffect);
+
     default:
       return false;
   }
@@ -92,6 +99,9 @@ export function effectHasAttack(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasAttack(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasAttack(effect.thenEffect);
 
     default:
       return false;

--- a/packages/core/src/engine/validActions/cards/effectDetection/movementEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/movementEffects.ts
@@ -12,6 +12,7 @@ import {
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
+  EFFECT_DISCARD_COST,
 } from "../../../../types/effectTypes.js";
 
 /**
@@ -34,6 +35,9 @@ export function effectHasMove(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasMove(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasMove(effect.thenEffect);
 
     default:
       return false;
@@ -60,6 +64,9 @@ export function effectHasInfluence(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasInfluence(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasInfluence(effect.thenEffect);
 
     default:
       return false;

--- a/packages/core/src/engine/validActions/cards/effectDetection/resourceEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/resourceEffects.ts
@@ -14,6 +14,7 @@ import {
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
+  EFFECT_DISCARD_COST,
 } from "../../../../types/effectTypes.js";
 
 /**
@@ -36,6 +37,9 @@ export function effectHasHeal(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasHeal(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasHeal(effect.thenEffect);
 
     default:
       return false;
@@ -63,6 +67,9 @@ export function effectHasDraw(effect: CardEffect): boolean {
     case EFFECT_SCALING:
       return effectHasDraw(effect.baseEffect);
 
+    case EFFECT_DISCARD_COST:
+      return effectHasDraw(effect.thenEffect);
+
     default:
       return false;
   }
@@ -89,6 +96,9 @@ export function effectHasModifier(effect: CardEffect): boolean {
     case EFFECT_SCALING:
       return effectHasModifier(effect.baseEffect);
 
+    case EFFECT_DISCARD_COST:
+      return effectHasModifier(effect.thenEffect);
+
     default:
       return false;
   }
@@ -114,6 +124,9 @@ export function effectHasManaGain(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasManaGain(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasManaGain(effect.thenEffect);
 
     default:
       return false;

--- a/packages/core/src/engine/validActions/cards/effectDetection/specialEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/specialEffects.ts
@@ -16,6 +16,7 @@ import {
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
+  EFFECT_DISCARD_COST,
 } from "../../../../types/effectTypes.js";
 
 /**
@@ -38,6 +39,9 @@ export function effectHasManaDrawPowered(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasManaDrawPowered(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasManaDrawPowered(effect.thenEffect);
 
     default:
       return false;
@@ -66,6 +70,9 @@ export function effectHasCrystal(effect: CardEffect): boolean {
     case EFFECT_SCALING:
       return effectHasCrystal(effect.baseEffect);
 
+    case EFFECT_DISCARD_COST:
+      return effectHasCrystal(effect.thenEffect);
+
     default:
       return false;
   }
@@ -92,6 +99,9 @@ export function effectHasCardBoost(effect: CardEffect): boolean {
     case EFFECT_SCALING:
       return effectHasCardBoost(effect.baseEffect);
 
+    case EFFECT_DISCARD_COST:
+      return effectHasCardBoost(effect.thenEffect);
+
     default:
       return false;
   }
@@ -117,6 +127,9 @@ export function effectHasEnemyTargeting(effect: CardEffect): boolean {
 
     case EFFECT_SCALING:
       return effectHasEnemyTargeting(effect.baseEffect);
+
+    case EFFECT_DISCARD_COST:
+      return effectHasEnemyTargeting(effect.thenEffect);
 
     default:
       return false;

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -35,7 +35,7 @@ import { getManaOptions } from "./mana.js";
 import { getUnitOptionsForCombat, getFullUnitOptions } from "./units/index.js";
 import { getSiteOptions } from "./sites.js";
 import { getTacticsOptions, getTacticEffectsOptions, getPendingTacticDecision } from "./tactics.js";
-import { getGladeWoundOptions, getDeepMineOptions } from "./pending.js";
+import { getGladeWoundOptions, getDeepMineOptions, getDiscardCostOptions } from "./pending.js";
 import { getChallengeOptions } from "./challenge.js";
 import { getCooperativeAssaultOptions } from "./cooperativeAssault.js";
 import { getSkillOptions } from "./skills.js";
@@ -91,6 +91,7 @@ export function getValidActions(
       tacticEffects: undefined,
       gladeWound: undefined,
       deepMine: undefined,
+      discardCost: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
       skills: undefined,
@@ -121,6 +122,7 @@ export function getValidActions(
         tacticEffects: { pendingDecision },
         gladeWound: undefined,
         deepMine: undefined,
+        discardCost: undefined,
         levelUpRewards: undefined,
         cooperativeAssault: undefined,
         skills: undefined,
@@ -144,6 +146,7 @@ export function getValidActions(
       tacticEffects: undefined,
       gladeWound: undefined,
       deepMine: undefined,
+      discardCost: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
       skills: undefined,
@@ -179,6 +182,7 @@ export function getValidActions(
       tacticEffects: undefined,
       gladeWound: gladeWoundOptions,
       deepMine: undefined,
+      discardCost: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
       skills: undefined,
@@ -214,6 +218,43 @@ export function getValidActions(
       tacticEffects: undefined,
       gladeWound: undefined,
       deepMine: deepMineOptions,
+      discardCost: undefined,
+      levelUpRewards: undefined,
+      cooperativeAssault: undefined,
+      skills: undefined,
+    };
+  }
+
+  // Handle pending discard cost - must resolve before other actions
+  if (player.pendingDiscard) {
+    const discardCostOptions = getDiscardCostOptions(state, player);
+    return {
+      canAct: true,
+      reason: undefined,
+      move: undefined,
+      explore: undefined,
+      playCard: undefined,
+      combat: undefined,
+      units: undefined,
+      sites: undefined,
+      mana: undefined,
+      turn: {
+        canEndTurn: false,
+        canAnnounceEndOfRound: false,
+        canUndo: getTurnOptions(state, player).canUndo, // Can undo card play that caused this
+        canRest: false,
+        restTypes: undefined,
+        canDeclareRest: false,
+        canCompleteRest: false,
+        isResting: false,
+      },
+      tactics: undefined,
+      enterCombat: undefined,
+      challenge: undefined,
+      tacticEffects: undefined,
+      gladeWound: undefined,
+      deepMine: undefined,
+      discardCost: discardCostOptions,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
       skills: undefined,
@@ -250,6 +291,7 @@ export function getValidActions(
         tacticEffects: undefined,
         gladeWound: undefined,
         deepMine: undefined,
+        discardCost: undefined,
         levelUpRewards: {
           level: firstPending.level,
           drawnSkills: firstPending.drawnSkills,
@@ -291,6 +333,7 @@ export function getValidActions(
       tacticEffects: undefined,
       gladeWound: undefined,
       deepMine: undefined,
+      discardCost: undefined,
       levelUpRewards: undefined,
       cooperativeAssault: undefined,
       skills: undefined,
@@ -330,6 +373,7 @@ export function getValidActions(
         tacticEffects: undefined,
         gladeWound: undefined,
         deepMine: undefined,
+        discardCost: undefined,
         levelUpRewards: undefined,
         cooperativeAssault: undefined,
         skills: getSkillOptions(state, player),
@@ -358,6 +402,7 @@ export function getValidActions(
     tacticEffects: getTacticEffectsOptions(state, player),
     gladeWound: undefined,
     deepMine: undefined,
+    discardCost: undefined,
     levelUpRewards: undefined,
     cooperativeAssault: getCooperativeAssaultOptions(state, player),
     skills: getSkillOptions(state, player),

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -4,14 +4,16 @@
  * Handles special pending states that require player resolution:
  * - Glade wound discard choices
  * - Deep mine crystal color choices
+ * - Discard as cost choices
  */
 
 import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
-import type { GladeWoundOptions, DeepMineOptions, BasicManaColor } from "@mage-knight/shared";
+import type { GladeWoundOptions, DeepMineOptions, BasicManaColor, DiscardCostOptions } from "@mage-knight/shared";
 import { mineColorToBasicManaColor } from "../../types/map.js";
 import { CARD_WOUND, hexKey } from "@mage-knight/shared";
 import { SiteType } from "../../types/map.js";
+import { getCardsEligibleForDiscardCost } from "../effects/discardEffects.js";
 
 /**
  * Get Magical Glade wound discard options for the player.
@@ -67,5 +69,31 @@ export function getDeepMineOptions(
 
   return {
     availableColors,
+  };
+}
+
+/**
+ * Get discard cost options for the player.
+ * Returns options if player has a pending discard cost to resolve.
+ */
+export function getDiscardCostOptions(
+  _state: GameState,
+  player: Player
+): DiscardCostOptions | undefined {
+  // Check if player has a pending discard cost
+  if (!player.pendingDiscard) {
+    return undefined;
+  }
+
+  const { sourceCardId, count, optional, filterWounds } = player.pendingDiscard;
+
+  // Get eligible cards from hand
+  const availableCardIds = getCardsEligibleForDiscardCost(player.hand, filterWounds);
+
+  return {
+    sourceCardId,
+    availableCardIds,
+    count,
+    optional,
   };
 }

--- a/packages/core/src/engine/validators/discardValidators.ts
+++ b/packages/core/src/engine/validators/discardValidators.ts
@@ -1,0 +1,97 @@
+/**
+ * Discard as cost validators
+ *
+ * Validates RESOLVE_DISCARD actions for cards that require discarding
+ * a card as a cost before gaining their benefit (e.g., Improvisation).
+ */
+
+import type { Validator, ValidationResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import { RESOLVE_DISCARD_ACTION } from "@mage-knight/shared";
+import { valid, invalid } from "./types.js";
+import {
+  DISCARD_COST_REQUIRED,
+  DISCARD_COST_INVALID_COUNT,
+  DISCARD_COST_CARD_NOT_ELIGIBLE,
+  DISCARD_COST_CANNOT_SKIP,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+import { getCardsEligibleForDiscardCost } from "../effects/discardEffects.js";
+
+/**
+ * Validate that the player has a pending discard cost
+ */
+export const validateHasPendingDiscard: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid("PLAYER_NOT_FOUND", "Player not found");
+  }
+
+  if (!player.pendingDiscard) {
+    return invalid(DISCARD_COST_REQUIRED, "No pending discard cost to resolve");
+  }
+
+  return valid();
+};
+
+/**
+ * Validate the discard action selection
+ */
+export const validateDiscardSelection: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_DISCARD_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid("PLAYER_NOT_FOUND", "Player not found");
+  }
+
+  if (!player.pendingDiscard) {
+    return valid(); // Let the other validator handle this
+  }
+
+  const { count, optional, filterWounds } = player.pendingDiscard;
+  const cardIds = action.cardIds;
+
+  // If skipping (empty cardIds), must be optional
+  if (cardIds.length === 0) {
+    if (!optional) {
+      return invalid(
+        DISCARD_COST_CANNOT_SKIP,
+        "Cannot skip: discard is required (not optional)"
+      );
+    }
+    return valid();
+  }
+
+  // Check card count matches
+  if (cardIds.length !== count) {
+    return invalid(
+      DISCARD_COST_INVALID_COUNT,
+      `Expected ${count} card(s) to discard, got ${cardIds.length}`
+    );
+  }
+
+  // Check all cards are eligible
+  const eligibleCards = getCardsEligibleForDiscardCost(player.hand, filterWounds);
+  for (const cardId of cardIds) {
+    if (!eligibleCards.includes(cardId)) {
+      return invalid(
+        DISCARD_COST_CARD_NOT_ELIGIBLE,
+        `Card ${cardId} is not eligible for discard`
+      );
+    }
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -1,6 +1,6 @@
 /**
  * Choice/resolution action validator registry
- * Handles RESOLVE_CHOICE_ACTION, SELECT_REWARD_ACTION, RESOLVE_GLADE_WOUND_ACTION, RESOLVE_DEEP_MINE_ACTION
+ * Handles RESOLVE_CHOICE_ACTION, SELECT_REWARD_ACTION, RESOLVE_GLADE_WOUND_ACTION, RESOLVE_DEEP_MINE_ACTION, RESOLVE_DISCARD_ACTION
  */
 
 import type { Validator } from "../types.js";
@@ -9,6 +9,7 @@ import {
   SELECT_REWARD_ACTION,
   RESOLVE_GLADE_WOUND_ACTION,
   RESOLVE_DEEP_MINE_ACTION,
+  RESOLVE_DISCARD_ACTION,
 } from "@mage-knight/shared";
 
 // Turn validators
@@ -43,6 +44,12 @@ import {
   validateDeepMineColorChoice,
 } from "../deepMineValidators.js";
 
+// Discard cost validators
+import {
+  validateHasPendingDiscard,
+  validateDiscardSelection,
+} from "../discardValidators.js";
+
 export const choiceRegistry: Record<string, Validator[]> = {
   [RESOLVE_CHOICE_ACTION]: [
     validateIsPlayersTurn,
@@ -66,5 +73,10 @@ export const choiceRegistry: Record<string, Validator[]> = {
     validateIsPlayersTurn,
     validateHasPendingDeepMineChoice,
     validateDeepMineColorChoice,
+  ],
+  [RESOLVE_DISCARD_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingDiscard,
+    validateDiscardSelection,
   ],
 };

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -179,6 +179,12 @@ export const GLADE_WOUND_NO_WOUNDS_IN_DISCARD = "GLADE_WOUND_NO_WOUNDS_IN_DISCAR
 export const DEEP_MINE_CHOICE_REQUIRED = "DEEP_MINE_CHOICE_REQUIRED" as const;
 export const DEEP_MINE_INVALID_COLOR = "DEEP_MINE_INVALID_COLOR" as const;
 
+// Discard as cost validation codes
+export const DISCARD_COST_REQUIRED = "DISCARD_COST_REQUIRED" as const;
+export const DISCARD_COST_INVALID_COUNT = "DISCARD_COST_INVALID_COUNT" as const;
+export const DISCARD_COST_CARD_NOT_ELIGIBLE = "DISCARD_COST_CARD_NOT_ELIGIBLE" as const;
+export const DISCARD_COST_CANNOT_SKIP = "DISCARD_COST_CANNOT_SKIP" as const;
+
 // Spell purchase validation codes
 export const SPELL_NOT_IN_OFFER = "SPELL_NOT_IN_OFFER" as const;
 export const NOT_AT_SPELL_SITE = "NOT_AT_SPELL_SITE" as const;
@@ -368,6 +374,11 @@ export type ValidationErrorCode =
   // Deep Mine validation
   | typeof DEEP_MINE_CHOICE_REQUIRED
   | typeof DEEP_MINE_INVALID_COLOR
+  // Discard as cost validation
+  | typeof DISCARD_COST_REQUIRED
+  | typeof DISCARD_COST_INVALID_COUNT
+  | typeof DISCARD_COST_CARD_NOT_ELIGIBLE
+  | typeof DISCARD_COST_CANNOT_SKIP
   // Spell purchase validation
   | typeof SPELL_NOT_IN_OFFER
   | typeof NOT_AT_SPELL_SITE

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -38,6 +38,7 @@ import {
   EFFECT_REVEAL_TILES,
   EFFECT_PAY_MANA,
   EFFECT_TERRAIN_BASED_BLOCK,
+  EFFECT_DISCARD_COST,
   MANA_ANY,
   type CombatType,
 } from "./effectTypes.js";
@@ -413,6 +414,29 @@ export interface TerrainBasedBlockEffect {
   readonly type: typeof EFFECT_TERRAIN_BASED_BLOCK;
 }
 
+/**
+ * Discard from hand as a cost, then execute a follow-up effect.
+ * Used by cards like Improvisation that require discarding before gaining benefit.
+ *
+ * Resolution:
+ * 1. Create pendingDiscard state with selectable cards
+ * 2. Player selects card(s) to discard via RESOLVE_DISCARD action
+ * 3. Discard happens, then thenEffect resolves
+ *
+ * Undo from card selection undoes the entire card play.
+ */
+export interface DiscardCostEffect {
+  readonly type: typeof EFFECT_DISCARD_COST;
+  /** How many cards must be discarded (usually 1) */
+  readonly count: number;
+  /** If true, discarding is optional (player can skip) */
+  readonly optional: boolean;
+  /** Effect to resolve after discarding succeeds */
+  readonly thenEffect: CardEffect;
+  /** If true, wounds cannot be discarded (default: true per standard rules) */
+  readonly filterWounds?: boolean;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -445,7 +469,8 @@ export type CardEffect =
   | DiscardCardEffect
   | RevealTilesEffect
   | PayManaCostEffect
-  | TerrainBasedBlockEffect;
+  | TerrainBasedBlockEffect
+  | DiscardCostEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -90,3 +90,7 @@ export const EFFECT_DISCARD_CARD = "discard_card" as const;
 export const EFFECT_REVEAL_TILES = "reveal_tiles" as const;
 // Pay mana as a cost (for skill activations)
 export const EFFECT_PAY_MANA = "pay_mana" as const;
+
+// === Discard as Cost Effect ===
+// Discard cards from hand as a cost, then resolve a follow-up effect (e.g., Improvisation)
+export const EFFECT_DISCARD_COST = "discard_cost" as const;

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -155,6 +155,24 @@ export interface PendingChoice {
   readonly options: readonly CardEffect[];
 }
 
+/**
+ * Pending discard cost resolution.
+ * Set when a card effect requires discarding cards as a cost (e.g., Improvisation).
+ * Contains source card and count needed for UI display and validation.
+ */
+export interface PendingDiscard {
+  /** Source card that triggered the discard requirement */
+  readonly sourceCardId: CardId;
+  /** How many cards must be discarded */
+  readonly count: number;
+  /** If true, discarding is optional (can skip) */
+  readonly optional: boolean;
+  /** Effect to resolve after discarding */
+  readonly thenEffect: CardEffect;
+  /** If true, wounds cannot be selected (default: true) */
+  readonly filterWounds: boolean;
+}
+
 // === Tactic-specific state types ===
 
 // Tactic-specific persistent state (survives across turns within a round)
@@ -282,6 +300,9 @@ export interface Player {
 
   // Magical Glade wound discard choice pending (when wounds exist in both hand and discard)
   readonly pendingGladeWoundChoice: boolean;
+
+  // Discard as cost pending (e.g., Improvisation requires discarding a card before gaining benefit)
+  readonly pendingDiscard: PendingDiscard | null;
 
   // Resting state: true when player has declared rest but not yet completed it
   // While resting, movement/combat/interaction are blocked but cards can still be played

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -560,6 +560,7 @@ export class GameServer {
       pendingRewards: [],
       pendingGladeWoundChoice: false,
       pendingDeepMineChoice: null,
+      pendingDiscard: null,
       healingPoints: 0,
       removedCards: [],
       isResting: false,

--- a/packages/server/src/stateFilters.ts
+++ b/packages/server/src/stateFilters.ts
@@ -23,6 +23,7 @@ import type {
   ClientPlayerUnit,
   ClientManaToken,
   ClientPendingChoice,
+  ClientPendingDiscard,
   ClientCombatState,
   ClientCombatEnemy,
   ClientHexEnemy,
@@ -227,6 +228,26 @@ export function toClientPlayer(player: Player, forPlayerId: string): ClientPlaye
 
     // Pending level ups (levels crossed, processed at end of turn)
     pendingLevelUps: player.pendingLevelUps,
+
+    // Pending discard cost (filters out thenEffect which is internal state)
+    pendingDiscard: player.pendingDiscard
+      ? toClientPendingDiscard(player.pendingDiscard)
+      : null,
+  };
+}
+
+/**
+ * Convert a PendingDiscard to ClientPendingDiscard.
+ * Filters out the thenEffect (internal implementation detail).
+ */
+export function toClientPendingDiscard(
+  pendingDiscard: NonNullable<Player["pendingDiscard"]>
+): ClientPendingDiscard {
+  return {
+    sourceCardId: pendingDiscard.sourceCardId,
+    count: pendingDiscard.count,
+    optional: pendingDiscard.optional,
+    filterWounds: pendingDiscard.filterWounds,
   };
 }
 

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -351,6 +351,14 @@ export interface ResolveDeepMineAction {
   readonly color: BasicManaColor; // The chosen crystal color
 }
 
+// Discard as cost action (e.g., Improvisation requires discarding before gaining benefit)
+export const RESOLVE_DISCARD_ACTION = "RESOLVE_DISCARD" as const;
+export interface ResolveDiscardAction {
+  readonly type: typeof RESOLVE_DISCARD_ACTION;
+  /** Card IDs to discard (length must match pendingDiscard.count, or empty to skip if optional) */
+  readonly cardIds: readonly CardId[];
+}
+
 // Combat action constants
 export const ENTER_COMBAT_ACTION = "ENTER_COMBAT" as const;
 export const CHALLENGE_RAMPAGING_ACTION = "CHALLENGE_RAMPAGING" as const;
@@ -567,6 +575,8 @@ export type PlayerAction =
   | ResolveGladeWoundAction
   // Deep Mine
   | ResolveDeepMineAction
+  // Discard as cost
+  | ResolveDiscardAction
   // Combat
   | EnterCombatAction
   | ChallengeRampagingAction

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -176,6 +176,7 @@ export type {
   ClientCombatState,
   ClientCombatEnemy,
   ClientPendingChoice,
+  ClientPendingDiscard,
   ClientPendingLevelUpReward,
 } from "./types/clientState.js";
 
@@ -232,6 +233,8 @@ export type {
   GladeWoundOptions,
   // Deep mine options
   DeepMineOptions,
+  // Discard cost options
+  DiscardCostOptions,
   // Level up rewards options
   LevelUpRewardsOptions,
   // Cooperative assault options

--- a/packages/shared/src/types/clientState.ts
+++ b/packages/shared/src/types/clientState.ts
@@ -41,6 +41,17 @@ export interface ClientPendingChoice {
   }[];
 }
 
+/**
+ * Pending discard as cost (e.g., Improvisation requires discarding before gaining benefit).
+ * Client-visible version omits thenEffect (internal state).
+ */
+export interface ClientPendingDiscard {
+  readonly sourceCardId: CardId;
+  readonly count: number;
+  readonly optional: boolean;
+  readonly filterWounds: boolean;
+}
+
 // Crystals (same as core, but defined here for independence)
 export interface ClientCrystals {
   readonly red: number;
@@ -151,6 +162,9 @@ export interface ClientPlayer {
 
   // Magical Glade wound discard choice pending
   readonly pendingGladeWoundChoice: boolean;
+
+  // Discard as cost pending (e.g., Improvisation)
+  readonly pendingDiscard: ClientPendingDiscard | null;
 
   // Deep Mine crystal color choice pending (available colors to choose from)
   readonly pendingDeepMineChoice: readonly BasicManaColor[] | null;

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -76,6 +76,9 @@ export interface ValidActions {
   /** Deep Mine crystal choice options (at end of turn) */
   readonly deepMine: DeepMineOptions | undefined;
 
+  /** Discard as cost options (when pendingDiscard is active) */
+  readonly discardCost: DiscardCostOptions | undefined;
+
   /** Level up reward options (when pending level up rewards exist) */
   readonly levelUpRewards: LevelUpRewardsOptions | undefined;
 
@@ -664,6 +667,25 @@ export interface GladeWoundOptions {
 export interface DeepMineOptions {
   /** Available crystal colors to choose from */
   readonly availableColors: readonly BasicManaColor[];
+}
+
+// ============================================================================
+// Discard as Cost
+// ============================================================================
+
+/**
+ * Options for discard as cost resolution (e.g., Improvisation).
+ * Only present when player has a pending discard cost.
+ */
+export interface DiscardCostOptions {
+  /** Source card that triggered the discard */
+  readonly sourceCardId: CardId;
+  /** Cards available to discard (filtered based on rules, e.g., no wounds) */
+  readonly availableCardIds: readonly CardId[];
+  /** How many cards must be selected */
+  readonly count: number;
+  /** If true, player can skip discarding */
+  readonly optional: boolean;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Adds `EFFECT_DISCARD_COST` effect type for cards requiring a card discard before gaining their benefit
- Implements complete pending state flow: effect creates `pendingDiscard` → player resolves via `RESOLVE_DISCARD_ACTION` → `thenEffect` resolves
- Updates Improvisation card to correctly model the discard cost mechanic

## Changes
- **Types**: New `DiscardCostEffect`, `PendingDiscard`, `ClientPendingDiscard`, `DiscardCostOptions`, `ResolveDiscardAction`
- **Effect Handler**: `handleDiscardCostEffect()` creates pending state
- **Command**: `resolveDiscardCommand.ts` handles player resolution (reversible for undo)
- **Validators**: `discardValidators.ts` validates card count and eligibility
- **ValidActions**: Shows `discardCost` options when `pendingDiscard` is active
- **Effect Detection**: All detection functions now look through `EFFECT_DISCARD_COST` wrappers
- **Card Helper**: `discardCost()` helper for card definitions
- **Improvisation**: Updated to use `discardCost(1, choice(move, influence, attack, block))`

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 1,289 tests pass (`pnpm test`)
- [x] Improvisation card correctly shows as playable with attack option in combat (existing test)
- [ ] Manual testing: Play Improvisation, verify discard prompt appears, select card, verify effect resolves
- [ ] Manual testing: Verify undo reverts the discard cost resolution

Closes #41