### PR TITLE
feat: add Blood Demon enemy

### DIFF
--- a/packages/shared/src/enemies/brown/blood-demon.ts
+++ b/packages/shared/src/enemies/brown/blood-demon.ts
@@ -1,0 +1,27 @@
+import { ELEMENT_PHYSICAL } from "../../elements.js";
+import {
+  ABILITY_BRUTAL,
+  ABILITY_ASSASSINATION,
+  ABILITY_ARCANE_IMMUNITY,
+} from "../abilities.js";
+import { RESIST_FIRE } from "../resistances.js";
+import {
+  ENEMY_COLOR_BROWN,
+  FACTION_DARK_CRUSADERS,
+  type EnemyDefinition,
+} from "../types.js";
+
+export const ENEMY_BLOOD_DEMON = "blood_demon" as const;
+
+export const BLOOD_DEMON: EnemyDefinition = {
+  id: ENEMY_BLOOD_DEMON,
+  name: "Blood Demon",
+  color: ENEMY_COLOR_BROWN,
+  attack: 6,
+  attackElement: ELEMENT_PHYSICAL,
+  armor: 6,
+  fame: 5,
+  resistances: [RESIST_FIRE],
+  abilities: [ABILITY_BRUTAL, ABILITY_ASSASSINATION, ABILITY_ARCANE_IMMUNITY],
+  faction: FACTION_DARK_CRUSADERS,
+};

--- a/packages/shared/src/enemies/brown/index.ts
+++ b/packages/shared/src/enemies/brown/index.ts
@@ -9,6 +9,7 @@
 import type { EnemyDefinition } from "../types.js";
 
 // Re-export individual enemies
+export { ENEMY_BLOOD_DEMON, BLOOD_DEMON } from "./blood-demon.js";
 export { ENEMY_MINOTAUR, MINOTAUR } from "./minotaur.js";
 export { ENEMY_GARGOYLE, GARGOYLE } from "./gargoyle.js";
 export { ENEMY_MEDUSA, MEDUSA } from "./medusa.js";
@@ -22,6 +23,7 @@ export { ENEMY_MANTICORE, MANTICORE } from "./manticore.js";
 export { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
 
 // Import for aggregation
+import { ENEMY_BLOOD_DEMON, BLOOD_DEMON } from "./blood-demon.js";
 import { ENEMY_MINOTAUR, MINOTAUR } from "./minotaur.js";
 import { ENEMY_GARGOYLE, GARGOYLE } from "./gargoyle.js";
 import { ENEMY_MEDUSA, MEDUSA } from "./medusa.js";
@@ -38,6 +40,7 @@ import { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
  * Union type of all brown (Dungeon monster) enemy IDs
  */
 export type BrownEnemyId =
+  | typeof ENEMY_BLOOD_DEMON
   | typeof ENEMY_MINOTAUR
   | typeof ENEMY_GARGOYLE
   | typeof ENEMY_MEDUSA
@@ -52,6 +55,7 @@ export type BrownEnemyId =
 
 /** All brown (Dungeon monster) enemies */
 export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
+  [ENEMY_BLOOD_DEMON]: BLOOD_DEMON,
   [ENEMY_MINOTAUR]: MINOTAUR,
   [ENEMY_GARGOYLE]: GARGOYLE,
   [ENEMY_MEDUSA]: MEDUSA,


### PR DESCRIPTION
## Summary
Adds Blood Demon to brown (dungeon) enemies with the following stats:
- Attack: 6 Physical
- Armor: 6
- Fame: 5
- Resistances: Fire
- Abilities: Brutal, Assassination, Arcane Immunity
- Faction: Dark Crusaders

## Changes
- Added `packages/shared/src/enemies/brown/blood-demon.ts` - Blood Demon definition
- Updated `packages/shared/src/enemies/brown/index.ts` - Export and include in BROWN_ENEMIES record

## Test Plan
- [x] Build passes
- [x] All tests pass
- [x] Lint passes
- Verify Blood Demon appears in dungeon encounters with correct stats

## Acceptance Criteria
All criteria from issue #374 have been addressed:
- [x] Blood Demon added to brown enemies
- [x] Faction set to Dark Crusaders
- [x] Brutal ability working (already implemented in #249)
- [x] Assassination ability working (implemented in #240)
- [x] Arcane Immunity ability working (implemented in #242)

Closes #374