### PR TITLE
fix: pass sourceCardId to resolveEffect for discard cost effects

### DIFF
--- a/packages/core/src/engine/__tests__/playCard.test.ts
+++ b/packages/core/src/engine/__tests__/playCard.test.ts
@@ -17,6 +17,7 @@ import {
   CARD_PROMISE,
   CARD_THREATEN,
   CARD_SWIFTNESS,
+  CARD_IMPROVISATION,
 } from "@mage-knight/shared";
 
 describe("PLAY_CARD action", () => {
@@ -242,6 +243,35 @@ describe("PLAY_CARD action", () => {
         CARD_MARCH,
         CARD_PROMISE,
       ]);
+    });
+  });
+
+  describe("discard cost effects", () => {
+    it("should create pendingDiscard state when playing Improvisation", () => {
+      // Player has Improvisation + another card to discard
+      const player = createTestPlayer({
+        hand: [CARD_IMPROVISATION, CARD_MARCH],
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Playing Improvisation should create a pendingDiscard state,
+      // not throw "DiscardCostEffect requires sourceCardId"
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_IMPROVISATION,
+        powered: false,
+      });
+
+      // Should have pendingDiscard set with the source card
+      const updatedPlayer = result.state.players[0];
+      expect(updatedPlayer.pendingDiscard).toBeDefined();
+      expect(updatedPlayer.pendingDiscard?.sourceCardId).toBe(CARD_IMPROVISATION);
+      expect(updatedPlayer.pendingDiscard?.count).toBe(1);
+
+      // Card should be in play area
+      expect(updatedPlayer.playArea).toContain(CARD_IMPROVISATION);
+      expect(updatedPlayer.hand).not.toContain(CARD_IMPROVISATION);
     });
   });
 

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -151,7 +151,6 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingGladeWoundChoice: false,
     pendingDiscard: null,
     pendingDeepMineChoice: null,
-    pendingDiscard: null,
     pendingDiscardForAttack: null,
     enemiesDefeatedThisTurn: 0,
     healingPoints: 0,

--- a/packages/core/src/engine/commands/playCardCommand.ts
+++ b/packages/core/src/engine/commands/playCardCommand.ts
@@ -120,8 +120,8 @@ export function createPlayCardCommand(params: PlayCardCommandParams): Command {
       players[playerIndex] = updatedPlayer;
       const newState: GameState = { ...state, players, source: updatedSource };
 
-      // Resolve the effect
-      const effectResult = resolveEffect(newState, params.playerId, effectToApply);
+      // Resolve the effect (pass cardId for effects that need to know their source)
+      const effectResult = resolveEffect(newState, params.playerId, effectToApply, params.cardId);
 
       // Check if this is a choice effect
       if (effectResult.requiresChoice) {


### PR DESCRIPTION
When playing cards with DiscardCostEffect (like Improvisation), the effect handler requires the source card ID to create the pendingDiscard state. Previously, resolveEffect was called without this parameter, causing "DiscardCostEffect requires sourceCardId" error.

- Pass params.cardId to resolveEffect in playCardCommand
- Add test for Improvisation creating pendingDiscard state
- Remove duplicate pendingDiscard key in testHelpers