### PR TITLE
feat: implement Sorcerers unit abilities with effect-based system (#292)

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit Ability Effects Registry
+ *
+ * This module defines CardEffect-based abilities for units that need
+ * complex effect resolution (compound effects, enemy targeting, etc.).
+ *
+ * Unit definitions in @mage-knight/shared reference these by effectId.
+ * The activation command looks up the effect here and resolves it.
+ *
+ * @module data/unitAbilityEffects
+ */
+
+import { ABILITY_FORTIFIED } from "@mage-knight/shared";
+import type { CardEffect } from "../types/cards.js";
+import {
+  EFFECT_SELECT_COMBAT_ENEMY,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_RANGED,
+} from "../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_ABILITY_NULLIFIER,
+  EFFECT_REMOVE_RESISTANCES,
+} from "../types/modifierConstants.js";
+
+// =============================================================================
+// EFFECT IDS
+// =============================================================================
+
+/**
+ * Sorcerers: White mana ability
+ * Strip fortification from one enemy + Ranged Attack 3
+ */
+export const SORCERERS_STRIP_FORTIFICATION = "sorcerers_strip_fortification" as const;
+
+/**
+ * Sorcerers: Green mana ability
+ * Strip resistances from one enemy + Ranged Attack 3
+ */
+export const SORCERERS_STRIP_RESISTANCES = "sorcerers_strip_resistances" as const;
+
+// =============================================================================
+// EFFECT DEFINITIONS
+// =============================================================================
+
+/**
+ * Sorcerers' White mana ability effect.
+ * Targets an enemy and:
+ * 1. Removes fortification (blocked by Arcane Immunity)
+ * 2. Grants Ranged Attack 3 (always works, bundled with targeting)
+ *
+ * Using bundledEffect ensures the ranged attack resolves after targeting,
+ * even when auto-resolving single-enemy scenarios.
+ *
+ * The bundled attack must be used in the same phase or is forfeited
+ * (standard combat accumulator behavior handles this).
+ */
+const SORCERERS_STRIP_FORTIFICATION_EFFECT: CardEffect = {
+  type: EFFECT_SELECT_COMBAT_ENEMY,
+  template: {
+    modifiers: [
+      {
+        modifier: { type: EFFECT_ABILITY_NULLIFIER, ability: ABILITY_FORTIFIED },
+        duration: DURATION_COMBAT,
+        description: "Target enemy loses fortification",
+      },
+    ],
+    bundledEffect: {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 3,
+      combatType: COMBAT_TYPE_RANGED,
+    },
+  },
+};
+
+/**
+ * Sorcerers' Green mana ability effect.
+ * Targets an enemy and:
+ * 1. Removes all resistances (blocked by Arcane Immunity)
+ * 2. Grants Ranged Attack 3 (always works, bundled with targeting)
+ *
+ * Using bundledEffect ensures the ranged attack resolves after targeting,
+ * even when auto-resolving single-enemy scenarios.
+ *
+ * The bundled attack must be used in the same phase or is forfeited
+ * (standard combat accumulator behavior handles this).
+ */
+const SORCERERS_STRIP_RESISTANCES_EFFECT: CardEffect = {
+  type: EFFECT_SELECT_COMBAT_ENEMY,
+  template: {
+    modifiers: [
+      {
+        modifier: { type: EFFECT_REMOVE_RESISTANCES },
+        duration: DURATION_COMBAT,
+        description: "Target enemy loses all resistances",
+      },
+    ],
+    bundledEffect: {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 3,
+      combatType: COMBAT_TYPE_RANGED,
+    },
+  },
+};
+
+// =============================================================================
+// REGISTRY
+// =============================================================================
+
+/**
+ * Registry mapping effect IDs to their CardEffect definitions.
+ * Used by activateUnitCommand to resolve effect-based unit abilities.
+ */
+export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
+  [SORCERERS_STRIP_FORTIFICATION]: SORCERERS_STRIP_FORTIFICATION_EFFECT,
+  [SORCERERS_STRIP_RESISTANCES]: SORCERERS_STRIP_RESISTANCES_EFFECT,
+};
+
+/**
+ * Get an effect by ID.
+ * @param effectId - The effect ID to look up
+ * @returns The CardEffect or undefined if not found
+ */
+export function getUnitAbilityEffect(effectId: string): CardEffect | undefined {
+  return UNIT_ABILITY_EFFECTS[effectId];
+}

