### PR TITLE
Restrict healing cards during combat

### DIFF
--- a/packages/core/src/engine/__tests__/healingDuringCombat.test.ts
+++ b/packages/core/src/engine/__tests__/healingDuringCombat.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Healing During Combat Tests
+ *
+ * Validates that healing effects are restricted during combat based on card categories.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getValidActions } from "../validActions/index.js";
+import { createPlayCardCommand } from "../commands/playCardCommand.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import {
+  CARD_TRANQUILITY,
+  CARD_REGENERATION,
+  CARD_RESTORATION,
+  CARD_REFRESHING_WALK,
+  CARD_POWER_OF_CRYSTALS,
+  CARD_WOUND,
+  MANA_GREEN,
+  MANA_BLACK,
+  MANA_SOURCE_TOKEN,
+  CHOICE_REQUIRED,
+} from "@mage-knight/shared";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+} from "../../types/combat.js";
+
+function getPlayableCard(state: ReturnType<typeof createTestGameState>, cardId: string) {
+  const validActions = getValidActions(state, "player1");
+  return validActions.playCard?.cards.find((card) => card.cardId === cardId);
+}
+
+describe("Healing cards during combat", () => {
+  it("blocks Tranquility basic/powered in all combat phases (sideways only when allowed)", () => {
+    const phases = [
+      COMBAT_PHASE_RANGED_SIEGE,
+      COMBAT_PHASE_BLOCK,
+      COMBAT_PHASE_ATTACK,
+    ];
+
+    for (const phase of phases) {
+      const player = createTestPlayer({
+        hand: [CARD_TRANQUILITY],
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(phase),
+      });
+
+      const playableCard = getPlayableCard(state, CARD_TRANQUILITY);
+
+      if (phase === COMBAT_PHASE_RANGED_SIEGE) {
+        expect(playableCard).toBeUndefined();
+        continue;
+      }
+
+      expect(playableCard).toBeDefined();
+      expect(playableCard?.canPlayBasic).toBe(false);
+      expect(playableCard?.canPlayPowered).toBe(false);
+      expect(playableCard?.canPlaySideways).toBe(true);
+    }
+  });
+
+  it("blocks Regeneration basic/powered during combat", () => {
+    const player = createTestPlayer({
+      hand: [CARD_REGENERATION],
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const playableCard = getPlayableCard(state, CARD_REGENERATION);
+    expect(playableCard).toBeDefined();
+    expect(playableCard?.canPlayBasic).toBe(false);
+    expect(playableCard?.canPlayPowered).toBe(false);
+  });
+
+  it("blocks Restoration basic/powered during combat even with mana available", () => {
+    const player = createTestPlayer({
+      hand: [CARD_RESTORATION],
+      pureMana: [
+        { color: MANA_GREEN, source: MANA_SOURCE_TOKEN },
+        { color: MANA_BLACK, source: MANA_SOURCE_TOKEN },
+      ],
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const playableCard = getPlayableCard(state, CARD_RESTORATION);
+    expect(playableCard).toBeDefined();
+    expect(playableCard?.canPlayBasic).toBe(false);
+    expect(playableCard?.canPlayPowered).toBe(false);
+    expect(playableCard?.canPlaySideways).toBe(true);
+  });
+});
+
+describe("Mixed-category healing cards during combat", () => {
+  it("plays Refreshing Walk for movement only (healing filtered out)", () => {
+    const player = createTestPlayer({
+      hand: [CARD_REFRESHING_WALK, CARD_WOUND],
+      movePoints: 0,
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const playableCard = getPlayableCard(state, CARD_REFRESHING_WALK);
+    expect(playableCard?.canPlayBasic).toBe(true);
+
+    const command = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_REFRESHING_WALK,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = command.execute(state);
+    const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+    expect(updatedPlayer?.movePoints).toBe(2);
+    expect(updatedPlayer?.hand).toContain(CARD_WOUND);
+  });
+
+  it("removes heal option from Power of Crystals powered choice in combat", () => {
+    const player = createTestPlayer({
+      hand: [CARD_POWER_OF_CRYSTALS, CARD_WOUND],
+      pureMana: [{ color: MANA_GREEN, source: MANA_SOURCE_TOKEN }],
+      movePoints: 0,
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const playableCard = getPlayableCard(state, CARD_POWER_OF_CRYSTALS);
+    expect(playableCard?.canPlayPowered).toBe(true);
+
+    const command = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_POWER_OF_CRYSTALS,
+      handIndex: 0,
+      powered: true,
+      manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = command.execute(state);
+    const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+
+    expect(result.events.some((event) => event.type === CHOICE_REQUIRED)).toBe(false);
+    expect(updatedPlayer?.movePoints).toBe(4);
+    expect(updatedPlayer?.hand).toContain(CARD_WOUND);
+  });
+});

--- a/packages/core/src/engine/effects/healingFilter.ts
+++ b/packages/core/src/engine/effects/healingFilter.ts
@@ -1,0 +1,106 @@
+/**
+ * Healing effect filtering for combat.
+ *
+ * Removes healing sub-effects from compound/choice effects when in combat.
+ */
+
+import type { CardEffect } from "../../types/cards.js";
+import {
+  EFFECT_GAIN_HEALING,
+  EFFECT_HEAL_UNIT,
+  EFFECT_COMPOUND,
+  EFFECT_CHOICE,
+  EFFECT_CONDITIONAL,
+  EFFECT_SCALING,
+  EFFECT_DISCARD_COST,
+  EFFECT_NOOP,
+  EFFECT_GAIN_ATTACK,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_GAIN_MOVE,
+  EFFECT_GAIN_INFLUENCE,
+} from "../../types/effectTypes.js";
+import type { ScalableBaseEffect } from "../../types/cards.js";
+
+export function filterHealingEffectsForCombat(effect: CardEffect): CardEffect | null {
+  switch (effect.type) {
+    case EFFECT_GAIN_HEALING:
+    case EFFECT_HEAL_UNIT:
+      return null;
+
+    case EFFECT_COMPOUND: {
+      const filteredEffects = effect.effects
+        .map((subEffect) => filterHealingEffectsForCombat(subEffect))
+        .filter((subEffect): subEffect is CardEffect => subEffect !== null);
+
+      if (filteredEffects.length === 0) {
+        return null;
+      }
+
+      return { ...effect, effects: filteredEffects };
+    }
+
+    case EFFECT_CHOICE: {
+      const filteredOptions = effect.options
+        .map((option) => filterHealingEffectsForCombat(option))
+        .filter((option): option is CardEffect => option !== null);
+
+      if (filteredOptions.length === 0) {
+        return null;
+      }
+
+      return { ...effect, options: filteredOptions };
+    }
+
+    case EFFECT_CONDITIONAL: {
+      const filteredThen = filterHealingEffectsForCombat(effect.thenEffect);
+      const filteredElse = effect.elseEffect
+        ? filterHealingEffectsForCombat(effect.elseEffect)
+        : null;
+
+      if (!filteredThen && !filteredElse) {
+        return null;
+      }
+
+      return {
+        ...effect,
+        thenEffect: filteredThen ?? { type: EFFECT_NOOP },
+        ...(effect.elseEffect
+          ? { elseEffect: filteredElse ?? { type: EFFECT_NOOP } }
+          : {}),
+      };
+    }
+
+    case EFFECT_SCALING: {
+      const filteredBase = filterHealingEffectsForCombat(effect.baseEffect);
+      if (!filteredBase || !isScalableBaseEffect(filteredBase)) {
+        return null;
+      }
+
+      return { ...effect, baseEffect: filteredBase };
+    }
+
+    case EFFECT_DISCARD_COST: {
+      const filteredThen = filterHealingEffectsForCombat(effect.thenEffect);
+      if (!filteredThen) {
+        return null;
+      }
+
+      return { ...effect, thenEffect: filteredThen };
+    }
+
+    default:
+      return effect;
+  }
+}
+
+function isScalableBaseEffect(effect: CardEffect): effect is ScalableBaseEffect {
+  switch (effect.type) {
+    case EFFECT_GAIN_ATTACK:
+    case EFFECT_GAIN_BLOCK:
+    case EFFECT_GAIN_MOVE:
+    case EFFECT_GAIN_INFLUENCE:
+      return true;
+    default:
+      return false;
+  }
+}

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -92,6 +92,9 @@ export {
 // Resolvability checks
 export * from "./resolvability.js";
 
+// Healing filters (combat)
+export { filterHealingEffectsForCombat } from "./healingFilter.js";
+
 // Atomic effects (gain move, attack, etc.)
 export {
   updatePlayer,

--- a/packages/core/src/engine/helpers/cardCategoryHelpers.ts
+++ b/packages/core/src/engine/helpers/cardCategoryHelpers.ts
@@ -1,0 +1,33 @@
+/**
+ * Card category helpers.
+ *
+ * Provides per-effect category resolution and healing category checks.
+ */
+
+import type { DeedCard, CardCategory } from "../../types/cards.js";
+import { CATEGORY_HEALING } from "../../types/cards.js";
+
+export type CardEffectKind = "basic" | "powered";
+
+export function getEffectCategories(
+  card: DeedCard,
+  effectKind: CardEffectKind
+): readonly CardCategory[] {
+  if (effectKind === "basic" && card.basicEffectCategories?.length) {
+    return card.basicEffectCategories;
+  }
+
+  if (effectKind === "powered" && card.poweredEffectCategories?.length) {
+    return card.poweredEffectCategories;
+  }
+
+  return card.categories;
+}
+
+export function hasHealingCategory(categories: readonly CardCategory[]): boolean {
+  return categories.includes(CATEGORY_HEALING);
+}
+
+export function isHealingOnlyCategories(categories: readonly CardCategory[]): boolean {
+  return categories.length === 1 && categories[0] === CATEGORY_HEALING;
+}

--- a/packages/core/src/engine/validActions/cards/effectDetection/index.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/index.ts
@@ -36,18 +36,17 @@ export {
 } from "./specialEffects.js";
 
 // Import for use in effectIsUtility
-import { effectHasHeal, effectHasDraw, effectHasModifier, effectHasManaGain } from "./resourceEffects.js";
+import { effectHasDraw, effectHasModifier, effectHasManaGain } from "./resourceEffects.js";
 import { effectHasManaDrawPowered, effectHasCrystal, effectHasCardBoost, effectHasEnemyTargeting } from "./specialEffects.js";
 
 /**
  * Check if an effect is a "utility" effect that can be played during any combat phase.
- * These include mana generation, card draws, healing, card boost, and enemy-targeting spells.
+ * These include mana generation, card draws, modifiers, card boost, and enemy-targeting spells.
  */
 export function effectIsUtility(effect: CardEffect): boolean {
   return (
     effectHasManaGain(effect) ||
     effectHasDraw(effect) ||
-    effectHasHeal(effect) ||
     effectHasModifier(effect) ||
     effectHasManaDrawPowered(effect) ||
     effectHasCardBoost(effect) ||

--- a/packages/core/src/engine/validators/registry/cardRegistry.ts
+++ b/packages/core/src/engine/validators/registry/cardRegistry.ts
@@ -14,6 +14,7 @@ import {
   validateCardInHand,
   validateCardExists,
   validateNotWound,
+  validateNoHealingCardInCombat,
 } from "../playCardValidators.js";
 
 // Mana validators
@@ -53,6 +54,7 @@ export const cardRegistry: Record<string, Validator[]> = {
     validateCardInHand,
     validateCardExists,
     validateNotWound,
+    validateNoHealingCardInCombat,
     // Mana validators - spell checks first, then dungeon/tomb rules, then time check, then availability, then color match
     validateSpellBasicManaRequirement, // Spells require mana even for basic effect
     validateSpellManaRequirement, // Spells require two mana sources for powered (black + color)

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -33,6 +33,7 @@ export const COLUMN_LIMIT_EXCEEDED = "COLUMN_LIMIT_EXCEEDED" as const;
 export const CARD_NOT_IN_HAND = "CARD_NOT_IN_HAND" as const;
 export const CARD_NOT_FOUND = "CARD_NOT_FOUND" as const;
 export const CANNOT_PLAY_WOUND = "CANNOT_PLAY_WOUND" as const;
+export const CANNOT_PLAY_HEALING_IN_COMBAT = "CANNOT_PLAY_HEALING_IN_COMBAT" as const;
 export const CHOICE_REQUIRED_CODE = "CHOICE_REQUIRED" as const;
 
 // Choice resolution validation codes
@@ -269,6 +270,7 @@ export type ValidationErrorCode =
   | typeof CARD_NOT_IN_HAND
   | typeof CARD_NOT_FOUND
   | typeof CANNOT_PLAY_WOUND
+  | typeof CANNOT_PLAY_HEALING_IN_COMBAT
   | typeof CHOICE_REQUIRED_CODE
   | typeof NO_PENDING_CHOICE
   | typeof INVALID_CHOICE_INDEX

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -617,9 +617,10 @@ export interface DeedCard {
   // For spells, this is the category for the basic effect
   readonly categories: readonly CardCategory[];
 
-  // Category for powered effect (spells only, if different from basic)
-  // If not set, powered effect uses the same categories as basic
-  readonly poweredCategories?: readonly CardCategory[];
+  // Optional per-effect category overrides
+  // Use when basic/powered effects differ (e.g., healing vs combat)
+  readonly basicEffectCategories?: readonly CardCategory[];
+  readonly poweredEffectCategories?: readonly CardCategory[];
 
   // Basic effect (play without mana)
   readonly basicEffect: CardEffect;


### PR DESCRIPTION
## Summary
- add per-effect category helpers and combat filtering for healing effects
- block healing-only card plays during combat and filter healing from mixed-category cards
- add tests for healing restrictions in combat

## Testing
- bun run build
- bun run lint
- bun run test

Closes #46