### PR TITLE
feat: Ritual Attack discard-as-cost

### DIFF
--- a/packages/core/src/data/advancedActions/helpers.ts
+++ b/packages/core/src/data/advancedActions/helpers.ts
@@ -37,9 +37,12 @@ import {
   COMBAT_TYPE_MELEE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
+  type CombatType,
 } from "../../types/effectTypes.js";
+import type { BasicManaColor, Element } from "@mage-knight/shared";
 import { ELEMENT_FIRE, ELEMENT_ICE } from "../../types/modifierConstants.js";
-import type { BasicManaColor } from "@mage-knight/shared";
+
+export { discardCost, discardCostByColor } from "../basicActions/helpers.js";
 
 /**
  * Creates a crystal gain effect for the specified color.
@@ -70,9 +73,10 @@ export function attack(amount: number): CardEffect {
  */
 export function attackWithElement(
   amount: number,
-  element: typeof ELEMENT_FIRE | typeof ELEMENT_ICE
+  element: Element,
+  combatType: CombatType = COMBAT_TYPE_MELEE
 ): CardEffect {
-  return { type: EFFECT_GAIN_ATTACK, amount, combatType: COMBAT_TYPE_MELEE, element };
+  return { type: EFFECT_GAIN_ATTACK, amount, combatType, element };
 }
 
 /**
@@ -204,4 +208,4 @@ export function takeWound(amount: number): CardEffect {
 }
 
 // Re-export element constants for convenience
-export { ELEMENT_FIRE, ELEMENT_ICE } from "../../types/modifierConstants.js";
+export { ELEMENT_FIRE, ELEMENT_ICE, ELEMENT_COLD_FIRE } from "../../types/modifierConstants.js";

--- a/packages/core/src/data/advancedActions/red/ritual-attack.ts
+++ b/packages/core/src/data/advancedActions/red/ritual-attack.ts
@@ -1,7 +1,24 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
+import {
+  COMBAT_TYPE_SIEGE,
+  CARD_COLOR_RED,
+  CARD_COLOR_BLUE,
+  CARD_COLOR_GREEN,
+  CARD_COLOR_WHITE,
+} from "../../../types/effectTypes.js";
 import { MANA_RED, CARD_RITUAL_ATTACK } from "@mage-knight/shared";
-import { attack, attackWithElement, ELEMENT_FIRE } from "../helpers.js";
+import {
+  attack,
+  attackWithElement,
+  rangedAttack,
+  rangedAttackWithElement,
+  siegeAttack,
+  discardCostByColor,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+} from "../helpers.js";
 
 export const RITUAL_ATTACK: DeedCard = {
   id: CARD_RITUAL_ATTACK,
@@ -11,8 +28,17 @@ export const RITUAL_ATTACK: DeedCard = {
   categories: [CATEGORY_COMBAT],
   // Basic: Throw away another Action card. Depending on its color, you get: Attack 5 for red, Ice Attack 3 for blue, Ranged Attack 3 for white, Siege Attack 2 for green.
   // Powered: Throw away another Action card. Depending on its color, you get: Fire Attack 6 for red, Cold Fire Attack 4 for blue, Ranged Fire Attack 4 for white, Siege Fire Attack 3 for green.
-  // TODO: Implement throw-away mechanic with color-dependent attack
-  basicEffect: attack(5),
-  poweredEffect: attackWithElement(6, ELEMENT_FIRE),
+  basicEffect: discardCostByColor(1, {
+    [CARD_COLOR_RED]: attack(5),
+    [CARD_COLOR_BLUE]: attackWithElement(3, ELEMENT_ICE),
+    [CARD_COLOR_WHITE]: rangedAttack(3),
+    [CARD_COLOR_GREEN]: siegeAttack(2),
+  }),
+  poweredEffect: discardCostByColor(1, {
+    [CARD_COLOR_RED]: attackWithElement(6, ELEMENT_FIRE),
+    [CARD_COLOR_BLUE]: attackWithElement(4, ELEMENT_COLD_FIRE),
+    [CARD_COLOR_WHITE]: rangedAttackWithElement(4, ELEMENT_FIRE),
+    [CARD_COLOR_GREEN]: attackWithElement(3, ELEMENT_FIRE, COMBAT_TYPE_SIEGE),
+  }),
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/basicActions/helpers.ts
+++ b/packages/core/src/data/basicActions/helpers.ts
@@ -6,9 +6,11 @@ import {
   EFFECT_CHOICE, EFFECT_COMPOUND, EFFECT_CHANGE_REPUTATION, EFFECT_GAIN_CRYSTAL,
   EFFECT_CONVERT_MANA_TO_CRYSTAL, EFFECT_CARD_BOOST, EFFECT_READY_UNIT,
   EFFECT_MANA_DRAW_POWERED, EFFECT_TERRAIN_BASED_BLOCK, EFFECT_DISCARD_COST,
+  EFFECT_NOOP,
   EFFECT_TRACK_ATTACK_DEFEAT_FAME,
   COMBAT_TYPE_MELEE, COMBAT_TYPE_RANGED, COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
+import type { BasicCardColor } from "../../types/effectTypes.js";
 import { MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE, type BasicManaColor, type CardId, type Element as SharedElement } from "@mage-knight/shared";
 import {
   ELEMENT_ICE, ELEMENT_FIRE, DURATION_TURN, EFFECT_RULE_OVERRIDE,
@@ -173,6 +175,27 @@ export function discardCost(
     count,
     optional,
     thenEffect,
+    filterWounds,
+  };
+}
+
+/**
+ * Discard as cost with color-dependent follow-up effect.
+ * The discarded card's color determines which effect resolves.
+ */
+export function discardCostByColor(
+  count: number,
+  thenEffectByColor: Record<BasicCardColor, CardEffect>,
+  optional: boolean = false,
+  filterWounds: boolean = true
+): CardEffect {
+  return {
+    type: EFFECT_DISCARD_COST,
+    count,
+    optional,
+    thenEffect: { type: EFFECT_NOOP },
+    colorMatters: true,
+    thenEffectByColor,
     filterWounds,
   };
 }

