### PR TITLE
Register Crystal Joy reclaim command factory

### DIFF
--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -11,7 +11,7 @@
  * | Combat | `combat.ts` | EnterCombat, EndCombatPhase, DeclareBlock, DeclareAttack, AssignDamage |
  * | Units | `units.ts` | RecruitUnit, ActivateUnit |
  * | Turn | `turn.ts` | EndTurn, Rest, AnnounceEndOfRound |
- * | Sites | `sites.ts` | Interact, EnterSite, ResolveGladeWound, ResolveDeepMine |
+ * | Sites | `sites.ts` | Interact, EnterSite, ResolveGladeWound, ResolveDeepMine, ResolveCrystalJoyReclaim |
  * | Tactics | `tactics.ts` | SelectTactic, ActivateTactic, ResolveTacticDecision, RerollSourceDice |
  * | Offers | `offers.ts` | BuySpell, LearnAdvancedAction, SelectReward |
  *
@@ -54,6 +54,7 @@ import {
   REROLL_SOURCE_DICE_ACTION,
   RESOLVE_GLADE_WOUND_ACTION,
   RESOLVE_DEEP_MINE_ACTION,
+  RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION,
   BUY_SPELL_ACTION,
   LEARN_ADVANCED_ACTION_ACTION,
   CHOOSE_LEVEL_UP_REWARDS_ACTION,
@@ -128,6 +129,7 @@ export {
   createResolveDeepMineCommandFromAction,
   createBurnMonasteryCommandFromAction,
   createPlunderVillageCommandFromAction,
+  createResolveCrystalJoyReclaimCommandFromAction,
 } from "./sites.js";
 
 // Tactics factories
@@ -213,6 +215,7 @@ import {
   createResolveDeepMineCommandFromAction,
   createBurnMonasteryCommandFromAction,
   createPlunderVillageCommandFromAction,
+  createResolveCrystalJoyReclaimCommandFromAction,
 } from "./sites.js";
 
 import {
@@ -286,6 +289,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [REROLL_SOURCE_DICE_ACTION]: createRerollSourceDiceCommandFromAction,
   [RESOLVE_GLADE_WOUND_ACTION]: createResolveGladeWoundCommandFromAction,
   [RESOLVE_DEEP_MINE_ACTION]: createResolveDeepMineCommandFromAction,
+  [RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION]: createResolveCrystalJoyReclaimCommandFromAction,
   [BUY_SPELL_ACTION]: createBuySpellCommandFromAction,
   [LEARN_ADVANCED_ACTION_ACTION]: createLearnAdvancedActionCommandFromAction,
   [CHOOSE_LEVEL_UP_REWARDS_ACTION]: createChooseLevelUpRewardsCommandFromAction,

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -11,10 +11,13 @@
  * - createEnterSiteCommandFromAction - Enter an adventure site
  * - createResolveGladeWoundCommandFromAction - Resolve Magical Glade wound choice
  * - createResolveDeepMineCommandFromAction - Resolve Deep Mine crystal color choice
+ * - createBurnMonasteryCommandFromAction - Burn a monastery (initiate combat)
+ * - createPlunderVillageCommandFromAction - Plunder a village (lose reputation, draw cards)
+ * - createResolveCrystalJoyReclaimCommandFromAction - Resolve Crystal Joy end-of-turn reclaim
  */
 
 import type { CommandFactory } from "./types.js";
-import type { PlayerAction, GladeWoundChoice, BasicManaColor } from "@mage-knight/shared";
+import type { PlayerAction, GladeWoundChoice, BasicManaColor, CardId } from "@mage-knight/shared";
 import {
   INTERACT_ACTION,
   ENTER_SITE_ACTION,
@@ -22,6 +25,7 @@ import {
   RESOLVE_DEEP_MINE_ACTION,
   BURN_MONASTERY_ACTION,
   PLUNDER_VILLAGE_ACTION,
+  RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION,
 } from "@mage-knight/shared";
 import { createInteractCommand } from "../interactCommand.js";
 import { createEnterSiteCommand } from "../enterSiteCommand.js";
@@ -29,6 +33,7 @@ import { createResolveGladeWoundCommand } from "../resolveGladeWoundCommand.js";
 import { createResolveDeepMineChoiceCommand } from "../resolveDeepMineChoiceCommand.js";
 import { createBurnMonasteryCommand } from "../burnMonasteryCommand.js";
 import { createPlunderVillageCommand } from "../plunderVillageCommand.js";
+import { createResolveCrystalJoyReclaimCommand } from "../resolveCrystalJoyReclaimCommand.js";
 import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
@@ -152,4 +157,34 @@ export const createPlunderVillageCommandFromAction: CommandFactory = (
 ) => {
   if (action.type !== PLUNDER_VILLAGE_ACTION) return null;
   return createPlunderVillageCommand({ playerId });
+};
+
+/**
+ * Helper to get crystal joy reclaim card ID from action.
+ */
+function getCrystalJoyReclaimCardFromAction(
+  action: PlayerAction
+): CardId | undefined {
+  if (action.type === RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION && "cardId" in action) {
+    return action.cardId;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve crystal joy reclaim command factory.
+ * Creates a command to resolve the Crystal Joy end-of-turn reclaim ability.
+ */
+export const createResolveCrystalJoyReclaimCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION) return null;
+
+  const cardId = getCrystalJoyReclaimCardFromAction(action);
+  return createResolveCrystalJoyReclaimCommand({
+    playerId,
+    cardId,
+  });
 };


### PR DESCRIPTION
## Summary
Completes the command pipeline for Crystal Joy's end-of-turn reclaim ability by registering the command factory with the action dispatcher.

- Adds `createResolveCrystalJoyReclaimCommandFromAction` factory to `commands/factories/sites.ts`
- Registers factory in `commands/factories/index.ts` (both exports and registry)
- RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION now dispatches correctly to `resolveCrystalJoyReclaimCommand`

## Test plan
- [x] Build succeeds with no type errors
- [x] All tests pass (1775 core tests, 48 server tests, 12 shared tests)
- [x] No lint errors introduced

Closes #759