### PR TITLE
feat: implement Thunderstorm skill for Braevalar (#362)

### DIFF
--- a/packages/core/src/data/skills/braevalar/thunderstorm.ts
+++ b/packages/core/src/data/skills/braevalar/thunderstorm.ts
@@ -1,19 +1,43 @@
 /**
  * Thunderstorm - Braevalar Skill
  * @module data/skills/braevalar/thunderstorm
+ *
+ * Once a round: Flip this to gain one green or blue mana token
+ * and one green or white mana token.
+ *
+ * This skill presents two sequential choices:
+ * 1. Choose green or blue mana
+ * 2. Choose green or white mana
+ *
+ * All four combinations are valid: green+green, green+white, blue+green, blue+white.
  */
 
 import type { SkillId } from "@mage-knight/shared";
+import { MANA_GREEN, MANA_BLUE, MANA_WHITE } from "@mage-knight/shared";
 import { CATEGORY_SPECIAL } from "../../../types/cards.js";
+import { EFFECT_GAIN_MANA } from "../../../types/effectTypes.js";
+import { compound, choice } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_ROUND } from "../types.js";
 
 export const SKILL_BRAEVALAR_THUNDERSTORM = "braevalar_thunderstorm" as SkillId;
 
 export const thunderstorm: SkillDefinition = {
   id: SKILL_BRAEVALAR_THUNDERSTORM,
-    name: "Thunderstorm",
-    heroId: "braevalar",
-    description: "Flip to gain 1 green/blue mana and 1 green/white mana",
-    usageType: SKILL_USAGE_ONCE_PER_ROUND,
-    categories: [CATEGORY_SPECIAL],
+  name: "Thunderstorm",
+  heroId: "braevalar",
+  description: "Flip to gain 1 green/blue mana and 1 green/white mana",
+  usageType: SKILL_USAGE_ONCE_PER_ROUND,
+  categories: [CATEGORY_SPECIAL],
+  effect: compound([
+    // First choice: Green or Blue mana token
+    choice([
+      { type: EFFECT_GAIN_MANA, color: MANA_GREEN },
+      { type: EFFECT_GAIN_MANA, color: MANA_BLUE },
+    ]),
+    // Second choice: Green or White mana token
+    choice([
+      { type: EFFECT_GAIN_MANA, color: MANA_GREEN },
+      { type: EFFECT_GAIN_MANA, color: MANA_WHITE },
+    ]),
+  ]),
 };