--- a/packages/core/src/engine/__tests__/ritualAttack.test.ts
+++ b/packages/core/src/engine/__tests__/ritualAttack.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for Ritual Attack discard-as-cost behavior.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  PLAY_CARD_ACTION,
+  RESOLVE_DISCARD_ACTION,
+  INVALID_ACTION,
+  CARD_RITUAL_ATTACK,
+  CARD_RAGE,
+  CARD_CRYSTALLIZE,
+  CARD_PROMISE,
+  CARD_MARCH,
+  CARD_FIREBALL,
+  MANA_SOURCE_TOKEN,
+  MANA_RED,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+
+describe("Ritual Attack", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  const basicCases = [
+    {
+      label: "red",
+      discard: CARD_RAGE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.normal).toBe(5);
+      },
+    },
+    {
+      label: "blue",
+      discard: CARD_CRYSTALLIZE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.normalElements.ice).toBe(3);
+      },
+    },
+    {
+      label: "white",
+      discard: CARD_PROMISE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.ranged).toBe(3);
+      },
+    },
+    {
+      label: "green",
+      discard: CARD_MARCH,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.siege).toBe(2);
+      },
+    },
+  ];
+
+  for (const testCase of basicCases) {
+    it(`basic effect uses ${testCase.label} discard`, () => {
+      const player = createTestPlayer({
+        hand: [CARD_RITUAL_ATTACK, testCase.discard],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_RITUAL_ATTACK,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0].pendingDiscard).toBeTruthy();
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [testCase.discard],
+      });
+
+      const attack = discardResult.state.players[0].combatAccumulator.attack;
+      testCase.assert(attack);
+    });
+  }
+
+  const poweredCases = [
+    {
+      label: "red",
+      discard: CARD_RAGE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.normalElements.fire).toBe(6);
+      },
+    },
+    {
+      label: "blue",
+      discard: CARD_CRYSTALLIZE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.normalElements.coldFire).toBe(4);
+      },
+    },
+    {
+      label: "white",
+      discard: CARD_PROMISE,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.rangedElements.fire).toBe(4);
+      },
+    },
+    {
+      label: "green",
+      discard: CARD_MARCH,
+      assert: (attack: ReturnType<typeof createTestPlayer>["combatAccumulator"]["attack"]) => {
+        expect(attack.siegeElements.fire).toBe(3);
+      },
+    },
+  ];
+
+  for (const testCase of poweredCases) {
+    it(`powered effect uses ${testCase.label} discard`, () => {
+      const player = createTestPlayer({
+        hand: [CARD_RITUAL_ATTACK, testCase.discard],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_RITUAL_ATTACK,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      expect(playResult.state.players[0].pendingDiscard).toBeTruthy();
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [testCase.discard],
+      });
+
+      const attack = discardResult.state.players[0].combatAccumulator.attack;
+      testCase.assert(attack);
+    });
+  }
+
+  it("filters discard options to action cards", () => {
+    const player = createTestPlayer({
+      hand: [CARD_RITUAL_ATTACK, CARD_RAGE, CARD_FIREBALL],
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const playResult = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_RITUAL_ATTACK,
+      powered: false,
+    });
+
+    const validActions = getValidActions(playResult.state, "player1");
+    expect(validActions.discardCost?.availableCardIds).toContain(CARD_RAGE);
+    expect(validActions.discardCost?.availableCardIds).not.toContain(CARD_FIREBALL);
+  });
+
+  it("rejects discarding a non-action card", () => {
+    const player = createTestPlayer({
+      hand: [CARD_RITUAL_ATTACK, CARD_RAGE, CARD_FIREBALL],
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const playResult = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_RITUAL_ATTACK,
+      powered: false,
+    });
+
+    const discardResult = engine.processAction(playResult.state, "player1", {
+      type: RESOLVE_DISCARD_ACTION,
+      cardIds: [CARD_FIREBALL],
+    });
+
+    expect(discardResult.events).toContainEqual(
+      expect.objectContaining({ type: INVALID_ACTION })
+    );
+  });
+});

