### PR TITLE
feat: add Krang Battle Rage card

### DIFF
--- a/packages/core/src/data/basicActions/red/index.ts
+++ b/packages/core/src/data/basicActions/red/index.ts
@@ -9,6 +9,7 @@ import {
   CARD_ARYTHEA_BATTLE_VERSATILITY,
   CARD_TOVAK_INSTINCT,
   CARD_KRANG_RUTHLESS_COERCION,
+  CARD_KRANG_BATTLE_RAGE,
 } from "@mage-knight/shared";
 
 // Re-export individual cards
@@ -18,6 +19,7 @@ export { IMPROVISATION } from "./improvisation.js";
 export { ARYTHEA_BATTLE_VERSATILITY } from "./arythea-battle-versatility.js";
 export { TOVAK_INSTINCT } from "./tovak-instinct.js";
 export { KRANG_RUTHLESS_COERCION } from "./krang-ruthless-coercion.js";
+export { KRANG_BATTLE_RAGE } from "./krang-battle-rage.js";
 
 // Import for aggregation
 import { RAGE } from "./rage.js";
@@ -26,6 +28,7 @@ import { IMPROVISATION } from "./improvisation.js";
 import { ARYTHEA_BATTLE_VERSATILITY } from "./arythea-battle-versatility.js";
 import { TOVAK_INSTINCT } from "./tovak-instinct.js";
 import { KRANG_RUTHLESS_COERCION } from "./krang-ruthless-coercion.js";
+import { KRANG_BATTLE_RAGE } from "./krang-battle-rage.js";
 
 /** All red-powered basic action cards */
 export const RED_BASIC_ACTIONS = {
@@ -35,4 +38,5 @@ export const RED_BASIC_ACTIONS = {
   [CARD_ARYTHEA_BATTLE_VERSATILITY]: ARYTHEA_BATTLE_VERSATILITY,
   [CARD_TOVAK_INSTINCT]: TOVAK_INSTINCT,
   [CARD_KRANG_RUTHLESS_COERCION]: KRANG_RUTHLESS_COERCION,
+  [CARD_KRANG_BATTLE_RAGE]: KRANG_BATTLE_RAGE,
 } as const;

--- a/packages/core/src/data/basicActions/red/krang-battle-rage.ts
+++ b/packages/core/src/data/basicActions/red/krang-battle-rage.ts
@@ -1,0 +1,35 @@
+import type { DeedCard } from "../../../types/cards.js";
+import { CATEGORY_COMBAT, DEED_CARD_TYPE_BASIC_ACTION } from "../../../types/cards.js";
+import { SCALING_PER_WOUND_THIS_COMBAT } from "../../../types/scaling.js";
+import { MANA_RED, CARD_KRANG_BATTLE_RAGE } from "@mage-knight/shared";
+import { scalingAttack } from "../../effectHelpers.js";
+
+/**
+ * Krang's Battle Rage (replaces Rage)
+ */
+export const KRANG_BATTLE_RAGE: DeedCard = {
+  id: CARD_KRANG_BATTLE_RAGE,
+  name: "Battle Rage",
+  cardType: DEED_CARD_TYPE_BASIC_ACTION,
+  poweredBy: [MANA_RED],
+  categories: [CATEGORY_COMBAT],
+  // Basic: Attack 2. +1 if you received a wound during this battle.
+  basicEffect: scalingAttack(
+    2,
+    { type: SCALING_PER_WOUND_THIS_COMBAT },
+    1,
+    undefined,
+    undefined,
+    { maximum: 1 }
+  ),
+  // Powered: Attack 4. +1 per wound received during this battle (max +4).
+  poweredEffect: scalingAttack(
+    4,
+    { type: SCALING_PER_WOUND_THIS_COMBAT },
+    1,
+    undefined,
+    undefined,
+    { maximum: 4 }
+  ),
+  sidewaysValue: 1,
+};

--- a/packages/core/src/engine/__tests__/battleRage.test.ts
+++ b/packages/core/src/engine/__tests__/battleRage.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests for Krang's Battle Rage basic action card
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveEffect } from "../effects/index.js";
+import { createTestGameState } from "./testHelpers.js";
+import { createCombatState } from "../../types/combat.js";
+import { KRANG_BATTLE_RAGE } from "../../data/basicActions/red/krang-battle-rage.js";
+import { ENEMY_PROWLERS } from "@mage-knight/shared";
+
+function createStateWithWounds(woundsThisCombat: number) {
+  const combat = { ...createCombatState([ENEMY_PROWLERS]), woundsThisCombat };
+  return createTestGameState({ combat });
+}
+
+describe("Battle Rage (Krang)", () => {
+  it("basic effect should be Attack 2 with no wounds", () => {
+    const state = createStateWithWounds(0);
+    const result = resolveEffect(state, "player1", KRANG_BATTLE_RAGE.basicEffect, KRANG_BATTLE_RAGE.id);
+
+    expect(result.state.players[0]?.combatAccumulator.attack.normal).toBe(2);
+  });
+
+  it("basic effect should cap bonus at +1", () => {
+    const state = createStateWithWounds(3);
+    const result = resolveEffect(state, "player1", KRANG_BATTLE_RAGE.basicEffect, KRANG_BATTLE_RAGE.id);
+
+    expect(result.state.players[0]?.combatAccumulator.attack.normal).toBe(3);
+  });
+
+  it("powered effect should scale by wounds this combat", () => {
+    const state = createStateWithWounds(2);
+    const result = resolveEffect(state, "player1", KRANG_BATTLE_RAGE.poweredEffect, KRANG_BATTLE_RAGE.id);
+
+    expect(result.state.players[0]?.combatAccumulator.attack.normal).toBe(6);
+  });
+
+  it("powered effect should cap bonus at +4", () => {
+    const state = createStateWithWounds(6);
+    const result = resolveEffect(state, "player1", KRANG_BATTLE_RAGE.poweredEffect, KRANG_BATTLE_RAGE.id);
+
+    expect(result.state.players[0]?.combatAccumulator.attack.normal).toBe(8);
+  });
+});

