### PR TITLE
feat: add scoringConfig to ScenarioConfig and wire up game end

### DIFF
--- a/packages/core/src/data/scenarios/firstReconnaissance.ts
+++ b/packages/core/src/data/scenarios/firstReconnaissance.ts
@@ -25,6 +25,8 @@ import {
   SCORING_CATEGORY_ACHIEVEMENTS,
   TACTIC_REMOVAL_ALL_USED,
   DUMMY_TACTIC_AFTER_HUMANS,
+  BASE_SCORE_INDIVIDUAL_FAME,
+  ACHIEVEMENT_MODE_SOLO,
   type ScenarioConfig,
 } from "@mage-knight/shared";
 
@@ -89,4 +91,15 @@ export const FIRST_RECONNAISSANCE: ScenarioConfig = {
       category: SCORING_CATEGORY_COMBAT,
     },
   ],
+
+  // Scoring configuration (new system)
+  // Solo intro scenario - achievements enabled but no titles (solo mode)
+  scoringConfig: {
+    baseScoreMode: BASE_SCORE_INDIVIDUAL_FAME,
+    achievements: {
+      enabled: true,
+      mode: ACHIEVEMENT_MODE_SOLO,
+    },
+    modules: [],
+  },
 };

--- a/packages/core/src/data/scenarios/fullConquestStub.ts
+++ b/packages/core/src/data/scenarios/fullConquestStub.ts
@@ -15,7 +15,11 @@ import {
   EXPANSION_SHADES_OF_TEZLA,
   TACTIC_REMOVAL_ALL_USED,
   DUMMY_TACTIC_AFTER_HUMANS,
+  BASE_SCORE_INDIVIDUAL_FAME,
+  ACHIEVEMENT_MODE_COMPETITIVE,
+  SCORING_MODULE_CITY_CONQUEST,
   type ScenarioConfig,
+  type CityConquestModule,
 } from "@mage-knight/shared";
 
 export const FULL_CONQUEST_STUB: ScenarioConfig = {
@@ -67,4 +71,24 @@ export const FULL_CONQUEST_STUB: ScenarioConfig = {
       category: SCORING_CATEGORY_ACHIEVEMENTS,
     },
   ],
+
+  // Scoring configuration (new system)
+  // Competitive scenario with city conquest module
+  scoringConfig: {
+    baseScoreMode: BASE_SCORE_INDIVIDUAL_FAME,
+    achievements: {
+      enabled: true,
+      mode: ACHIEVEMENT_MODE_COMPETITIVE,
+    },
+    modules: [
+      {
+        type: SCORING_MODULE_CITY_CONQUEST,
+        leaderPoints: 7,
+        participantPoints: 4,
+        titleName: "Greatest City Conqueror",
+        titleBonus: 5,
+        titleTiedBonus: 2,
+      } satisfies CityConquestModule,
+    ],
+  },
 };

--- a/packages/core/src/engine/commands/endRound/gameEnd.ts
+++ b/packages/core/src/engine/commands/endRound/gameEnd.ts
@@ -38,8 +38,10 @@ export function checkGameEnd(
   const events: GameEvent[] = [];
 
   // Calculate final scores using the full scoring system
+  // Use scenario's scoringConfig if provided, otherwise fall back to default
   const isSolo = state.players.length === 1;
-  const scoringConfig = createDefaultScoringConfig(isSolo);
+  const scoringConfig =
+    state.scenarioConfig.scoringConfig ?? createDefaultScoringConfig(isSolo);
   const finalScoreResult = calculateFinalScores(state, scoringConfig);
 
   // Convert to simple format for event
@@ -62,6 +64,7 @@ export function checkGameEnd(
     type: GAME_ENDED,
     winningPlayerId,
     finalScores,
+    fullScoreResult: finalScoreResult,
   });
 
   return {

--- a/packages/shared/src/events/lifecycle/game.ts
+++ b/packages/shared/src/events/lifecycle/game.ts
@@ -6,6 +6,8 @@
  * @module events/lifecycle/game
  */
 
+import type { FinalScoreResult } from "../../scoring/index.js";
+
 // ============================================================================
 // GAME_STARTED
 // ============================================================================
@@ -112,6 +114,8 @@ export interface GameEndedEvent {
     readonly playerId: string;
     readonly score: number;
   }[];
+  /** Full scoring breakdown for detailed display (optional for backwards compatibility) */
+  readonly fullScoreResult?: FinalScoreResult;
 }
 
 /**
@@ -119,17 +123,25 @@ export interface GameEndedEvent {
  *
  * @param winningPlayerId - ID of winner, or null for tie
  * @param finalScores - Array of player IDs and their scores
+ * @param fullScoreResult - Optional full scoring breakdown
  * @returns A new GameEndedEvent
  */
 export function createGameEndedEvent(
   winningPlayerId: string | null,
-  finalScores: readonly { readonly playerId: string; readonly score: number }[]
+  finalScores: readonly { readonly playerId: string; readonly score: number }[],
+  fullScoreResult?: FinalScoreResult
 ): GameEndedEvent {
-  return {
+  const event: GameEndedEvent = {
     type: GAME_ENDED,
     winningPlayerId,
     finalScores,
   };
+
+  if (fullScoreResult !== undefined) {
+    return { ...event, fullScoreResult };
+  }
+
+  return event;
 }
 
 /**

--- a/packages/shared/src/scenarios.ts
+++ b/packages/shared/src/scenarios.ts
@@ -5,6 +5,7 @@
  */
 
 import type { HexDirection } from "./hex.js";
+import type { ScenarioScoringConfig } from "./scoring/index.js";
 
 // === Tactic Removal Modes ===
 // Defines what happens to tactics at end of each day/night
@@ -189,4 +190,7 @@ export interface ScenarioConfig {
 
   // Scoring
   readonly scoringRules: readonly ScoringRule[];
+
+  /** Optional scoring configuration. If not provided, uses basic fame only. */
+  readonly scoringConfig?: ScenarioScoringConfig;
 }


### PR DESCRIPTION
## Summary

- Adds optional `scoringConfig` field to `ScenarioConfig` interface in shared package
- Adds `scoringConfig` to First Reconnaissance scenario (solo mode, achievements enabled, no modules)
- Adds `scoringConfig` to Full Conquest stub (competitive mode with city conquest module)
- Updates game end logic to use scenario's `scoringConfig` with fallback to default
- Updates `GameEndedEvent` to include full `FinalScoreResult` for detailed UI display

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All 1416 existing tests pass
- [x] Backwards compatible - scenarios without `scoringConfig` still work via `createDefaultScoringConfig()` fallback

Closes #563