### PR TITLE
refactor(core): move getCard to helpers to break effects/validActions circular dependency

### DIFF
--- a/packages/core/src/engine/effects/cardBoostEffects.ts
+++ b/packages/core/src/engine/effects/cardBoostEffects.ts
@@ -18,7 +18,7 @@ import type { Player } from "../../types/player.js";
 import type { DeedCard, CardEffect, ScalableBaseEffect, ResolveBoostTargetEffect } from "../../types/cards.js";
 import { DEED_CARD_TYPE_BASIC_ACTION, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../types/cards.js";
 import { CARD_WOUND } from "@mage-knight/shared";
-import { getCard } from "../validActions/cards/index.js";
+import { getCard } from "../helpers/cardLookup.js";
 import {
   EFFECT_GAIN_MOVE,
   EFFECT_GAIN_INFLUENCE,

--- a/packages/core/src/engine/effects/cardBoostResolvers.ts
+++ b/packages/core/src/engine/effects/cardBoostResolvers.ts
@@ -34,7 +34,7 @@ import type {
 } from "../../types/cards.js";
 import type { EffectResolutionResult } from "./types.js";
 import type { EffectResolver } from "./compound.js";
-import { getCard } from "../validActions/cards/index.js";
+import { getCard } from "../helpers/cardLookup.js";
 import { updatePlayer } from "./atomicEffects.js";
 import {
   getEligibleBoostTargets,

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -62,7 +62,7 @@ import type {
   DiscardWoundsEffect,
   TrackAttackDefeatFameEffect,
 } from "../../types/effectTypes.js";
-import { getCard } from "../validActions/cards/index.js";
+import { getCard } from "../helpers/cardLookup.js";
 
 // ============================================================================
 // TYPES

--- a/packages/core/src/engine/effects/effectUndoContext.ts
+++ b/packages/core/src/engine/effects/effectUndoContext.ts
@@ -17,7 +17,7 @@ import type { GameState } from "../../state/GameState.js";
 import type { ManaColor, BasicManaColor, CardId } from "@mage-knight/shared";
 import type { CardEffect, ManaDrawSetColorEffect, ResolveBoostTargetEffect } from "../../types/cards.js";
 import { EFFECT_MANA_DRAW_SET_COLOR, EFFECT_RESOLVE_BOOST_TARGET } from "../../types/effectTypes.js";
-import { getCard } from "../validActions/cards/index.js";
+import { getCard } from "../helpers/cardLookup.js";
 import { addBonusToEffect } from "./cardBoostEffects.js";
 import { reverseEffect } from "./reverse.js";
 import { getPlayerIndexById } from "../helpers/playerHelpers.js";

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -33,7 +33,7 @@ import {
   MANA_GREEN,
   MANA_WHITE,
 } from "@mage-knight/shared";
-import { getCard } from "../validActions/cards/index.js";
+import { getCard } from "../helpers/cardLookup.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
 import {
   EFFECT_GAIN_MOVE,

--- a/packages/core/src/engine/helpers/cardLookup.ts
+++ b/packages/core/src/engine/helpers/cardLookup.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure card lookup by ID. Lives here to avoid circular dependency between
+ * engine/effects and engine/validActions (both need card lookup).
+ */
+
+import type { DeedCard } from "../../types/cards.js";
+import { getBasicActionCard } from "../../data/basicActions/index.js";
+import { getAdvancedActionCard } from "../../data/advancedActions/index.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import { getArtifactCard } from "../../data/artifacts/index.js";
+
+/**
+ * Get a card definition by ID.
+ * Supports basic action, advanced action, and spell cards.
+ */
+export function getCard(cardId: string): DeedCard | null {
+  // Try basic action cards first
+  try {
+    return getBasicActionCard(cardId as Parameters<typeof getBasicActionCard>[0]);
+  } catch {
+    // Not a basic action, continue
+  }
+
+  // Try advanced action cards
+  try {
+    return getAdvancedActionCard(cardId as Parameters<typeof getAdvancedActionCard>[0]);
+  } catch {
+    // Not an advanced action either
+  }
+
+  // Try spell cards
+  const spell = getSpellCard(cardId as Parameters<typeof getSpellCard>[0]);
+  if (spell) {
+    return spell;
+  }
+
+  // Try artifact cards
+  const artifact = getArtifactCard(cardId as Parameters<typeof getArtifactCard>[0]);
+  if (artifact) {
+    return artifact;
+  }
+
+  // Card not found
+  return null;
+}

--- a/packages/core/src/engine/helpers/index.ts
+++ b/packages/core/src/engine/helpers/index.ts
@@ -2,6 +2,8 @@
  * Helper functions for game engine operations
  */
 
+export { getCard } from "./cardLookup.js";
+
 export {
   getPlayerByIdOrThrow,
   getPlayerIndexByIdOrThrow,

--- a/packages/core/src/engine/validActions/cards/index.ts
+++ b/packages/core/src/engine/validActions/cards/index.ts
@@ -5,12 +5,6 @@
  * and how (basic, powered, or sideways) based on the current game state.
  */
 
-import type { DeedCard } from "../../../types/cards.js";
-import { getBasicActionCard } from "../../../data/basicActions/index.js";
-import { getAdvancedActionCard } from "../../../data/advancedActions/index.js";
-import { getSpellCard } from "../../../data/spells/index.js";
-import { getArtifactCard } from "../../../data/artifacts/index.js";
-
 // Re-export combat playability
 export { getPlayableCardsForCombat } from "./combat.js";
 
@@ -38,37 +32,5 @@ export {
 // Re-export mana payment functions (for use by other modules if needed)
 export { canPayForSpellBasic, findPayableManaColor } from "./manaPayment.js";
 
-/**
- * Get a card definition by ID.
- * Supports basic action, advanced action, and spell cards.
- */
-export function getCard(cardId: string): DeedCard | null {
-  // Try basic action cards first
-  try {
-    return getBasicActionCard(cardId as Parameters<typeof getBasicActionCard>[0]);
-  } catch {
-    // Not a basic action, continue
-  }
-
-  // Try advanced action cards
-  try {
-    return getAdvancedActionCard(cardId as Parameters<typeof getAdvancedActionCard>[0]);
-  } catch {
-    // Not an advanced action either
-  }
-
-  // Try spell cards
-  const spell = getSpellCard(cardId as Parameters<typeof getSpellCard>[0]);
-  if (spell) {
-    return spell;
-  }
-
-  // Try artifact cards
-  const artifact = getArtifactCard(cardId as Parameters<typeof getArtifactCard>[0]);
-  if (artifact) {
-    return artifact;
-  }
-
-  // Card not found
-  return null;
-}
+// Re-export card lookup for backward compatibility (implementation lives in helpers to avoid circular deps)
+export { getCard } from "../../helpers/cardLookup.js";


### PR DESCRIPTION
## Summary
Move `getCard` to a neutral location to break the circular dependency:
- **engine/effects/** imported `getCard` from **engine/validActions/cards**
- **engine/validActions/** imported `isEffectResolvable` from **engine/effects**

`getCard` is a pure lookup and doesn't belong in validActions.

## Changes
- **Added** `engine/helpers/cardLookup.ts` with `getCard` (and data-layer imports)
- **Updated** 5 files in `engine/effects/` to import from `../helpers/cardLookup.js`:
  - resolvability.ts, describeEffect.ts, cardBoostEffects.ts, cardBoostResolvers.ts, effectUndoContext.ts
- **Updated** `engine/validActions/cards/index.ts`: removed `getCard` implementation and unused data imports; added re-export from helpers for backward compatibility
- **Updated** `engine/helpers/index.ts`: export `getCard` from cardLookup

## Result
- `effects/` no longer imports from `validActions/`
- `getCard` lives in `helpers/` where both can use it
- No behavior changes, only import paths