### PR TITLE
feat: Implement Hot Swordsmanship skill for Arythea (#312)

### DIFF
--- a/packages/core/src/data/skills/arythea/hotSwordsmanship.ts
+++ b/packages/core/src/data/skills/arythea/hotSwordsmanship.ts
@@ -5,15 +5,17 @@
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_COMBAT } from "../../../types/cards.js";
+import { attack, choice, fireAttack } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_ARYTHEA_HOT_SWORDSMANSHIP = "arythea_hot_swordsmanship" as SkillId;
 
 export const hotSwordsmanship: SkillDefinition = {
   id: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
-    name: "Hot Swordsmanship",
-    heroId: "arythea",
-    description: "Attack 2 or Fire Attack 2",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_COMBAT],
+  name: "Hot Swordsmanship",
+  heroId: "arythea",
+  description: "Attack 2 or Fire Attack 2",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  effect: choice([attack(2), fireAttack(2)]),
+  categories: [CATEGORY_COMBAT],
 };

--- a/packages/core/src/engine/__tests__/skillHotSwordsmanship.test.ts
+++ b/packages/core/src/engine/__tests__/skillHotSwordsmanship.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for Hot Swordsmanship skill (Arythea)
+ *
+ * Skill effect: Attack 2 or Fire Attack 2.
+ * Only usable during the attack phase of combat.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CHOICE_RESOLVED,
+  ENEMY_PROWLERS,
+  ELEMENT_FIRE,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_ARYTHEA_HOT_SWORDSMANSHIP } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  COMBAT_PHASE_ATTACK,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_RANGED_SIEGE,
+  createCombatState,
+} from "../../types/combat.js";
+
+describe("Hot Swordsmanship skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate during attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+        })
+      );
+      expect(result.state.players[0].pendingChoice?.options).toHaveLength(2);
+    });
+
+    it("should reject if not in attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if in ranged/siege phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_RANGED_SIEGE,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("pending choice", () => {
+    it("should create pending choice with 2 options after activation", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      const updatedPlayer = result.state.players[0];
+      expect(updatedPlayer.pendingChoice).not.toBeNull();
+      expect(updatedPlayer.pendingChoice?.options).toHaveLength(2);
+      expect(updatedPlayer.pendingChoice?.skillId).toBe(
+        SKILL_ARYTHEA_HOT_SWORDSMANSHIP
+      );
+      expect(updatedPlayer.pendingChoice?.cardId).toBeNull();
+    });
+  });
+
+  describe("attack options", () => {
+    it("should grant Attack 2 when choosing physical option", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      const afterChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      });
+
+      expect(afterChoice.events).toContainEqual(
+        expect.objectContaining({
+          type: CHOICE_RESOLVED,
+        })
+      );
+
+      const updatedPlayer = afterChoice.state.players[0];
+      expect(updatedPlayer.combatAccumulator.attack.normal).toBe(2);
+      expect(updatedPlayer.pendingChoice).toBeNull();
+    });
+
+    it("should grant Fire Attack 2 when choosing fire option", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+      });
+
+      const afterChoice = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      });
+
+      const updatedPlayer = afterChoice.state.players[0];
+      expect(
+        updatedPlayer.combatAccumulator.attack.normalElements[ELEMENT_FIRE]
+      ).toBe(2);
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill during attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+        })
+      );
+    });
+
+    it("should not show skill during ranged/siege phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_RANGED_SIEGE,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+          })
+        );
+      }
+    });
+
+    it("should not show skill during block phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_HOT_SWORDSMANSHIP],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
+          })
+        );
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/rules/skillPhasing.ts
+++ b/packages/core/src/engine/rules/skillPhasing.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared skill phasing rules.
+ *
+ * These helpers are used by both validators and ValidActions computation
+ * to prevent rule drift between what actions are validated and what options
+ * are shown to the player.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import { COMBAT_PHASE_ATTACK } from "../../types/combat.js";
+import type { SkillId } from "@mage-knight/shared";
+import { SKILL_ARYTHEA_HOT_SWORDSMANSHIP } from "../../data/skills/index.js";
+
+/**
+ * Skills that provide melee attacks and can only be used during attack phase.
+ * These differ from ranged/siege skills which can be used during ranged/siege or attack phases.
+ */
+const MELEE_ATTACK_SKILLS: readonly SkillId[] = [SKILL_ARYTHEA_HOT_SWORDSMANSHIP];
+
+/**
+ * Check if a melee attack skill can be used in the current combat phase.
+ * Returns true only if in combat during the attack phase.
+ */
+export function canUseMeleeAttackSkill(state: GameState): boolean {
+  return state.combat !== null && state.combat.phase === COMBAT_PHASE_ATTACK;
+}
+
+/**
+ * Check if a skill ID is a melee attack skill.
+ */
+export function isMeleeAttackSkill(skillId: SkillId): boolean {
+  return MELEE_ATTACK_SKILLS.includes(skillId);
+}

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -24,10 +24,11 @@ import {
   SKILL_ARYTHEA_POLARIZATION,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_ARYTHEA_DARK_PATHS,
+  SKILL_ARYTHEA_BURNING_POWER,
+  SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
   SKILL_BRAEVALAR_THUNDERSTORM,
   SKILL_BRAEVALAR_SECRET_WAYS,
   SKILL_NOROWAS_DAY_SHARPSHOOTING,
-  SKILL_ARYTHEA_BURNING_POWER,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -37,6 +38,7 @@ import {
 } from "../../types/combat.js";
 import { CARD_WOUND } from "@mage-knight/shared";
 import { canActivatePolarization } from "../commands/skills/polarizationEffect.js";
+import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
 
 /**
  * Skills that have effect implementations and can be activated.
@@ -49,10 +51,11 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_ARYTHEA_POLARIZATION,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_ARYTHEA_DARK_PATHS,
+  SKILL_ARYTHEA_BURNING_POWER,
+  SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
   SKILL_BRAEVALAR_THUNDERSTORM,
   SKILL_BRAEVALAR_SECRET_WAYS,
   SKILL_NOROWAS_DAY_SHARPSHOOTING,
-  SKILL_ARYTHEA_BURNING_POWER,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN]);
@@ -132,6 +135,14 @@ export function getSkillOptions(
         (state.combat.phase !== COMBAT_PHASE_RANGED_SIEGE &&
           state.combat.phase !== COMBAT_PHASE_ATTACK)
       ) {
+        continue;
+      }
+    }
+
+    // Melee attack skills are only available during attack phase
+    // Uses shared rule from rules/skillPhasing.ts to stay aligned with validators
+    if (isMeleeAttackSkill(skillId)) {
+      if (!canUseMeleeAttackSkill(state)) {
         continue;
       }
     }

--- a/packages/core/src/engine/validators/registry/skillRegistry.ts
+++ b/packages/core/src/engine/validators/registry/skillRegistry.ts
@@ -19,6 +19,7 @@ import {
   validateCombatSkillInCombat,
   validateBlockSkillInBlockPhase,
   validateRangedSkillInRangedPhase,
+  validateMeleeAttackSkillInAttackPhase,
   validateSkillRequirements,
 } from "../skillValidators.js";
 
@@ -32,6 +33,7 @@ export const skillRegistry: Record<string, Validator[]> = {
     validateCombatSkillInCombat,
     validateBlockSkillInBlockPhase,
     validateRangedSkillInRangedPhase,
+    validateMeleeAttackSkillInAttackPhase,
     validateSkillRequirements,
   ],
 };

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -41,6 +41,7 @@ import {
 } from "../../types/combat.js";
 import { CARD_WOUND } from "@mage-knight/shared";
 import { getPlayerById } from "../helpers/playerHelpers.js";
+import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN]);
 
@@ -175,6 +176,31 @@ export const validateRangedSkillInRangedPhase: Validator = (state, _playerId, ac
       return invalid(
         WRONG_COMBAT_PHASE,
         `${skill?.name ?? useSkillAction.skillId} can only be used during the ranged/siege or attack phase`
+      );
+    }
+  }
+
+  return valid();
+};
+
+/**
+ * Validates that melee attack skills are only used during the attack phase.
+ * These skills differ from ranged/siege attacks which can be used during ranged/siege phase as well.
+ * Uses shared rule from rules/skillPhasing.ts to stay aligned with ValidActions.
+ */
+export const validateMeleeAttackSkillInAttackPhase: Validator = (
+  state,
+  _playerId,
+  action
+) => {
+  const useSkillAction = action as UseSkillAction;
+
+  if (isMeleeAttackSkill(useSkillAction.skillId)) {
+    if (!canUseMeleeAttackSkill(state)) {
+      const skill = SKILLS[useSkillAction.skillId];
+      return invalid(
+        WRONG_COMBAT_PHASE,
+        `${skill?.name ?? useSkillAction.skillId} can only be used during the attack phase`
       );
     }
   }


### PR DESCRIPTION
## Summary
Implements the Hot Swordsmanship skill for Arythea, completing issue #312.

- **Effect Definition**: Provides a choice between Attack 2 (physical) or Fire Attack 2
- **Combat Phase Validation**: Only usable during the attack phase of combat
- **Validator Improvements**: Added new melee attack skill validator to distinguish from ranged/siege skills
- **Valid Actions**: Registered with validActions for correct UI state filtering
- **Test Coverage**: Comprehensive tests covering activation, phase restrictions, both attack options, and valid actions

## Details

Hot Swordsmanship is a once-per-turn combat skill that allows players to choose between:
1. **Physical Attack 2**: Standard melee damage
2. **Fire Attack 2**: Fire-elemental melee damage (effective vs ice-resistant enemies, ineffective vs fire-resistant enemies)

This is the fire-element equivalent of Tovak's Cold Swordsmanship skill, using identical attack points but with fire damage instead.

## Acceptance Criteria ✓
- [x] Effect definition added to skill
- [x] Category set to Combat  
- [x] Player can choose between physical or fire attack
- [x] Both options grant Attack 2
- [x] Only usable during combat attack phase
- [x] Test coverage for both options

Closes #312