### PR TITLE
feat: add Tirelessness movement bonus

### DIFF
--- a/packages/core/src/data/basicActions/blue/wolfhawk-tirelessness.ts
+++ b/packages/core/src/data/basicActions/blue/wolfhawk-tirelessness.ts
@@ -1,7 +1,9 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_MOVEMENT, DEED_CARD_TYPE_BASIC_ACTION } from "../../../types/cards.js";
+import { EFFECT_APPLY_MODIFIER } from "../../../types/effectTypes.js";
+import { DURATION_TURN, EFFECT_MOVEMENT_CARD_BONUS } from "../../../types/modifierConstants.js";
 import { MANA_BLUE, CARD_WOLFHAWK_TIRELESSNESS } from "@mage-knight/shared";
-import { move } from "../helpers.js";
+import { compound, move } from "../helpers.js";
 
 /**
  * Wolfhawk's Tirelessness (replaces Stamina)
@@ -12,7 +14,17 @@ export const WOLFHAWK_TIRELESSNESS: DeedCard = {
   cardType: DEED_CARD_TYPE_BASIC_ACTION,
   poweredBy: [MANA_BLUE],
   categories: [CATEGORY_MOVEMENT],
-  basicEffect: move(2),
-  poweredEffect: move(4),
+  basicEffect: compound(move(2), {
+    type: EFFECT_APPLY_MODIFIER,
+    modifier: { type: EFFECT_MOVEMENT_CARD_BONUS, amount: 1, remaining: 1 },
+    duration: DURATION_TURN,
+    description: "Next movement card gets +1 Move this turn",
+  }),
+  poweredEffect: compound(move(4), {
+    type: EFFECT_APPLY_MODIFIER,
+    modifier: { type: EFFECT_MOVEMENT_CARD_BONUS, amount: 1 },
+    duration: DURATION_TURN,
+    description: "Each other movement card gets +1 Move this turn",
+  }),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/tirelessness.test.ts
+++ b/packages/core/src/engine/__tests__/tirelessness.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for Wolfhawk's Tirelessness
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import type { ActiveModifier } from "../../types/modifiers.js";
+import {
+  PLAY_CARD_ACTION,
+  PLAY_CARD_SIDEWAYS_ACTION,
+  PLAY_SIDEWAYS_AS_MOVE,
+  CARD_WOLFHAWK_TIRELESSNESS,
+  CARD_MARCH,
+  CARD_SWIFTNESS,
+  CARD_PROMISE,
+  MANA_BLUE,
+  MANA_SOURCE_TOKEN,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import {
+  DURATION_TURN,
+  EFFECT_MOVEMENT_CARD_BONUS,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../modifierConstants.js";
+
+describe("Tirelessness", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  it("basic effect grants +1 to the next movement card only", () => {
+    const player = createTestPlayer({
+      hand: [CARD_WOLFHAWK_TIRELESSNESS, CARD_MARCH, CARD_SWIFTNESS],
+      movePoints: 0,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const afterTirelessness = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_WOLFHAWK_TIRELESSNESS,
+      powered: false,
+    });
+
+    expect(afterTirelessness.state.players[0].movePoints).toBe(2);
+    expect(afterTirelessness.state.activeModifiers).toHaveLength(1);
+    expect(afterTirelessness.state.activeModifiers[0]?.effect.type).toBe(
+      EFFECT_MOVEMENT_CARD_BONUS
+    );
+
+    const afterMarch = engine.processAction(afterTirelessness.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_MARCH,
+      powered: false,
+    });
+
+    expect(afterMarch.state.players[0].movePoints).toBe(5);
+    expect(afterMarch.state.activeModifiers).toHaveLength(0);
+
+    const afterSwiftness = engine.processAction(afterMarch.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_SWIFTNESS,
+      powered: false,
+    });
+
+    expect(afterSwiftness.state.players[0].movePoints).toBe(7);
+  });
+
+  it("powered effect grants +1 to all subsequent movement cards", () => {
+    const player = createTestPlayer({
+      hand: [CARD_WOLFHAWK_TIRELESSNESS, CARD_MARCH, CARD_SWIFTNESS],
+      movePoints: 0,
+      pureMana: [{ color: MANA_BLUE, source: MANA_TOKEN_SOURCE_CARD }],
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const afterTirelessness = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_WOLFHAWK_TIRELESSNESS,
+      powered: true,
+      manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+    });
+
+    expect(afterTirelessness.state.players[0].movePoints).toBe(4);
+    expect(afterTirelessness.state.activeModifiers).toHaveLength(1);
+
+    const afterMarch = engine.processAction(afterTirelessness.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_MARCH,
+      powered: false,
+    });
+
+    expect(afterMarch.state.players[0].movePoints).toBe(7);
+    expect(afterMarch.state.activeModifiers).toHaveLength(1);
+
+    const afterSwiftness = engine.processAction(afterMarch.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_SWIFTNESS,
+      powered: false,
+    });
+
+    expect(afterSwiftness.state.players[0].movePoints).toBe(10);
+    expect(afterSwiftness.state.activeModifiers).toHaveLength(1);
+  });
+
+  it("sideways move benefits from the bonus", () => {
+    const player = createTestPlayer({
+      hand: [CARD_WOLFHAWK_TIRELESSNESS, CARD_PROMISE],
+      movePoints: 0,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const afterTirelessness = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_WOLFHAWK_TIRELESSNESS,
+      powered: false,
+    });
+
+    const afterSideways = engine.processAction(afterTirelessness.state, "player1", {
+      type: PLAY_CARD_SIDEWAYS_ACTION,
+      cardId: CARD_PROMISE,
+      as: PLAY_SIDEWAYS_AS_MOVE,
+    });
+
+    expect(afterSideways.state.players[0].movePoints).toBe(4);
+  });
+
+  it("non-move cards do not consume the bonus", () => {
+    const player = createTestPlayer({
+      hand: [CARD_WOLFHAWK_TIRELESSNESS, CARD_PROMISE, CARD_MARCH],
+      movePoints: 0,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const afterTirelessness = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_WOLFHAWK_TIRELESSNESS,
+      powered: false,
+    });
+
+    const afterPromise = engine.processAction(afterTirelessness.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_PROMISE,
+      powered: false,
+    });
+
+    expect(afterPromise.state.activeModifiers).toHaveLength(1);
+
+    const afterMarch = engine.processAction(afterPromise.state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_MARCH,
+      powered: false,
+    });
+
+    expect(afterMarch.state.players[0].movePoints).toBe(5);
+    expect(afterMarch.state.activeModifiers).toHaveLength(0);
+  });
+
+  it("stacks multiple movement bonuses", () => {
+    const player = createTestPlayer({
+      hand: [CARD_MARCH],
+      movePoints: 0,
+    });
+
+    const modifierOne: ActiveModifier = {
+      id: "bonus_one",
+      source: {
+        type: SOURCE_CARD,
+        cardId: CARD_WOLFHAWK_TIRELESSNESS,
+        playerId: "player1",
+      },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_MOVEMENT_CARD_BONUS, amount: 1, remaining: 1 },
+      createdAtRound: 1,
+      createdByPlayerId: "player1",
+    };
+
+    const modifierTwo: ActiveModifier = {
+      id: "bonus_two",
+      source: {
+        type: SOURCE_CARD,
+        cardId: CARD_WOLFHAWK_TIRELESSNESS,
+        playerId: "player1",
+      },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_MOVEMENT_CARD_BONUS, amount: 1, remaining: 1 },
+      createdAtRound: 1,
+      createdByPlayerId: "player1",
+    };
+
+    const state = createTestGameState({
+      players: [player],
+      activeModifiers: [modifierOne, modifierTwo],
+    });
+
+    const result = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_MARCH,
+      powered: false,
+    });
+
+    expect(result.state.players[0].movePoints).toBe(4);
+    expect(result.state.activeModifiers).toHaveLength(0);
+  });
+});

--- a/packages/core/src/engine/modifiers/index.ts
+++ b/packages/core/src/engine/modifiers/index.ts
@@ -40,7 +40,7 @@ export {
 export { getEffectiveUnitResistances } from "./units.js";
 
 // Card values
-export { getEffectiveSidewaysValue, isRuleActive } from "./cardValues.js";
+export { getEffectiveSidewaysValue, isRuleActive, consumeMovementCardBonus } from "./cardValues.js";
 
 // Lifecycle
 export {

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -48,6 +48,7 @@ export const TERRAIN_ALL = "all" as const;
 export const EFFECT_TERRAIN_COST = "terrain_cost" as const;
 export const EFFECT_TERRAIN_SAFE = "terrain_safe" as const;
 export const EFFECT_SIDEWAYS_VALUE = "sideways_value" as const;
+export const EFFECT_MOVEMENT_CARD_BONUS = "movement_card_bonus" as const;
 export const EFFECT_COMBAT_VALUE = "combat_value" as const;
 export const EFFECT_ENEMY_STAT = "enemy_stat" as const;
 export const EFFECT_RULE_OVERRIDE = "rule_override" as const;

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -28,6 +28,7 @@ import {
   EFFECT_ENEMY_STAT,
   EFFECT_REMOVE_PHYSICAL_RESISTANCE,
   EFFECT_REMOVE_RESISTANCES,
+  EFFECT_MOVEMENT_CARD_BONUS,
   EFFECT_RULE_OVERRIDE,
   EFFECT_SIDEWAYS_VALUE,
   EFFECT_TERRAIN_COST,
@@ -121,6 +122,14 @@ export interface SidewaysValueModifier {
   readonly condition?:
     | typeof SIDEWAYS_CONDITION_NO_MANA_USED
     | typeof SIDEWAYS_CONDITION_WITH_MANA_MATCHING_COLOR;
+}
+
+// Movement card bonus modifier (e.g., "next movement card gets +1")
+export interface MovementCardBonusModifier {
+  readonly type: typeof EFFECT_MOVEMENT_CARD_BONUS;
+  readonly amount: number;
+  /** If set, decrements each time a movement card bonus is applied */
+  readonly remaining?: number;
 }
 
 // Combat value modifier (e.g., "+2 Attack")
@@ -224,6 +233,7 @@ export type ModifierEffect =
   | TerrainCostModifier
   | TerrainSafeModifier
   | SidewaysValueModifier
+  | MovementCardBonusModifier
   | CombatValueModifier
   | EnemyStatModifier
   | RuleOverrideModifier

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -162,6 +162,11 @@ export interface PendingChoice {
   readonly unitInstanceId: string | null; // For unit effect-based abilities (e.g., Sorcerers)
   readonly options: readonly CardEffect[];
   /**
+   * Tracks whether a movement card bonus (Tirelessness) was already applied
+   * during this card's resolution to avoid double-applying across choices.
+   */
+  readonly movementBonusApplied?: boolean;
+  /**
    * Remaining effects to resolve after this choice is resolved.
    * Used when a compound effect is interrupted by a choice - the remaining
    * sub-effects are stored here so they can continue after the choice is resolved.


### PR DESCRIPTION
Closes #131

## Summary
- add movement card bonus modifier and consumption logic
- apply Tirelessness modifiers and movement bonus handling in card/sideways/choice flows
- add Tirelessness tests

## Testing
- bun run build
- bun run lint
- bun run test