### PR TITLE
feat: ValidActions discriminated union redesign

### DIFF
--- a/packages/client/src/components/CardInteraction/UnifiedCardMenu.tsx
+++ b/packages/client/src/components/CardInteraction/UnifiedCardMenu.tsx
@@ -114,7 +114,10 @@ export function UnifiedCardMenu() {
   const isInCombat = gameState?.combat !== null;
 
   // Can undo (for effect choice state)
-  const canUndo = gameState?.validActions.turn?.canUndo ?? false;
+  const canUndo =
+    gameState?.validActions && "turn" in gameState.validActions
+      ? gameState.validActions.turn.canUndo
+      : false;
 
   // Save position for ChoiceSelection fallback (during transition)
   useEffect(() => {

--- a/packages/client/src/components/CardInteraction/utils/manaSourceHelpers.ts
+++ b/packages/client/src/components/CardInteraction/utils/manaSourceHelpers.ts
@@ -58,8 +58,10 @@ export function getAvailableManaSources(
     }
   }
 
-  // 3. Check available dice from the source
-  const manaOptions = state.validActions.mana;
+  // 3. Check available dice from the source (only in combat or normal_turn)
+  const va = state.validActions;
+  const manaOptions =
+    va.mode === "combat" || va.mode === "normal_turn" ? va.mana : undefined;
   if (manaOptions) {
     // Matching color dice
     const matchingDice = manaOptions.availableDice.filter(

--- a/packages/client/src/components/Combat/CombatOverlay.tsx
+++ b/packages/client/src/components/Combat/CombatOverlay.tsx
@@ -323,7 +323,10 @@ function AccumulatorDisplay() {
 function CombatOverlayInner({ combat, combatOptions }: CombatOverlayProps) {
   const { phase, enemies } = combat;
   const { state, sendAction } = useGame();
-  const canUndo = state?.validActions.turn?.canUndo ?? false;
+  const canUndo =
+    state?.validActions && "turn" in state.validActions
+      ? state.validActions.turn.canUndo
+      : false;
 
   // Visual effect state - use a counter to force animation restart
   const [activeEffect, setActiveEffect] = useState<EffectType>(null);

--- a/packages/client/src/components/GameBoard/PixiHexGrid.tsx
+++ b/packages/client/src/components/GameBoard/PixiHexGrid.tsx
@@ -17,7 +17,7 @@
  * Phase 5: Particle effects and polish ✓
  */
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { Application, Container } from "pixi.js";
 import type { HexCoord } from "@mage-knight/shared";
 import { hexKey, ENTER_SITE_ACTION, BURN_MONASTERY_ACTION, PLUNDER_VILLAGE_ACTION } from "@mage-knight/shared";
@@ -240,6 +240,15 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
     };
   }, [player?.position]);
 
+  // Site options only available during normal_turn
+  const siteOptions = useMemo(
+    () =>
+      state?.validActions?.mode === "normal_turn"
+        ? state.validActions.sites ?? null
+        : null,
+    [state?.validActions]
+  );
+
   // Enhanced keyboard handler that intercepts Space for site actions
   const handleGameKeyDown = useCallback((event: KeyboardEvent) => {
     // Don't handle if overlays are active or site panel is open
@@ -248,8 +257,8 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
       return;
     }
 
-    // Space - toggle site action list (only if it's my turn)
-    if (event.code === "Space" && isMyTurn && state?.validActions.sites) {
+    // Space - toggle site action list (only if it's my turn and we have site options)
+    if (event.code === "Space" && isMyTurn && siteOptions) {
       event.preventDefault();
       if (showSiteActionList) {
         handleCloseSiteActionList();
@@ -268,7 +277,7 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
     handleKeyDown(event);
   }, [
     isMyTurn,
-    state?.validActions.sites,
+    siteOptions,
     showSiteActionList,
     isOverlayActive,
     isSitePanelOpen,
@@ -519,7 +528,7 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
         siteOptions={
           sitePanelHex && player?.position &&
           sitePanelHex.q === player.position.q && sitePanelHex.r === player.position.r
-            ? state?.validActions.sites ?? null
+            ? siteOptions
             : null
         }
         hex={sitePanelHex ? state?.map.hexes[hexKey(sitePanelHex)] ?? null : null}
@@ -530,9 +539,9 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
       />
 
       {/* Site Action List - compact action menu on Space key */}
-      {showSiteActionList && actionListPosition && state?.validActions.sites && (
+      {showSiteActionList && actionListPosition && siteOptions && (
         <SiteActionList
-          siteOptions={state.validActions.sites}
+          siteOptions={siteOptions}
           position={actionListPosition}
           onAction={handleSiteAction}
           onClose={handleCloseSiteActionList}

--- a/packages/client/src/components/GameBoard/hooks/useGameBoardSelectors.ts
+++ b/packages/client/src/components/GameBoard/hooks/useGameBoardSelectors.ts
@@ -29,31 +29,32 @@ export function useGameBoardSelectors({
   hoveredHex,
   playerPosition,
 }: UseGameBoardSelectorsParams): UseGameBoardSelectorsReturn {
-  // Memoized valid move targets
-  const validMoveTargets = useMemo<readonly MoveTarget[]>(
-    () => state?.validActions.move?.targets ?? [],
-    [state?.validActions.move?.targets]
-  );
+  // Memoized valid move targets (only in normal_turn)
+  const validMoveTargets = useMemo<readonly MoveTarget[]>(() => {
+    const va = state?.validActions;
+    return va?.mode === "normal_turn" ? (va.move?.targets ?? []) : [];
+  }, [state?.validActions]);
 
-  const reachableHexes = useMemo<readonly ReachableHex[]>(
-    () => state?.validActions.move?.reachable ?? [],
-    [state?.validActions.move?.reachable]
-  );
+  const reachableHexes = useMemo<readonly ReachableHex[]>(() => {
+    const va = state?.validActions;
+    return va?.mode === "normal_turn" ? (va.move?.reachable ?? []) : [];
+  }, [state?.validActions]);
 
-  // Challenge target hexes (rampaging enemies that can be challenged from adjacent hex)
-  const challengeTargetHexes = useMemo<readonly HexCoord[]>(
-    () => state?.validActions.challenge?.targetHexes ?? [],
-    [state?.validActions.challenge?.targetHexes]
-  );
+  // Challenge target hexes (only in normal_turn)
+  const challengeTargetHexes = useMemo<readonly HexCoord[]>(() => {
+    const va = state?.validActions;
+    return va?.mode === "normal_turn" ? (va.challenge?.targetHexes ?? []) : [];
+  }, [state?.validActions]);
 
   const exploreTargets = useMemo<ExploreTarget[]>(() => {
-    if (!state?.validActions.explore) return [];
-    return state.validActions.explore.directions.map((dir) => ({
+    const va = state?.validActions;
+    if (va?.mode !== "normal_turn" || !va.explore) return [];
+    return va.explore.directions.map((dir) => ({
       coord: dir.targetCoord,
       direction: dir.direction,
       fromTileCoord: dir.fromTileCoord,
     }));
-  }, [state?.validActions.explore]);
+  }, [state?.validActions]);
 
   // Path preview computation
   const pathPreview = useMemo<HexCoord[]>(() => {

--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -71,7 +71,10 @@ export function GameView() {
 
   // Check if we're in tactic selection mode
   // Only dim the world after intro completes - don't dim during the theatrical reveal
-  const isTacticSelectionActive = player && player.selectedTacticId === null && !!state.validActions.tactics;
+  const isTacticSelectionActive =
+    player &&
+    player.selectedTacticId === null &&
+    state.validActions.mode === "tactics_selection";
   const shouldDimForTactics = isTacticSelectionActive && isIntroComplete;
 
   const appClassName = [
@@ -105,7 +108,11 @@ export function GameView() {
           <PixiCombatOverlay combat={state.combat} />
           <CombatOverlay
             combat={state.combat}
-            combatOptions={state.validActions.combat}
+            combatOptions={
+              state.validActions.mode === "combat"
+                ? state.validActions.combat
+                : undefined
+            }
           />
         </>
       )}

--- a/packages/client/src/components/Hand/PixiTacticCarousel.tsx
+++ b/packages/client/src/components/Hand/PixiTacticCarousel.tsx
@@ -104,8 +104,10 @@ export function PixiTacticCarousel({ viewMode, isActive = true }: PixiTacticCaro
 
   // Get available tactics from game state
   const availableTactics = useMemo(() => {
-    return state?.validActions.tactics?.availableTactics ?? [];
-  }, [state?.validActions.tactics?.availableTactics]);
+    return state?.validActions?.mode === "tactics_selection"
+      ? (state.validActions.tactics.availableTactics ?? [])
+      : [];
+  }, [state?.validActions]);
 
   const timeOfDay = state?.timeOfDay ?? "day";
 

--- a/packages/client/src/components/Hand/PlayerHand.tsx
+++ b/packages/client/src/components/Hand/PlayerHand.tsx
@@ -54,7 +54,7 @@ export function PlayerHand({ onOfferViewChange }: PlayerHandProps = {}) {
   const needsTacticSelection = !!(
     player &&
     player.selectedTacticId === null &&
-    state?.validActions.tactics
+    state?.validActions?.mode === "tactics_selection"
   );
 
   // Track previous tactic selection state to detect when selection completes
@@ -166,8 +166,12 @@ export function PlayerHand({ onOfferViewChange }: PlayerHandProps = {}) {
 
   // Get playable cards from validActions - memoized to avoid hook dependency issues
   const playableCardMap = useMemo(() => {
-    if (!state) return new Map();
-    const playableCards = state.validActions.playCard?.cards ?? [];
+    if (!state?.validActions) return new Map();
+    const va = state.validActions;
+    const playableCards =
+      (va.mode === "combat" || va.mode === "normal_turn")
+        ? (va.playCard?.cards ?? [])
+        : [];
     return new Map(playableCards.map(c => [c.cardId, c]));
   }, [state]);
 
@@ -185,8 +189,11 @@ export function PlayerHand({ onOfferViewChange }: PlayerHandProps = {}) {
 
   // Get activatable units from validActions
   const activatableUnits = useMemo(() => {
-    return state?.validActions.units?.activatable ?? [];
-  }, [state?.validActions.units?.activatable]);
+    const va = state?.validActions;
+    if (!va || (va.mode !== "combat" && va.mode !== "normal_turn"))
+      return [];
+    return va.units?.activatable ?? [];
+  }, [state?.validActions]);
 
   // Close unit menu when activatable units change (unit was activated and spent)
   useEffect(() => {

--- a/packages/client/src/components/Hand/TacticCarouselPane.tsx
+++ b/packages/client/src/components/Hand/TacticCarouselPane.tsx
@@ -247,7 +247,10 @@ export function TacticCarouselPane({ viewMode }: TacticCarouselPaneProps) {
   }
 
   // Get available tactics from validActions
-  const tacticsOptions = state.validActions.tactics;
+  const tacticsOptions =
+    state.validActions?.mode === "tactics_selection"
+      ? state.validActions.tactics
+      : undefined;
   if (!tacticsOptions) {
     return (
       <div className={`tactic-carousel tactic-carousel--${viewMode} tactic-carousel--empty`}>

--- a/packages/client/src/components/HexContextMenu/HexContextMenu.tsx
+++ b/packages/client/src/components/HexContextMenu/HexContextMenu.tsx
@@ -143,8 +143,11 @@ export function HexContextMenu({
       }
     }
 
-    // End Turn option (if valid and has passive effect)
-    const canEndTurn = state?.validActions.turn?.canEndTurn ?? false;
+    // End Turn option (if valid and has passive effect; only in normal_turn)
+    const canEndTurn =
+      state?.validActions?.mode === "normal_turn"
+        ? (state.validActions.turn.canEndTurn ?? false)
+        : false;
     if (canEndTurn && siteOptions.endOfTurnEffect) {
       const endColors = getActionColors("end-turn");
       items.push({
@@ -166,7 +169,7 @@ export function HexContextMenu({
     });
 
     return items;
-  }, [siteOptions, state?.validActions.turn?.canEndTurn]);
+  }, [siteOptions, state?.validActions]);
 
   const handleSelect = useCallback(
     (id: string) => {

--- a/packages/client/src/components/OfferView/PixiOfferView.tsx
+++ b/packages/client/src/components/OfferView/PixiOfferView.tsx
@@ -140,7 +140,11 @@ export function PixiOfferView({ isVisible, onClose, initialTab = "units" }: Pixi
     if (!state || !player) return [];
 
     if (pane === "units") {
-      const recruitableUnits = state.validActions?.units?.recruitable ?? [];
+      const va = state.validActions;
+      const recruitableUnits =
+        va?.mode === "combat" || va?.mode === "normal_turn"
+          ? (va.units?.recruitable ?? [])
+          : [];
       const recruitableMap = new Map(recruitableUnits.map((r) => [r.unitId, r]));
 
       const unitCards = state.offers.units.map((unitId) => {

--- a/packages/client/src/components/Overlays/ChoiceSelection.tsx
+++ b/packages/client/src/components/Overlays/ChoiceSelection.tsx
@@ -119,7 +119,10 @@ export function ChoiceSelection() {
   // Extract data before hooks (may be undefined if no pending choice)
   const pendingChoice = player?.pendingChoice;
   const sourceCardId = pendingChoice?.cardId;
-  const canUndo = state?.validActions.turn?.canUndo ?? false;
+  const canUndo =
+    state?.validActions && "turn" in state.validActions
+      ? state.validActions.turn.canUndo
+      : false;
   const isInCombat = state?.combat !== null;
 
   // Don't render if UnifiedCardMenu is handling the interaction

--- a/packages/client/src/components/Overlays/GladeWoundDecision.tsx
+++ b/packages/client/src/components/Overlays/GladeWoundDecision.tsx
@@ -10,7 +10,10 @@ export function GladeWoundDecision() {
   const { state, sendAction } = useGame();
 
   // Check if we have a pending glade wound decision
-  const gladeWoundOptions = state?.validActions.gladeWound;
+  const gladeWoundOptions =
+    state?.validActions?.mode === "pending_glade_wound"
+      ? state.validActions.gladeWound
+      : undefined;
   if (!gladeWoundOptions) {
     return null;
   }

--- a/packages/client/src/components/Overlays/LevelUpRewardSelection.tsx
+++ b/packages/client/src/components/Overlays/LevelUpRewardSelection.tsx
@@ -80,7 +80,10 @@ export function LevelUpRewardSelection() {
   const [selectedAA, setSelectedAA] = useState<CardId | null>(null);
 
   // Check if we have level up rewards to show
-  const levelUpRewards = state?.validActions.levelUpRewards;
+  const levelUpRewards =
+    state?.validActions?.mode === "pending_level_up"
+      ? state.validActions.levelUpRewards
+      : undefined;
 
   // Don't show if no pending level up rewards
   if (!player || !levelUpRewards) {

--- a/packages/client/src/components/Overlays/ManaSearchReroll.tsx
+++ b/packages/client/src/components/Overlays/ManaSearchReroll.tsx
@@ -36,8 +36,11 @@ export function ManaSearchReroll() {
   const [selectedDice, setSelectedDice] = useState<string[]>([]);
   const [isOpen, setIsOpen] = useState(false);
 
-  // Check if Mana Search reroll is available
-  const canRerollSourceDice = state?.validActions.tacticEffects?.canRerollSourceDice;
+  // Check if Mana Search reroll is available (only in normal_turn)
+  const canRerollSourceDice =
+    state?.validActions?.mode === "normal_turn"
+      ? state.validActions.tacticEffects?.canRerollSourceDice
+      : undefined;
   if (!canRerollSourceDice || !player || !state) {
     return null;
   }

--- a/packages/client/src/components/Overlays/ManaStealDecision.tsx
+++ b/packages/client/src/components/Overlays/ManaStealDecision.tsx
@@ -33,7 +33,10 @@ export function ManaStealDecision() {
   const { state, sendAction } = useGame();
 
   // Check if we have a pending Mana Steal decision
-  const pendingDecision = state?.validActions.tacticEffects?.pendingDecision;
+  const pendingDecision =
+    state?.validActions?.mode === "pending_tactic_decision"
+      ? state.validActions.tacticDecision
+      : undefined;
   if (
     !pendingDecision ||
     pendingDecision.type !== TACTIC_DECISION_MANA_STEAL ||

--- a/packages/client/src/components/Overlays/MidnightMeditationDecision.tsx
+++ b/packages/client/src/components/Overlays/MidnightMeditationDecision.tsx
@@ -21,7 +21,10 @@ export function MidnightMeditationDecision() {
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
 
   // Check if we have a pending Midnight Meditation decision
-  const pendingDecision = state?.validActions.tacticEffects?.pendingDecision;
+  const pendingDecision =
+    state?.validActions?.mode === "pending_tactic_decision"
+      ? state.validActions.tacticDecision
+      : undefined;
   if (
     !pendingDecision ||
     pendingDecision.type !== TACTIC_DECISION_MIDNIGHT_MEDITATION ||

--- a/packages/client/src/components/Overlays/PreparationDecision.tsx
+++ b/packages/client/src/components/Overlays/PreparationDecision.tsx
@@ -19,7 +19,10 @@ export function PreparationDecision() {
   const player = useMyPlayer();
 
   // Check if we have a pending Preparation decision
-  const pendingDecision = state?.validActions.tacticEffects?.pendingDecision;
+  const pendingDecision =
+    state?.validActions?.mode === "pending_tactic_decision"
+      ? state.validActions.tacticDecision
+      : undefined;
   if (
     !pendingDecision ||
     pendingDecision.type !== TACTIC_DECISION_PREPARATION ||

--- a/packages/client/src/components/Overlays/RestCompletionOverlay.tsx
+++ b/packages/client/src/components/Overlays/RestCompletionOverlay.tsx
@@ -25,7 +25,10 @@ export function RestCompletionOverlay() {
   const player = useMyPlayer();
 
   // Check if we're in resting state
-  const isResting = state?.validActions.turn?.isResting ?? false;
+  const isResting =
+    state?.validActions?.mode === "normal_turn"
+      ? (state.validActions.turn.isResting ?? false)
+      : false;
   const isActive = isResting && !!player;
 
   // Register this overlay to disable background interactions when active

--- a/packages/client/src/components/Overlays/RethinkDecision.tsx
+++ b/packages/client/src/components/Overlays/RethinkDecision.tsx
@@ -21,7 +21,10 @@ export function RethinkDecision() {
   const [selectedIndices, setSelectedIndices] = useState<number[]>([]);
 
   // Check if we have a pending Rethink decision
-  const pendingDecision = state?.validActions.tacticEffects?.pendingDecision;
+  const pendingDecision =
+    state?.validActions?.mode === "pending_tactic_decision"
+      ? state.validActions.tacticDecision
+      : undefined;
   if (
     !pendingDecision ||
     pendingDecision.type !== TACTIC_DECISION_RETHINK ||

--- a/packages/client/src/components/Overlays/SparingPowerDecision.tsx
+++ b/packages/client/src/components/Overlays/SparingPowerDecision.tsx
@@ -12,7 +12,10 @@ export function SparingPowerDecision() {
   const player = useMyPlayer();
 
   // Check if we have a pending Sparing Power decision
-  const pendingDecision = state?.validActions.tacticEffects?.pendingDecision;
+  const pendingDecision =
+    state?.validActions?.mode === "pending_tactic_decision"
+      ? state.validActions.tacticDecision
+      : undefined;
   if (
     !pendingDecision ||
     pendingDecision.type !== TACTIC_DECISION_SPARING_POWER ||

--- a/packages/client/src/components/TurnActions/TurnActions.tsx
+++ b/packages/client/src/components/TurnActions/TurnActions.tsx
@@ -66,16 +66,20 @@ export function TurnActions() {
       setSealAnimState("visible");
     }
   }, [hasTactic, isIntroComplete]);
-  const canUndo = state?.validActions.turn?.canUndo ?? false;
+  const va = state?.validActions;
+  const canUndo =
+    va && "turn" in va ? va.turn.canUndo : false;
 
-  // Check for activatable tactics
-  const canActivate = state?.validActions.tacticEffects?.canActivate;
+  // Check for activatable tactics (only in normal_turn)
+  const canActivate =
+    va?.mode === "normal_turn" ? va.tacticEffects?.canActivate : undefined;
   const canActivateTheRightMoment = canActivate?.theRightMoment === true;
   const canActivateLongNight = canActivate?.longNight === true;
   const canActivateMidnightMeditation = canActivate?.midnightMeditation === true;
 
-  // Check for rest options (resting state is handled by RestCompletionOverlay)
-  const canDeclareRest = state?.validActions.turn?.canDeclareRest ?? false;
+  // Check for rest options (only in normal_turn; resting state is handled by RestCompletionOverlay)
+  const canDeclareRest =
+    va?.mode === "normal_turn" ? (va.turn.canDeclareRest ?? false) : false;
 
   // Ctrl+Z / Cmd+Z keyboard shortcut for undo
   useEffect(() => {

--- a/packages/core/src/engine/__tests__/cardSwiftReflexes.test.ts
+++ b/packages/core/src/engine/__tests__/cardSwiftReflexes.test.ts
@@ -429,7 +429,9 @@ describe("Swift Reflexes", () => {
       // In block phase with 0-attack enemy, the enemy should be filtered from block targets
       // We can check that enemyBlockStates doesn't include this enemy
       expect(
-        validActions.combat?.blockPhase?.enemyBlockStates?.length ?? 0
+        validActions.mode === "combat"
+          ? (validActions.combat.enemyBlockStates?.length ?? 0)
+          : 0
       ).toBe(0);
     });
   });

--- a/packages/core/src/engine/__tests__/combatDefend.test.ts
+++ b/packages/core/src/engine/__tests__/combatDefend.test.ts
@@ -559,16 +559,17 @@ describe("Combat Defend Ability", () => {
       // In attack phase, enemies should show their armor values
       // The Defend bonus won't be pre-applied in validActions because it only
       // triggers on attack declaration. ValidActions shows base effective armor.
-      expect(validActions.combat?.enemies).toBeDefined();
+      expect(validActions.mode).toBe("combat");
+      expect(validActions.combat.enemies).toBeDefined();
 
       // Basic enemy should show armor 4 (base)
-      const basicEnemy = validActions.combat?.enemies?.find(
+      const basicEnemy = validActions.combat.enemies?.find(
         (e) => e.enemyInstanceId === "enemy_0"
       );
       expect(basicEnemy?.armor).toBe(4);
 
       // Defend enemy should show armor 4 (base)
-      const defendEnemy = validActions.combat?.enemies?.find(
+      const defendEnemy = validActions.combat.enemies?.find(
         (e) => e.enemyInstanceId === "enemy_1"
       );
       expect(defendEnemy?.armor).toBe(4);

--- a/packages/core/src/engine/__tests__/combatElusive.test.ts
+++ b/packages/core/src/engine/__tests__/combatElusive.test.ts
@@ -772,7 +772,8 @@ describe("Combat Elusive Ability", () => {
 
       // Get valid actions - should show elusive armor
       const validActions = getValidActions(state, "player1");
-      const enemyState = validActions.combat?.enemies?.[0];
+      const enemyState =
+        validActions.mode === "combat" ? validActions.combat.enemies?.[0] : undefined;
 
       expect(enemyState?.armor).toBe(8); // Shows elusive armor
     });
@@ -814,7 +815,8 @@ describe("Combat Elusive Ability", () => {
 
       // Get valid actions - should show base armor since blocked
       const validActions = getValidActions(state, "player1");
-      const enemyState = validActions.combat?.enemies?.[0];
+      const enemyState =
+        validActions.mode === "combat" ? validActions.combat.enemies?.[0] : undefined;
 
       expect(enemyState?.armor).toBe(4); // Shows base armor (blocked)
     });

--- a/packages/core/src/engine/__tests__/combatSummon.test.ts
+++ b/packages/core/src/engine/__tests__/combatSummon.test.ts
@@ -342,7 +342,8 @@ describe("Combat Summon Ability", () => {
 
       // Valid actions should NOT include the hidden summoner in block options
       const validActions = getValidActions(state, "player1");
-      const blockOptions = validActions.combat?.blocks ?? [];
+      const blockOptions =
+        validActions.mode === "combat" ? (validActions.combat.blocks ?? []) : [];
 
       expect(blockOptions.map((b) => b.enemyInstanceId)).not.toContain(
         summoner?.instanceId
@@ -383,7 +384,10 @@ describe("Combat Summon Ability", () => {
 
       // Valid actions should NOT include the hidden summoner in damage assignments
       const validActions = getValidActions(state, "player1");
-      const damageOptions = validActions.combat?.damageAssignments ?? [];
+      const damageOptions =
+        validActions.mode === "combat"
+          ? (validActions.combat.damageAssignments ?? [])
+          : [];
 
       const summonerId = state.combat?.enemies.find(
         (e) => e.enemyId === ENEMY_ORC_SUMMONERS
@@ -471,7 +475,8 @@ describe("Combat Summon Ability", () => {
 
       // Should be able to attack the summoner
       const validActions = getValidActions(state, "player1");
-      const attackOptions = validActions.combat?.enemies ?? [];
+      const attackOptions =
+        validActions.mode === "combat" ? (validActions.combat.enemies ?? []) : [];
 
       expect(attackOptions.map((e) => e.enemyInstanceId)).toContain(
         state.combat?.enemies[0].instanceId
@@ -563,7 +568,8 @@ describe("Combat Summon Ability", () => {
       // (because it wasn't hidden since no summon occurred)
       // However, Orc Summoners have attack 0, so there's nothing to block
       const validActions = getValidActions(state, "player1");
-      const blockOptions = validActions.combat?.blocks ?? [];
+      const blockOptions =
+        validActions.mode === "combat" ? (validActions.combat.blocks ?? []) : [];
 
       // Orc Summoners have attack 0, so they won't appear as something to block
       // This is correct behavior - they don't attack
@@ -924,16 +930,19 @@ describe("Combat Summon Ability", () => {
 
       // In Ranged/Siege phase, Fortified enemies can only be attacked with Siege
       const validActions = getValidActions(state, "player1");
-      const rangedAttacks = validActions.combat?.attacks?.filter(
-        (a) => a.attackType === "ranged"
-      ) ?? [];
+      const rangedAttacks =
+        validActions.mode === "combat" && validActions.combat.assignableAttacks
+          ? validActions.combat.assignableAttacks.filter(
+              (a) => a.attackType === "ranged"
+            )
+          : [];
 
       const enemyInstanceId = state.combat?.enemies[0]?.instanceId ?? "";
 
       // Should NOT be able to use regular ranged attacks on Fortified enemy
       // Either there are no ranged attacks, or none target this enemy
-      const canTargetWithRanged = rangedAttacks.some((a) =>
-        a.targets.includes(enemyInstanceId)
+      const canTargetWithRanged = rangedAttacks.some(
+        (a) => a.enemyInstanceId === enemyInstanceId
       );
       expect(canTargetWithRanged).toBe(false);
     });

--- a/packages/core/src/engine/__tests__/healingDuringCombat.test.ts
+++ b/packages/core/src/engine/__tests__/healingDuringCombat.test.ts
@@ -28,6 +28,7 @@ import {
 
 function getPlayableCard(state: ReturnType<typeof createTestGameState>, cardId: string) {
   const validActions = getValidActions(state, "player1");
+  if (validActions.mode !== "combat" && validActions.mode !== "normal_turn") return undefined;
   return validActions.playCard?.cards.find((card) => card.cardId === cardId);
 }
 

--- a/packages/core/src/engine/__tests__/ritualAttack.test.ts
+++ b/packages/core/src/engine/__tests__/ritualAttack.test.ts
@@ -165,8 +165,9 @@ describe("Ritual Attack", () => {
     });
 
     const validActions = getValidActions(playResult.state, "player1");
-    expect(validActions.discardCost?.availableCardIds).toContain(CARD_RAGE);
-    expect(validActions.discardCost?.availableCardIds).not.toContain(CARD_FIREBALL);
+    expect(validActions.mode).toBe("pending_discard_cost");
+    expect(validActions.discardCost.availableCardIds).toContain(CARD_RAGE);
+    expect(validActions.discardCost.availableCardIds).not.toContain(CARD_FIREBALL);
   });
 
   it("rejects discarding a non-action card", () => {

--- a/packages/core/src/engine/__tests__/skillBurningPower.test.ts
+++ b/packages/core/src/engine/__tests__/skillBurningPower.test.ts
@@ -16,6 +16,7 @@ import {
   CHOICE_RESOLVED,
   ENEMY_PROWLERS,
   ELEMENT_FIRE,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_ARYTHEA_BURNING_POWER } from "../../data/skills/index.js";
@@ -236,8 +237,9 @@ describe("Burning Power skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_ARYTHEA_BURNING_POWER,
         })
@@ -263,8 +265,9 @@ describe("Burning Power skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_ARYTHEA_BURNING_POWER,
         })
@@ -290,8 +293,9 @@ describe("Burning Power skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_BURNING_POWER,
           })

--- a/packages/core/src/engine/__tests__/skillDarkPaths.test.ts
+++ b/packages/core/src/engine/__tests__/skillDarkPaths.test.ts
@@ -14,6 +14,7 @@ import {
   TIME_OF_DAY_DAY,
   TIME_OF_DAY_NIGHT,
   ENEMY_PROWLERS,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_ARYTHEA_DARK_PATHS } from "../../data/skills/index.js";
@@ -192,8 +193,9 @@ describe("Dark Paths skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_ARYTHEA_DARK_PATHS,
         })
@@ -218,8 +220,9 @@ describe("Dark Paths skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_ARYTHEA_DARK_PATHS,
         })
@@ -244,8 +247,9 @@ describe("Dark Paths skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_DARK_PATHS,
           })

--- a/packages/core/src/engine/__tests__/skillDaySharpshooting.test.ts
+++ b/packages/core/src/engine/__tests__/skillDaySharpshooting.test.ts
@@ -12,6 +12,7 @@ import {
   USE_SKILL_ACTION,
   SKILL_USED,
   INVALID_ACTION,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_NOROWAS_DAY_SHARPSHOOTING } from "../../data/skills/index.js";
@@ -138,8 +139,9 @@ describe("Day Sharpshooting skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_NOROWAS_DAY_SHARPSHOOTING,
         })
@@ -165,8 +167,9 @@ describe("Day Sharpshooting skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_NOROWAS_DAY_SHARPSHOOTING,
         })
@@ -192,8 +195,9 @@ describe("Day Sharpshooting skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_NOROWAS_DAY_SHARPSHOOTING,
           })

--- a/packages/core/src/engine/__tests__/skillIFeelNoPain.test.ts
+++ b/packages/core/src/engine/__tests__/skillIFeelNoPain.test.ts
@@ -22,6 +22,7 @@ import {
   CARD_MARCH,
   CARD_RAGE,
   CARD_WOUND,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_TOVAK_I_FEEL_NO_PAIN } from "../../data/skills/index.js";
@@ -226,8 +227,9 @@ describe("I Feel No Pain skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or the skill is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_I_FEEL_NO_PAIN,
           })
@@ -282,8 +284,9 @@ describe("I Feel No Pain skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or the skill is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_I_FEEL_NO_PAIN,
           })
@@ -529,8 +532,9 @@ describe("I Feel No Pain skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_TOVAK_I_FEEL_NO_PAIN,
         })
@@ -555,8 +559,9 @@ describe("I Feel No Pain skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or the skill is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_I_FEEL_NO_PAIN,
           })
@@ -582,7 +587,7 @@ describe("I Feel No Pain skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should be undefined since no skills are available
-      expect(validActions.skills).toBeUndefined();
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/engine/__tests__/skillPolarization.test.ts
+++ b/packages/core/src/engine/__tests__/skillPolarization.test.ts
@@ -28,6 +28,7 @@ import {
   TIME_OF_DAY_DAY,
   TIME_OF_DAY_NIGHT,
   MANA_TOKEN_SOURCE_CARD,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_ARYTHEA_POLARIZATION } from "../../data/skills/index.js";
@@ -445,8 +446,9 @@ describe("Polarization skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should not include Polarization
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_POLARIZATION,
           })
@@ -581,8 +583,9 @@ describe("Polarization skill", () => {
       // Skill should not be activatable with only black during night
       const validActions = getValidActions(state, "player1");
 
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_POLARIZATION,
           })
@@ -688,8 +691,9 @@ describe("Polarization skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_ARYTHEA_POLARIZATION,
         })
@@ -718,8 +722,9 @@ describe("Polarization skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or Polarization is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_POLARIZATION,
           })
@@ -746,8 +751,9 @@ describe("Polarization skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_ARYTHEA_POLARIZATION,
           })
@@ -775,7 +781,7 @@ describe("Polarization skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should be undefined since no skills are available
-      expect(validActions.skills).toBeUndefined();
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
     });
   });
 

--- a/packages/core/src/engine/__tests__/skillRitualOfPain.test.ts
+++ b/packages/core/src/engine/__tests__/skillRitualOfPain.test.ts
@@ -253,7 +253,10 @@ describe("Ritual of Pain skill", () => {
     };
 
     const validActions = getValidActions(otherTurnState, "player2");
-    const woundCard = validActions.playCard?.cards.find((card) => card.cardId === CARD_WOUND);
+    const woundCard =
+      (validActions.mode === "combat" || validActions.mode === "normal_turn")
+        ? validActions.playCard?.cards.find((card) => card.cardId === CARD_WOUND)
+        : undefined;
     expect(woundCard?.canPlaySideways).toBe(true);
     expect(woundCard?.sidewaysOptions?.[0]?.value).toBe(3);
   });

--- a/packages/core/src/engine/__tests__/skillShieldMastery.test.ts
+++ b/packages/core/src/engine/__tests__/skillShieldMastery.test.ts
@@ -16,6 +16,7 @@ import {
   UNDO_ACTION,
   RESOLVE_CHOICE_ACTION,
   CHOICE_RESOLVED,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_TOVAK_SHIELD_MASTERY } from "../../data/skills/index.js";
@@ -441,8 +442,9 @@ describe("Shield Mastery skill", () => {
 
       const validActions = getValidActions(state, "player1");
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_TOVAK_SHIELD_MASTERY,
         })
@@ -468,8 +470,9 @@ describe("Shield Mastery skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or Shield Mastery is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_SHIELD_MASTERY,
           })
@@ -496,8 +499,9 @@ describe("Shield Mastery skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or Shield Mastery is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_SHIELD_MASTERY,
           })
@@ -524,8 +528,9 @@ describe("Shield Mastery skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Either skills is undefined or Shield Mastery is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_SHIELD_MASTERY,
           })
@@ -552,7 +557,7 @@ describe("Shield Mastery skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should be undefined since no skills are available
-      expect(validActions.skills).toBeUndefined();
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/engine/__tests__/skillThunderstorm.test.ts
+++ b/packages/core/src/engine/__tests__/skillThunderstorm.test.ts
@@ -33,6 +33,7 @@ import {
   MANA_BLUE,
   MANA_WHITE,
   MANA_TOKEN_SOURCE_CARD,
+  getSkillsFromValidActions,
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_BRAEVALAR_THUNDERSTORM } from "../../data/skills/index.js";
@@ -425,9 +426,10 @@ describe("Thunderstorm skill", () => {
       const state = createTestGameState({ players: [player] });
 
       const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_BRAEVALAR_THUNDERSTORM,
         })
@@ -449,10 +451,11 @@ describe("Thunderstorm skill", () => {
       const state = createTestGameState({ players: [player] });
 
       const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
 
       // Either skills is undefined or the skill is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_BRAEVALAR_THUNDERSTORM,
           })
@@ -477,7 +480,7 @@ describe("Thunderstorm skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should be undefined since no skills are available
-      expect(validActions.skills).toBeUndefined();
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
     });
   });
 

--- a/packages/core/src/engine/__tests__/skillWhoNeedsMagic.test.ts
+++ b/packages/core/src/engine/__tests__/skillWhoNeedsMagic.test.ts
@@ -21,6 +21,7 @@ import {
 } from "@mage-knight/shared";
 import { Hero } from "../../types/hero.js";
 import { SKILL_TOVAK_WHO_NEEDS_MAGIC } from "../../data/skills/index.js";
+import { getSkillsFromValidActions } from "@mage-knight/shared";
 import { getValidActions } from "../validActions/index.js";
 import { getManaOptions } from "../validActions/mana.js";
 import { RULE_SOURCE_BLOCKED } from "../../types/modifierConstants.js";
@@ -358,9 +359,10 @@ describe("Who Needs Magic? skill", () => {
       const state = createTestGameState({ players: [player] });
 
       const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
 
-      expect(validActions.skills).toBeDefined();
-      expect(validActions.skills?.activatable).toContainEqual(
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
         expect.objectContaining({
           skillId: SKILL_TOVAK_WHO_NEEDS_MAGIC,
         })
@@ -381,10 +383,11 @@ describe("Who Needs Magic? skill", () => {
       const state = createTestGameState({ players: [player] });
 
       const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
 
       // Either skills is undefined or the skill is not in the list
-      if (validActions.skills) {
-        expect(validActions.skills.activatable).not.toContainEqual(
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
           expect.objectContaining({
             skillId: SKILL_TOVAK_WHO_NEEDS_MAGIC,
           })
@@ -408,7 +411,7 @@ describe("Who Needs Magic? skill", () => {
       const validActions = getValidActions(state, "player1");
 
       // Skills should be undefined since no skills are available
-      expect(validActions.skills).toBeUndefined();
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
     });
   });
 

--- a/packages/core/src/engine/__tests__/tactics.test.ts
+++ b/packages/core/src/engine/__tests__/tactics.test.ts
@@ -443,17 +443,10 @@ describe("Tactics Selection", () => {
       // Get valid actions
       const validActions = getValidActions(stateAfterSelect, "player1");
 
-      // Should have pending decision
-      expect(validActions.tacticEffects?.pendingDecision).toBeDefined();
-      expect(validActions.tacticEffects?.pendingDecision?.type).toBe(TACTIC_RETHINK);
-
-      // Should NOT have tactics selection available
-      expect(validActions.tactics).toBeUndefined();
-
-      // Should NOT have other actions available
-      expect(validActions.move).toBeUndefined();
-      expect(validActions.playCard).toBeUndefined();
-      expect(validActions.turn).toBeUndefined();
+      // Should be pending_tactic_decision state with Rethink
+      expect(validActions.mode).toBe("pending_tactic_decision");
+      expect(validActions.tacticDecision).toBeDefined();
+      expect(validActions.tacticDecision?.type).toBe(TACTIC_RETHINK);
     });
 
     it("Rethink resolution shuffles discard into deck and draws from combined pool", () => {

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -77,486 +77,130 @@ export function getValidActions(
   state: GameState,
   playerId: string
 ): ValidActions {
-  // Check if player can act at all
   const canActResult = checkCanAct(state, playerId);
 
   if (!canActResult.canAct) {
     return {
-      canAct: false,
-      reason: canActResult.reason,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: undefined,
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "cannot_act",
+      reason: canActResult.reason ?? "Unknown reason",
     };
   }
 
   const player = canActResult.player;
 
-  // Handle tactics selection phase
+  // === Tactics Phase ===
   if (isTacticsPhase(state)) {
-    // Check if player has a pending tactic decision to resolve
     const pendingDecision = getPendingTacticDecision(state, player);
     if (pendingDecision) {
       return {
-        canAct: true,
-        reason: undefined,
-        move: undefined,
-        explore: undefined,
-        playCard: undefined,
-        combat: undefined,
-        units: undefined,
-        sites: undefined,
-        mana: undefined,
-        turn: undefined,
-        tactics: undefined, // No more tactic selection - must resolve first
-        enterCombat: undefined,
-        challenge: undefined,
-        tacticEffects: { pendingDecision },
-        gladeWound: undefined,
-        deepMine: undefined,
-        discardCost: undefined,
-        discardForAttack: undefined,
-        discardForCrystal: undefined,
-        artifactCrystalColor: undefined,
-        levelUpRewards: undefined,
-        cooperativeAssault: undefined,
-        skills: undefined,
+        mode: "pending_tactic_decision",
+        tacticDecision: pendingDecision,
       };
     }
-
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: undefined,
+      mode: "tactics_selection",
       tactics: getTacticsOptions(state, playerId),
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
     };
   }
 
-  // Handle pending glade wound choice - must resolve before other actions
+  // === Pending States (must resolve before other actions) ===
   if (player.pendingGladeWoundChoice) {
-    const gladeWoundOptions = getGladeWoundOptions(state, player);
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: false, // Can't undo during glade choice
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: false,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: gladeWoundOptions,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_glade_wound",
+      turn: { canUndo: false },
+      gladeWound: getGladeWoundOptions(state, player),
     };
   }
-
-  // Handle pending deep mine choice - must resolve before other actions
   if (player.pendingDeepMineChoice) {
-    const deepMineOptions = getDeepMineOptions(state, player);
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: false, // Can't undo during deep mine choice
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: false,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: deepMineOptions,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_deep_mine",
+      turn: { canUndo: false },
+      deepMine: getDeepMineOptions(state, player),
     };
   }
-
-  // Handle pending discard cost - must resolve before other actions
   if (player.pendingDiscard) {
-    const discardCostOptions = getDiscardCostOptions(state, player);
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: getTurnOptions(state, player).canUndo, // Can undo card play that caused this
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: false,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: discardCostOptions,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_discard_cost",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      discardCost: getDiscardCostOptions(state, player),
     };
   }
-
-  // Handle pending discard-for-attack (Sword of Justice) - must resolve before other actions
   if (player.pendingDiscardForAttack) {
-    const discardForAttackOptions = getDiscardForAttackOptions(state, player);
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: getTurnOptions(state, player).canUndo, // Can undo card play that caused this
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: false,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: discardForAttackOptions,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_discard_for_attack",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      discardForAttack: getDiscardForAttackOptions(state, player),
     };
   }
-
-  // Handle pending discard-for-crystal (Savage Harvesting) - must resolve before other actions
   if (player.pendingDiscardForCrystal) {
-    // Check if awaiting color choice (second step - artifact was discarded)
     if (player.pendingDiscardForCrystal.awaitingColorChoice) {
-      const artifactColorOptions = getArtifactCrystalColorOptions(state, player);
       return {
-        canAct: true,
-        reason: undefined,
-        move: undefined,
-        explore: undefined,
-        playCard: undefined,
-        combat: undefined,
-        units: undefined,
-        sites: undefined,
-        mana: undefined,
-        turn: {
-          canEndTurn: false,
-          canAnnounceEndOfRound: false,
-          canUndo: getTurnOptions(state, player).canUndo,
-          canRest: false,
-          restTypes: undefined,
-          canDeclareRest: false,
-          canCompleteRest: false,
-          isResting: false,
-        },
-        tactics: undefined,
-        enterCombat: undefined,
-        challenge: undefined,
-        tacticEffects: undefined,
-        gladeWound: undefined,
-        deepMine: undefined,
-        discardCost: undefined,
-        discardForAttack: undefined,
-        discardForCrystal: undefined,
-        artifactCrystalColor: artifactColorOptions,
-        levelUpRewards: undefined,
-        cooperativeAssault: undefined,
-        skills: undefined,
+        mode: "pending_artifact_crystal_color",
+        turn: { canUndo: getTurnOptions(state, player).canUndo },
+        artifactCrystalColor: getArtifactCrystalColorOptions(state, player),
       };
     }
-
-    // First step - select card to discard
-    const discardForCrystalOptions = getDiscardForCrystalOptions(state, player);
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: getTurnOptions(state, player).canUndo,
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: false,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: discardForCrystalOptions,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_discard_for_crystal",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      discardForCrystal: getDiscardForCrystalOptions(state, player),
     };
   }
-
-  // Handle pending level up rewards - must resolve before other actions
   if (player.pendingLevelUpRewards.length > 0) {
-    const firstPending = player.pendingLevelUpRewards[0];
-    if (firstPending) {
-      return {
-        canAct: true,
-        reason: undefined,
-        move: undefined,
-        explore: undefined,
-        playCard: undefined,
-        combat: undefined,
-        units: undefined,
-        sites: undefined,
-        mana: undefined,
-        turn: {
-          canEndTurn: false,
-          canAnnounceEndOfRound: false,
-          canUndo: false, // Can't undo during level up selection
-          canRest: false,
-          restTypes: undefined,
-          canDeclareRest: false,
-          canCompleteRest: false,
-          isResting: false,
-        },
-        tactics: undefined,
-        enterCombat: undefined,
-        challenge: undefined,
-        tacticEffects: undefined,
-        gladeWound: undefined,
-        deepMine: undefined,
-        discardCost: undefined,
-        discardForAttack: undefined,
-        levelUpRewards: {
-          level: firstPending.level,
-          drawnSkills: firstPending.drawnSkills,
-          commonPoolSkills: state.offers.commonSkills,
-          availableAAs: state.offers.advancedActions.cards,
-        },
-        cooperativeAssault: undefined,
-        skills: undefined,
-      };
-    }
+    const firstPending = player.pendingLevelUpRewards[0]!;
+    return {
+      mode: "pending_level_up",
+      turn: { canUndo: false },
+      levelUpRewards: {
+        level: firstPending.level,
+        drawnSkills: firstPending.drawnSkills,
+        commonPoolSkills: state.offers.commonSkills,
+        availableAAs: state.offers.advancedActions.cards,
+      },
+    };
   }
-
-  // Handle pending choice - must resolve before other actions
   if (hasPendingChoice(player)) {
     return {
-      canAct: true,
-      reason: undefined,
-      move: undefined,
-      explore: undefined,
-      playCard: undefined,
-      combat: undefined,
-      units: undefined,
-      sites: undefined,
-      mana: undefined,
-      // Only turn options (undo) available during pending choice
-      turn: {
-        canEndTurn: false,
-        canAnnounceEndOfRound: false,
-        canUndo: getTurnOptions(state, player).canUndo,
-        canRest: false,
-        restTypes: undefined,
-        canDeclareRest: false,
-        canCompleteRest: false,
-        isResting: player.isResting,
-      },
-      tactics: undefined,
-      enterCombat: undefined,
-      challenge: undefined,
-      tacticEffects: undefined,
-      gladeWound: undefined,
-      deepMine: undefined,
-      discardCost: undefined,
-      discardForAttack: undefined,
-      discardForCrystal: undefined,
-      artifactCrystalColor: undefined,
-      levelUpRewards: undefined,
-      cooperativeAssault: undefined,
-      skills: undefined,
+      mode: "pending_choice",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
     };
   }
 
-  // Handle combat
+  // === Combat ===
   if (isInCombat(state) && state.combat) {
     const combatOptions = getCombatOptions(state);
     if (combatOptions) {
-      const playCardOptions = getPlayableCardsForCombat(state, player, state.combat);
-      const manaOptions = getManaOptions(state, player);
-      const unitOptions = getUnitOptionsForCombat(state, player, state.combat);
+      const playCardOptions = getPlayableCardsForCombat(
+        state,
+        player,
+        state.combat
+      );
       return {
-        canAct: true,
-        reason: undefined,
-        move: undefined,
-        explore: undefined,
-        playCard: playCardOptions.cards.length > 0 ? playCardOptions : undefined,
+        mode: "combat",
+        turn: { canUndo: getTurnOptions(state, player).canUndo },
         combat: combatOptions,
-        units: unitOptions,
-        sites: undefined,
-        mana: manaOptions,
-        turn: {
-          canEndTurn: false,
-          canAnnounceEndOfRound: false,
-          canUndo: getTurnOptions(state, player).canUndo,
-          canRest: false,
-          restTypes: undefined,
-          canDeclareRest: false,
-          canCompleteRest: false,
-          isResting: player.isResting,
-        },
-        tactics: undefined,
-        enterCombat: undefined,
-        challenge: undefined,
-        tacticEffects: undefined,
-        gladeWound: undefined,
-        deepMine: undefined,
-        discardCost: undefined,
-        discardForAttack: undefined,
-        discardForCrystal: undefined,
-        artifactCrystalColor: undefined,
-        levelUpRewards: undefined,
-        cooperativeAssault: undefined,
+        playCard:
+          playCardOptions.cards.length > 0 ? playCardOptions : undefined,
+        mana: getManaOptions(state, player),
+        units: getUnitOptionsForCombat(state, player, state.combat),
         skills: getSkillOptions(state, player),
       };
     }
   }
 
-  // Normal turn - compute all options
+  // === Normal Turn ===
   const playCardOptions = getPlayableCardsForNormalTurn(state, player);
-  const manaOptions = getManaOptions(state, player);
-
   return {
-    canAct: true,
-    reason: undefined,
+    mode: "normal_turn",
+    turn: getTurnOptions(state, player),
     move: getValidMoveTargets(state, player),
     explore: getValidExploreOptions(state, player),
     playCard: playCardOptions.cards.length > 0 ? playCardOptions : undefined,
-    combat: undefined,
     units: getFullUnitOptions(state, player),
     sites: getSiteOptions(state, player),
-    mana: manaOptions,
-    turn: getTurnOptions(state, player),
-    tactics: undefined,
-    enterCombat: undefined, // TODO: getEnterCombatOptions(state, player)
+    mana: getManaOptions(state, player),
     challenge: getChallengeOptions(state, player),
     tacticEffects: getTacticEffectsOptions(state, player),
-    gladeWound: undefined,
-    deepMine: undefined,
-    discardCost: undefined,
-    discardForAttack: undefined,
-    discardForCrystal: undefined,
-    artifactCrystalColor: undefined,
-    levelUpRewards: undefined,
     cooperativeAssault: getCooperativeAssaultOptions(state, player),
     skills: getSkillOptions(state, player),
   };

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -183,6 +183,21 @@ export type {
 // Valid actions types
 export type {
   ValidActions,
+  ValidActionsMode,
+  BlockingTurnOptions,
+  CannotActState,
+  TacticsSelectionState,
+  PendingTacticDecisionState,
+  PendingGladeWoundState,
+  PendingDeepMineState,
+  PendingDiscardCostState,
+  PendingDiscardForAttackState,
+  PendingDiscardForCrystalState,
+  PendingArtifactCrystalColorState,
+  PendingLevelUpState,
+  PendingChoiceState,
+  CombatState,
+  NormalTurnState,
   MoveOptions,
   MoveTarget,
   ReachableHex,
@@ -250,6 +265,14 @@ export type {
   ActivatableSkill,
   // Cumbersome ability options
   CumbersomeOption,
+} from "./types/validActions.js";
+export {
+  canAct,
+  isNormalTurn,
+  isCombat,
+  isPendingState,
+  isBlockingState,
+  getSkillsFromValidActions,
 } from "./types/validActions.js";
 
 // Shared value constants (sub-unions)


### PR DESCRIPTION
## Summary

Implements the ValidActions redesign from the combined design document: replace the flat `ValidActions` type with a **discriminated union** on `mode`, so the game state machine is explicit in the types and maintenance is localized.

## Changes

### Shared (`packages/shared`)
- **Removed** flat `ValidActions` interface (~23 optional fields).
- **Added** `BlockingTurnOptions` and mixins (`HasManaOptions`, `HasSkillOptions`, `HasCardOptions`, `HasUnitOptions`).
- **Added** state interfaces: `CannotActState`, `TacticsSelectionState`, `PendingTacticDecisionState`, all `Pending*` states, `CombatState`, `NormalTurnState`.
- **Union**: `ValidActions` is now `Union<...all state types>` discriminated by `mode`.
- **Type guards**: `canAct`, `isNormalTurn`, `isCombat`, `isPendingState`, `isBlockingState`, `getSkillsFromValidActions`.

### Server (`packages/core`)
- `getValidActions` returns a single object per state (e.g. `{ mode: 'cannot_act', reason }`, `{ mode: 'normal_turn', turn, move, ... }`).
- No more listing every unused field as `undefined` on 12+ return paths.
- Pending tactic decision is `mode: 'pending_tactic_decision'` with `tacticDecision` (no longer nested under `tacticEffects`).

### Client (`packages/client`)
- Overlays and components branch on `validActions.mode` (e.g. `mode === 'pending_glade_wound'`) and use the corresponding field.
- Turn/undo/rest/skills use `'turn' in validActions` or `mode === 'normal_turn'` / `mode === 'combat'` where appropriate.
- Selectors and helpers (`useGameBoardSelectors`, `manaSourceHelpers`) only read move/explore/mana when `mode === 'normal_turn'` (or combat for mana).

### Tests
- Tactics test expects `mode === 'pending_tactic_decision'` and `tacticDecision`.
- Combat/skill/discard tests use `mode === 'combat'` or `getSkillsFromValidActions(validActions)` for type-safe access.

## Benefits

| Aspect | Before | After |
|--------|--------|--------|
| New pending state | 12+ return paths + client checks | 4 places (type, union, `getValidActions`, client branch) |
| New field on normal turn | 12+ return paths | 1 return path + type |
| Type safety | Weak (all optional) | Strong (mode discriminates) |
| Client state detection | Implicit (which fields are set) | Explicit (`switch` / `mode === ...`) |
| Compiler help | Minimal | Full narrowing on `validActions.mode` |

## Checklist

- [x] Types and union in `shared`
- [x] `getValidActions` updated in `core`
- [x] Client components and selectors updated
- [x] Core tests updated
- [x] Exports and type guards in `shared` index