### PR TITLE
fix: enable HMR for pixiTextureLoader utility module

### DIFF
--- a/packages/client/src/utils/pixiTextureLoader.ts
+++ b/packages/client/src/utils/pixiTextureLoader.ts
@@ -408,3 +408,15 @@ export function getTextureCacheSize(): number {
 export function isTextureCached(cacheKey: string): boolean {
   return textureCache.has(cacheKey);
 }
+
+// ============================================================================
+// HMR Support
+// ============================================================================
+
+// Accept self-updates to prevent full page reloads
+if (import.meta.hot) {
+  import.meta.hot.accept();
+
+  // Debug log for HMR acceptance
+  console.log("[HMR] pixiTextureLoader module accepted update");
+}


### PR DESCRIPTION
## Summary

Fixed HMR (Hot Module Replacement) to work properly when editing the pixiTextureLoader utility module. Previously, changes to this file would trigger a full page reload instead of hot-updating.

## Changes

- Added `import.meta.hot.accept()` to `pixiTextureLoader.ts` to enable HMR self-acceptance
- Included debug log for HMR acceptance confirmation

## How This Works

The texture loader module is imported by 6 different components:
- PixiFloatingHand
- PixiUnitCarousel
- PixiTacticCarousel
- PixiCardCanvas
- PixiOfferView
- PieMenuRenderer

By handling HMR at the utility module level (rather than in each importer), we avoid requiring each component to implement its own HMR logic. The module's internal state is well-encapsulated, making it safe to accept its own updates.

## Test Plan

1. Start the dev server: `bun run dev`
2. Open the app in browser
3. Edit `packages/client/src/utils/pixiTextureLoader.ts` (e.g., modify the debug log)
4. Save the file
5. Verify in browser console that HMR accepted the update (no full page reload)
6. Confirm the change was applied without reloading

## Verification

- ✅ Build passes: `bun run build`
- ✅ Lint passes: `bun run lint`