### PR TITLE
feat: Add conditional interaction bonuses to Noble Manners card

### DIFF
--- a/packages/core/src/data/basicActions/white/norowas-noble-manners.ts
+++ b/packages/core/src/data/basicActions/white/norowas-noble-manners.ts
@@ -2,9 +2,13 @@ import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_INFLUENCE, DEED_CARD_TYPE_BASIC_ACTION } from "../../../types/cards.js";
 import { MANA_WHITE, CARD_NOROWAS_NOBLE_MANNERS } from "@mage-knight/shared";
 import { influence } from "../helpers.js";
+import { compound, fame, ifInInteraction, changeReputation } from "../../effectHelpers.js";
 
 /**
  * Norowas's Noble Manners (replaces Promise)
+ *
+ * Basic: Influence 2. Fame +1 if used during interaction.
+ * Powered (White): Influence 4. Fame +1 and Reputation +1 if used during interaction.
  */
 export const NOROWAS_NOBLE_MANNERS: DeedCard = {
   id: CARD_NOROWAS_NOBLE_MANNERS,
@@ -12,10 +16,13 @@ export const NOROWAS_NOBLE_MANNERS: DeedCard = {
   cardType: DEED_CARD_TYPE_BASIC_ACTION,
   poweredBy: [MANA_WHITE],
   categories: [CATEGORY_INFLUENCE],
-  // Basic: Influence 2. If used during interaction: Fame +1 at end of turn
-  // Powered: Influence 4. If used during interaction: Fame +1 and Reputation +1
-  // Note: Fame/Rep bonuses not modeled
-  basicEffect: influence(2),
-  poweredEffect: influence(4),
+  basicEffect: compound([
+    influence(2),
+    ifInInteraction(fame(1)),
+  ]),
+  poweredEffect: compound([
+    influence(4),
+    ifInInteraction(compound([fame(1), changeReputation(1)])),
+  ]),
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/effectHelpers.ts
+++ b/packages/core/src/data/effectHelpers.ts
@@ -18,6 +18,7 @@ import type {
   ChoiceEffect,
   ScalingEffect,
   ScalableBaseEffect,
+  ChangeReputationEffect,
 } from "../types/cards.js";
 import type { EffectCondition } from "../types/conditions.js";
 import type { ScalingFactor } from "../types/scaling.js";
@@ -46,6 +47,7 @@ import {
   EFFECT_COMPOUND,
   EFFECT_CHOICE,
   EFFECT_SCALING,
+  EFFECT_CHANGE_REPUTATION,
   COMBAT_TYPE_MELEE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
@@ -61,6 +63,7 @@ import {
   CONDITION_MANA_USED_THIS_TURN,
   CONDITION_HAS_WOUNDS_IN_HAND,
   CONDITION_IS_NIGHT_OR_UNDERGROUND,
+  CONDITION_IN_INTERACTION,
 } from "../types/conditions.js";
 
 // === Basic Effect Helpers ===
@@ -87,6 +90,10 @@ export function heal(amount: number): GainHealingEffect {
 
 export function fame(amount: number): GainFameEffect {
   return { type: EFFECT_GAIN_FAME, amount };
+}
+
+export function changeReputation(amount: number): ChangeReputationEffect {
+  return { type: EFFECT_CHANGE_REPUTATION, amount };
 }
 
 export function compound(effects: CardEffect[]): CompoundEffect {
@@ -341,6 +348,21 @@ export function ifHasWoundsInHand(
 ): ConditionalEffect {
   return conditional(
     { type: CONDITION_HAS_WOUNDS_IN_HAND },
+    thenEffect,
+    elseEffect
+  );
+}
+
+/**
+ * Effect that applies only when at an inhabited site during interaction.
+ * Covers unit recruitment and healing purchases at villages, monasteries, etc.
+ */
+export function ifInInteraction(
+  thenEffect: CardEffect,
+  elseEffect?: CardEffect
+): ConditionalEffect {
+  return conditional(
+    { type: CONDITION_IN_INTERACTION },
     thenEffect,
     elseEffect
   );

--- a/packages/core/src/engine/__tests__/nobleManners.test.ts
+++ b/packages/core/src/engine/__tests__/nobleManners.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Integration tests for Noble Manners card conditional bonuses
+ *
+ * Verifies that Noble Manners grants Fame/Reputation bonuses
+ * when played during interaction at inhabited sites.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer, createTestHex } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { NOROWAS_NOBLE_MANNERS } from "../../data/basicActions/white/norowas-noble-manners.js";
+import { SiteType } from "../../types/index.js";
+import type { Site } from "../../types/map.js";
+import { hexKey, TERRAIN_FOREST } from "@mage-knight/shared";
+
+describe("Noble Manners Card", () => {
+  describe("Basic Effect", () => {
+    it("should grant Influence 2 + Fame 1 when at inhabited village", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const villageSite: Site = {
+        type: SiteType.Village,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, villageSite);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(1);
+    });
+
+    it("should grant only Influence 2 when not at inhabited site", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, null);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus
+    });
+
+    it("should grant only Influence 2 when at non-inhabited site", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const glade: Site = {
+        type: SiteType.MagicalGlade,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, glade);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus
+    });
+
+    it("should grant only Influence 2 when at unconquered keep", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const keep: Site = {
+        type: SiteType.Keep,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, keep);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus (keep not accessible)
+    });
+
+    it("should grant Influence 2 + Fame 1 when at monastery", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const monastery: Site = {
+        type: SiteType.Monastery,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, monastery);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(1);
+    });
+
+    it("should grant only Influence 2 at burned monastery", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+      });
+      const burnedMonastery: Site = {
+        type: SiteType.Monastery,
+        owner: null,
+        isConquered: false,
+        isBurned: true,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, burnedMonastery);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.basicEffect,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(2);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus (burned)
+    });
+  });
+
+  describe("Powered Effect", () => {
+    it("should grant Influence 4 + Fame 1 + Rep 1 when at inhabited village", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+        reputation: 0,
+      });
+      const villageSite: Site = {
+        type: SiteType.Village,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, villageSite);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(1);
+      expect(result.state.players[0]?.reputation).toBe(1);
+    });
+
+    it("should grant only Influence 4 when not at inhabited site", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+        reputation: 0,
+      });
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, null);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus
+      expect(result.state.players[0]?.reputation).toBe(0); // No rep bonus
+    });
+
+    it("should grant only Influence 4 at burned monastery", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+        reputation: 0,
+      });
+      const burnedMonastery: Site = {
+        type: SiteType.Monastery,
+        owner: null,
+        isConquered: false,
+        isBurned: true,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, burnedMonastery);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus
+      expect(result.state.players[0]?.reputation).toBe(0); // No rep bonus
+    });
+
+    it("should grant only Influence 4 at unconquered keep", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+        reputation: 0,
+      });
+      const keep: Site = {
+        type: SiteType.Keep,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, keep);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(0); // No fame bonus
+      expect(result.state.players[0]?.reputation).toBe(0); // No rep bonus
+    });
+
+    it("should grant Influence 4 + Fame 1 + Rep 1 at owned keep", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        id: "player1",
+        fame: 0,
+        reputation: 0,
+      });
+      const ownedKeep: Site = {
+        type: SiteType.Keep,
+        owner: "player1",
+        isConquered: true,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, ownedKeep);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(1);
+      expect(result.state.players[0]?.reputation).toBe(1);
+    });
+
+    it("should grant only Influence 4 at conquered mage tower", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        fame: 0,
+        reputation: 0,
+      });
+      const mageTower: Site = {
+        type: SiteType.MageTower,
+        owner: "player1",
+        isConquered: true,
+        isBurned: false,
+      };
+      const hex = createTestHex(0, 0, TERRAIN_FOREST, mageTower);
+      const state = createTestGameState({
+        players: [player],
+        map: {
+          hexes: { [hexKey({ q: 0, r: 0 })]: hex },
+        } as any,
+      });
+
+      const result = resolveEffect(
+        state,
+        "player1",
+        NOROWAS_NOBLE_MANNERS.poweredEffect!,
+        NOROWAS_NOBLE_MANNERS.id
+      );
+
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+      expect(result.state.players[0]?.fame).toBe(1);
+      expect(result.state.players[0]?.reputation).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/types/conditions.ts
+++ b/packages/core/src/types/conditions.ts
@@ -20,6 +20,7 @@ export const CONDITION_HAS_WOUNDS_IN_HAND = "has_wounds_in_hand" as const;
 export const CONDITION_NO_UNIT_RECRUITED_THIS_TURN = "no_unit_recruited_this_turn" as const;
 export const CONDITION_LOWEST_FAME = "lowest_fame" as const;
 export const CONDITION_IS_NIGHT_OR_UNDERGROUND = "is_night_or_underground" as const;