--- a/packages/core/src/engine/__tests__/scalingEffects.test.ts
+++ b/packages/core/src/engine/__tests__/scalingEffects.test.ts
@@ -9,6 +9,7 @@ import { resolveEffect } from "../effects/index.js";
 import {
   SCALING_PER_ENEMY,
   SCALING_PER_WOUND_IN_HAND,
+  SCALING_PER_WOUND_THIS_COMBAT,
   SCALING_PER_UNIT,
 } from "../../types/scaling.js";
 import { createCombatState } from "../../types/combat.js";
@@ -94,6 +95,21 @@ describe("Scaling Effects", () => {
         });
         const state = createTestGameState({ players: [player] });
         const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_IN_HAND });
+        expect(count).toBe(3);
+      });
+    });
+
+    describe("SCALING_PER_WOUND_THIS_COMBAT", () => {
+      it("should return 0 when not in combat", () => {
+        const state = createTestGameState({ combat: null });
+        const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_THIS_COMBAT });
+        expect(count).toBe(0);
+      });
+
+      it("should return wounds taken this combat", () => {
+        const combat = { ...createCombatState([ENEMY_PROWLERS]), woundsThisCombat: 3 };
+        const state = createTestGameState({ combat });
+        const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_THIS_COMBAT });
         expect(count).toBe(3);
       });
     });

