### PR TITLE
feat: Add Zombie Horde enemy (closes #439)

### DIFF
--- a/packages/shared/src/enemies/green/index.ts
+++ b/packages/shared/src/enemies/green/index.ts
@@ -27,6 +27,7 @@ export { ENEMY_ELVEN_PROTECTORS, ELVEN_PROTECTORS } from "./elven-protectors.js"
 export { ENEMY_CLOUD_GRIFFONS, CLOUD_GRIFFONS } from "./cloud-griffons.js";
 export { ENEMY_CRYSTAL_SPRITES, CRYSTAL_SPRITES } from "./crystal-sprites.js";
 export { ENEMY_ORC_TRACKER, ORC_TRACKER } from "./orc-tracker.js";
+export { ENEMY_ZOMBIE_HORDE, ZOMBIE_HORDE } from "./zombie-horde.js";
 
 // Import for aggregation
 import { ENEMY_DIGGERS, DIGGERS } from "./diggers.js";
@@ -48,6 +49,7 @@ import { ENEMY_ELVEN_PROTECTORS, ELVEN_PROTECTORS } from "./elven-protectors.js"
 import { ENEMY_CLOUD_GRIFFONS, CLOUD_GRIFFONS } from "./cloud-griffons.js";
 import { ENEMY_CRYSTAL_SPRITES, CRYSTAL_SPRITES } from "./crystal-sprites.js";
 import { ENEMY_ORC_TRACKER, ORC_TRACKER } from "./orc-tracker.js";
+import { ENEMY_ZOMBIE_HORDE, ZOMBIE_HORDE } from "./zombie-horde.js";
 
 /**
  * Union type of all green (Marauding Orc) enemy IDs
@@ -71,7 +73,8 @@ export type GreenEnemyId =
   | typeof ENEMY_ELVEN_PROTECTORS
   | typeof ENEMY_CLOUD_GRIFFONS
   | typeof ENEMY_CRYSTAL_SPRITES
-  | typeof ENEMY_ORC_TRACKER;
+  | typeof ENEMY_ORC_TRACKER
+  | typeof ENEMY_ZOMBIE_HORDE;
 
 /** All green (Marauding Orc) enemies */
 export const GREEN_ENEMIES: Record<GreenEnemyId, EnemyDefinition> = {
@@ -94,6 +97,7 @@ export const GREEN_ENEMIES: Record<GreenEnemyId, EnemyDefinition> = {
   [ENEMY_CLOUD_GRIFFONS]: CLOUD_GRIFFONS,
   [ENEMY_CRYSTAL_SPRITES]: CRYSTAL_SPRITES,
   [ENEMY_ORC_TRACKER]: ORC_TRACKER,
+  [ENEMY_ZOMBIE_HORDE]: ZOMBIE_HORDE,
 };
 
 // =============================================================================

--- a/packages/shared/src/enemies/green/zombie-horde.ts
+++ b/packages/shared/src/enemies/green/zombie-horde.ts
@@ -1,0 +1,24 @@
+import { ELEMENT_PHYSICAL } from "../../elements.js";
+import { ABILITY_CUMBERSOME } from "../abilities.js";
+import { ENEMY_COLOR_GREEN, FACTION_DARK_CRUSADERS, type EnemyDefinition } from "../types.js";
+import { RESIST_ICE } from "../resistances.js";
+
+export const ENEMY_ZOMBIE_HORDE = "zombie_horde" as const;
+
+export const ZOMBIE_HORDE: EnemyDefinition = {
+  id: ENEMY_ZOMBIE_HORDE,
+  name: "Zombie Horde",
+  color: ENEMY_COLOR_GREEN,
+  attack: 0, // Multiple attacks - use attacks array
+  attackElement: ELEMENT_PHYSICAL,
+  armor: 5,
+  fame: 2,
+  resistances: [RESIST_ICE],
+  abilities: [ABILITY_CUMBERSOME],
+  faction: FACTION_DARK_CRUSADERS,
+  attacks: [
+    { damage: 1, element: ELEMENT_PHYSICAL },
+    { damage: 1, element: ELEMENT_PHYSICAL },
+    { damage: 1, element: ELEMENT_PHYSICAL },
+  ],
+};

--- a/packages/shared/src/enemies/index.ts
+++ b/packages/shared/src/enemies/index.ts
@@ -133,6 +133,7 @@ export {
   ENEMY_ELVEN_PROTECTORS,
   GREEN_ENEMIES,
   ENEMY_CRYSTAL_SPRITES,
+  ENEMY_ZOMBIE_HORDE,
   ENEMY_ORC, // Test alias
 } from "./green/index.js";
 


### PR DESCRIPTION
## Description

Implements the Zombie Horde enemy as specified in issue #439.

## Changes

- ✅ Add ENEMY_ZOMBIE_HORDE constant to green.ts
- ✅ Add to GreenEnemyId type
- ✅ Add definition with correct stats:
  - Attack: Multiple Attacks (1, 1, 1) - Physical
  - Armor: 5
  - Fame: 2
  - Resistances: Ice
  - Abilities: Cumbersome
  - Faction: Dark Crusaders

## Implementation Details

- Created `packages/shared/src/enemies/green/zombie-horde.ts` with the enemy definition
- Multiple attacks implemented using the `attacks` array with three separate attacks of 1 damage each
- Cumbersome ability applied to allow Move point reduction
- Ice resistance applied
- Faction set to FACTION_DARK_CRUSADERS

## Testing

- ✅ TypeScript compilation passes
- ✅ Linter passes
- ✅ All type definitions updated correctly

Closes #439