### PR TITLE
Add Shocktroops (Gray) enemy (#426)

### DIFF
--- a/packages/shared/src/enemies/gray/index.ts
+++ b/packages/shared/src/enemies/gray/index.ts
@@ -14,6 +14,7 @@ export { ENEMY_SWORDSMEN, SWORDSMEN } from "./swordsmen.js";
 export { ENEMY_GOLEMS, GOLEMS } from "./golems.js";
 export { ENEMY_HEROES, HEROES } from "./heroes.js";
 export { ENEMY_THUGS_GRAY, THUGS_GRAY } from "./thugs-gray.js";
+export { ENEMY_SHOCKTROOPS_GRAY, SHOCKTROOPS_GRAY } from "./shocktroops.js";
 
 // Import for aggregation
 import { ENEMY_CROSSBOWMEN, CROSSBOWMEN } from "./crossbowmen.js";
@@ -22,6 +23,7 @@ import { ENEMY_SWORDSMEN, SWORDSMEN } from "./swordsmen.js";
 import { ENEMY_GOLEMS, GOLEMS } from "./golems.js";
 import { ENEMY_HEROES, HEROES } from "./heroes.js";
 import { ENEMY_THUGS_GRAY, THUGS_GRAY } from "./thugs-gray.js";
+import { ENEMY_SHOCKTROOPS_GRAY, SHOCKTROOPS_GRAY } from "./shocktroops.js";
 
 /**
  * Union type of all gray (Keep garrison) enemy IDs
@@ -32,7 +34,8 @@ export type GrayEnemyId =
   | typeof ENEMY_SWORDSMEN
   | typeof ENEMY_GOLEMS
   | typeof ENEMY_HEROES
-  | typeof ENEMY_THUGS_GRAY;
+  | typeof ENEMY_THUGS_GRAY
+  | typeof ENEMY_SHOCKTROOPS_GRAY;
 
 /** All gray (Keep garrison) enemies */
 export const GRAY_ENEMIES: Record<GrayEnemyId, EnemyDefinition> = {
@@ -42,6 +45,7 @@ export const GRAY_ENEMIES: Record<GrayEnemyId, EnemyDefinition> = {
   [ENEMY_GOLEMS]: GOLEMS,
   [ENEMY_HEROES]: HEROES,
   [ENEMY_THUGS_GRAY]: THUGS_GRAY,
+  [ENEMY_SHOCKTROOPS_GRAY]: SHOCKTROOPS_GRAY,
 };
 
 // =============================================================================

--- a/packages/shared/src/enemies/gray/shocktroops.ts
+++ b/packages/shared/src/enemies/gray/shocktroops.ts
@@ -1,0 +1,18 @@
+import { ELEMENT_PHYSICAL } from "../../elements.js";
+import { ABILITY_UNFORTIFIED, ABILITY_ELUSIVE } from "../abilities.js";
+import { ENEMY_COLOR_GRAY, type EnemyDefinition } from "../types.js";
+
+export const ENEMY_SHOCKTROOPS_GRAY = "shocktroops_gray" as const;
+
+export const SHOCKTROOPS_GRAY: EnemyDefinition = {
+  id: ENEMY_SHOCKTROOPS_GRAY,
+  name: "Shocktroops",
+  color: ENEMY_COLOR_GRAY,
+  attack: 5,
+  attackElement: ELEMENT_PHYSICAL,
+  armor: 3,
+  armorElusive: 6, // Elusive (6): uses 6 normally, 3 if all attacks blocked
+  fame: 3,
+  resistances: [],
+  abilities: [ABILITY_UNFORTIFIED, ABILITY_ELUSIVE],
+};

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -145,6 +145,7 @@ export {
   ENEMY_GOLEMS,
   ENEMY_HEROES,
   ENEMY_THUGS_GRAY,
+  ENEMY_SHOCKTROOPS_GRAY,
   GRAY_ENEMIES,
   ENEMY_WOLF, // Test alias
 } from "./gray/index.js";


### PR DESCRIPTION
## Description

Implements the Shocktroops (Gray) enemy as specified in issue #426.

## Changes

- Added `ENEMY_SHOCKTROOPS_GRAY` constant in `packages/shared/src/enemies/gray/shocktroops.ts`
- Added to `GrayEnemyId` type union
- Added to `GRAY_ENEMIES` record
- Exported from gray and main enemy index files

## Enemy Stats

- **Color**: Gray (Keep Garrison)
- **Attack**: 5 Physical
- **Armor**: 3
- **Armor Elusive**: 6 (uses 6 normally, 3 if all attacks blocked)
- **Abilities**: Unfortified, Elusive (6)
- **Fame**: 3
- **Resistances**: None

## Acceptance Criteria

- ✅ Enemy constant defined
- ✅ Attack 5 physical configured
- ✅ Armor 3 configured
- ✅ Unfortified ability assigned
- ✅ Elusive (6) ability assigned
- ✅ Fame 3 configured

Closes #426