### PR TITLE
feat: add Air Elemental enemy

### DIFF
--- a/packages/shared/src/enemies/brown/air-elemental.ts
+++ b/packages/shared/src/enemies/brown/air-elemental.ts
@@ -1,0 +1,20 @@
+import { ELEMENT_COLD_FIRE } from "../../elements.js";
+import { ABILITY_ELUSIVE, ABILITY_SWIFT } from "../abilities.js";
+import { RESIST_FIRE, RESIST_ICE } from "../resistances.js";
+import { ENEMY_COLOR_BROWN, FACTION_ELEMENTALIST, type EnemyDefinition } from "../types.js";
+
+export const ENEMY_AIR_ELEMENTAL = "air_elemental" as const;
+
+export const AIR_ELEMENTAL: EnemyDefinition = {
+  id: ENEMY_AIR_ELEMENTAL,
+  name: "Air Elemental",
+  color: ENEMY_COLOR_BROWN,
+  attack: 3,
+  attackElement: ELEMENT_COLD_FIRE,
+  armor: 4,
+  armorElusive: 8, // Elusive: uses 8 normally, 4 if all attacks blocked
+  fame: 4,
+  resistances: [RESIST_FIRE, RESIST_ICE],
+  abilities: [ABILITY_SWIFT, ABILITY_ELUSIVE],
+  faction: FACTION_ELEMENTALIST,
+};

--- a/packages/shared/src/enemies/brown/index.ts
+++ b/packages/shared/src/enemies/brown/index.ts
@@ -9,6 +9,7 @@
 import type { EnemyDefinition } from "../types.js";
 
 // Re-export individual enemies
+export { ENEMY_AIR_ELEMENTAL, AIR_ELEMENTAL } from "./air-elemental.js";
 export { ENEMY_BLOOD_DEMON, BLOOD_DEMON } from "./blood-demon.js";
 export { ENEMY_MINOTAUR, MINOTAUR } from "./minotaur.js";
 export { ENEMY_GARGOYLE, GARGOYLE } from "./gargoyle.js";
@@ -23,6 +24,7 @@ export { ENEMY_MANTICORE, MANTICORE } from "./manticore.js";
 export { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
 
 // Import for aggregation
+import { ENEMY_AIR_ELEMENTAL, AIR_ELEMENTAL } from "./air-elemental.js";
 import { ENEMY_BLOOD_DEMON, BLOOD_DEMON } from "./blood-demon.js";
 import { ENEMY_MINOTAUR, MINOTAUR } from "./minotaur.js";
 import { ENEMY_GARGOYLE, GARGOYLE } from "./gargoyle.js";
@@ -40,6 +42,7 @@ import { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
  * Union type of all brown (Dungeon monster) enemy IDs
  */
 export type BrownEnemyId =
+  | typeof ENEMY_AIR_ELEMENTAL
   | typeof ENEMY_BLOOD_DEMON
   | typeof ENEMY_MINOTAUR
   | typeof ENEMY_GARGOYLE
@@ -55,6 +58,7 @@ export type BrownEnemyId =
 
 /** All brown (Dungeon monster) enemies */
 export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
+  [ENEMY_AIR_ELEMENTAL]: AIR_ELEMENTAL,
   [ENEMY_BLOOD_DEMON]: BLOOD_DEMON,
   [ENEMY_MINOTAUR]: MINOTAUR,
   [ENEMY_GARGOYLE]: GARGOYLE,


### PR DESCRIPTION
## Summary

Adds the Air Elemental enemy to the brown (dungeon) enemies.

## Enemy Stats

| Property | Value |
|----------|-------|
| **Name** | Air Elemental |
| **Color** | Brown (Dungeon) |
| **Faction** | Elementalist |
| **Attack** | 3 Cold Fire |
| **Armor** | 4 (base) / 8 (elusive) |
| **Fame** | 4 |
| **Resistances** | Fire, Ice |
| **Abilities** | Swift, Elusive |

## Changes

- Added `air-elemental.ts` with the Air Elemental enemy definition
- Updated `brown/index.ts` to export the new enemy and include it in `BrownEnemyId` type and `BROWN_ENEMIES` record

## Test Plan

- [x] Build passes
- [x] Lint passes  
- [x] All tests pass (1540 tests)
- [ ] Air Elemental appears in Elementalist expansion dungeon draws

## Acceptance Criteria

- [x] Air Elemental added to brown enemies
- [x] Faction set to Elementalist
- [x] Swift ability working (already implemented)
- [x] Elusive ability working (implemented in #241)
- [ ] Appears in Elementalist expansion dungeon draws

Closes #371