### PR TITLE
feat: implement Heroes unit special rules (#285)

### DIFF
--- a/packages/core/src/engine/__tests__/heroesSpecialRules.test.ts
+++ b/packages/core/src/engine/__tests__/heroesSpecialRules.test.ts
@@ -1,0 +1,1069 @@
+/**
+ * Heroes Special Rules tests
+ *
+ * Tests for the Heroes unit's special recruitment and combat rules:
+ * - AC #1: Reputation counts double when recruiting Heroes
+ * - AC #2: Cannot recruit Heroes and Thugs in same interaction
+ * - AC #3: Heroes cannot use abilities in fortified site assaults without 2 Influence payment
+ * - AC #4: Damage can still be assigned to Heroes during assaults (even without payment)
+ * - AC #5: Special recruitment rules don't apply for artifact/spell recruitment
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import {
+  RECRUIT_UNIT_ACTION,
+  UNIT_HEROES,
+  UNIT_THUGS,
+  UNIT_PEASANTS,
+  INVALID_ACTION,
+  ACTIVATE_UNIT_ACTION,
+  ASSIGN_DAMAGE_ACTION,
+  DAMAGE_TARGET_UNIT,
+  PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+  HEROES_ASSAULT_INFLUENCE_PAID,
+  hexKey,
+  TERRAIN_PLAINS,
+} from "@mage-knight/shared";
+import type { PlayerUnit } from "../../types/unit.js";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import { SiteType, TileId } from "../../types/map.js";
+import {
+  COMBAT_PHASE_ATTACK,
+  COMBAT_PHASE_ASSIGN_DAMAGE,
+} from "../../types/combat.js";
+import {
+  getReputationCostModifier,
+  violatesHeroesThugsExclusion,
+  hasRecruitedHeroThisInteraction,
+} from "../validActions/units/recruitment.js";
+import { validateHeroesAssaultRestriction } from "../validators/units/activationValidators.js";
+import type { CombatState } from "../../types/combat.js";
+import { getCombatOptions } from "../validActions/combat.js";
+
+/**
+ * Create a Heroes unit for testing damage assignment.
+ * Since Heroes has no abilities defined in the base game (they vary by card),
+ * we use the base createPlayerUnit for damage tests.
+ */
+function createHeroesUnit(instanceId: string): PlayerUnit {
+  return createPlayerUnit(UNIT_HEROES, instanceId);
+}
+
+/**
+ * Create a combat state for assault testing
+ */
+function createAssaultCombatState(
+  phase: typeof COMBAT_PHASE_ATTACK | typeof COMBAT_PHASE_ASSIGN_DAMAGE,
+  isAtFortifiedSite: boolean,
+  assaultOrigin: { q: number; r: number } | null,
+  paidHeroesAssaultInfluence: boolean = false
+): CombatState {
+  const base = createUnitCombatState(phase, isAtFortifiedSite, assaultOrigin);
+  return {
+    ...base,
+    paidHeroesAssaultInfluence,
+  };
+}
+
+describe("Heroes Special Rules", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("AC #1: Reputation counts double for Heroes recruitment", () => {
+    describe("getReputationCostModifier", () => {
+      it("should double positive reputation modifier for Heroes", () => {
+        // At reputation +3, base modifier is -2 (saves 2 influence)
+        // For Heroes, it should be -4 (saves 4 influence)
+        const normalModifier = getReputationCostModifier(3);
+        const heroesModifier = getReputationCostModifier(3, UNIT_HEROES);
+
+        expect(normalModifier).toBe(-2);
+        expect(heroesModifier).toBe(-4);
+      });
+
+      it("should double negative reputation modifier for Heroes", () => {
+        // At reputation -3, base modifier is +2 (costs 2 more influence)
+        // For Heroes, it should be +4 (costs 4 more influence)
+        const normalModifier = getReputationCostModifier(-3);
+        const heroesModifier = getReputationCostModifier(-3, UNIT_HEROES);
+
+        expect(normalModifier).toBe(2);
+        expect(heroesModifier).toBe(4);
+      });
+
+      it("should not double modifier for non-Heroes units", () => {
+        const peasantsModifier = getReputationCostModifier(3, UNIT_PEASANTS);
+        const thugsModifier = getReputationCostModifier(3, UNIT_THUGS);
+
+        expect(peasantsModifier).toBe(-2);
+        expect(thugsModifier).toBe(-2);
+      });
+
+      it("should double maximum reputation modifier (+7) for Heroes", () => {
+        // At +7, base modifier is -5
+        // For Heroes, it should be -10
+        const heroesModifier = getReputationCostModifier(7, UNIT_HEROES);
+        expect(heroesModifier).toBe(-10);
+      });
+
+      it("should double minimum reputation modifier (-7) for Heroes", () => {
+        // At -7, base modifier is +5
+        // For Heroes, it should be +10
+        const heroesModifier = getReputationCostModifier(-7, UNIT_HEROES);
+        expect(heroesModifier).toBe(10);
+      });
+
+      it("should return 0 for reputation 0 regardless of unit", () => {
+        expect(getReputationCostModifier(0)).toBe(0);
+        expect(getReputationCostModifier(0, UNIT_HEROES)).toBe(0);
+        expect(getReputationCostModifier(0, UNIT_PEASANTS)).toBe(0);
+      });
+
+      it("should not double modifier if Hero already recruited this interaction", () => {
+        // The doubled modifier only applies to the FIRST Hero recruited
+        const firstHeroModifier = getReputationCostModifier(3, UNIT_HEROES, false);
+        const secondHeroModifier = getReputationCostModifier(3, UNIT_HEROES, true);
+
+        expect(firstHeroModifier).toBe(-4); // Doubled
+        expect(secondHeroModifier).toBe(-2); // Not doubled (already recruited one)
+      });
+    });
+
+    describe("reputation modifier integration", () => {
+      it("should apply doubled modifier when recruiting Heroes with positive reputation", () => {
+        // Create a state with a village and units offer that includes Heroes
+        // Heroes base cost is 9, not 7
+        const player = createTestPlayer({
+          position: { q: 0, r: 0 },
+          units: [],
+          commandTokens: 2,
+          reputation: 5, // Base modifier -3, doubled for Heroes = -6
+          influencePoints: 10, // Heroes base cost is 9, with -6 modifier = 3
+        });
+
+        const hexWithVillage = {
+          coord: { q: 0, r: 0 },
+          terrain: TERRAIN_PLAINS,
+          tileId: TileId.StartingTileA,
+          site: {
+            type: SiteType.Village,
+            owner: null,
+            isConquered: false,
+            isBurned: false,
+          },
+          enemies: [],
+          shieldTokens: [],
+          rampagingEnemies: [],
+        };
+
+        const state = createTestGameState({
+          players: [player],
+          map: {
+            hexes: {
+              [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+            },
+            tiles: [],
+            tileDeck: { countryside: [], core: [] },
+          },
+          offers: {
+            units: [UNIT_HEROES],
+            advancedActions: [],
+            spells: [],
+            artifacts: [],
+          },
+        });
+
+        // Try to recruit Heroes with cost accounting for doubled modifier
+        // Heroes base cost 9, reputation +5 = -3 base modifier, doubled = -6
+        // So effective cost = 9 - 6 = 3
+        const result = engine.processAction(state, "player1", {
+          type: RECRUIT_UNIT_ACTION,
+          unitId: UNIT_HEROES,
+          influenceSpent: 3,
+        });
+
+        // Should succeed - Heroes recruited
+        const hasHeroes = result.state.players[0].units.some(
+          (u) => u.unitId === UNIT_HEROES
+        );
+        expect(hasHeroes).toBe(true);
+      });
+
+      it("should apply doubled modifier when recruiting Heroes with negative reputation", () => {
+        // Heroes base cost is 9
+        const player = createTestPlayer({
+          position: { q: 0, r: 0 },
+          units: [],
+          commandTokens: 2,
+          reputation: -5, // Base modifier +3, doubled for Heroes = +6
+          influencePoints: 20, // Heroes base cost is 9, with +6 modifier = 15
+        });
+
+        const hexWithVillage = {
+          coord: { q: 0, r: 0 },
+          terrain: TERRAIN_PLAINS,
+          tileId: TileId.StartingTileA,
+          site: {
+            type: SiteType.Village,
+            owner: null,
+            isConquered: false,
+            isBurned: false,
+          },
+          enemies: [],
+          shieldTokens: [],
+          rampagingEnemies: [],
+        };
+
+        const state = createTestGameState({
+          players: [player],
+          map: {
+            hexes: {
+              [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+            },
+            tiles: [],
+            tileDeck: { countryside: [], core: [] },
+          },
+          offers: {
+            units: [UNIT_HEROES],
+            advancedActions: [],
+            spells: [],
+            artifacts: [],
+          },
+        });
+
+        // Try to recruit Heroes with cost accounting for doubled modifier
+        // Heroes base cost 9, reputation -5 = +3 base modifier, doubled = +6
+        // So effective cost = 9 + 6 = 15
+        const result = engine.processAction(state, "player1", {
+          type: RECRUIT_UNIT_ACTION,
+          unitId: UNIT_HEROES,
+          influenceSpent: 15,
+        });
+
+        // Should succeed - Heroes recruited
+        const hasHeroes = result.state.players[0].units.some(
+          (u) => u.unitId === UNIT_HEROES
+        );
+        expect(hasHeroes).toBe(true);
+      });
+    });
+  });
+
+  describe("AC #2: Cannot recruit Heroes and Thugs in same interaction", () => {
+    describe("violatesHeroesThugsExclusion", () => {
+      it("should block Heroes if Thugs already recruited", () => {
+        const result = violatesHeroesThugsExclusion(UNIT_HEROES, [UNIT_THUGS]);
+        expect(result).toBe(true);
+      });
+
+      it("should block Thugs if Heroes already recruited", () => {
+        const result = violatesHeroesThugsExclusion(UNIT_THUGS, [UNIT_HEROES]);
+        expect(result).toBe(true);
+      });
+
+      it("should allow Heroes if no conflicting unit recruited", () => {
+        const result = violatesHeroesThugsExclusion(UNIT_HEROES, [UNIT_PEASANTS]);
+        expect(result).toBe(false);
+      });
+
+      it("should allow Thugs if no conflicting unit recruited", () => {
+        const result = violatesHeroesThugsExclusion(UNIT_THUGS, [UNIT_PEASANTS]);
+        expect(result).toBe(false);
+      });
+
+      it("should allow non-conflicting units regardless of prior recruitment", () => {
+        expect(violatesHeroesThugsExclusion(UNIT_PEASANTS, [UNIT_HEROES])).toBe(false);
+        expect(violatesHeroesThugsExclusion(UNIT_PEASANTS, [UNIT_THUGS])).toBe(false);
+      });
+
+      it("should allow recruiting same type multiple times", () => {
+        // Can recruit multiple Heroes if no Thugs
+        expect(violatesHeroesThugsExclusion(UNIT_HEROES, [UNIT_HEROES])).toBe(false);
+        // Can recruit multiple Thugs if no Heroes
+        expect(violatesHeroesThugsExclusion(UNIT_THUGS, [UNIT_THUGS])).toBe(false);
+      });
+    });
+
+    describe("hasRecruitedHeroThisInteraction", () => {
+      it("should return true if Heroes in recruited list", () => {
+        expect(hasRecruitedHeroThisInteraction([UNIT_HEROES])).toBe(true);
+        expect(hasRecruitedHeroThisInteraction([UNIT_PEASANTS, UNIT_HEROES])).toBe(true);
+      });
+
+      it("should return false if no Heroes in recruited list", () => {
+        expect(hasRecruitedHeroThisInteraction([])).toBe(false);
+        expect(hasRecruitedHeroThisInteraction([UNIT_PEASANTS])).toBe(false);
+        expect(hasRecruitedHeroThisInteraction([UNIT_THUGS])).toBe(false);
+      });
+    });
+
+    describe("recruitment integration", () => {
+      it("should reject Thugs recruitment after Heroes", () => {
+        const player = createTestPlayer({
+          position: { q: 0, r: 0 },
+          units: [],
+          commandTokens: 3,
+          influencePoints: 20,
+          unitsRecruitedThisInteraction: [UNIT_HEROES], // Already recruited Heroes
+        });
+
+        const hexWithVillage = {
+          coord: { q: 0, r: 0 },
+          terrain: TERRAIN_PLAINS,
+          tileId: TileId.StartingTileA,
+          site: {
+            type: SiteType.Village,
+            owner: null,
+            isConquered: false,
+            isBurned: false,
+          },
+          enemies: [],
+          shieldTokens: [],
+          rampagingEnemies: [],
+        };
+
+        const state = createTestGameState({
+          players: [player],
+          map: {
+            hexes: {
+              [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+            },
+            tiles: [],
+            tileDeck: { countryside: [], core: [] },
+          },
+          offers: {
+            units: [UNIT_THUGS],
+            advancedActions: [],
+            spells: [],
+            artifacts: [],
+          },
+        });
+
+        // Thugs base cost is 5
+        const result = engine.processAction(state, "player1", {
+          type: RECRUIT_UNIT_ACTION,
+          unitId: UNIT_THUGS,
+          influenceSpent: 5,
+        });
+
+        // Should be rejected
+        const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+        expect(invalidEvent).toBeDefined();
+        if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+          expect(invalidEvent.reason).toContain("Heroes");
+          expect(invalidEvent.reason).toContain("Thugs");
+        }
+      });
+
+      it("should reject Heroes recruitment after Thugs", () => {
+        const player = createTestPlayer({
+          position: { q: 0, r: 0 },
+          units: [],
+          commandTokens: 3,
+          influencePoints: 20,
+          unitsRecruitedThisInteraction: [UNIT_THUGS], // Already recruited Thugs
+        });
+
+        const hexWithVillage = {
+          coord: { q: 0, r: 0 },
+          terrain: TERRAIN_PLAINS,
+          tileId: TileId.StartingTileA,
+          site: {
+            type: SiteType.Village,
+            owner: null,
+            isConquered: false,
+            isBurned: false,
+          },
+          enemies: [],
+          shieldTokens: [],
+          rampagingEnemies: [],
+        };
+
+        const state = createTestGameState({
+          players: [player],
+          map: {
+            hexes: {
+              [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+            },
+            tiles: [],
+            tileDeck: { countryside: [], core: [] },
+          },
+          offers: {
+            units: [UNIT_HEROES],
+            advancedActions: [],
+            spells: [],
+            artifacts: [],
+          },
+        });
+
+        // Heroes base cost is 9
+        const result = engine.processAction(state, "player1", {
+          type: RECRUIT_UNIT_ACTION,
+          unitId: UNIT_HEROES,
+          influenceSpent: 9,
+        });
+
+        // Should be rejected
+        const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+        expect(invalidEvent).toBeDefined();
+        if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+          expect(invalidEvent.reason).toContain("Heroes");
+          expect(invalidEvent.reason).toContain("Thugs");
+        }
+      });
+    });
+  });
+
+  describe("AC #3: Heroes assault restrictions", () => {
+    describe("validateHeroesAssaultRestriction (unit tests)", () => {
+      it("should reject Heroes activation during fortified assault without payment", () => {
+        // Create Heroes unit
+        const heroesUnit = createHeroesUnit("heroes_1");
+        const player = createTestPlayer({
+          units: [heroesUnit],
+          commandTokens: 2,
+        });
+
+        // Create state with fortified site assault
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          true, // Fortified site
+          { q: -1, r: 0 }, // Assault origin (indicates assault, not defense)
+          false // Not paid
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const action = {
+          type: ACTIVATE_UNIT_ACTION as const,
+          unitInstanceId: "heroes_1",
+          abilityIndex: 0,
+        };
+
+        const result = validateHeroesAssaultRestriction(state, "player1", action);
+
+        expect(result.valid).toBe(false);
+        if (!result.valid) {
+          expect(result.error.message).toContain("Heroes");
+          expect(result.error.message).toContain("Influence");
+        }
+      });
+
+      it("should allow Heroes activation after paying 2 influence", () => {
+        const heroesUnit = createHeroesUnit("heroes_1");
+        const player = createTestPlayer({
+          units: [heroesUnit],
+          commandTokens: 2,
+        });
+
+        // Create state with assault, payment MADE
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          true,
+          { q: -1, r: 0 },
+          true // Paid
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const action = {
+          type: ACTIVATE_UNIT_ACTION as const,
+          unitInstanceId: "heroes_1",
+          abilityIndex: 0,
+        };
+
+        const result = validateHeroesAssaultRestriction(state, "player1", action);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should allow Heroes activation at non-fortified site without payment", () => {
+        const heroesUnit = createHeroesUnit("heroes_1");
+        const player = createTestPlayer({
+          units: [heroesUnit],
+          commandTokens: 2,
+        });
+
+        // Non-fortified combat
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          false, // Not fortified
+          null,
+          false
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const action = {
+          type: ACTIVATE_UNIT_ACTION as const,
+          unitInstanceId: "heroes_1",
+          abilityIndex: 0,
+        };
+
+        const result = validateHeroesAssaultRestriction(state, "player1", action);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should allow Heroes activation when defending fortified site (not assault)", () => {
+        const heroesUnit = createHeroesUnit("heroes_1");
+        const player = createTestPlayer({
+          units: [heroesUnit],
+          commandTokens: 2,
+        });
+
+        // Fortified site but NOT assault (assaultOrigin null = defending)
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          true, // Fortified site
+          null, // No assault origin = defending
+          false
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const action = {
+          type: ACTIVATE_UNIT_ACTION as const,
+          unitInstanceId: "heroes_1",
+          abilityIndex: 0,
+        };
+
+        const result = validateHeroesAssaultRestriction(state, "player1", action);
+
+        expect(result.valid).toBe(true);
+      });
+
+      it("should allow non-Heroes units during assault without payment", () => {
+        // Thugs unit - not Heroes
+        const thugsUnit = createPlayerUnit(UNIT_THUGS, "thugs_1");
+        const player = createTestPlayer({
+          units: [thugsUnit],
+          commandTokens: 2,
+        });
+
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          true,
+          { q: -1, r: 0 },
+          false // Not paid - but shouldn't matter for non-Heroes
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const action = {
+          type: ACTIVATE_UNIT_ACTION as const,
+          unitInstanceId: "thugs_1",
+          abilityIndex: 0,
+        };
+
+        const result = validateHeroesAssaultRestriction(state, "player1", action);
+
+        expect(result.valid).toBe(true);
+      });
+    });
+
+    describe("PAY_HEROES_ASSAULT_INFLUENCE_ACTION", () => {
+      it("should pay 2 influence and update combat state", () => {
+        const player = createTestPlayer({
+          influencePoints: 5,
+        });
+
+        const combatState = createAssaultCombatState(
+          COMBAT_PHASE_ATTACK,
+          true,
+          { q: -1, r: 0 },
+          false
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const result = engine.processAction(state, "player1", {
+          type: PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+        });
+
+        // Verify payment was recorded
+        expect(result.state.combat?.paidHeroesAssaultInfluence).toBe(true);
+        expect(result.state.players[0].influencePoints).toBe(3); // 5 - 2
+
+        // Check for payment event
+        const paymentEvent = result.events.find(
+          (e) => e.type === HEROES_ASSAULT_INFLUENCE_PAID
+        );
+        expect(paymentEvent).toBeDefined();
+      });
+
+      it("should reject payment when not in assault combat", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      // Non-assault combat
+      const combatState = createUnitCombatState(
+        COMBAT_PHASE_ATTACK,
+        false, // Not fortified
+        null // No assault
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+      });
+
+      // Should be rejected - not an assault
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should reject payment when already paid", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      // Assault combat with payment already made
+      const combatState = {
+        ...createUnitCombatState(COMBAT_PHASE_ATTACK, true, { q: -1, r: 0 }),
+        paidHeroesAssaultInfluence: true,
+      };
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+      });
+
+      // Should be rejected - already paid
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("already");
+      }
+    });
+
+    it("should reject payment when insufficient influence", () => {
+      const player = createTestPlayer({
+        influencePoints: 1, // Not enough (need 2)
+      });
+
+      const combatState = createUnitCombatState(
+        COMBAT_PHASE_ATTACK,
+        true,
+        { q: -1, r: 0 }
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+      });
+
+      // Should be rejected - insufficient influence
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("influence");
+      }
+    });
+    });
+  });
+
+  describe("AC #4: Damage can be assigned to Heroes during assault", () => {
+    it("should allow assigning damage to Heroes during assault without payment", () => {
+      // Heroes unit ready to take damage
+      const heroesUnit = createHeroesUnit("heroes_1");
+      const player = createTestPlayer({
+        units: [heroesUnit],
+        commandTokens: 2,
+      });
+
+      // Fortified site assault in assign damage phase
+      const combatState = createAssaultCombatState(
+        COMBAT_PHASE_ASSIGN_DAMAGE,
+        true, // Fortified site
+        { q: -1, r: 0 }, // Assault origin
+        false // Not paid - but damage should still be assignable
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ASSIGN_DAMAGE_ACTION,
+        enemyInstanceId: "enemy_1",
+        assignments: [
+          {
+            target: DAMAGE_TARGET_UNIT,
+            unitInstanceId: "heroes_1",
+            amount: 3, // Diggers attack is 3
+          },
+        ],
+      });
+
+      // Should succeed - damage assignment to Heroes is always allowed
+      // Heroes should be wounded
+      expect(result.state.players[0].units[0].wounded).toBe(true);
+
+      // No invalid action event
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeUndefined();
+    });
+
+    it("should allow assigning damage to Heroes even with paidHeroesAssaultInfluence false", () => {
+      const heroesUnit = createHeroesUnit("heroes_1");
+      const player = createTestPlayer({
+        units: [heroesUnit],
+        commandTokens: 2,
+        influencePoints: 0, // No influence to pay
+      });
+
+      // Assault combat, payment NOT made
+      const combatState = createAssaultCombatState(
+        COMBAT_PHASE_ASSIGN_DAMAGE,
+        true,
+        { q: -1, r: 0 },
+        false
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ASSIGN_DAMAGE_ACTION,
+        enemyInstanceId: "enemy_1",
+        assignments: [
+          {
+            target: DAMAGE_TARGET_UNIT,
+            unitInstanceId: "heroes_1",
+            amount: 3,
+          },
+        ],
+      });
+
+      // Should succeed - damage assignment is separate from ability activation
+      expect(result.state.players[0].units[0].wounded).toBe(true);
+    });
+  });
+
+  describe("FAQ clarifications", () => {
+    it("should track unitsRecruitedThisInteraction correctly", () => {
+      // Peasants cost 4, Heroes cost 9 (base)
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        units: [],
+        commandTokens: 3,
+        reputation: 0,
+        influencePoints: 20,
+        unitsRecruitedThisInteraction: [], // Fresh interaction
+      });
+
+      const hexWithVillage = {
+        coord: { q: 0, r: 0 },
+        terrain: TERRAIN_PLAINS,
+        tileId: TileId.StartingTileA,
+        site: {
+          type: SiteType.Village,
+          owner: null,
+          isConquered: false,
+          isBurned: false,
+        },
+        enemies: [],
+        shieldTokens: [],
+        rampagingEnemies: [],
+      };
+
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+        offers: {
+          units: [UNIT_PEASANTS, UNIT_HEROES],
+          advancedActions: [],
+          spells: [],
+          artifacts: [],
+        },
+      });
+
+      // First recruit Peasants (cost 4)
+      const afterFirstRecruit = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+      });
+
+      // unitsRecruitedThisInteraction should track Peasants
+      expect(afterFirstRecruit.state.players[0].unitsRecruitedThisInteraction).toContain(
+        UNIT_PEASANTS
+      );
+
+      // Now recruit Heroes (cost 9)
+      const afterSecondRecruit = engine.processAction(afterFirstRecruit.state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_HEROES,
+        influenceSpent: 9,
+      });
+
+      // Both should be tracked
+      expect(afterSecondRecruit.state.players[0].unitsRecruitedThisInteraction).toContain(
+        UNIT_PEASANTS
+      );
+      expect(afterSecondRecruit.state.players[0].unitsRecruitedThisInteraction).toContain(
+        UNIT_HEROES
+      );
+    });
+
+    it("doubled reputation applies only to first Hero recruited in interaction", () => {
+      // With high reputation, first Hero gets doubled discount, second doesn't
+      // Heroes base cost is 9
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        units: [],
+        commandTokens: 3,
+        reputation: 5, // Base -3, doubled = -6 for first Hero
+        influencePoints: 50,
+        unitsRecruitedThisInteraction: [],
+      });
+
+      const hexWithVillage = {
+        coord: { q: 0, r: 0 },
+        terrain: TERRAIN_PLAINS,
+        tileId: TileId.StartingTileA,
+        site: {
+          type: SiteType.Village,
+          owner: null,
+          isConquered: false,
+          isBurned: false,
+        },
+        enemies: [],
+        shieldTokens: [],
+        rampagingEnemies: [],
+      };
+
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+        offers: {
+          units: [UNIT_HEROES, UNIT_HEROES], // Two Heroes in offer
+          advancedActions: [],
+          spells: [],
+          artifacts: [],
+        },
+      });
+
+      // First Hero: base 9, doubled modifier -6 = cost 3
+      const afterFirstHero = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_HEROES,
+        influenceSpent: 3,
+      });
+
+      // Should succeed
+      const firstHeroRecruited = afterFirstHero.state.players[0].units.filter(
+        (u) => u.unitId === UNIT_HEROES
+      ).length;
+      expect(firstHeroRecruited).toBe(1);
+
+      // Influence should be 50 - 3 = 47
+      expect(afterFirstHero.state.players[0].influencePoints).toBe(47);
+
+      // Second Hero: base 9, regular modifier -3 = cost 6 (not doubled)
+      const afterSecondHero = engine.processAction(afterFirstHero.state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_HEROES,
+        influenceSpent: 6,
+      });
+
+      // Should succeed
+      const secondHeroRecruited = afterSecondHero.state.players[0].units.filter(
+        (u) => u.unitId === UNIT_HEROES
+      ).length;
+      expect(secondHeroRecruited).toBe(2);
+
+      // Influence should be 47 - 6 = 41
+      expect(afterSecondHero.state.players[0].influencePoints).toBe(41);
+    });
+  });
+
+  describe("ValidActions for Heroes assault influence", () => {
+    it("should expose canPayHeroesAssaultInfluence during fortified assault", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      const combatState = createAssaultCombatState(
+        COMBAT_PHASE_ATTACK,
+        true, // Fortified
+        { q: -1, r: 0 }, // Assault origin
+        false // Not paid yet
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const options = getCombatOptions(state);
+
+      expect(options).toBeDefined();
+      expect(options?.canPayHeroesAssaultInfluence).toBe(true);
+      expect(options?.heroesAssaultInfluenceCost).toBe(2);
+      expect(options?.heroesAssaultInfluencePaid).toBe(false);
+    });
+
+    it("should not expose Heroes assault fields for non-fortified combat", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      const combatState = createUnitCombatState(
+        COMBAT_PHASE_ATTACK,
+        false, // Not fortified
+        null // Not an assault
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const options = getCombatOptions(state);
+
+      expect(options).toBeDefined();
+      // These fields should be undefined (not present) for non-assault combat
+      expect(options?.canPayHeroesAssaultInfluence).toBeUndefined();
+      expect(options?.heroesAssaultInfluenceCost).toBeUndefined();
+      expect(options?.heroesAssaultInfluencePaid).toBeUndefined();
+    });
+
+    it("should set canPayHeroesAssaultInfluence to false after payment", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      const combatState = createAssaultCombatState(
+        COMBAT_PHASE_ATTACK,
+        true,
+        { q: -1, r: 0 },
+        true // Already paid
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const options = getCombatOptions(state);
+
+      expect(options).toBeDefined();
+      expect(options?.canPayHeroesAssaultInfluence).toBe(false);
+      expect(options?.heroesAssaultInfluencePaid).toBe(true);
+    });
+
+    it("should set canPayHeroesAssaultInfluence to false when insufficient influence", () => {
+      const player = createTestPlayer({
+        influencePoints: 1, // Not enough (need 2)
+      });
+
+      const combatState = createAssaultCombatState(
+        COMBAT_PHASE_ATTACK,
+        true,
+        { q: -1, r: 0 },
+        false
+      );
+
+      const state = createTestGameState({
+        players: [player],
+        combat: combatState,
+      });
+
+      const options = getCombatOptions(state);
+
+      expect(options).toBeDefined();
+      expect(options?.canPayHeroesAssaultInfluence).toBe(false);
+      expect(options?.heroesAssaultInfluencePaid).toBe(false);
+    });
+
+    it("should expose Heroes assault fields during all combat phases", () => {
+      const player = createTestPlayer({
+        influencePoints: 5,
+      });
+
+      // Test multiple phases
+      const phases = [
+        COMBAT_PHASE_ATTACK,
+        COMBAT_PHASE_ASSIGN_DAMAGE,
+      ] as const;
+
+      for (const phase of phases) {
+        const combatState = createAssaultCombatState(
+          phase,
+          true,
+          { q: -1, r: 0 },
+          false
+        );
+
+        const state = createTestGameState({
+          players: [player],
+          combat: combatState,
+        });
+
+        const options = getCombatOptions(state);
+
+        expect(options?.heroesAssaultInfluenceCost).toBe(2);
+        expect(options?.heroesAssaultInfluencePaid).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -144,6 +144,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     hasCombattedThisTurn: false,
     hasPlunderedThisTurn: false,
     hasRecruitedUnitThisTurn: false,
+    unitsRecruitedThisInteraction: [],
     manaUsedThisTurn: [],
     spellColorsCastThisTurn: [],
     spellsCastByColorThisTurn: {},
@@ -329,12 +330,15 @@ export function createTacticsSelectionState(
   };
 }
 
+import { COMBAT_CONTEXT_STANDARD } from "../../types/combat.js";
+
 /**
  * Create a combat state for unit tests with a default enemy
  */
 export function createUnitCombatState(
   phase: CombatPhase,
-  isAtFortifiedSite = false
+  isAtFortifiedSite = false,
+  assaultOrigin: { q: number; r: number } | null = null
 ): CombatState {
   return {
     enemies: [
@@ -365,11 +369,14 @@ export function createUnitCombatState(
     isAtFortifiedSite,
     unitsAllowed: true,
     nightManaRules: false,
-    assaultOrigin: null,
+    assaultOrigin,
     combatHexCoord: null,
     allDamageBlockedThisPhase: false,
     discardEnemiesOnFailure: false,
     pendingDamage: {},
     pendingBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    paidHeroesAssaultInfluence: false,
   };
 }

--- a/packages/core/src/engine/commands/combat/index.ts
+++ b/packages/core/src/engine/commands/combat/index.ts
@@ -67,3 +67,10 @@ export {
   SPEND_MOVE_ON_CUMBERSOME_COMMAND,
   type SpendMoveOnCumbersomeCommandParams,
 } from "./spendMoveOnCumbersomeCommand.js";
+
+export {
+  createPayHeroesAssaultInfluenceCommand,
+  PAY_HEROES_ASSAULT_INFLUENCE_COMMAND,
+  HEROES_ASSAULT_INFLUENCE_COST,
+  type PayHeroesAssaultInfluenceCommandParams,
+} from "./payHeroesAssaultInfluenceCommand.js";

--- a/packages/core/src/engine/commands/combat/payHeroesAssaultInfluenceCommand.ts
+++ b/packages/core/src/engine/commands/combat/payHeroesAssaultInfluenceCommand.ts
@@ -1,0 +1,121 @@
+/**
+ * Pay Heroes Assault Influence Command
+ *
+ * Allows player to pay 2 Influence during a fortified site assault to enable
+ * Heroes units to use their abilities for the rest of the combat.
+ *
+ * Per rulebook: Heroes cannot use abilities in fortified assaults unless
+ * 2 Influence is paid once per combat. Damage assignment to Heroes is still
+ * allowed without payment.
+ *
+ * @module engine/commands/combat/payHeroesAssaultInfluenceCommand
+ */
+
+import type { Command, CommandResult } from "../../commands.js";
+import type { GameState } from "../../../state/GameState.js";
+import { HEROES_ASSAULT_INFLUENCE_PAID } from "@mage-knight/shared";
+
+export const PAY_HEROES_ASSAULT_INFLUENCE_COMMAND = "PAY_HEROES_ASSAULT_INFLUENCE" as const;
+
+/** Cost in influence to enable Heroes abilities during fortified site assaults */
+export const HEROES_ASSAULT_INFLUENCE_COST = 2;
+
+export interface PayHeroesAssaultInfluenceCommandParams {
+  readonly playerId: string;
+}
+
+export function createPayHeroesAssaultInfluenceCommand(
+  params: PayHeroesAssaultInfluenceCommandParams
+): Command {
+  // Capture state for undo
+  let previousInfluencePoints = 0;
+
+  return {
+    type: PAY_HEROES_ASSAULT_INFLUENCE_COMMAND,
+    playerId: params.playerId,
+    isReversible: true,
+
+    execute(state: GameState): CommandResult {
+      if (!state.combat) {
+        throw new Error("Not in combat");
+      }
+
+      // Validate this is a fortified site assault
+      if (!state.combat.isAtFortifiedSite || state.combat.assaultOrigin === null) {
+        throw new Error("Not a fortified site assault - Heroes special rule does not apply");
+      }
+
+      // Validate not already paid
+      if (state.combat.paidHeroesAssaultInfluence) {
+        throw new Error("Heroes assault influence already paid this combat");
+      }
+
+      const player = state.players.find((p) => p.id === params.playerId);
+      if (!player) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+      const playerIndex = state.players.indexOf(player);
+
+      // Validate player has enough influence
+      if (player.influencePoints < HEROES_ASSAULT_INFLUENCE_COST) {
+        throw new Error(
+          `Insufficient influence (has ${player.influencePoints}, needs ${HEROES_ASSAULT_INFLUENCE_COST})`
+        );
+      }
+
+      // Capture for undo
+      previousInfluencePoints = player.influencePoints;
+
+      // Deduct influence from player
+      const updatedPlayers = state.players.map((p, i) =>
+        i === playerIndex
+          ? { ...p, influencePoints: p.influencePoints - HEROES_ASSAULT_INFLUENCE_COST }
+          : p
+      );
+
+      // Mark influence as paid in combat state
+      const updatedCombat = {
+        ...state.combat,
+        paidHeroesAssaultInfluence: true,
+      };
+
+      return {
+        state: { ...state, players: updatedPlayers, combat: updatedCombat },
+        events: [
+          {
+            type: HEROES_ASSAULT_INFLUENCE_PAID,
+            playerId: params.playerId,
+            influenceSpent: HEROES_ASSAULT_INFLUENCE_COST,
+          },
+        ],
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      if (!state.combat) {
+        throw new Error("Not in combat (undo)");
+      }
+
+      const playerIndex = state.players.findIndex((p) => p.id === params.playerId);
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      // Restore player's influence
+      const updatedPlayers = state.players.map((p, i) =>
+        i === playerIndex ? { ...p, influencePoints: previousInfluencePoints } : p
+      );
+
+      // Mark as unpaid
+      const updatedCombat = {
+        ...state.combat,
+        paidHeroesAssaultInfluence: false,
+      };
+
+      return {
+        state: { ...state, players: updatedPlayers, combat: updatedCombat },
+        events: [],
+      };
+    },
+  };
+}

--- a/packages/core/src/engine/commands/endTurn/playerReset.ts
+++ b/packages/core/src/engine/commands/endTurn/playerReset.ts
@@ -29,6 +29,7 @@ export function createResetPlayer(
     playedCardFromHandThisTurn: false,
     hasPlunderedThisTurn: false,
     hasRecruitedUnitThisTurn: false,
+    unitsRecruitedThisInteraction: [], // Reset interaction tracking at turn end
     isResting: false, // Reset resting state at turn start
     // Mana resets
     pureMana: [],

--- a/packages/core/src/engine/commands/factories/combat.ts
+++ b/packages/core/src/engine/commands/factories/combat.ts
@@ -31,6 +31,7 @@ import {
   ASSIGN_BLOCK_ACTION,
   UNASSIGN_BLOCK_ACTION,
   SPEND_MOVE_ON_CUMBERSOME_ACTION,
+  PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
 } from "@mage-knight/shared";
 import {
   createEnterCombatCommand,
@@ -44,6 +45,7 @@ import {
   createAssignBlockCommand,
   createUnassignBlockCommand,
   createSpendMoveOnCumbersomeCommand,
+  createPayHeroesAssaultInfluenceCommand,
 } from "../combat/index.js";
 
 /**
@@ -268,5 +270,23 @@ export const createSpendMoveOnCumbersomeCommandFromAction: CommandFactory = (
     playerId,
     enemyInstanceId: action.enemyInstanceId,
     movePointsToSpend: action.movePointsToSpend,
+  });
+};
+
+/**
+ * Pay Heroes assault influence command factory.
+ * Creates a command to pay 2 Influence to enable Heroes unit abilities
+ * during a fortified site assault.
+ *
+ * Part of the Heroes special rules system.
+ */
+export const createPayHeroesAssaultInfluenceCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== PAY_HEROES_ASSAULT_INFLUENCE_ACTION) return null;
+  return createPayHeroesAssaultInfluenceCommand({
+    playerId,
   });
 };

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -64,6 +64,7 @@ import {
   CANCEL_COOPERATIVE_PROPOSAL_ACTION,
   USE_SKILL_ACTION,
   SPEND_MOVE_ON_CUMBERSOME_ACTION,
+  PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -97,6 +98,7 @@ export {
   createAssignBlockCommandFromAction,
   createUnassignBlockCommandFromAction,
   createSpendMoveOnCumbersomeCommandFromAction,
+  createPayHeroesAssaultInfluenceCommandFromAction,
 } from "./combat.js";
 
 // Unit factories
@@ -182,6 +184,7 @@ import {
   createAssignBlockCommandFromAction,
   createUnassignBlockCommandFromAction,
   createSpendMoveOnCumbersomeCommandFromAction,
+  createPayHeroesAssaultInfluenceCommandFromAction,
 } from "./combat.js";
 
 import {
@@ -291,4 +294,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [USE_SKILL_ACTION]: createUseSkillCommandFromAction,
   // Cumbersome ability actions
   [SPEND_MOVE_ON_CUMBERSOME_ACTION]: createSpendMoveOnCumbersomeCommandFromAction,
+  // Heroes assault influence payment action
+  [PAY_HEROES_ASSAULT_INFLUENCE_ACTION]: createPayHeroesAssaultInfluenceCommandFromAction,
 };

--- a/packages/core/src/engine/commands/moveCommand.ts
+++ b/packages/core/src/engine/commands/moveCommand.ts
@@ -159,6 +159,8 @@ export function createMoveCommand(params: MoveCommandParams): Command {
         position: params.to,
         movePoints: player.movePoints - params.terrainCost,
         hasMovedThisTurn: true,
+        // Clear interaction tracking when moving - new site = new interaction
+        unitsRecruitedThisInteraction: [],
       };
 
       let updatedState: GameState = state;

--- a/packages/core/src/engine/commands/units/recruitUnitCommand.ts
+++ b/packages/core/src/engine/commands/units/recruitUnitCommand.ts
@@ -42,6 +42,7 @@ export function createRecruitUnitCommand(
   let previousInfluence = 0;
   let previousHasTakenAction = false;
   let previousHasRecruitedUnit = false;
+  let previousUnitsRecruitedThisInteraction: readonly UnitId[] = [];
 
   return {
     type: RECRUIT_UNIT_COMMAND,
@@ -66,6 +67,7 @@ export function createRecruitUnitCommand(
       previousInfluence = player.influencePoints;
       previousHasTakenAction = player.hasTakenActionThisTurn;
       previousHasRecruitedUnit = player.hasRecruitedUnitThisTurn;
+      previousUnitsRecruitedThisInteraction = player.unitsRecruitedThisInteraction;
 
       // Create new unit instance
       const newUnit = createPlayerUnit(params.unitId, instanceId);
@@ -73,12 +75,17 @@ export function createRecruitUnitCommand(
       // Update player: add unit, deduct influence, mark action taken
       // Note: Recruiting counts as an interaction (action), so player can't move afterward.
       // Multiple recruits in one turn are still allowed per rulebook rules.
+      // Track the unit in unitsRecruitedThisInteraction for Heroes/Thugs exclusion check
       const updatedPlayer = {
         ...player,
         units: [...player.units, newUnit],
         influencePoints: player.influencePoints - params.influenceSpent,
         hasTakenActionThisTurn: true,
         hasRecruitedUnitThisTurn: true,
+        unitsRecruitedThisInteraction: [
+          ...player.unitsRecruitedThisInteraction,
+          params.unitId,
+        ],
       };
 
       const players = state.players.map((p, i) =>
@@ -133,6 +140,7 @@ export function createRecruitUnitCommand(
         influencePoints: previousInfluence,
         hasTakenActionThisTurn: previousHasTakenAction,
         hasRecruitedUnitThisTurn: previousHasRecruitedUnit,
+        unitsRecruitedThisInteraction: previousUnitsRecruitedThisInteraction,
       };
 
       const players = state.players.map((p, i) =>

--- a/packages/core/src/engine/validators/combatValidators/heroesAssaultValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/heroesAssaultValidators.ts
@@ -1,0 +1,109 @@
+/**
+ * Heroes Assault Validators
+ *
+ * Validators for the PAY_HEROES_ASSAULT_INFLUENCE_ACTION.
+ * Heroes units cannot use abilities in fortified site assaults unless
+ * 2 Influence is paid once per combat.
+ *
+ * @module validators/combatValidators/heroesAssaultValidators
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import type { ValidationResult } from "../types.js";
+import { valid, invalid } from "../types.js";
+import { PAY_HEROES_ASSAULT_INFLUENCE_ACTION } from "@mage-knight/shared";
+import {
+  NOT_IN_COMBAT,
+  PLAYER_NOT_FOUND,
+  INSUFFICIENT_INFLUENCE,
+  HEROES_ASSAULT_INFLUENCE_ALREADY_PAID,
+  HEROES_ASSAULT_NOT_APPLICABLE,
+} from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
+import { HEROES_ASSAULT_INFLUENCE_COST } from "../../commands/combat/payHeroesAssaultInfluenceCommand.js";
+
+/**
+ * Validate player is in combat for Heroes assault payment.
+ */
+export function validateHeroesPaymentInCombat(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== PAY_HEROES_ASSAULT_INFLUENCE_ACTION) return valid();
+
+  if (!state.combat) {
+    return invalid(NOT_IN_COMBAT, "Not in combat");
+  }
+
+  return valid();
+}
+
+/**
+ * Validate this is a fortified site assault (not defense or dungeon/tomb).
+ */
+export function validateHeroesAssaultApplicable(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== PAY_HEROES_ASSAULT_INFLUENCE_ACTION) return valid();
+  if (!state.combat) return valid(); // Other validator handles
+
+  // Must be a fortified site assault (not defense)
+  if (!state.combat.isAtFortifiedSite || state.combat.assaultOrigin === null) {
+    return invalid(
+      HEROES_ASSAULT_NOT_APPLICABLE,
+      "Heroes assault influence only applies to fortified site assaults"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * Validate influence has not already been paid this combat.
+ */
+export function validateHeroesInfluenceNotAlreadyPaid(
+  state: GameState,
+  _playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== PAY_HEROES_ASSAULT_INFLUENCE_ACTION) return valid();
+  if (!state.combat) return valid(); // Other validator handles
+
+  if (state.combat.paidHeroesAssaultInfluence) {
+    return invalid(
+      HEROES_ASSAULT_INFLUENCE_ALREADY_PAID,
+      "Heroes assault influence has already been paid this combat"
+    );
+  }
+
+  return valid();
+}
+
+/**
+ * Validate player has enough influence to pay for Heroes assault.
+ */
+export function validateHeroesInfluenceAvailable(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== PAY_HEROES_ASSAULT_INFLUENCE_ACTION) return valid();
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (player.influencePoints < HEROES_ASSAULT_INFLUENCE_COST) {
+    return invalid(
+      INSUFFICIENT_INFLUENCE,
+      `Insufficient influence (need ${HEROES_ASSAULT_INFLUENCE_COST}, have ${player.influencePoints})`
+    );
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/combatValidators/index.ts
+++ b/packages/core/src/engine/validators/combatValidators/index.ts
@@ -70,3 +70,11 @@ export {
   validateCumbersomeEnemy,
   validateHasMovePointsForCumbersome,
 } from "./cumbersomeValidators.js";
+
+// Heroes assault validators
+export {
+  validateHeroesPaymentInCombat,
+  validateHeroesAssaultApplicable,
+  validateHeroesInfluenceNotAlreadyPaid,
+  validateHeroesInfluenceAvailable,
+} from "./heroesAssaultValidators.js";

--- a/packages/core/src/engine/validators/registry/combatRegistry.ts
+++ b/packages/core/src/engine/validators/registry/combatRegistry.ts
@@ -22,6 +22,7 @@ import {
   ASSIGN_BLOCK_ACTION,
   UNASSIGN_BLOCK_ACTION,
   SPEND_MOVE_ON_CUMBERSOME_ACTION,
+  PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
 } from "@mage-knight/shared";
 
 // Turn validators
@@ -79,6 +80,11 @@ import {
   validateSpendCumbersomePhase,
   validateCumbersomeEnemy,
   validateHasMovePointsForCumbersome,
+  // Heroes assault validators
+  validateHeroesPaymentInCombat,
+  validateHeroesAssaultApplicable,
+  validateHeroesInfluenceNotAlreadyPaid,
+  validateHeroesInfluenceAvailable,
 } from "../combatValidators/index.js";
 
 // Challenge rampaging validators
@@ -183,5 +189,13 @@ export const combatRegistry: Record<string, Validator[]> = {
     validateSpendCumbersomePhase,
     validateCumbersomeEnemy,
     validateHasMovePointsForCumbersome,
+  ],
+  // Heroes assault influence payment action
+  [PAY_HEROES_ASSAULT_INFLUENCE_ACTION]: [
+    validateIsPlayersTurn,
+    validateHeroesPaymentInCombat,
+    validateHeroesAssaultApplicable,
+    validateHeroesInfluenceNotAlreadyPaid,
+    validateHeroesInfluenceAvailable,
   ],
 };

--- a/packages/core/src/engine/validators/registry/unitRegistry.ts
+++ b/packages/core/src/engine/validators/registry/unitRegistry.ts
@@ -23,12 +23,14 @@ import {
   validateUnitCanActivate,
   validateAtRecruitmentSite,
   validateUnitTypeMatchesSite,
+  validateHeroesThugsExclusion,
   validateAbilityIndex,
   validateAbilityMatchesPhase,
   validateSiegeRequirement,
   validateCombatRequiredForAbility,
   validateUnitsAllowedInCombat,
   validateUnitAbilityManaCost,
+  validateHeroesAssaultRestriction,
 } from "../units/index.js";
 
 export const unitRegistry: Record<string, Validator[]> = {
@@ -41,6 +43,7 @@ export const unitRegistry: Record<string, Validator[]> = {
     validateInfluenceCost,
     validateAtRecruitmentSite,
     validateUnitTypeMatchesSite,
+    validateHeroesThugsExclusion, // Heroes/Thugs cannot be recruited in same interaction
   ],
   [ACTIVATE_UNIT_ACTION]: [
     validateIsPlayersTurn,
@@ -52,6 +55,7 @@ export const unitRegistry: Record<string, Validator[]> = {
     validateAbilityIndex,
     validateCombatRequiredForAbility, // Combat abilities require being in combat
     validateUnitsAllowedInCombat, // Dungeon/Tomb: units cannot be used
+    validateHeroesAssaultRestriction, // Heroes need 2 Influence paid in fortified assaults
     validateAbilityMatchesPhase, // Ability type must match combat phase
     validateSiegeRequirement, // Ranged can't hit fortified in ranged phase
     validateUnitAbilityManaCost, // Validate mana source if ability has mana cost

--- a/packages/core/src/engine/validators/units/index.ts
+++ b/packages/core/src/engine/validators/units/index.ts
@@ -11,6 +11,7 @@ export {
   validateInfluenceCost,
   validateAtRecruitmentSite,
   validateUnitTypeMatchesSite,
+  validateHeroesThugsExclusion,
 } from "./recruitmentValidators.js";
 
 export {
@@ -23,4 +24,5 @@ export {
   validateCombatRequiredForAbility,
   validateUnitsAllowedInCombat,
   validateUnitAbilityManaCost,
+  validateHeroesAssaultRestriction,
 } from "./activationValidators.js";

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -127,6 +127,11 @@ export const PASSIVE_ABILITY = "PASSIVE_ABILITY" as const;
 export const SIEGE_REQUIRED = "SIEGE_REQUIRED" as const;
 export const UNIT_ABILITY_REQUIRES_MANA = "UNIT_ABILITY_REQUIRES_MANA" as const;
 export const UNIT_ABILITY_MANA_UNAVAILABLE = "UNIT_ABILITY_MANA_UNAVAILABLE" as const;
+// Heroes unit special rules
+export const HEROES_THUGS_EXCLUSION = "HEROES_THUGS_EXCLUSION" as const;
+export const HEROES_ASSAULT_INFLUENCE_NOT_PAID = "HEROES_ASSAULT_INFLUENCE_NOT_PAID" as const;
+export const HEROES_ASSAULT_INFLUENCE_ALREADY_PAID = "HEROES_ASSAULT_INFLUENCE_ALREADY_PAID" as const;
+export const HEROES_ASSAULT_NOT_APPLICABLE = "HEROES_ASSAULT_NOT_APPLICABLE" as const;
 
 // Site interaction validation codes
 export const NO_SITE = "NO_SITE" as const;
@@ -342,6 +347,11 @@ export type ValidationErrorCode =
   | typeof SIEGE_REQUIRED
   | typeof UNIT_ABILITY_REQUIRES_MANA
   | typeof UNIT_ABILITY_MANA_UNAVAILABLE
+  // Heroes unit special rules
+  | typeof HEROES_THUGS_EXCLUSION
+  | typeof HEROES_ASSAULT_INFLUENCE_NOT_PAID
+  | typeof HEROES_ASSAULT_INFLUENCE_ALREADY_PAID
+  | typeof HEROES_ASSAULT_NOT_APPLICABLE
   // Site interaction validation
   | typeof NO_SITE
   | typeof NOT_INHABITED

--- a/packages/core/src/types/combat.ts
+++ b/packages/core/src/types/combat.ts
@@ -154,6 +154,12 @@ export interface CombatState {
    * Persists even after defender dies.
    */
   readonly defendBonuses: DefendBonusMap;
+  /**
+   * Heroes special rule: tracks whether 2 influence has been paid this combat
+   * to allow Heroes units to use abilities during fortified site assaults.
+   * Reset when combat ends. Only applies when isAtFortifiedSite && assaultOrigin !== null.
+   */
+  readonly paidHeroesAssaultInfluence: boolean;
 }
 
 /**
@@ -245,6 +251,7 @@ export function createCombatState(
     cumbersomeReductions: {},
     usedDefend: {},
     defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
   };
 
   // Only include enemyAssignments if provided (avoids exactOptionalPropertyTypes issues)

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -309,6 +309,12 @@ export interface Player {
   // Unit recruitment tracking (for "On Her Own" skill condition)
   readonly hasRecruitedUnitThisTurn: boolean;
 
+  // Heroes special rule: track units recruited during current site interaction.
+  // Cleared when player moves away from a site. Used for:
+  // - Double reputation modifier (applies once per interaction when recruiting Heroes)
+  // - Heroes/Thugs exclusion (cannot recruit both in same interaction)
+  readonly unitsRecruitedThisInteraction: readonly import("@mage-knight/shared").UnitId[];
+
   // Mana usage tracking (for conditional effects)
   readonly manaUsedThisTurn: readonly ManaColor[];
 

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -551,6 +551,7 @@ export class GameServer {
       playedCardFromHandThisTurn: false,
       hasPlunderedThisTurn: false,
       hasRecruitedUnitThisTurn: false,
+      unitsRecruitedThisInteraction: [],
       manaUsedThisTurn: [],
       spellColorsCastThisTurn: [],
       spellsCastByColorThisTurn: {},

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -4,7 +4,7 @@
 
 import type { HexCoord, HexDirection } from "./hex.js";
 import type { CardId, SkillId, BasicManaColor, ManaColor } from "./ids.js";
-import type { UnitId } from "./units/index.js";
+import type { UnitId, RecruitmentSource } from "./units/index.js";
 import type { ManaSourceType, SparingPowerChoice } from "./valueConstants.js";
 import type { EnemyId } from "./enemies/index.js";
 import type { CombatType } from "./combatTypes.js";
@@ -228,12 +228,29 @@ export interface RecruitUnitAction {
   readonly type: typeof RECRUIT_UNIT_ACTION;
   readonly unitId: UnitId;
   readonly influenceSpent: number; // Must meet unit's cost
+  /**
+   * Source of recruitment - determines which special rules apply.
+   * Defaults to "normal" if not specified (standard recruitment at a site).
+   * "artifact" or "spell" bypass Heroes/Thugs special rules.
+   */
+  readonly source?: RecruitmentSource;
 }
 
 export const DISBAND_UNIT_ACTION = "DISBAND_UNIT" as const;
 export interface DisbandUnitAction {
   readonly type: typeof DISBAND_UNIT_ACTION;
   readonly unitInstanceId: string;
+}
+
+// Heroes special rule: pay influence for assault abilities
+export const PAY_HEROES_ASSAULT_INFLUENCE_ACTION = "PAY_HEROES_ASSAULT_INFLUENCE" as const;
+/**
+ * Pay 2 influence to allow Heroes units to use abilities during
+ * fortified site assaults. Per rulebook, Heroes refuse to participate
+ * in assaults on Keeps, Mage Towers, and Cities without this payment.
+ */
+export interface PayHeroesAssaultInfluenceAction {
+  readonly type: typeof PAY_HEROES_ASSAULT_INFLUENCE_ACTION;
 }
 
 export const BUY_SPELL_ACTION = "BUY_SPELL" as const;
@@ -573,6 +590,7 @@ export type PlayerAction =
   // Interactions
   | RecruitUnitAction
   | DisbandUnitAction
+  | PayHeroesAssaultInfluenceAction
   | BuySpellAction
   | LearnAdvancedActionAction
   | BuyHealingAction

--- a/packages/shared/src/events/combat/blocking.ts
+++ b/packages/shared/src/events/combat/blocking.ts
@@ -267,3 +267,65 @@ export function isMoveSpentOnCumbersomeEvent(
 ): event is MoveSpentOnCumbersomeEvent {
   return event.type === MOVE_SPENT_ON_CUMBERSOME;
 }
+
+// ============================================================================
+// HEROES_ASSAULT_INFLUENCE_PAID (Heroes special rule)
+// ============================================================================
+
+/**
+ * Event type constant for Heroes assault influence payment.
+ * @see HeroesAssaultInfluencePaidEvent
+ */
+export const HEROES_ASSAULT_INFLUENCE_PAID = "HEROES_ASSAULT_INFLUENCE_PAID" as const;
+
+/**
+ * Emitted when 2 Influence is paid to enable Heroes unit abilities
+ * during a fortified site assault.
+ *
+ * Per rulebook: Heroes cannot use abilities in fortified assaults
+ * unless 2 Influence is paid once per combat.
+ *
+ * @remarks
+ * - Only valid during fortified site assaults
+ * - Payment enables all Heroes units for remaining combat
+ * - One-time payment per combat
+ * - Damage assignment to Heroes is allowed without payment
+ *
+ * @example
+ * ```typescript
+ * if (event.type === HEROES_ASSAULT_INFLUENCE_PAID) {
+ *   enableHeroesAbilities();
+ *   updateInfluenceDisplay(event.influenceSpent);
+ * }
+ * ```
+ */
+export interface HeroesAssaultInfluencePaidEvent {
+  readonly type: typeof HEROES_ASSAULT_INFLUENCE_PAID;
+  /** Player who paid the influence */
+  readonly playerId: string;
+  /** Amount of influence spent (always 2) */
+  readonly influenceSpent: number;
+}
+
+/**
+ * Creates a HeroesAssaultInfluencePaidEvent.
+ */
+export function createHeroesAssaultInfluencePaidEvent(
+  playerId: string,
+  influenceSpent: number
+): HeroesAssaultInfluencePaidEvent {
+  return {
+    type: HEROES_ASSAULT_INFLUENCE_PAID,
+    playerId,
+    influenceSpent,
+  };
+}
+
+/**
+ * Type guard for HeroesAssaultInfluencePaidEvent.
+ */
+export function isHeroesAssaultInfluencePaidEvent(
+  event: { type: string }
+): event is HeroesAssaultInfluencePaidEvent {
+  return event.type === HEROES_ASSAULT_INFLUENCE_PAID;
+}

--- a/packages/shared/src/events/combat/index.ts
+++ b/packages/shared/src/events/combat/index.ts
@@ -45,7 +45,7 @@ export * from "./resolution.js";
 // Import constants for the isCombatEvent guard
 import { COMBAT_TRIGGERED, COMBAT_STARTED, ENEMY_SUMMONED, SUMMONED_ENEMY_DISCARDED } from "./initiation.js";
 import { COMBAT_PHASE_CHANGED } from "./phases.js";
-import { ENEMY_BLOCKED, BLOCK_FAILED, BLOCK_ASSIGNED, BLOCK_UNASSIGNED, MOVE_SPENT_ON_CUMBERSOME } from "./blocking.js";
+import { ENEMY_BLOCKED, BLOCK_FAILED, BLOCK_ASSIGNED, BLOCK_UNASSIGNED, MOVE_SPENT_ON_CUMBERSOME, HEROES_ASSAULT_INFLUENCE_PAID } from "./blocking.js";
 import { ENEMY_DEFEATED, ATTACK_FAILED, ATTACK_ASSIGNED, ATTACK_UNASSIGNED } from "./attacks.js";
 import {
   DAMAGE_ASSIGNED,
@@ -81,5 +81,6 @@ export function isCombatEvent(event: { type: string }): boolean {
     ENEMY_SUMMONED,
     SUMMONED_ENEMY_DISCARDED,
     MOVE_SPENT_ON_CUMBERSOME,
+    HEROES_ASSAULT_INFLUENCE_PAID,
   ].includes(event.type as typeof COMBAT_STARTED);
 }

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -172,6 +172,7 @@ import type {
   BlockAssignedEvent,
   BlockUnassignedEvent,
   MoveSpentOnCumbersomeEvent,
+  HeroesAssaultInfluencePaidEvent,
   EnemyDefeatedEvent,
   AttackFailedEvent,
   AttackAssignedEvent,
@@ -345,6 +346,7 @@ export type GameEvent =
   | BlockAssignedEvent
   | BlockUnassignedEvent
   | MoveSpentOnCumbersomeEvent
+  | HeroesAssaultInfluencePaidEvent
   | EnemyDefeatedEvent
   | AttackFailedEvent
   | AttackAssignedEvent

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -226,6 +226,17 @@ export interface CombatOptions {
 
   /** Available move points for Cumbersome reduction */
   readonly availableMovePoints?: number;
+
+  // ---- Heroes assault influence payment (fortified site assaults) ----
+
+  /** Whether player can pay 2 Influence to allow Heroes to use abilities */
+  readonly canPayHeroesAssaultInfluence?: boolean;
+
+  /** Cost to enable Heroes abilities (always 2) */
+  readonly heroesAssaultInfluenceCost?: number;
+
+  /** Whether Heroes assault influence has already been paid this combat */
+  readonly heroesAssaultInfluencePaid?: boolean;
 }
 
 export interface BlockOption {

--- a/packages/shared/src/units/index.ts
+++ b/packages/shared/src/units/index.ts
@@ -40,6 +40,13 @@ export type {
   UnitAbility,
   UnitTerrainModifier,
   UnitDefinition,
+  RecruitmentSource,
+} from "./types.js";
+
+export {
+  RECRUITMENT_SOURCE_NORMAL,
+  RECRUITMENT_SOURCE_ARTIFACT,
+  RECRUITMENT_SOURCE_SPELL,
 } from "./types.js";
 
 // =============================================================================

--- a/packages/shared/src/units/types.ts
+++ b/packages/shared/src/units/types.ts
@@ -18,6 +18,21 @@ import { type ManaColor } from "../ids.js";
 export type UnitType = "regular" | "elite";
 
 /**
+ * Source of unit recruitment - determines which special rules apply.
+ * - "normal": Standard recruitment at a site (all special rules apply)
+ * - "artifact": Recruited via Banner of Command artifact (bypasses special rules)
+ * - "spell": Recruited via Call to Glory spell (bypasses special rules)
+ */
+export const RECRUITMENT_SOURCE_NORMAL = "normal" as const;
+export const RECRUITMENT_SOURCE_ARTIFACT = "artifact" as const;
+export const RECRUITMENT_SOURCE_SPELL = "spell" as const;
+
+export type RecruitmentSource =
+  | typeof RECRUITMENT_SOURCE_NORMAL
+  | typeof RECRUITMENT_SOURCE_ARTIFACT
+  | typeof RECRUITMENT_SOURCE_SPELL;
+
+/**
  * Recruitment site where units can be hired
  */
 export type RecruitSite =


### PR DESCRIPTION
## Summary
- Implements doubled reputation modifier for Heroes recruitment (first Hero only per interaction)
- Adds Heroes/Thugs recruitment conflict validation (cannot recruit both in same interaction)
- Implements fortified site assault restrictions (requires 2 Influence payment to use Heroes abilities)
- Damage assignment to Heroes always allowed during assaults (independent of ability payment)

## Test plan
- [x] Verify doubled reputation modifier for positive reputation values (+3 = -4 modifier for Heroes)
- [x] Verify doubled reputation modifier for negative reputation values (-3 = +4 modifier for Heroes)
- [x] Verify only first Hero gets doubled modifier in same interaction
- [x] Verify Heroes recruitment blocked after Thugs recruited in same interaction
- [x] Verify Thugs recruitment blocked after Heroes recruited in same interaction
- [x] Verify Heroes abilities blocked during fortified assault without payment
- [x] Verify PAY_HEROES_ASSAULT_INFLUENCE_ACTION unlocks abilities
- [x] Verify damage can be assigned to Heroes during assault without payment
- [x] Verify ValidActions exposes Heroes assault influence options

Closes #285