### PR TITLE
fix: fix card placement for monastery AA, spells, and level-up async flow

### DIFF
--- a/packages/core/src/engine/__tests__/spellAndAdvancedAction.test.ts
+++ b/packages/core/src/engine/__tests__/spellAndAdvancedAction.test.ts
@@ -169,8 +169,8 @@ describe("Spell Purchase and Advanced Action Learning", () => {
           cardId: CARD_FIREBALL,
         });
 
-        // Spell should be in discard
-        expect(result.state.players[0].discard).toContain(CARD_FIREBALL);
+        // Spell should be on top of deed deck (per game rules: "put on top of their Deed deck")
+        expect(result.state.players[0].deck[0]).toBe(CARD_FIREBALL);
 
         // Influence should be consumed
         expect(result.state.players[0].influencePoints).toBe(0);
@@ -211,8 +211,8 @@ describe("Spell Purchase and Advanced Action Learning", () => {
           cardId: CARD_FIREBALL,
         });
 
-        // Spell should be in discard
-        expect(result.state.players[0].discard).toContain(CARD_FIREBALL);
+        // Spell should be on top of deed deck
+        expect(result.state.players[0].deck[0]).toBe(CARD_FIREBALL);
 
         // Influence should be consumed (10 - 7 = 3)
         expect(result.state.players[0].influencePoints).toBe(3);
@@ -275,7 +275,7 @@ describe("Spell Purchase and Advanced Action Learning", () => {
         });
 
         // Should not buy the spell
-        expect(result.state.players[0].discard).not.toContain(CARD_FIREBALL);
+        expect(result.state.players[0].deck).not.toContain(CARD_FIREBALL);
 
         // Check for invalid action
         const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
@@ -481,7 +481,7 @@ describe("Spell Purchase and Advanced Action Learning", () => {
         });
 
         // Should not buy the spell
-        expect(result.state.players[0].discard).not.toContain(CARD_FIREBALL);
+        expect(result.state.players[0].deck).not.toContain(CARD_FIREBALL);
 
         // Influence should not be consumed
         expect(result.state.players[0].influencePoints).toBe(7);
@@ -520,8 +520,8 @@ describe("Spell Purchase and Advanced Action Learning", () => {
           fromMonastery: true,
         });
 
-        // Advanced action should be in discard
-        expect(result.state.players[0].discard).toContain(CARD_BLOOD_RAGE);
+        // Advanced action should be on top of deed deck (per game rules: "put on top of their Deed deck")
+        expect(result.state.players[0].deck[0]).toBe(CARD_BLOOD_RAGE);
 
         // Influence should be consumed
         expect(result.state.players[0].influencePoints).toBe(0);
@@ -694,8 +694,8 @@ describe("Spell Purchase and Advanced Action Learning", () => {
           fromMonastery: false,
         });
 
-        // Advanced action should be in discard
-        expect(result.state.players[0].discard).toContain(CARD_FIRE_BOLT);
+        // Advanced action should be on top of deed deck
+        expect(result.state.players[0].deck[0]).toBe(CARD_FIRE_BOLT);
 
         // Pending reward should be consumed
         expect(result.state.players[0].pendingRewards).toHaveLength(0);

--- a/packages/core/src/engine/commands/buySpellCommand.ts
+++ b/packages/core/src/engine/commands/buySpellCommand.ts
@@ -4,7 +4,7 @@
  * Handles purchasing a spell from the spell offer at a conquered Mage Tower:
  * - Costs 7 influence points
  * - Removes the spell from the offer
- * - Adds the spell to the player's discard pile
+ * - Adds the spell to the top of the player's deed deck
  * - Replenishes the offer from the spell deck
  */
 