--- a/packages/core/src/engine/__tests__/unitSorcerers.test.ts
+++ b/packages/core/src/engine/__tests__/unitSorcerers.test.ts
@@ -1,0 +1,540 @@
+/**
+ * Sorcerers Unit Ability Tests
+ *
+ * Sorcerers have three abilities:
+ * 1. Basic Ranged Attack 3 (no mana cost)
+ * 2. (White Mana) Strip fortifications from one enemy + Ranged Attack 3
+ * 3. (Green Mana) Strip resistances from one enemy + Ranged Attack 3
+ *
+ * FAQ Notes:
+ * - Arcane Immunity blocks fortification/resistance removal, but ranged attack still works
+ * - Bundled ranged attack must be used in same phase or forfeited
+ * - Can target different enemies for debuff vs attack (compound effect)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+} from "./testHelpers.js";
+import {
+  INVALID_ACTION,
+  UNIT_SORCERERS,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  UNIT_ACTIVATED,
+  CHOICE_REQUIRED,
+  MANA_SOURCE_TOKEN,
+  MANA_WHITE,
+  MANA_GREEN,
+  ENEMY_GUARDSMEN,
+  ENEMY_GOLEMS,
+  ENEMY_SORCERERS,
+  ABILITY_FORTIFIED,
+  getEnemy,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_ATTACK,
+  type CombatState,
+  type CombatEnemy,
+} from "../../types/combat.js";
+import {
+  isAbilityNullified,
+  areResistancesRemoved,
+} from "../modifiers/index.js";
+import { SORCERERS } from "@mage-knight/shared";
+
+/**
+ * Create a combat state with customizable enemies for Sorcerers tests
+ */
+function createSorcerersCombatState(
+  phase: "ranged_siege" | "attack",
+  enemies: CombatEnemy[],
+  isAtFortifiedSite = false
+): CombatState {
+  return {
+    enemies,
+    phase,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+  };
+}
+
+/**
+ * Create a combat enemy from an enemy ID
+ */
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isBlocked: false,
+    isDefeated: false,
+    isRequiredForConquest: true,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+  };
+}
+
+describe("Sorcerers Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(SORCERERS.name).toBe("Sorcerers");
+      expect(SORCERERS.level).toBe(3);
+      expect(SORCERERS.influence).toBe(9);
+      expect(SORCERERS.armor).toBe(4);
+    });
+
+    it("should have three abilities", () => {
+      expect(SORCERERS.abilities.length).toBe(3);
+    });
+
+    it("should have basic Ranged Attack 3 as first ability (no mana cost)", () => {
+      const ability = SORCERERS.abilities[0];
+      expect(ability?.type).toBe("ranged_attack");
+      expect(ability?.value).toBe(3);
+      expect(ability?.manaCost).toBeUndefined();
+    });
+
+    it("should have Strip Fortification + Ranged Attack 3 as second ability (white mana)", () => {
+      const ability = SORCERERS.abilities[1];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBe(MANA_WHITE);
+      expect(ability?.displayName).toContain("Fortification");
+    });
+
+    it("should have Strip Resistances + Ranged Attack 3 as third ability (green mana)", () => {
+      const ability = SORCERERS.abilities[2];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBe(MANA_GREEN);
+      expect(ability?.displayName).toContain("Resistances");
+    });
+  });
+
+  describe("Basic Ranged Attack (Ability 0)", () => {
+    it("should activate basic ranged attack and add to accumulator", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 0, // Basic Ranged Attack 3
+      });
+
+      // Verify ranged attack added to accumulator
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+
+      // Verify unit is now spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Check event was emitted
+      const activateEvent = result.events.find(
+        (e) => e.type === UNIT_ACTIVATED
+      );
+      expect(activateEvent).toBeDefined();
+    });
+
+    it("should allow basic ranged attack in attack phase", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 0, // Basic Ranged Attack 3
+      });
+
+      // Verify success
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should not require mana for basic ability", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [], // No mana available
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 0, // Basic Ranged Attack 3
+      });
+
+      // Should succeed without mana
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+    });
+  });
+
+  describe("Strip Fortification Effect (Ability 1 - White Mana)", () => {
+    it("should require white mana", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [], // No mana
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 1, // Strip Fortification + Ranged Attack 3
+      });
+
+      // Should fail - no mana source provided
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should activate with white mana token and add ranged attack", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Create a fortified enemy (Guardsmen have ABILITY_FORTIFIED)
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 1, // Strip Fortification + Ranged Attack 3
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Verify unit is spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Verify mana token was consumed
+      expect(result.state.players[0].pureMana.length).toBe(0);
+
+      // Verify ranged attack added (3 from the effect)
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+
+      // Verify fortification is nullified on enemy
+      expect(isAbilityNullified(result.state, "player1", "enemy_0", ABILITY_FORTIFIED)).toBe(true);
+    });
+
+    it("should strip fortification modifier from targeted enemy", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Create two enemies, both fortified
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN),
+        createCombatEnemy("enemy_1", ENEMY_GUARDSMEN),
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Step 1: Activate ability - this creates a pending choice for enemy selection
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // With multiple enemies, a choice should be required
+      expect(activateResult.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = activateResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      // Step 2: Resolve choice by selecting enemy_0
+      const choiceResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Select first enemy
+      });
+
+      // First enemy should have fortification nullified
+      expect(isAbilityNullified(choiceResult.state, "player1", "enemy_0", ABILITY_FORTIFIED)).toBe(true);
+
+      // Second enemy should still be fortified (only one enemy targeted)
+      expect(isAbilityNullified(choiceResult.state, "player1", "enemy_1", ABILITY_FORTIFIED)).toBe(false);
+
+      // Ranged attack should have been added
+      expect(choiceResult.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+    });
+  });
+
+  describe("Strip Resistances Effect (Ability 2 - Green Mana)", () => {
+    it("should require green mana", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [], // No mana
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 2, // Strip Resistances + Ranged Attack 3
+      });
+
+      // Should fail - no mana source provided
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should activate with green mana token and add ranged attack", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_GREEN, source: "card" }],
+      });
+
+      // Create an enemy with resistances (Golems have physical/ice resistance)
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 2, // Strip Resistances + Ranged Attack 3
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      });
+
+      // Verify unit is spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Verify mana token was consumed
+      expect(result.state.players[0].pureMana.length).toBe(0);
+
+      // Verify ranged attack added
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+
+      // Verify resistances are removed on enemy
+      expect(areResistancesRemoved(result.state, "enemy_0")).toBe(true);
+    });
+
+    it("should strip resistances only from targeted enemy", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_GREEN, source: "card" }],
+      });
+
+      // Create two enemies with resistances
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GOLEMS),
+        createCombatEnemy("enemy_1", ENEMY_GOLEMS),
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Step 1: Activate ability - this creates a pending choice for enemy selection
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 2,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      });
+
+      // With multiple enemies, a choice should be required
+      expect(activateResult.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = activateResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      // Step 2: Resolve choice by selecting enemy_0
+      const choiceResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Select first enemy
+      });
+
+      // First enemy should have resistances removed
+      expect(areResistancesRemoved(choiceResult.state, "enemy_0")).toBe(true);
+
+      // Second enemy should still have resistances
+      expect(areResistancesRemoved(choiceResult.state, "enemy_1")).toBe(false);
+
+      // Ranged attack should have been added
+      expect(choiceResult.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+    });
+  });
+
+  describe("Arcane Immunity Interaction", () => {
+    it("should not strip fortification from Arcane Immune enemy but still add ranged attack", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Enemy Sorcerers have Arcane Immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_SORCERERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 1, // Strip Fortification + Ranged Attack 3
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Unit should be spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Ranged attack should still be added (per FAQ)
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+
+      // Fortification should NOT be nullified (Arcane Immunity blocks it)
+      expect(isAbilityNullified(result.state, "player1", "enemy_0", ABILITY_FORTIFIED)).toBe(false);
+    });
+
+    it("should not strip resistances from Arcane Immune enemy but still add ranged attack", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_GREEN, source: "card" }],
+      });
+
+      // Enemy Sorcerers have Arcane Immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_SORCERERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createSorcerersCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 2, // Strip Resistances + Ranged Attack 3
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      });
+
+      // Unit should be spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Ranged attack should still be added (per FAQ)
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+
+      // Resistances should NOT be removed (Arcane Immunity blocks it)
+      expect(areResistancesRemoved(result.state, "enemy_0")).toBe(false);
+    });
+  });
+
+  describe("Combat Requirement", () => {
+    it("should reject effect abilities when not in combat", () => {
+      const unit = createPlayerUnit(UNIT_SORCERERS, "sorcerers_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // No combat state
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "sorcerers_1",
+        abilityIndex: 1, // Strip Fortification + Ranged Attack 3
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Unit should still be ready (action rejected)
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+
+      // Check for invalid action event
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/engine/commands/playCard/choiceHandling.ts
+++ b/packages/core/src/engine/commands/playCard/choiceHandling.ts
@@ -130,6 +130,7 @@ export function handleChoiceEffect(
     pendingChoice: {
       cardId,
       skillId: null,
+      unitInstanceId: null,
       options: resolvableOptions,
     },
   };

--- a/packages/core/src/engine/commands/resolveChoiceCommand.ts
+++ b/packages/core/src/engine/commands/resolveChoiceCommand.ts
@@ -179,6 +179,7 @@ export function createResolveChoiceCommand(
           pendingChoice: {
             cardId: player.pendingChoice.cardId, // Keep original card ID for context
             skillId: player.pendingChoice.skillId, // Keep original skill ID for context
+            unitInstanceId: player.pendingChoice.unitInstanceId, // Keep original unit ID for context
             options: resolvableOptions,
           },
         };

--- a/packages/core/src/engine/commands/skills/shieldMasteryEffect.ts
+++ b/packages/core/src/engine/commands/skills/shieldMasteryEffect.ts
@@ -49,6 +49,7 @@ export function applyShieldMasteryEffect(
     pendingChoice: {
       cardId: null,
       skillId: SKILL_TOVAK_SHIELD_MASTERY,
+      unitInstanceId: null,
       options: [
         block(3),      // Physical Block 3
         fireBlock(2),  // Fire Block 2 (efficient vs ice attacks)

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -67,8 +67,8 @@ function registerAllEffects(resolver: EffectHandler): void {
   // Card boost effects (CardBoost, ResolveBoostTarget)
   registerCardBoostEffects(resolver);
 
-  // Combat enemy targeting effects
-  registerCombatEffects();
+  // Combat enemy targeting effects (pass resolver for bundled effect support)
+  registerCombatEffects(resolver);
 
   // Mana draw effects (ManaDrawPowered, ManaDrawPickDie, ManaDrawSetColor)
   registerManaDrawEffects();

--- a/packages/core/src/engine/validators/units/activationValidators.ts
+++ b/packages/core/src/engine/validators/units/activationValidators.ts
@@ -21,6 +21,7 @@ import {
   UNIT_ABILITY_BLOCK,
   UNIT_ABILITY_RANGED_ATTACK,
   UNIT_ABILITY_SIEGE_ATTACK,
+  UNIT_ABILITY_EFFECT,
   UNIT_ABILITY_SWIFT,
   UNIT_ABILITY_BRUTAL,
   UNIT_ABILITY_POISON,
@@ -214,7 +215,9 @@ export function validateAbilityMatchesPhase(
   switch (ability.type) {
     case UNIT_ABILITY_RANGED_ATTACK:
     case UNIT_ABILITY_SIEGE_ATTACK:
+    case UNIT_ABILITY_EFFECT:
       // Valid in Ranged & Siege phase or Attack phase
+      // Effect-based abilities (like Sorcerers) include ranged attacks so follow ranged rules
       if (phase !== COMBAT_PHASE_RANGED_SIEGE && phase !== COMBAT_PHASE_ATTACK) {
         return invalid(
           WRONG_PHASE_FOR_ABILITY,
@@ -325,11 +328,13 @@ export function validateCombatRequiredForAbility(
   if (!ability) return valid(); // Other validator handles
 
   // Combat abilities require being in combat
+  // Note: UNIT_ABILITY_EFFECT is treated as combat (Sorcerers' effects target enemies)
   const combatAbilities: readonly string[] = [
     UNIT_ABILITY_ATTACK,
     UNIT_ABILITY_BLOCK,
     UNIT_ABILITY_RANGED_ATTACK,
     UNIT_ABILITY_SIEGE_ATTACK,
+    UNIT_ABILITY_EFFECT,
   ];
 
   if (combatAbilities.includes(ability.type) && !state.combat) {

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -321,6 +321,12 @@ export interface CombatEnemyTargetTemplate {
   }[];
   /** If true, defeat the enemy immediately (for powered versions like Tornado) */
   readonly defeat?: boolean;
+  /**
+   * Optional bundled effect to resolve AFTER applying modifiers/defeat.
+   * Used by Sorcerers' abilities to grant ranged attack after stripping fortification/resistances.
+   * Note: The bundled effect is NOT blocked by Arcane Immunity - it always resolves.
+   */
+  readonly bundledEffect?: CardEffect;
 }
 
 /**

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -147,11 +147,12 @@ export function getTotalBlock(accumulator: CombatAccumulator): number {
   return accumulator.block;
 }
 
-// Pending choice - when a card or skill requires player selection
+// Pending choice - when a card, skill, or unit ability requires player selection
 export interface PendingChoice {
-  // Source of the choice - either a card or a skill (exactly one should be set)
+  // Source of the choice - exactly one should be set
   readonly cardId: CardId | null;
   readonly skillId: SkillId | null;
+  readonly unitInstanceId: string | null; // For unit effect-based abilities (e.g., Sorcerers)
   readonly options: readonly CardEffect[];
 }
 

--- a/packages/shared/src/units/constants.ts
+++ b/packages/shared/src/units/constants.ts
@@ -40,3 +40,5 @@ export const UNIT_ABILITY_BRUTAL = "brutal" as const satisfies UnitAbilityType;
 export const UNIT_ABILITY_POISON = "poison" as const satisfies UnitAbilityType;
 export const UNIT_ABILITY_PARALYZE =
   "paralyze" as const satisfies UnitAbilityType;
+export const UNIT_ABILITY_EFFECT =
+  "effect" as const satisfies UnitAbilityType;

--- a/packages/shared/src/units/elite/sorcerers.ts
+++ b/packages/shared/src/units/elite/sorcerers.ts
@@ -1,15 +1,32 @@
 /**
  * Sorcerers unit definition
+ *
+ * Abilities:
+ * 1. Basic Ranged Attack 3
+ * 2. (White Mana) Strip fortifications from one enemy + Ranged Attack 3
+ * 3. (Green Mana) Strip resistances from one enemy + Ranged Attack 3
+ *
+ * FAQ Notes:
+ * - Arcane Immunity blocks fortification/resistance removal, but ranged attack still works
+ * - Bundled ranged attack must be used in same phase or forfeited
+ * - Can target different enemies for debuff vs attack (compound effect)
  */
 
+import { MANA_WHITE, MANA_GREEN } from "../../ids.js";
 import { RESIST_FIRE, RESIST_ICE } from "../../enemies/index.js";
 import type { UnitDefinition } from "../types.js";
 import {
   UNIT_TYPE_ELITE,
   RECRUIT_SITE_MAGE_TOWER,
   RECRUIT_SITE_MONASTERY,
+  UNIT_ABILITY_RANGED_ATTACK,
+  UNIT_ABILITY_EFFECT,
 } from "../constants.js";
 import { UNIT_SORCERERS } from "../ids.js";
+
+// Effect IDs reference effects defined in core/src/data/unitAbilityEffects.ts
+const SORCERERS_STRIP_FORTIFICATION = "sorcerers_strip_fortification";
+const SORCERERS_STRIP_RESISTANCES = "sorcerers_strip_resistances";
 
 export const SORCERERS: UnitDefinition = {
   id: UNIT_SORCERERS,
@@ -20,6 +37,26 @@ export const SORCERERS: UnitDefinition = {
   armor: 4,
   resistances: [RESIST_FIRE, RESIST_ICE],
   recruitSites: [RECRUIT_SITE_MAGE_TOWER, RECRUIT_SITE_MONASTERY],
-  abilities: [], // Special: provides two mana tokens
+  abilities: [
+    // Basic: Ranged Attack 3 (no mana cost)
+    {
+      type: UNIT_ABILITY_RANGED_ATTACK,
+      value: 3,
+    },
+    // White mana: Strip fortification from one enemy + Ranged Attack 3
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: SORCERERS_STRIP_FORTIFICATION,
+      displayName: "Strip Fortification + Ranged Attack 3",
+      manaCost: MANA_WHITE,
+    },
+    // Green mana: Strip resistances from one enemy + Ranged Attack 3
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: SORCERERS_STRIP_RESISTANCES,
+      displayName: "Strip Resistances + Ranged Attack 3",
+      manaCost: MANA_GREEN,
+    },
+  ],
   copies: 2,
 };

--- a/packages/shared/src/units/index.ts
+++ b/packages/shared/src/units/index.ts
@@ -66,6 +66,7 @@ export {
   UNIT_ABILITY_BRUTAL,
   UNIT_ABILITY_POISON,
   UNIT_ABILITY_PARALYZE,
+  UNIT_ABILITY_EFFECT,
 } from "./constants.js";
 
 // =============================================================================

--- a/packages/shared/src/units/types.ts
+++ b/packages/shared/src/units/types.ts
@@ -42,7 +42,8 @@ export type UnitAbilityType =
   | "swift"
   | "brutal"
   | "poison"
-  | "paralyze";
+  | "paralyze"
+  | "effect";
 
 /**
  * Re-use EnemyResistances interface for consistency
@@ -80,6 +81,17 @@ export interface UnitAbility {
    * If undefined, the ability is free to use.
    */
   readonly manaCost?: ManaColor;
+  /**
+   * For effect-based abilities (type="effect"), this ID references the effect
+   * definition in core's unit ability effects registry. The effect will be
+   * resolved using the standard card effect system.
+   */
+  readonly effectId?: string;
+  /**
+   * Display name for the ability (used for effect-based abilities).
+   * Simple abilities derive their name from the type field.
+   */
+  readonly displayName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implement the Sorcerers elite unit (level 3) with correct abilities per the rulebook
- Create a new effect-based unit ability system that reuses the existing card effect infrastructure
- The three abilities are:
  1. **Basic Ranged Attack 3** (no mana cost)
  2. **Strip Fortification + Ranged Attack 3** (white mana) - removes fortification from one enemy
  3. **Strip Resistances + Ranged Attack 3** (green mana) - removes all resistances from one enemy

### Key Implementation Details

- **New `UNIT_ABILITY_EFFECT` type** - extends UnitAbilityType for complex effects
- **Unit ability effects registry** (`core/src/data/unitAbilityEffects.ts`) - maps effectId to CardEffect definitions
- **Extended `CombatEnemyTargetTemplate`** - new `bundledEffect` field ensures ranged attack resolves after enemy targeting
- **Updated `activateUnitCommand`** - handles effect-based abilities via the standard effect resolution system
- **Arcane Immunity interaction** - correctly blocks debuff effects but NOT the bundled ranged attack (per FAQ)

### Files Changed

| Area | Files |
|------|-------|
| Types | `shared/units/types.ts`, `shared/units/constants.ts`, `core/types/cards.ts`, `core/types/player.ts` |
| Unit Definition | `shared/units/elite/sorcerers.ts` |
| Effect System | `core/data/unitAbilityEffects.ts` (new), `core/engine/effects/combatEffects.ts` |
| Commands | `core/engine/commands/units/activateUnitCommand.ts` |
| Validators | `core/engine/validators/units/activationValidators.ts`, `core/engine/validActions/units/activation.ts` |
| Tests | `core/engine/__tests__/unitSorcerers.test.ts` (new - 17 tests) |

## Test Plan

- [x] All 17 new Sorcerers unit tests pass
- [x] All 1307 existing tests pass (2 skipped as before)
- [x] Lint passes
- [x] Build passes

### Test Coverage

1. **Unit Definition Tests** - verify ability structure and mana costs
2. **Basic Ranged Attack Tests** - works in ranged/attack phase, no mana needed
3. **Strip Fortification Tests** - requires white mana, applies modifier to targeted enemy only
4. **Strip Resistances Tests** - requires green mana, applies modifier to targeted enemy only
5. **Arcane Immunity Tests** - debuffs blocked but ranged attack works
6. **Combat Requirement Tests** - rejects effect abilities outside combat

Closes #292