--- a/packages/core/src/engine/__tests__/skillThunderstorm.test.ts
+++ b/packages/core/src/engine/__tests__/skillThunderstorm.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Tests for Thunderstorm skill (Braevalar)
+ *
+ * Skill effect: Once a round, flip this to gain one green or blue mana token
+ * and one green or white mana token.
+ *
+ * Key rules:
+ * - Once per round (flip to activate)
+ * - First choice: green OR blue mana token
+ * - Second choice: green OR white mana token
+ * - Choices are independent (can choose green twice)
+ * - Grants mana tokens (not crystals)
+ *
+ * Possible combinations:
+ * - Green + Green (2 green)
+ * - Green + White
+ * - Blue + Green
+ * - Blue + White
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  UNDO_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CHOICE_REQUIRED,
+  CARD_MARCH,
+  MANA_GREEN,
+  MANA_BLUE,
+  MANA_WHITE,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_BRAEVALAR_THUNDERSTORM } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+
+describe("Thunderstorm skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate skill and present first choice (green or blue)", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // Should emit SKILL_USED event
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+        })
+      );
+
+      // Should emit CHOICE_REQUIRED event with first choice options
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CHOICE_REQUIRED,
+          playerId: "player1",
+          skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+          options: expect.arrayContaining([
+            expect.stringContaining("green"),
+            expect.stringContaining("blue"),
+          ]),
+        })
+      );
+
+      // Should have pending choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      expect(result.state.players[0].pendingChoice?.options).toHaveLength(2);
+    });
+
+    it("should add skill to usedThisRound cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      expect(
+        result.state.players[0].skillCooldowns.usedThisRound
+      ).toContain(SKILL_BRAEVALAR_THUNDERSTORM);
+    });
+
+    it("should reject if skill not learned", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [], // No skills learned
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if skill already used this round", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [SKILL_BRAEVALAR_THUNDERSTORM], // Already used
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("mana combinations", () => {
+    it("should allow green + green combination", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // First choice: select green (index 0)
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      // Should have one green mana token
+      expect(afterFirstChoice.state.players[0].pureMana).toHaveLength(1);
+      expect(afterFirstChoice.state.players[0].pureMana[0]).toEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+
+      // Should have second choice pending (green or white)
+      expect(afterFirstChoice.state.players[0].pendingChoice).not.toBeNull();
+
+      // Second choice: select green (index 0)
+      const afterSecondChoice = engine.processAction(afterFirstChoice.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      // Should have two green mana tokens
+      expect(afterSecondChoice.state.players[0].pureMana).toHaveLength(2);
+      expect(afterSecondChoice.state.players[0].pureMana).toEqual([
+        { color: MANA_GREEN, source: MANA_TOKEN_SOURCE_CARD },
+        { color: MANA_GREEN, source: MANA_TOKEN_SOURCE_CARD },
+      ]);
+
+      // No more pending choice
+      expect(afterSecondChoice.state.players[0].pendingChoice).toBeNull();
+    });
+
+    it("should allow green + white combination", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // First choice: select green (index 0)
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      // Second choice: select white (index 1)
+      const afterSecondChoice = engine.processAction(afterFirstChoice.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1, // White
+      });
+
+      // Should have green and white mana tokens
+      expect(afterSecondChoice.state.players[0].pureMana).toHaveLength(2);
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_WHITE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should allow blue + green combination", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // First choice: select blue (index 1)
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1, // Blue
+      });
+
+      // Second choice: select green (index 0)
+      const afterSecondChoice = engine.processAction(afterFirstChoice.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      // Should have blue and green mana tokens
+      expect(afterSecondChoice.state.players[0].pureMana).toHaveLength(2);
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should allow blue + white combination", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // First choice: select blue (index 1)
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1, // Blue
+      });
+
+      // Second choice: select white (index 1)
+      const afterSecondChoice = engine.processAction(afterFirstChoice.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1, // White
+      });
+
+      // Should have blue and white mana tokens
+      expect(afterSecondChoice.state.players[0].pureMana).toHaveLength(2);
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(afterSecondChoice.state.players[0].pureMana).toContainEqual({
+        color: MANA_WHITE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+  });
+
+  describe("mana tokens (not crystals)", () => {
+    it("should grant mana tokens not crystals", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate and resolve both choices
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      const afterSecondChoice = engine.processAction(afterFirstChoice.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Green
+      });
+
+      // Crystals should remain unchanged
+      expect(afterSecondChoice.state.players[0].crystals).toEqual({
+        red: 0,
+        blue: 0,
+        green: 0,
+        white: 0,
+      });
+
+      // Tokens should be added with CARD source
+      expect(afterSecondChoice.state.players[0].pureMana).toHaveLength(2);
+      for (const token of afterSecondChoice.state.players[0].pureMana) {
+        expect(token.source).toBe(MANA_TOKEN_SOURCE_CARD);
+      }
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill in valid actions when available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      expect(validActions.skills).toBeDefined();
+      expect(validActions.skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+        })
+      );
+    });
+
+    it("should not show skill in valid actions when on cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [SKILL_BRAEVALAR_THUNDERSTORM], // Already used
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      // Either skills is undefined or the skill is not in the list
+      if (validActions.skills) {
+        expect(validActions.skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+          })
+        );
+      }
+    });
+
+    it("should not show skill if player has not learned it", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [], // No skills
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      // Skills should be undefined since no skills are available
+      expect(validActions.skills).toBeUndefined();
+    });
+  });
+
+  describe("undo", () => {
+    it("should be undoable before making first choice", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // Verify skill was activated
+      expect(
+        afterSkill.state.players[0].skillCooldowns.usedThisRound
+      ).toContain(SKILL_BRAEVALAR_THUNDERSTORM);
+      expect(afterSkill.state.players[0].pendingChoice).not.toBeNull();
+
+      // Undo
+      const afterUndo = engine.processAction(afterSkill.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Skill should be removed from cooldown
+      expect(
+        afterUndo.state.players[0].skillCooldowns.usedThisRound
+      ).not.toContain(SKILL_BRAEVALAR_THUNDERSTORM);
+
+      // Pending choice should be cleared
+      expect(afterUndo.state.players[0].pendingChoice).toBeNull();
+
+      // No mana tokens should be gained
+      expect(afterUndo.state.players[0].pureMana).toHaveLength(0);
+    });
+
+    it("should be undoable after making first choice", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_THUNDERSTORM],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_THUNDERSTORM,
+      });
+
+      // Make first choice (green)
+      const afterFirstChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      });
+
+      // Verify first choice was applied and second choice is pending
+      expect(afterFirstChoice.state.players[0].pureMana).toHaveLength(1);
+      expect(afterFirstChoice.state.players[0].pendingChoice).not.toBeNull();
+
+      // Undo the first choice
+      const afterUndo = engine.processAction(afterFirstChoice.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Mana token should be removed
+      expect(afterUndo.state.players[0].pureMana).toHaveLength(0);
+
+      // Should be back to first choice pending
+      expect(afterUndo.state.players[0].pendingChoice).not.toBeNull();
+      expect(afterUndo.state.players[0].pendingChoice?.options).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -5,13 +5,21 @@
  * "once per turn" and "once per round" skills that require explicit activation.
  *
  * Passive skills don't require this command - they are always active.
+ *
+ * Skills can have effects defined via the `effect` property, which are resolved
+ * using the standard effect resolution system. This supports compound effects,
+ * choice effects, and other effect types.
  */
 
 import type { Command, CommandResult } from "../commands.js";
 import type { GameState } from "../../state/GameState.js";
-import type { Player, SkillCooldowns } from "../../types/player.js";
+import type { Player, SkillCooldowns, PendingChoice } from "../../types/player.js";
 import type { SkillId } from "@mage-knight/shared";
-import { createSkillUsedEvent } from "@mage-knight/shared";
+import type { GameEvent } from "@mage-knight/shared";
+import {
+  createSkillUsedEvent,
+  CHOICE_REQUIRED,
+} from "@mage-knight/shared";
 import { USE_SKILL_COMMAND } from "./commandTypes.js";
 import {
   SKILLS,
@@ -30,6 +38,14 @@ import {
   removeIFeelNoPainEffect,
 } from "./skills/index.js";
 import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
+import {
+  resolveEffect,
+  reverseEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type { CardEffect, ChoiceEffect, CompoundEffect } from "../../types/cards.js";
+import { EFFECT_CHOICE, EFFECT_COMPOUND } from "../../types/effectTypes.js";
 
 export { USE_SKILL_COMMAND };
 
@@ -41,8 +57,11 @@ export interface UseSkillCommandParams {
 /**
  * Apply the skill effect based on skill ID.
  * Returns updated state with skill effects applied.
+ *
+ * This handles skills with custom effect handlers.
+ * Skills with generic `effect` properties are handled separately.
  */
-function applySkillEffect(
+function applyCustomSkillEffect(
   state: GameState,
   playerId: string,
   skillId: SkillId
@@ -58,7 +77,7 @@ function applySkillEffect(
       return applyIFeelNoPainEffect(state, playerId);
 
     default:
-      // Skill has no implemented effect yet
+      // Skill has no custom handler - will use generic effect resolution
       return state;
   }
 }
@@ -66,8 +85,10 @@ function applySkillEffect(
 /**
  * Remove the skill effect for undo.
  * Returns updated state with skill effects removed.
+ *
+ * This handles skills with custom effect handlers.
  */
-function removeSkillEffect(
+function removeCustomSkillEffect(
   state: GameState,
   playerId: string,
   skillId: SkillId
@@ -85,6 +106,17 @@ function removeSkillEffect(
     default:
       return state;
   }
+}
+
+/**
+ * Check if a skill has a custom effect handler.
+ */
+function hasCustomHandler(skillId: SkillId): boolean {
+  return [
+    SKILL_TOVAK_WHO_NEEDS_MAGIC,
+    SKILL_TOVAK_SHIELD_MASTERY,
+    SKILL_TOVAK_I_FEEL_NO_PAIN,
+  ].includes(skillId);
 }
 
 /**
@@ -134,10 +166,191 @@ function removeFromCooldowns(
 }
 
 /**
+ * Result of extracting choice info from an effect.
+ */
+interface ChoiceExtractionResult {
+  readonly options: readonly CardEffect[];
+  readonly remainingEffects?: readonly CardEffect[];
+}
+
+/**
+ * Get the choice options from an effect resolution result.
+ * Handles both direct choice effects and compound effects that start with a choice.
+ * Also returns any remaining effects that should be resolved after the choice.
+ */
+function getChoiceOptions(
+  effectResult: { dynamicChoiceOptions?: readonly CardEffect[] },
+  effectToApply: CardEffect
+): ChoiceExtractionResult | null {
+  if (effectResult.dynamicChoiceOptions) {
+    return { options: effectResult.dynamicChoiceOptions };
+  }
+
+  if (effectToApply.type === EFFECT_CHOICE) {
+    const choiceEffect = effectToApply as ChoiceEffect;
+    return { options: choiceEffect.options };
+  }
+
+  // For compound effects, find the first choice sub-effect and track remaining effects
+  // When a compound effect returns requiresChoice, it means a choice effect
+  // in the sequence was reached and needs resolution
+  if (effectToApply.type === EFFECT_COMPOUND) {
+    const compoundEffect = effectToApply as CompoundEffect;
+    for (let i = 0; i < compoundEffect.effects.length; i++) {
+      const subEffect = compoundEffect.effects[i];
+      if (subEffect && subEffect.type === EFFECT_CHOICE) {
+        const choiceEffect = subEffect as ChoiceEffect;
+        // Get effects that come after this choice
+        const remainingEffects = compoundEffect.effects.slice(i + 1);
+        if (remainingEffects.length > 0) {
+          return {
+            options: choiceEffect.options,
+            remainingEffects,
+          };
+        }
+        return {
+          options: choiceEffect.options,
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Handle choice effect by setting up pending choice state.
+ */
+function handleSkillChoiceEffect(
+  state: GameState,
+  playerId: string,
+  playerIndex: number,
+  skillId: SkillId,
+  effectResult: { state: GameState; description: string; dynamicChoiceOptions?: readonly CardEffect[] },
+  choiceOptions: readonly CardEffect[],
+  remainingEffects?: readonly CardEffect[]
+): CommandResult {
+  // Filter options to only include resolvable ones
+  const resolvableOptions = choiceOptions.filter((opt) =>
+    isEffectResolvable(effectResult.state, playerId, opt)
+  );
+
+  // If no options are resolvable, skip the choice entirely
+  // But still need to process remaining effects if any
+  if (resolvableOptions.length === 0) {
+    if (remainingEffects && remainingEffects.length > 0) {
+      // Continue with remaining effects
+      const compoundResult = resolveEffect(effectResult.state, playerId, {
+        type: EFFECT_COMPOUND,
+        effects: remainingEffects,
+      });
+      return {
+        state: compoundResult.state,
+        events: [createSkillUsedEvent(playerId, skillId)],
+      };
+    }
+    return {
+      state: effectResult.state,
+      events: [createSkillUsedEvent(playerId, skillId)],
+    };
+  }
+
+  // If only one option is resolvable, auto-resolve it
+  if (resolvableOptions.length === 1) {
+    const singleOption = resolvableOptions[0];
+    if (!singleOption) {
+      throw new Error("Expected single resolvable option");
+    }
+
+    const autoResolveResult = resolveEffect(effectResult.state, playerId, singleOption);
+
+    // If there are remaining effects, continue resolving them
+    if (remainingEffects && remainingEffects.length > 0) {
+      const compoundResult = resolveEffect(autoResolveResult.state, playerId, {
+        type: EFFECT_COMPOUND,
+        effects: remainingEffects,
+      });
+
+      // Check if the remaining effects require a choice
+      if (compoundResult.requiresChoice) {
+        const nextChoiceInfo = getChoiceOptions(compoundResult, {
+          type: EFFECT_COMPOUND,
+          effects: remainingEffects,
+        });
+
+        if (nextChoiceInfo) {
+          return handleSkillChoiceEffect(
+            compoundResult.state,  // Use current state, not original
+            playerId,
+            playerIndex,
+            skillId,
+            compoundResult,
+            nextChoiceInfo.options,
+            nextChoiceInfo.remainingEffects
+          );
+        }
+      }
+
+      return {
+        state: compoundResult.state,
+        events: [createSkillUsedEvent(playerId, skillId)],
+      };
+    }
+
+    return {
+      state: autoResolveResult.state,
+      events: [createSkillUsedEvent(playerId, skillId)],
+    };
+  }
+
+  // Multiple options available - present choice to player
+  const player = effectResult.state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  const newPendingChoice: PendingChoice = {
+    cardId: null,
+    skillId,
+    unitInstanceId: null,
+    options: resolvableOptions,
+    ...(remainingEffects && { remainingEffects }),
+  };
+
+  const playerWithChoice: Player = {
+    ...player,
+    pendingChoice: newPendingChoice,
+  };
+
+  // Update state with pending choice
+  const playersWithChoice = [...effectResult.state.players];
+  playersWithChoice[playerIndex] = playerWithChoice;
+
+  const events: GameEvent[] = [
+    createSkillUsedEvent(playerId, skillId),
+    {
+      type: CHOICE_REQUIRED,
+      playerId,
+      cardId: null,
+      skillId,
+      options: resolvableOptions.map((opt) => describeEffect(opt)),
+    },
+  ];
+
+  return {
+    state: { ...effectResult.state, players: playersWithChoice },
+    events,
+  };
+}
+
+/**
  * Create a use skill command.
  */
 export function createUseSkillCommand(params: UseSkillCommandParams): Command {
   const { playerId, skillId } = params;
+
+  // Store the effect that was applied so we can reverse it on undo
+  let appliedEffect: CardEffect | null = null;
 
   return {
     type: USE_SKILL_COMMAND,
@@ -174,9 +387,47 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
 
       let updatedState: GameState = { ...state, players };
 
-      // Apply skill effect
-      updatedState = applySkillEffect(updatedState, playerId, skillId);
+      // Check if skill has a custom handler
+      if (hasCustomHandler(skillId)) {
+        updatedState = applyCustomSkillEffect(updatedState, playerId, skillId);
+        return {
+          state: updatedState,
+          events: [createSkillUsedEvent(playerId, skillId)],
+        };
+      }
 
+      // Check if skill has a generic effect defined
+      if (skill.effect) {
+        appliedEffect = skill.effect;
+
+        // Resolve the effect using the standard effect resolution system
+        const effectResult = resolveEffect(updatedState, playerId, skill.effect);
+
+        // Check if this is a choice effect
+        if (effectResult.requiresChoice) {
+          const choiceInfo = getChoiceOptions(effectResult, skill.effect);
+
+          if (choiceInfo) {
+            return handleSkillChoiceEffect(
+              updatedState,
+              playerId,
+              playerIndex,
+              skillId,
+              effectResult,
+              choiceInfo.options,
+              choiceInfo.remainingEffects
+            );
+          }
+        }
+
+        // No choice required - return final state
+        return {
+          state: effectResult.state,
+          events: [createSkillUsedEvent(playerId, skillId)],
+        };
+      }
+
+      // No effect defined - just apply cooldown
       return {
         state: updatedState,
         events: [createSkillUsedEvent(playerId, skillId)],
@@ -203,22 +454,35 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
       );
 
       // Update player with restored cooldowns
-      const updatedPlayer: Player = {
+      let updatedPlayer: Player = {
         ...player,
         skillCooldowns: updatedCooldowns,
+        pendingChoice: null, // Clear any pending choice
       };
+
+      // Check if skill has a custom handler
+      if (hasCustomHandler(skillId)) {
+        const players = [...state.players];
+        players[playerIndex] = updatedPlayer;
+        let updatedState: GameState = { ...state, players };
+        updatedState = removeCustomSkillEffect(updatedState, playerId, skillId);
+        return {
+          state: updatedState,
+          events: [],
+        };
+      }
+
+      // Reverse the generic effect if one was applied (only if it wasn't a choice effect)
+      if (appliedEffect && appliedEffect.type !== EFFECT_CHOICE) {
+        updatedPlayer = reverseEffect(updatedPlayer, appliedEffect);
+      }
 
       const players = [...state.players];
       players[playerIndex] = updatedPlayer;
 
-      let updatedState: GameState = { ...state, players };
-
-      // Remove skill effect
-      updatedState = removeSkillEffect(updatedState, playerId, skillId);
-
       return {
-        state: updatedState,
-        events: [], // No event for undo
+        state: { ...state, players },
+        events: [],
       };
     },
   };

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -42,6 +42,7 @@ import {
   EFFECT_CHANGE_REPUTATION,
   EFFECT_GAIN_FAME,
   EFFECT_GAIN_CRYSTAL,
+  EFFECT_GAIN_MANA,
   EFFECT_CRYSTALLIZE_COLOR,
   EFFECT_DRAW_CARDS,
   EFFECT_TAKE_WOUND,
@@ -156,6 +157,21 @@ export function reverseEffect(player: Player, effect: CardEffect): Player {
           [effect.color]: Math.max(0, player.crystals[effect.color] - 1),
         },
       };
+
+    case EFFECT_GAIN_MANA: {
+      // Reverse mana token gain by removing a matching token from pureMana
+      const tokenIndex = player.pureMana.findIndex((t) => t.color === effect.color);
+      if (tokenIndex === -1) {
+        // Token not found - can't reverse (might have been spent)
+        return player;
+      }
+      const newPureMana = [...player.pureMana];
+      newPureMana.splice(tokenIndex, 1);
+      return {
+        ...player,
+        pureMana: newPureMana,
+      };
+    }
 
     case EFFECT_CRYSTALLIZE_COLOR:
       // Reverse crystallize: remove the crystal and restore the mana token

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -20,6 +20,7 @@ import {
   SKILL_TOVAK_WHO_NEEDS_MAGIC,
   SKILL_TOVAK_SHIELD_MASTERY,
   SKILL_TOVAK_I_FEEL_NO_PAIN,
+  SKILL_BRAEVALAR_THUNDERSTORM,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
@@ -33,6 +34,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_TOVAK_WHO_NEEDS_MAGIC,
   SKILL_TOVAK_SHIELD_MASTERY,
   SKILL_TOVAK_I_FEEL_NO_PAIN,
+  SKILL_BRAEVALAR_THUNDERSTORM,
 ]);
 
 /**

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -154,6 +154,12 @@ export interface PendingChoice {
   readonly skillId: SkillId | null;
   readonly unitInstanceId: string | null; // For unit effect-based abilities (e.g., Sorcerers)
   readonly options: readonly CardEffect[];
+  /**
+   * Remaining effects to resolve after this choice is resolved.
+   * Used when a compound effect is interrupted by a choice - the remaining
+   * sub-effects are stored here so they can continue after the choice is resolved.
+   */
+  readonly remainingEffects?: readonly CardEffect[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implement Braevalar's Thunderstorm skill which allows flipping once per round to gain two mana tokens through sequential choices
- First choice: green OR blue mana token; Second choice: green OR white mana token
- Extend compound effect system to support multiple sequential choices via `remainingEffects` tracking
- Add proper undo support for `EFFECT_GAIN_MANA`

## Changes
- `packages/core/src/data/skills/braevalar/thunderstorm.ts` - Add effect definition using compound+choice effects
- `packages/core/src/types/player.ts` - Add `remainingEffects` field to `PendingChoice` interface
- `packages/core/src/engine/commands/resolveChoiceCommand.ts` - Continue compound effects after choice resolution
- `packages/core/src/engine/commands/useSkillCommand.ts` - Track and pass remainingEffects for compound choices
- `packages/core/src/engine/effects/reverse.ts` - Add `EFFECT_GAIN_MANA` reversal for proper undo
- `packages/core/src/engine/validActions/skills.ts` - Add Thunderstorm to IMPLEMENTED_SKILLS
- `packages/core/src/engine/__tests__/skillThunderstorm.test.ts` - Comprehensive tests

## Test plan
- [x] Tests for all 4 mana combinations (green+green, green+white, blue+green, blue+white)
- [x] Tests for skill cooldown tracking (once per round)
- [x] Tests for valid actions filtering
- [x] Tests for undo behavior (before and after first choice)
- [x] All existing tests pass (1494 core + 48 server)

Closes #362