@@ -73,7 +73,7 @@ export function createBuySpellCommand(params: BuySpellCommandParams): Command {
   // Store previous state for undo
   let previousOffers: GameState["offers"] | null = null;
   let previousDecks: GameState["decks"] | null = null;
-  let previousDiscard: readonly CardId[] = [];
+  let previousDeck: readonly CardId[] = [];
   let previousInfluencePoints = 0;
   let previousHasTakenAction = false;
 
@@ -98,15 +98,15 @@ export function createBuySpellCommand(params: BuySpellCommandParams): Command {
       // Store previous state for undo
       previousOffers = state.offers;
       previousDecks = state.decks;
-      previousDiscard = player.discard;
+      previousDeck = player.deck;
       previousInfluencePoints = player.influencePoints;
       previousHasTakenAction = player.hasTakenActionThisTurn;
 
-      // Consume influence and add spell to discard pile
+      // Consume influence and add spell to top of deed deck (per game rules)
       const updatedPlayer = {
         ...player,
         influencePoints: player.influencePoints - SPELL_PURCHASE_COST,
-        discard: [...player.discard, params.cardId],
+        deck: [params.cardId, ...player.deck],
         hasTakenActionThisTurn: true,
       };
 
@@ -169,7 +169,7 @@ export function createBuySpellCommand(params: BuySpellCommandParams): Command {
       // Restore player state
       const updatedPlayer = {
         ...player,
-        discard: previousDiscard,
+        deck: previousDeck,
         influencePoints: previousInfluencePoints,
         hasTakenActionThisTurn: previousHasTakenAction,
       };

--- a/packages/core/src/engine/commands/learnAdvancedActionCommand.ts
+++ b/packages/core/src/engine/commands/learnAdvancedActionCommand.ts
@@ -7,7 +7,7 @@
  *
  * Both cases:
  * - Removes the AA from the offer
- * - Adds the AA to the player's discard pile
+ * - Adds the AA to the top of the player's deed deck
  * - Replenishes the offer from the deck (regular offer only)
  */
 
@@ -112,7 +112,7 @@ export function createLearnAdvancedActionCommand(
   // Store previous state for undo
   let previousOffers: GameState["offers"] | null = null;
   let previousDecks: GameState["decks"] | null = null;
-  let previousDiscard: readonly CardId[] = [];
+  let previousDeck: readonly CardId[] = [];
   let previousInfluencePoints = 0;
   let previousPendingRewards: readonly SiteReward[] = [];
   let previousHasTakenAction = false;
@@ -138,15 +138,15 @@ export function createLearnAdvancedActionCommand(
       // Store previous state for undo
       previousOffers = state.offers;
       previousDecks = state.decks;
-      previousDiscard = player.discard;
+      previousDeck = player.deck;
       previousInfluencePoints = player.influencePoints;
       previousPendingRewards = player.pendingRewards;
       previousHasTakenAction = player.hasTakenActionThisTurn;
 
-      // Base update: add AA to discard pile
+      // Base update: add AA to top of deed deck (per game rules)
       let updatedPlayer = {
         ...player,
-        discard: [...player.discard, params.cardId],
+        deck: [params.cardId, ...player.deck],
         hasTakenActionThisTurn: true,
       };
 
@@ -234,7 +234,7 @@ export function createLearnAdvancedActionCommand(
       // Restore player state
       const updatedPlayer = {
         ...player,
-        discard: previousDiscard,
+        deck: previousDeck,
         influencePoints: previousInfluencePoints,
         pendingRewards: previousPendingRewards,
         hasTakenActionThisTurn: previousHasTakenAction,


### PR DESCRIPTION
## Summary

Fixes two critical bugs affecting card placement:

1. **Monastery AA & Spell Purchases**: Cards were placed in discard pile instead of top of deed deck
   - Per Mage Knight rules: "put on top of their Deed deck"
   - Affected: `learnAdvancedActionCommand.ts`, `buySpellCommand.ts`

2. **Level-Up Async Flow**: Wrong order of operations prevented AA from appearing in hand
   - Hand was drawn before pending rewards created
   - AA selected during async phase wouldn't appear until next turn
   - Now: level-ups process before card draw; hand drawn after reward selection

## Changes

### Command Fixes
- **learnAdvancedActionCommand.ts**: Place AA on `deck[0]` instead of `discard`
- **buySpellCommand.ts**: Place spell on `deck[0]` instead of `discard`

### Async Flow Fix (endTurn)
- **endTurn/index.ts**: 
  - Move `processLevelUps()` BEFORE `processCardFlow()`
  - Skip card draw if pending even-level rewards exist
  - Other players can now play while current player decides

### Reward Selection
- **chooseLevelUpRewardsCommand.ts**: Draw cards up to hand limit after placing AA
  - AA is now immediately available in hand after selection

### Tests
- Updated `spellAndAdvancedAction.test.ts` to verify deck placement for purchases
- Updated `levelUp.test.ts` to verify hand placement for async flow
- Added integration test for full level-up end-of-turn sequence

## Test Results
✅ 1802 core tests pass
✅ 48 server tests pass  
✅ 12 shared tests pass
✅ All tests: 1862 pass, 0 fail