### PR TITLE
feat: implement Earthquake fortification-conditional armor reduction

### DIFF
--- a/packages/core/src/data/spells/red/tremor.ts
+++ b/packages/core/src/data/spells/red/tremor.ts
@@ -1,7 +1,13 @@
 /**
  * Tremor / Earthquake (Red Spell #11)
- * Basic: Target enemy gets Armor -3, OR all enemies get Armor -2.
- * Powered: Target enemy gets Armor -4, OR all enemies get Armor -3.
+ * Basic: Target enemy gets Armor -3, OR all enemies get Armor -2. Armor cannot be reduced below 1.
+ * Powered: Target enemy gets Armor -3 (or -6 if fortified), OR all enemies get Armor -2 (or -4 if fortified).
+ *          Armor cannot be reduced below 1.
+ *
+ * Rules Notes:
+ * - "Fortified" means the enemy either has the Fortified ability OR is a site defender at a fortified site.
+ * - Doubly fortified (site + ability) still gets the same reduction as singly fortified.
+ * - Arcane Immune enemies are unaffected by both Tremor and Earthquake.
  */
 
 import type { DeedCard } from "../../../types/cards.js";
@@ -74,11 +80,12 @@ export const TREMOR: DeedCard = {
               modifier: {
                 type: EFFECT_ENEMY_STAT,
                 stat: ENEMY_STAT_ARMOR,
-                amount: -4,
+                amount: -3,
+                fortifiedAmount: -6,
                 minimum: 1,
               },
               duration: DURATION_COMBAT,
-              description: "Target enemy gets Armor -4",
+              description: "Target enemy gets Armor -3 (or -6 if fortified)",
             },
           ],
         },
@@ -90,10 +97,11 @@ export const TREMOR: DeedCard = {
         modifier: {
           type: EFFECT_ENEMY_STAT,
           stat: ENEMY_STAT_ARMOR,
-          amount: -3,
+          amount: -2,
+          fortifiedAmount: -4,
           minimum: 1,
         },
-        description: "All enemies get Armor -3",
+        description: "All enemies get Armor -2 (or -4 if fortified)",
       },
     ],
   },

--- a/packages/core/src/engine/commands/combat/declareAttackCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareAttackCommand.ts
@@ -109,7 +109,8 @@ export function createDeclareAttackCommand(
           state,
           e.instanceId,
           baseArmor,
-          resistanceCount
+          resistanceCount,
+          params.playerId
         );
       }, 0);
 

--- a/packages/core/src/engine/validActions/combatAttack.ts
+++ b/packages/core/src/engine/validActions/combatAttack.ts
@@ -126,7 +126,7 @@ export function computeEnemyAttackState(
   // Then apply modifiers (Tremor, Vampiric, etc.)
   const baseArmor = getBaseArmorForPhase(enemy, combat.phase, state, playerId);
   const resistanceCount = enemy.definition.resistances.length;
-  const armor = getEffectiveEnemyArmor(state, enemy.instanceId, baseArmor, resistanceCount);
+  const armor = getEffectiveEnemyArmor(state, enemy.instanceId, baseArmor, resistanceCount, playerId);
   const canDefeat = totalEffectiveDamage >= armor;
 
   // Determine if enemy is fortified - check both site fortification and enemy ability

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -139,6 +139,7 @@ export interface EnemyStatModifier {
   readonly amount: number;
   readonly minimum: number; // usually 1
   readonly perResistance?: boolean; // Resistance Break: -1 per resistance
+  readonly fortifiedAmount?: number; // Earthquake: alternative amount if target is fortified
 }
 
 // Rule override modifier (e.g., "ignore fortification")


### PR DESCRIPTION
## Summary

Implements the Earthquake spell's fortification-conditional armor reduction for issue #210.

- Added `fortifiedAmount` field to `EnemyStatModifier` for fortification-based armor reduction
- Earthquake now correctly applies: -3/-6 (single target, fortified) or -2/-4 (all enemies, fortified)
- Updated `getEffectiveEnemyArmor()` to check fortification status and use appropriate amount
- Doubly fortified enemies (site + ability) receive same reduction as singly fortified

## Changes

- **packages/core/src/types/modifiers.ts**: Added `fortifiedAmount?: number` to `EnemyStatModifier`
- **packages/core/src/engine/modifiers/combat.ts**: Updated armor calculation to check fortification
- **packages/core/src/data/spells/red/tremor.ts**: Updated Earthquake with correct values
- **packages/core/src/engine/__tests__/combatModifiers.test.ts**: Added 4 comprehensive tests

## Test Plan

- [x] Build passes
- [x] Lint passes  
- [x] All 1373 core tests pass
- [x] Tests verify fortified enemy uses -6/-4 (fortifiedAmount)
- [x] Tests verify non-fortified enemy uses -3/-2 (base amount)
- [x] Tests verify mixed fortification applies per-enemy
- [x] Tests verify double fortification same as single

## Acceptance Criteria

All criteria from issue #210 addressed:
- [x] Tremor: Target enemy -3 armor (min 1)
- [x] Tremor: All enemies -2 armor (min 1)
- [x] Earthquake: Target enemy -3 armor, or -6 if fortified (min 1)
- [x] Earthquake: All enemies -2/-4 based on individual fortification (min 1)
- [x] Arcane Immune enemies unaffected by both
- [x] Card playable even if no valid targets (FAQ S2)
- [x] Doubly fortified still gets same reduction as singly fortified

Closes #210