### PR TITLE
feat(client): Wire up discard-as-cost UI for Improvisation (#110)

### DIFF
--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -21,6 +21,7 @@ import { SparingPowerDecision } from "./Overlays/SparingPowerDecision";
 import { ManaSearchReroll } from "./Overlays/ManaSearchReroll";
 import { GladeWoundDecision } from "./Overlays/GladeWoundDecision";
 import { RestCompletionOverlay } from "./Overlays/RestCompletionOverlay";
+import { DiscardCostOverlay } from "./Overlays/DiscardCostOverlay";
 import { LevelUpRewardSelection } from "./Overlays/LevelUpRewardSelection";
 import { CombatOverlay, PixiCombatOverlay } from "./Combat";
 import { OfferView, type OfferPane } from "./OfferView";
@@ -103,6 +104,7 @@ export function GameView() {
       <ManaSearchReroll />
       <GladeWoundDecision />
       <RestCompletionOverlay />
+      <DiscardCostOverlay />
       {inCombat && (
         <>
           <PixiCombatOverlay combat={state.combat} />

--- a/packages/client/src/components/Overlays/DiscardCostOverlay.tsx
+++ b/packages/client/src/components/Overlays/DiscardCostOverlay.tsx
@@ -1,0 +1,75 @@
+/**
+ * DiscardCostOverlay - Card selection UI for discard-as-cost (e.g. Improvisation)
+ *
+ * Shown when validActions.mode === "pending_discard_cost".
+ * Uses CardSelectionOverlay to let the player select the required card(s) to discard,
+ * then sends RESOLVE_DISCARD_ACTION. Cancel/undo sends UNDO_ACTION to revert the play.
+ */
+
+import { useCallback } from "react";
+import { RESOLVE_DISCARD_ACTION, UNDO_ACTION } from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import { useGame } from "../../hooks/useGame";
+import { CardSelectionOverlay } from "./CardSelectionOverlay";
+
+export function DiscardCostOverlay() {
+  const { state, sendAction } = useGame();
+
+  const isActive =
+    state?.validActions?.mode === "pending_discard_cost" &&
+    state.validActions.discardCost != null;
+
+  const discardCost = isActive ? state.validActions.discardCost : null;
+
+  const handleSelect = useCallback(
+    (selectedCards: readonly CardId[]) => {
+      sendAction({
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: selectedCards,
+      });
+    },
+    [sendAction]
+  );
+
+  const handleSkip = useCallback(() => {
+    sendAction({
+      type: RESOLVE_DISCARD_ACTION,
+      cardIds: [],
+    });
+  }, [sendAction]);
+
+  const handleUndo = useCallback(() => {
+    sendAction({ type: UNDO_ACTION });
+  }, [sendAction]);
+
+  if (!isActive || !discardCost) {
+    return null;
+  }
+
+  const { availableCardIds, count, optional } = discardCost;
+  const minSelect = optional ? 0 : count;
+  const maxSelect = count;
+
+  const instruction =
+    count === 1
+      ? optional
+        ? "Select a card to discard (or skip)"
+        : "Select a card to discard"
+      : optional
+        ? `Select up to ${count} cards to discard (or skip)`
+        : `Select ${count} cards to discard`;
+
+  return (
+    <CardSelectionOverlay
+      cards={availableCardIds}
+      instruction={instruction}
+      minSelect={minSelect}
+      maxSelect={maxSelect}
+      canSkip={optional}
+      skipText="Skip"
+      onSelect={handleSelect}
+      onSkip={optional ? handleSkip : undefined}
+      onUndo={handleUndo}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
Implements the discard-as-cost UI so that when a player plays Improvisation (or any card with discard-as-cost), the client shows a discard-selection overlay, lets them pick the required card(s), then sends the resolve action. Undo reverts the play.

## Changes
- **DiscardCostOverlay** (`packages/client/src/components/Overlays/DiscardCostOverlay.tsx`): New overlay that renders when `validActions.mode === 'pending_discard_cost'`. Uses the existing `CardSelectionOverlay` with:
  - `cards` = `discardCost.availableCardIds`
  - `minSelect` / `maxSelect` from `discardCost.count` (0 allowed when `discardCost.optional`)
  - `canSkip` and Skip button when `discardCost.optional`
  - On confirm: `sendAction({ type: RESOLVE_DISCARD_ACTION, cardIds })`
  - On cancel: `sendAction({ type: UNDO_ACTION })`
- **GameView**: Mount `DiscardCostOverlay` alongside `RestCompletionOverlay` and other overlays.

## Acceptance criteria (from #110)
- [x] Playing Improvisation triggers the discard selection UI.
- [x] After selecting a card and confirming, the choice of effects (Move/Influence/Attack/Block) appears.
- [x] Undo returns the card to hand and restores the discarded card.
- [x] Works in and out of combat.

## Out of scope
- No engine or validator changes.
- Reuses `CardSelectionOverlay` from #109; no new card-selection component.