### PR TITLE
fix: correct Red Cape Monks abilities to match rulebook

### DIFF
--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -25,6 +25,7 @@ import {
   UNIT_FIRE_GOLEMS,
   UNIT_ICE_GOLEMS,
   UNIT_NORTHERN_MONKS,
+  UNIT_RED_CAPE_MONKS,
   UNIT_GUARDIAN_GOLEMS,
   CARD_WOUND,
   UNIT_STATE_READY,
@@ -1273,6 +1274,201 @@ describe("Unit Combat Abilities", () => {
         unitInstanceId: "northern_monks_1",
         abilityIndex: 3, // Ice Block 4 (requires blue mana)
         manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Should fail - wrong mana color
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+  });
+
+  describe("Red Cape Monks abilities", () => {
+    it("should activate free physical Attack 3 (ability index 0)", () => {
+      // Red Cape Monks have Attack 3 (physical, free) at index 0
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 0, // Attack 3 (physical, free)
+      });
+
+      // Should succeed without mana
+      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(3);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Check event
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+      if (activateEvent && activateEvent.type === UNIT_ACTIVATED) {
+        expect(activateEvent.abilityUsed).toBe(UNIT_ABILITY_ATTACK);
+        expect(activateEvent.abilityValue).toBe(3);
+      }
+    });
+
+    it("should activate free physical Block 3 (ability index 1)", () => {
+      // Red Cape Monks have Block 3 (physical, free) at index 1
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 1, // Block 3 (physical, free)
+      });
+
+      // Should succeed without mana
+      expect(result.state.players[0].combatAccumulator.block).toBe(3);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Check event
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+      if (activateEvent && activateEvent.type === UNIT_ACTIVATED) {
+        expect(activateEvent.abilityUsed).toBe(UNIT_ABILITY_BLOCK);
+        expect(activateEvent.abilityValue).toBe(3);
+      }
+    });
+
+    it("should activate Fire Attack 4 with red mana (ability index 2)", () => {
+      // Red Cape Monks have Fire Attack 4 (requires red mana) at index 2
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_RED, source: "card" }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 2, // Fire Attack 4 (requires red mana)
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Should succeed with red mana
+      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(4);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      // Red mana should be consumed
+      expect(result.state.players[0].pureMana.length).toBe(0);
+
+      // Check event
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+      if (activateEvent && activateEvent.type === UNIT_ACTIVATED) {
+        expect(activateEvent.abilityUsed).toBe(UNIT_ABILITY_ATTACK);
+        expect(activateEvent.abilityValue).toBe(4);
+      }
+    });
+
+    it("should activate Fire Block 4 with red mana (ability index 3)", () => {
+      // Red Cape Monks have Fire Block 4 (requires red mana) at index 3
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_RED, source: "card" }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 3, // Fire Block 4 (requires red mana)
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Should succeed with red mana
+      expect(result.state.players[0].combatAccumulator.block).toBe(4);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      // Red mana should be consumed
+      expect(result.state.players[0].pureMana.length).toBe(0);
+
+      // Check event
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+      if (activateEvent && activateEvent.type === UNIT_ACTIVATED) {
+        expect(activateEvent.abilityUsed).toBe(UNIT_ABILITY_BLOCK);
+        expect(activateEvent.abilityValue).toBe(4);
+      }
+    });
+
+    it("should reject Fire Attack 4 without red mana", () => {
+      // Red Cape Monks have Fire Attack 4 (requires red mana) at index 2
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [], // No mana available
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 2, // Fire Attack 4 (requires red mana)
+        // No manaSource provided
+      });
+
+      // Should fail - mana required
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("red mana");
+      }
+    });
+
+    it("should reject Fire Block 4 with wrong mana color (blue)", () => {
+      // Red Cape Monks need red mana, but we provide blue
+      const unit = createPlayerUnit(UNIT_RED_CAPE_MONKS, "red_cape_monks_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_BLUE, source: "card" }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "red_cape_monks_1",
+        abilityIndex: 3, // Fire Block 4 (requires red mana)
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
       });
 
       // Should fail - wrong mana color

--- a/packages/shared/src/units/regular/redCapeMonks.ts
+++ b/packages/shared/src/units/regular/redCapeMonks.ts
@@ -1,8 +1,13 @@
 /**
  * Red Cape Monks unit definition
+ *
+ * Rulebook abilities:
+ * - Ability 1: Attack OR Block 3 (physical, free)
+ * - Ability 2: Fire Attack OR Fire Block 4 (red mana)
  */
 
-import { ELEMENT_FIRE } from "../../elements.js";
+import { ELEMENT_FIRE, ELEMENT_PHYSICAL } from "../../elements.js";
+import { MANA_RED } from "../../ids.js";
 import type { UnitDefinition } from "../types.js";
 import {
   UNIT_TYPE_REGULAR,
@@ -22,8 +27,12 @@ export const RED_CAPE_MONKS: UnitDefinition = {
   resistances: [],
   recruitSites: [RECRUIT_SITE_MONASTERY],
   abilities: [
-    { type: UNIT_ABILITY_ATTACK, value: 4, element: ELEMENT_FIRE },
-    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_FIRE },
+    // Ability 1: Attack 3 OR Block 3 (physical, free)
+    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
+    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_PHYSICAL },
+    // Ability 2: Fire Attack 4 OR Fire Block 4 (red mana)
+    { type: UNIT_ABILITY_ATTACK, value: 4, element: ELEMENT_FIRE, manaCost: MANA_RED },
+    { type: UNIT_ABILITY_BLOCK, value: 4, element: ELEMENT_FIRE, manaCost: MANA_RED },
   ],
   copies: 1,
 };


### PR DESCRIPTION
## Summary
- Fixed Red Cape Monks unit abilities to match the rulebook specification
- Was: Fire Attack 4 + Fire Block 3 (separate, no mana cost)
- Now: Attack 3 OR Block 3 (physical, free) + Fire Attack 4 OR Fire Block 4 (red mana)

## Changes
- **packages/shared/src/units/regular/redCapeMonks.ts**: Corrected abilities — added physical Attack/Block 3 (free), Fire Attack/Block 4 (red mana cost), following the same pattern as Northern Monks
- **packages/core/src/engine/__tests__/unitActivation.test.ts**: Added 6 tests for Red Cape Monks abilities (free physical, mana-powered fire, mana rejection)
- **packages/core/src/engine/__tests__/unitElementalTracking.test.ts**: Updated existing tests to use correct ability indices and mana requirements

## Test Plan
- [x] Free physical Attack 3 (index 0) works without mana
- [x] Free physical Block 3 (index 1) works without mana
- [x] Fire Attack 4 (index 2) works with red mana
- [x] Fire Block 4 (index 3) works with red mana
- [x] Fire abilities rejected without mana
- [x] Fire abilities rejected with wrong mana color
- [x] Elemental tracking correctly records fire vs physical damage
- [x] All 1810+ tests pass

Closes #269