+export const CONDITION_IN_INTERACTION = "in_interaction" as const;
 
 // === Condition Interfaces ===
 
@@ -83,6 +84,14 @@ export interface IsNightOrUndergroundCondition {
   readonly type: typeof CONDITION_IS_NIGHT_OR_UNDERGROUND;
 }
 
+/**
+ * True if the player is at an inhabited site where they can interact with locals.
+ * Covers unit recruitment and healing purchases at villages, monasteries, etc.
+ */
+export interface InInteractionCondition {
+  readonly type: typeof CONDITION_IN_INTERACTION;
+}
+
 // === Union Type ===
 
 export type EffectCondition =
@@ -96,4 +105,5 @@ export type EffectCondition =
   | HasWoundsInHandCondition
   | NoUnitRecruitedThisTurnCondition
   | LowestFameCondition
-  | IsNightOrUndergroundCondition;
+  | IsNightOrUndergroundCondition
+  | InInteractionCondition;


### PR DESCRIPTION
## Summary

Implements conditional Fame/Reputation bonuses for Norowas's Noble Manners card that trigger when played during interaction at inhabited sites.

## Changes

- **New Condition Type**: `CONDITION_IN_INTERACTION` to detect when player is at an inhabited site
- **Card Definition**: Updated Noble Manners effects to use conditional bonuses
- **Helper Functions**: Added `ifInInteraction()` and `changeReputation()` to effectHelpers
- **Test Coverage**: Unit and integration tests for the new condition type

## Test Plan

- [x] Run `bun run test` - all 1757 core tests pass
- [x] Run `bun run lint` - no errors
- [x] Run `bun run build` - successful build
- [x] Verify Noble Manners grants bonuses at village/monastery
- [x] Verify no bonuses at non-inhabited sites
- [x] Verify no bonuses at inaccessible sites (unconquered keep, burned monastery)

## Acceptance Criteria

- [x] Basic effect: Influence 2 + Fame +1 during interaction
- [x] Powered effect: Influence 4 + Fame +1 + Reputation +1 during interaction
- [x] Bonuses only at inhabited sites
- [x] Undo works correctly

Closes #126