--- a/packages/core/src/engine/effects/scalingEvaluator.ts
+++ b/packages/core/src/engine/effects/scalingEvaluator.ts
@@ -7,6 +7,7 @@ import type { ScalingFactor } from "../../types/scaling.js";
 import {
   SCALING_PER_ENEMY,
   SCALING_PER_WOUND_IN_HAND,
+  SCALING_PER_WOUND_THIS_COMBAT,
   SCALING_PER_UNIT,
   SCALING_PER_CRYSTAL_COLOR,
   SCALING_PER_EMPTY_COMMAND_TOKEN,
@@ -42,6 +43,11 @@ export function evaluateScalingFactor(
     case SCALING_PER_WOUND_IN_HAND: {
       // Count wounds in player's hand
       return player.hand.filter((c) => c === CARD_WOUND).length;
+    }
+
+    case SCALING_PER_WOUND_THIS_COMBAT: {
+      if (!state.combat) return 0;
+      return state.combat.woundsThisCombat;
     }
 
     case SCALING_PER_UNIT: {

--- a/packages/core/src/types/hero.ts
+++ b/packages/core/src/types/hero.ts
@@ -31,6 +31,7 @@ import {
   CARD_WOLFHAWK_TIRELESSNESS,
   CARD_KRANG_SAVAGE_HARVESTING,
   CARD_KRANG_RUTHLESS_COERCION,
+  CARD_KRANG_BATTLE_RAGE,
   CARD_BRAEVALAR_DRUIDIC_PATHS,
   CARD_BRAEVALAR_ONE_WITH_THE_LAND,
 } from "@mage-knight/shared";
@@ -182,6 +183,7 @@ export const HEROES: Record<Hero, HeroDefinition> = {
     startingCards: buildStartingDeck([
       { replace: CARD_MARCH, with: CARD_KRANG_SAVAGE_HARVESTING },
       { replace: CARD_THREATEN, with: CARD_KRANG_RUTHLESS_COERCION },
+      { replace: CARD_RAGE, with: CARD_KRANG_BATTLE_RAGE },
     ]),
     skills: HERO_SKILLS[Hero.Krang],
     crystalColors: [BASIC_MANA_RED, BASIC_MANA_GREEN, BASIC_MANA_WHITE],

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -140,11 +140,13 @@ export type {
   ScalingFactor,
   ScalingPerEnemyFactor,
   ScalingPerWoundInHandFactor,
+  ScalingPerWoundThisCombatFactor,
   ScalingPerUnitFactor,
 } from "./scaling.js";
 export {
   SCALING_PER_ENEMY,
   SCALING_PER_WOUND_IN_HAND,
+  SCALING_PER_WOUND_THIS_COMBAT,
   SCALING_PER_UNIT,
 } from "./scaling.js";
 
@@ -177,6 +179,7 @@ export {
   CARD_WOLFHAWK_TIRELESSNESS,
   CARD_KRANG_SAVAGE_HARVESTING,
   CARD_KRANG_RUTHLESS_COERCION,
+  CARD_KRANG_BATTLE_RAGE,
   CARD_BRAEVALAR_DRUIDIC_PATHS,
   CARD_BRAEVALAR_ONE_WITH_THE_LAND,
   // Wound

--- a/packages/core/src/types/scaling.ts
+++ b/packages/core/src/types/scaling.ts
@@ -7,14 +7,13 @@
 // === Scaling Factor Type Constants ===
 export const SCALING_PER_ENEMY = "per_enemy" as const;
 export const SCALING_PER_WOUND_IN_HAND = "per_wound_in_hand" as const;
+export const SCALING_PER_WOUND_THIS_COMBAT = "per_wound_this_combat" as const;
 export const SCALING_PER_UNIT = "per_unit" as const;
 export const SCALING_PER_CRYSTAL_COLOR = "per_crystal_color" as const;
 export const SCALING_PER_EMPTY_COMMAND_TOKEN = "per_empty_command_token" as const;
 
 // Note: SCALING_PER_WOUND_PLAYED was removed because wounds cannot be "played"
-// as cards in Mage Knight - they are dead cards. If a future card needs
-// wound-based scaling (like "per wound taken this combat"), it should be
-// added as a new scaling factor type.
+// as cards in Mage Knight - they are dead cards.
 
 // === Scaling Factor Interfaces ===
 
@@ -24,6 +23,10 @@ export interface ScalingPerEnemyFactor {
 
 export interface ScalingPerWoundInHandFactor {
   readonly type: typeof SCALING_PER_WOUND_IN_HAND;
+}
+
+export interface ScalingPerWoundThisCombatFactor {
+  readonly type: typeof SCALING_PER_WOUND_THIS_COMBAT;
 }
 
 export interface ScalingPerUnitFactor {
@@ -65,6 +68,7 @@ export interface UnitFilter {
 export type ScalingFactor =
   | ScalingPerEnemyFactor
   | ScalingPerWoundInHandFactor
+  | ScalingPerWoundThisCombatFactor
   | ScalingPerUnitFactor
   | ScalingPerCrystalColorFactor
   | ScalingPerEmptyCommandTokenFactor;

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -51,6 +51,7 @@ export const CARD_WOLFHAWK_TIRELESSNESS = cardId("wolfhawk_tirelessness");
 // Krang (Lost Legion expansion)
 export const CARD_KRANG_SAVAGE_HARVESTING = cardId("krang_savage_harvesting");
 export const CARD_KRANG_RUTHLESS_COERCION = cardId("krang_ruthless_coercion");
+export const CARD_KRANG_BATTLE_RAGE = cardId("krang_battle_rage");
 
 // Braevalar (Shades of Tezla expansion)
 export const CARD_BRAEVALAR_DRUIDIC_PATHS = cardId("braevalar_druidic_paths");
@@ -144,6 +145,7 @@ export type HeroSpecificCardId =
   | typeof CARD_WOLFHAWK_TIRELESSNESS
   | typeof CARD_KRANG_SAVAGE_HARVESTING
   | typeof CARD_KRANG_RUTHLESS_COERCION
+  | typeof CARD_KRANG_BATTLE_RAGE
   | typeof CARD_BRAEVALAR_DRUIDIC_PATHS
   | typeof CARD_BRAEVALAR_ONE_WITH_THE_LAND;
 


### PR DESCRIPTION
## Summary
- add Krang Battle Rage basic action card and Krang replacement mapping
- add scaling factor for wounds taken this combat
- add Battle Rage and scaling tests

## Testing
- bun run build
- bun run lint
- bun run test

Closes #139