### PR TITLE
Add Pain Wraith (Brown) enemy - Dark Crusaders

### DIFF
--- a/packages/shared/src/enemies/brown/index.ts
+++ b/packages/shared/src/enemies/brown/index.ts
@@ -24,6 +24,7 @@ export { ENEMY_HYDRA, HYDRA } from "./hydra.js";
 export { ENEMY_MANTICORE, MANTICORE } from "./manticore.js";
 export { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
 export { ENEMY_VAMPIRE, VAMPIRE } from "./vampire.js";
+export { ENEMY_PAIN_WRAITH, PAIN_WRAITH } from "./pain-wraith.js";
 
 // Import for aggregation
 import { ENEMY_AIR_ELEMENTAL, AIR_ELEMENTAL } from "./air-elemental.js";
@@ -41,6 +42,7 @@ import { ENEMY_HYDRA, HYDRA } from "./hydra.js";
 import { ENEMY_MANTICORE, MANTICORE } from "./manticore.js";
 import { ENEMY_WATER_ELEMENTAL, WATER_ELEMENTAL } from "./water-elemental.js";
 import { ENEMY_VAMPIRE, VAMPIRE } from "./vampire.js";
+import { ENEMY_PAIN_WRAITH, PAIN_WRAITH } from "./pain-wraith.js";
 
 /**
  * Union type of all brown (Dungeon monster) enemy IDs
@@ -60,7 +62,8 @@ export type BrownEnemyId =
   | typeof ENEMY_HYDRA
   | typeof ENEMY_MANTICORE
   | typeof ENEMY_WATER_ELEMENTAL
-  | typeof ENEMY_VAMPIRE;
+  | typeof ENEMY_VAMPIRE
+  | typeof ENEMY_PAIN_WRAITH;
 
 /** All brown (Dungeon monster) enemies */
 export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
@@ -79,4 +82,5 @@ export const BROWN_ENEMIES: Record<BrownEnemyId, EnemyDefinition> = {
   [ENEMY_MANTICORE]: MANTICORE,
   [ENEMY_WATER_ELEMENTAL]: WATER_ELEMENTAL,
   [ENEMY_VAMPIRE]: VAMPIRE,
+  [ENEMY_PAIN_WRAITH]: PAIN_WRAITH,
 };

--- a/packages/shared/src/enemies/brown/pain-wraith.ts
+++ b/packages/shared/src/enemies/brown/pain-wraith.ts
@@ -1,0 +1,23 @@
+import { ELEMENT_PHYSICAL } from "../../elements.js";
+import { ABILITY_ELUSIVE, ABILITY_PARALYZE } from "../abilities.js";
+import {
+  ENEMY_COLOR_BROWN,
+  FACTION_DARK_CRUSADERS,
+  type EnemyDefinition,
+} from "../types.js";
+
+export const ENEMY_PAIN_WRAITH = "pain_wraith" as const;
+
+export const PAIN_WRAITH: EnemyDefinition = {
+  id: ENEMY_PAIN_WRAITH,
+  name: "Pain Wraith",
+  color: ENEMY_COLOR_BROWN,
+  attack: 4,
+  attackElement: ELEMENT_PHYSICAL,
+  armor: 4,
+  armorElusive: 8, // Elusive: uses 8 normally, 4 if all attacks blocked
+  fame: 3,
+  resistances: [],
+  abilities: [ABILITY_ELUSIVE, ABILITY_PARALYZE],
+  faction: FACTION_DARK_CRUSADERS,
+};

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -165,6 +165,7 @@ export {
   ENEMY_MANTICORE,
   ENEMY_WATER_ELEMENTAL,
   ENEMY_VAMPIRE,
+  ENEMY_PAIN_WRAITH,
   BROWN_ENEMIES,
 } from "./brown/index.js";
 


### PR DESCRIPTION
Implements #422

## Summary
Adds the Pain Wraith enemy to the brown (Dungeon) enemy set.

## Changes
- ✅ Add ENEMY_PAIN_WRAITH constant
- ✅ Add to BrownEnemyId type union  
- ✅ Configure attack: 4 Physical
- ✅ Configure armor: 4
- ✅ Add Elusive (8) ability with armorElusive: 8
- ✅ Add Paralyze ability
- ✅ Set fame: 3
- ✅ Set faction: FACTION_DARK_CRUSADERS

## Acceptance Criteria
All acceptance criteria from #422 have been met:
- ✅ Enemy constant defined
- ✅ Attack 4 physical configured
- ✅ Armor 4 configured
- ✅ Elusive (8) ability assigned
- ✅ Paralyze ability assigned
- ✅ Fame 3 configured
- ✅ Dark Crusaders faction set