### PR TITLE
feat: add Bright Negotiation effect (#323)

### DIFF
--- a/packages/core/src/data/skills/norowas/brightNegotiation.ts
+++ b/packages/core/src/data/skills/norowas/brightNegotiation.ts
@@ -5,6 +5,7 @@
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_INFLUENCE } from "../../../types/cards.js";
+import { ifNightOrUnderground, influence } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_NOROWAS_BRIGHT_NEGOTIATION = "norowas_bright_negotiation" as SkillId;
@@ -15,5 +16,6 @@ export const brightNegotiation: SkillDefinition = {
   heroId: "norowas",
   description: "Influence 3 (Day) or Influence 2 (Night)",
   usageType: SKILL_USAGE_ONCE_PER_TURN,
+  effect: ifNightOrUnderground(influence(2), influence(3)),
   categories: [CATEGORY_INFLUENCE],
 };

--- a/packages/core/src/engine/__tests__/conditionalEffects.test.ts
+++ b/packages/core/src/engine/__tests__/conditionalEffects.test.ts
@@ -51,6 +51,7 @@ import {
 } from "../../data/effectHelpers.js";
 import { ENEMY_PROWLERS } from "@mage-knight/shared";
 import { daySharpshooting } from "../../data/skills/norowas/daySharpshooting.js";
+import { brightNegotiation } from "../../data/skills/norowas/brightNegotiation.js";
 
 describe("Conditional Effects", () => {
   describe("evaluateCondition", () => {
@@ -660,6 +661,50 @@ describe("Conditional Effects", () => {
         const result = resolveEffect(state, "player1", effect, "test-skill");
 
         expect(result.state.players[0]?.combatAccumulator.attack.ranged).toBe(0);
+      });
+    });
+
+    describe("Bright Negotiation (Norowas)", () => {
+      it("should grant Influence 3 during day on the surface", () => {
+        const state = createTestGameState({ timeOfDay: TIME_OF_DAY_DAY, combat: null });
+
+        const effect = brightNegotiation.effect;
+        if (!effect) {
+          throw new Error("Bright Negotiation effect is missing");
+        }
+
+        const result = resolveEffect(state, "player1", effect, "test-skill");
+
+        expect(result.state.players[0]?.influencePoints).toBe(3);
+      });
+
+      it("should grant Influence 2 at night on the surface", () => {
+        const state = createTestGameState({ timeOfDay: TIME_OF_DAY_NIGHT, combat: null });
+
+        const effect = brightNegotiation.effect;
+        if (!effect) {
+          throw new Error("Bright Negotiation effect is missing");
+        }
+
+        const result = resolveEffect(state, "player1", effect, "test-skill");
+
+        expect(result.state.players[0]?.influencePoints).toBe(2);
+      });
+
+      it("should grant Influence 2 in a dungeon during day", () => {
+        const combat = createCombatState([ENEMY_PROWLERS], false, {
+          nightManaRules: true,
+        });
+        const state = createTestGameState({ timeOfDay: TIME_OF_DAY_DAY, combat });
+
+        const effect = brightNegotiation.effect;
+        if (!effect) {
+          throw new Error("Bright Negotiation effect is missing");
+        }
+
+        const result = resolveEffect(state, "player1", effect, "test-skill");
+
+        expect(result.state.players[0]?.influencePoints).toBe(2);
       });
     });
   });


### PR DESCRIPTION
## Summary
- add Bright Negotiation day/night influence effect with dungeon override
- add Bright Negotiation conditional tests

## Testing
- bun run build
- bun run lint
- bun run test

Closes #323