--- a/packages/core/src/engine/helpers/cardColor.ts
+++ b/packages/core/src/engine/helpers/cardColor.ts
@@ -1,0 +1,56 @@
+/**
+ * Action card color helpers.
+ *
+ * Used for effects that depend on the color of a discarded Action card
+ * (e.g., Ritual Attack).
+ */
+
+import type { CardId } from "@mage-knight/shared";
+import type { BasicCardColor } from "../../types/effectTypes.js";
+import {
+  CARD_COLOR_RED,
+  CARD_COLOR_BLUE,
+  CARD_COLOR_GREEN,
+  CARD_COLOR_WHITE,
+} from "../../types/effectTypes.js";
+import {
+  RED_BASIC_ACTIONS,
+  BLUE_BASIC_ACTIONS,
+  GREEN_BASIC_ACTIONS,
+  WHITE_BASIC_ACTIONS,
+} from "../../data/basicActions/index.js";
+import {
+  RED_ADVANCED_ACTIONS,
+  BLUE_ADVANCED_ACTIONS,
+  GREEN_ADVANCED_ACTIONS,
+  WHITE_ADVANCED_ACTIONS,
+} from "../../data/advancedActions/index.js";
+
+const RED_ACTION_CARD_IDS = new Set<string>([
+  ...Object.keys(RED_BASIC_ACTIONS),
+  ...Object.keys(RED_ADVANCED_ACTIONS),
+]);
+const BLUE_ACTION_CARD_IDS = new Set<string>([
+  ...Object.keys(BLUE_BASIC_ACTIONS),
+  ...Object.keys(BLUE_ADVANCED_ACTIONS),
+]);
+const GREEN_ACTION_CARD_IDS = new Set<string>([
+  ...Object.keys(GREEN_BASIC_ACTIONS),
+  ...Object.keys(GREEN_ADVANCED_ACTIONS),
+]);
+const WHITE_ACTION_CARD_IDS = new Set<string>([
+  ...Object.keys(WHITE_BASIC_ACTIONS),
+  ...Object.keys(WHITE_ADVANCED_ACTIONS),
+]);
+
+/**
+ * Get the frame color of an Action card by ID.
+ * Returns null for non-action cards or unsupported colors.
+ */
+export function getActionCardColor(cardId: CardId): BasicCardColor | null {
+  if (RED_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_RED;
+  if (BLUE_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_BLUE;
+  if (GREEN_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_GREEN;
+  if (WHITE_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_WHITE;
+  return null;
+}

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -93,10 +93,14 @@ export function getDiscardCostOptions(
     return undefined;
   }
 
-  const { sourceCardId, count, optional, filterWounds } = player.pendingDiscard;
+  const { sourceCardId, count, optional, filterWounds, colorMatters } = player.pendingDiscard;
 
   // Get eligible cards from hand
-  const availableCardIds = getCardsEligibleForDiscardCost(player.hand, filterWounds);
+  const availableCardIds = getCardsEligibleForDiscardCost(
+    player.hand,
+    filterWounds,
+    colorMatters ?? false
+  );
 
   return {
     sourceCardId,

--- a/packages/core/src/engine/validators/discardValidators.ts
+++ b/packages/core/src/engine/validators/discardValidators.ts
@@ -60,7 +60,7 @@ export const validateDiscardSelection: Validator = (
     return valid(); // Let the other validator handle this
   }
 
-  const { count, optional, filterWounds } = player.pendingDiscard;
+  const { count, optional, filterWounds, colorMatters } = player.pendingDiscard;
   const cardIds = action.cardIds;
 
   // If skipping (empty cardIds), must be optional
@@ -83,7 +83,11 @@ export const validateDiscardSelection: Validator = (
   }
 
   // Check all cards are eligible
-  const eligibleCards = getCardsEligibleForDiscardCost(player.hand, filterWounds);
+  const eligibleCards = getCardsEligibleForDiscardCost(
+    player.hand,
+    filterWounds,
+    colorMatters ?? false
+  );
   for (const cardId of cardIds) {
     if (!eligibleCards.includes(cardId)) {
       return invalid(

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -47,6 +47,7 @@ import {
   EFFECT_POLARIZE_MANA,
   MANA_ANY,
   type CombatType,
+  type BasicCardColor,
 } from "./effectTypes.js";
 import type { EffectCondition } from "./conditions.js";
 import type { ScalingFactor } from "./scaling.js";
@@ -449,6 +450,10 @@ export interface DiscardCostEffect {
   readonly optional: boolean;
   /** Effect to resolve after discarding succeeds */
   readonly thenEffect: CardEffect;
+  /** If true, the discarded card color determines which effect resolves */
+  readonly colorMatters?: boolean;
+  /** Per-color effects when colorMatters is true */
+  readonly thenEffectByColor?: Partial<Record<BasicCardColor, CardEffect>>;
   /** If true, wounds cannot be discarded (default: true per standard rules) */
   readonly filterWounds?: boolean;
 }

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -63,6 +63,8 @@ export type CardColor =
   | typeof CARD_COLOR_WHITE
   | typeof CARD_COLOR_WOUND;
 
+export type BasicCardColor = Exclude<CardColor, typeof CARD_COLOR_WOUND>;
+
 // === Mana "Any" Constant ===
 // Used when an effect can produce any color of mana
 export const MANA_ANY = "any" as const;

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -34,6 +34,7 @@ export interface PendingLevelUpReward {
 }
 import type { Hero } from "./hero.js";
 import type { CardEffect } from "./cards.js";
+import type { BasicCardColor } from "./effectTypes.js";
 import type { PlayerUnit } from "./unit.js";
 import type { SourceDieId } from "./mana.js";
 
@@ -190,6 +191,10 @@ export interface PendingDiscard {
   readonly optional: boolean;
   /** Effect to resolve after discarding */
   readonly thenEffect: CardEffect;
+  /** If true, discarded card color determines which effect resolves */
+  readonly colorMatters?: boolean;
+  /** Per-color effects when colorMatters is true */
+  readonly thenEffectByColor?: Partial<Record<BasicCardColor, CardEffect>>;
   /** If true, wounds cannot be selected (default: true) */
   readonly filterWounds: boolean;
 }


### PR DESCRIPTION
## Summary
- implement color-dependent discard-as-cost for Ritual Attack
- restrict discard options to action cards with known colors
- add tests for basic/powered color mapping and discard validation

## Testing
- bun run build
- bun run lint
- bun run test

Closes #111