### PR TITLE
feat: implement Open map slot generation with column limits

### DIFF
--- a/packages/core/src/engine/validators/registry/movementRegistry.ts
+++ b/packages/core/src/engine/validators/registry/movementRegistry.ts
@@ -35,6 +35,7 @@ import {
   validateExploreMoveCost,
   validateTilesAvailable,
   validateCoreNotOnCoastline,
+  validateColumnLimit,
 } from "../exploreValidators.js";
 
 // Choice validators
@@ -83,6 +84,7 @@ export const movementRegistry: Record<string, Validator[]> = {
     validateExploreDirection, // Uses getValidExploreOptions which checks all tiles and adjacency
     validateWedgeDirection, // Wedge maps only allow NE/E directions
     validateCoreNotOnCoastline, // Wedge maps: core tiles cannot be on coastline
+    validateColumnLimit, // Open 3/4/5 maps: enforce column limits
     validateSlotNotFilled, // Now handled by validateExploreDirection
   ],
 };

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -27,6 +27,7 @@ export const NO_TILES_AVAILABLE = "NO_TILES_AVAILABLE" as const;
 export const SLOT_ALREADY_FILLED = "SLOT_ALREADY_FILLED" as const;
 export const INVALID_WEDGE_DIRECTION = "INVALID_WEDGE_DIRECTION" as const;
 export const CORE_TILE_ON_COASTLINE = "CORE_TILE_ON_COASTLINE" as const;
+export const COLUMN_LIMIT_EXCEEDED = "COLUMN_LIMIT_EXCEEDED" as const;
 
 // Card play validation codes
 export const CARD_NOT_IN_HAND = "CARD_NOT_IN_HAND" as const;
@@ -253,6 +254,7 @@ export type ValidationErrorCode =
   | typeof SLOT_ALREADY_FILLED
   | typeof INVALID_WEDGE_DIRECTION
   | typeof CORE_TILE_ON_COASTLINE
+  | typeof COLUMN_LIMIT_EXCEEDED
   | typeof CARD_NOT_IN_HAND
   | typeof CARD_NOT_FOUND
   | typeof CANNOT_PLAY_WOUND

--- a/packages/core/src/types/map.ts
+++ b/packages/core/src/types/map.ts
@@ -197,6 +197,8 @@ export interface TileSlot {
   readonly coord: HexCoord;
   /** Row in the grid (0 = starting tile, 1 = first expansion, etc.) */
   readonly row: number;
+  /** Column relative to center (0 = center, negative = left, positive = right) */
+  readonly column: number;
   /** Whether this slot has a tile placed in it */
   readonly filled: boolean;
 }


### PR DESCRIPTION
## Summary

Implement slot generation for Open map shapes (3, 4, 5 columns) with column tracking and limits.

- Add `column` field to `TileSlot` interface for lateral position tracking
- Implement `generateOpenSlots` function for diamond/kite shaped map grids
- Add `validateColumnLimit` validator to enforce map shape boundaries
- Update `ValidActions` exploration logic to filter options by column limits
- Add helper functions: `getColumnRangeForShape`, `getMaxColumnsForShape`, `isColumnValid`

## Column Ranges

| Shape   | Columns | Range (relative to center) |
|---------|---------|---------------------------|
| Open 5  | 5       | -2, -1, 0, +1, +2 (symmetric) |
| Open 4  | 4       | -1, 0, +1, +2 (asymmetric, leans right) |
| Open 3  | 3       | -1, 0, +1 (symmetric) |

## Test Plan

- [x] All 1317 existing tests pass
- [x] Added 27 new tests covering:
  - TileSlot column field assignment for wedge and open maps
  - `generateOpenSlots` creates correct diamond shape
  - Column limit enforcement for Open 3/4/5 maps
  - `getColumnRangeForShape` returns correct ranges
  - `getMaxColumnsForShape` returns correct values
  - `isColumnValid` validates columns correctly

Closes #557