### PR TITLE
feat: implement terrain cost reduction commands and validators

### DIFF
--- a/packages/core/src/__tests__/terrainCostReductionCommands.test.ts
+++ b/packages/core/src/__tests__/terrainCostReductionCommands.test.ts
@@ -1,0 +1,422 @@
+/**
+ * Tests for terrain cost reduction commands and validators
+ *
+ * Tests:
+ * - Hex command: Valid coordinate applies modifier
+ * - Hex command: Invalid coordinate rejected by validator
+ * - Terrain command: Valid terrain applies modifier
+ * - Terrain command: Invalid terrain rejected by validator
+ * - Commands create modifiers with correct properties
+ * - Modifiers have DURATION_TURN
+ * - No modifiers applied for invalid actions
+ * - isReversible flag set correctly
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createTestGameState, createTestPlayer } from "../engine/__tests__/testHelpers.js";
+import {
+  createResolveHexCostReductionCommand,
+  createResolveTerrainCostReductionCommand,
+} from "../engine/commands/terrainCostReductionCommands.js";
+import {
+  validateHasPendingHexCostReduction,
+  validateHexCostReductionCoordinate,
+  validateHasPendingTerrainCostReduction,
+  validateTerrainCostReductionTerrain,
+} from "../engine/validators/terrainCostReductionValidators.js";
+import {
+  RESOLVE_HEX_COST_REDUCTION_ACTION,
+  RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+  TERRAIN_FOREST,
+  TERRAIN_HILLS,
+  TERRAIN_PLAINS,
+} from "@mage-knight/shared";
+import type { HexCoord, PlayerAction } from "@mage-knight/shared";
+import {
+  TERRAIN_COST_REDUCTION_REQUIRED,
+  TERRAIN_COST_REDUCTION_INVALID_COORDINATE,
+  TERRAIN_COST_REDUCTION_INVALID_TERRAIN,
+} from "../engine/validators/validationCodes.js";
+import { DURATION_TURN, EFFECT_TERRAIN_COST, TERRAIN_ALL } from "../types/modifierConstants.js";
+import type { PendingTerrainCostReduction } from "../types/player.js";
+
+const PLAYER_ID = "player1";
+const COORD_A: HexCoord = { q: 0, r: 1 };
+const COORD_B: HexCoord = { q: 1, r: 0 };
+const COORD_C: HexCoord = { q: 2, r: 0 };
+
+function createHexPendingState(
+  availableCoordinates: readonly HexCoord[] = [COORD_A, COORD_B]
+): PendingTerrainCostReduction {
+  return {
+    mode: "hex",
+    availableCoordinates,
+    availableTerrains: [],
+    reduction: -1,
+    minimumCost: 2,
+  };
+}
+
+function createTerrainPendingState(
+  availableTerrains: readonly string[] = [TERRAIN_FOREST, TERRAIN_HILLS, TERRAIN_PLAINS]
+): PendingTerrainCostReduction {
+  return {
+    mode: "terrain",
+    availableCoordinates: [],
+    availableTerrains,
+    reduction: -1,
+    minimumCost: 2,
+  };
+}
+
+describe("Terrain Cost Reduction Commands", () => {
+  describe("resolveHexCostReductionCommand", () => {
+    it("applies terrain cost modifier for specific coordinate", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState(),
+          }),
+        ],
+      });
+
+      const command = createResolveHexCostReductionCommand({
+        playerId: PLAYER_ID,
+        coordinate: COORD_A,
+      });
+
+      const result = command.execute(state);
+
+      // Modifier should be added
+      expect(result.state.activeModifiers).toHaveLength(1);
+      const modifier = result.state.activeModifiers[0]!;
+      expect(modifier.effect.type).toBe(EFFECT_TERRAIN_COST);
+      expect(modifier.duration).toBe(DURATION_TURN);
+      expect(modifier.createdByPlayerId).toBe(PLAYER_ID);
+
+      // Check the terrain cost modifier specifics
+      if (modifier.effect.type === EFFECT_TERRAIN_COST) {
+        expect(modifier.effect.terrain).toBe(TERRAIN_ALL);
+        expect(modifier.effect.amount).toBe(-1);
+        expect(modifier.effect.minimum).toBe(2);
+        expect(modifier.effect.specificCoordinate).toEqual(COORD_A);
+      }
+    });
+
+    it("clears pending terrain cost reduction state", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState(),
+          }),
+        ],
+      });
+
+      const command = createResolveHexCostReductionCommand({
+        playerId: PLAYER_ID,
+        coordinate: COORD_A,
+      });
+
+      const result = command.execute(state);
+      const player = result.state.players.find((p) => p.id === PLAYER_ID);
+      expect(player?.pendingTerrainCostReduction).toBeNull();
+    });
+
+    it("is not reversible", () => {
+      const command = createResolveHexCostReductionCommand({
+        playerId: PLAYER_ID,
+        coordinate: COORD_A,
+      });
+      expect(command.isReversible).toBe(false);
+    });
+
+    it("returns empty events", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState(),
+          }),
+        ],
+      });
+
+      const command = createResolveHexCostReductionCommand({
+        playerId: PLAYER_ID,
+        coordinate: COORD_A,
+      });
+
+      const result = command.execute(state);
+      expect(result.events).toHaveLength(0);
+    });
+
+    it("throws if player not found", () => {
+      const state = createTestGameState({
+        players: [createTestPlayer({ id: "other_player" })],
+      });
+
+      const command = createResolveHexCostReductionCommand({
+        playerId: PLAYER_ID,
+        coordinate: COORD_A,
+      });
+
+      expect(() => command.execute(state)).toThrow("Player not found");
+    });
+  });
+
+  describe("resolveTerrainCostReductionCommand", () => {
+    it("applies terrain cost modifier for specific terrain type", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState(),
+          }),
+        ],
+      });
+
+      const command = createResolveTerrainCostReductionCommand({
+        playerId: PLAYER_ID,
+        terrain: TERRAIN_FOREST,
+      });
+
+      const result = command.execute(state);
+
+      // Modifier should be added
+      expect(result.state.activeModifiers).toHaveLength(1);
+      const modifier = result.state.activeModifiers[0]!;
+      expect(modifier.effect.type).toBe(EFFECT_TERRAIN_COST);
+      expect(modifier.duration).toBe(DURATION_TURN);
+      expect(modifier.createdByPlayerId).toBe(PLAYER_ID);
+
+      // Check the terrain cost modifier specifics
+      if (modifier.effect.type === EFFECT_TERRAIN_COST) {
+        expect(modifier.effect.terrain).toBe(TERRAIN_FOREST);
+        expect(modifier.effect.amount).toBe(-1);
+        expect(modifier.effect.minimum).toBe(2);
+        expect(modifier.effect.specificCoordinate).toBeUndefined();
+      }
+    });
+
+    it("clears pending terrain cost reduction state", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState(),
+          }),
+        ],
+      });
+
+      const command = createResolveTerrainCostReductionCommand({
+        playerId: PLAYER_ID,
+        terrain: TERRAIN_FOREST,
+      });
+
+      const result = command.execute(state);
+      const player = result.state.players.find((p) => p.id === PLAYER_ID);
+      expect(player?.pendingTerrainCostReduction).toBeNull();
+    });
+
+    it("is not reversible", () => {
+      const command = createResolveTerrainCostReductionCommand({
+        playerId: PLAYER_ID,
+        terrain: TERRAIN_FOREST,
+      });
+      expect(command.isReversible).toBe(false);
+    });
+  });
+});
+
+describe("Terrain Cost Reduction Validators", () => {
+  describe("validateHasPendingHexCostReduction", () => {
+    it("succeeds when player has pending hex cost reduction", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState(),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_HEX_COST_REDUCTION_ACTION,
+        coordinate: COORD_A,
+      };
+
+      const result = validateHasPendingHexCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("fails when no pending state", () => {
+      const state = createTestGameState({
+        players: [createTestPlayer()],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_HEX_COST_REDUCTION_ACTION,
+        coordinate: COORD_A,
+      };
+
+      const result = validateHasPendingHexCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(TERRAIN_COST_REDUCTION_REQUIRED);
+      }
+    });
+
+    it("fails when pending state is terrain mode, not hex", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState(),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_HEX_COST_REDUCTION_ACTION,
+        coordinate: COORD_A,
+      };
+
+      const result = validateHasPendingHexCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("validateHexCostReductionCoordinate", () => {
+    it("succeeds for valid coordinate", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState([COORD_A, COORD_B]),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_HEX_COST_REDUCTION_ACTION,
+        coordinate: COORD_A,
+      };
+
+      const result = validateHexCostReductionCoordinate(state, PLAYER_ID, action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("fails for invalid coordinate", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState([COORD_A, COORD_B]),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_HEX_COST_REDUCTION_ACTION,
+        coordinate: COORD_C, // Not in available list
+      };
+
+      const result = validateHexCostReductionCoordinate(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(TERRAIN_COST_REDUCTION_INVALID_COORDINATE);
+      }
+    });
+  });
+
+  describe("validateHasPendingTerrainCostReduction", () => {
+    it("succeeds when player has pending terrain cost reduction", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState(),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+        terrain: TERRAIN_FOREST,
+      };
+
+      const result = validateHasPendingTerrainCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("fails when no pending state", () => {
+      const state = createTestGameState({
+        players: [createTestPlayer()],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+        terrain: TERRAIN_FOREST,
+      };
+
+      const result = validateHasPendingTerrainCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(TERRAIN_COST_REDUCTION_REQUIRED);
+      }
+    });
+
+    it("fails when pending state is hex mode, not terrain", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createHexPendingState(),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+        terrain: TERRAIN_FOREST,
+      };
+
+      const result = validateHasPendingTerrainCostReduction(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("validateTerrainCostReductionTerrain", () => {
+    it("succeeds for valid terrain", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState([
+              TERRAIN_FOREST,
+              TERRAIN_HILLS,
+            ]),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+        terrain: TERRAIN_FOREST,
+      };
+
+      const result = validateTerrainCostReductionTerrain(state, PLAYER_ID, action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("fails for invalid terrain", () => {
+      const state = createTestGameState({
+        players: [
+          createTestPlayer({
+            pendingTerrainCostReduction: createTerrainPendingState([TERRAIN_FOREST]),
+          }),
+        ],
+      });
+
+      const action: PlayerAction = {
+        type: RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+        terrain: TERRAIN_HILLS, // Not in available list
+      };
+
+      const result = validateTerrainCostReductionTerrain(state, PLAYER_ID, action);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(TERRAIN_COST_REDUCTION_INVALID_TERRAIN);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -156,6 +156,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingDeepMineChoice: null,
     pendingDiscardForAttack: null,
     pendingDiscardForCrystal: null,
+    pendingTerrainCostReduction: null,
     pendingAttackDefeatFame: [],
     enemiesDefeatedThisTurn: 0,
     healingPoints: 0,

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -68,6 +68,8 @@ import {
   USE_SKILL_ACTION,
   SPEND_MOVE_ON_CUMBERSOME_ACTION,
   PAY_HEROES_ASSAULT_INFLUENCE_ACTION,
+  RESOLVE_HEX_COST_REDUCTION_ACTION,
+  RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -164,6 +166,12 @@ export {
 // Skill factories
 export { createUseSkillCommandFromAction } from "./skills.js";
 
+// Terrain cost reduction factories
+export {
+  createResolveHexCostReductionCommandFromAction,
+  createResolveTerrainCostReductionCommandFromAction,
+} from "./terrainCostReduction.js";
+
 // Import all factories for the registry
 import {
   createMoveCommandFromAction,
@@ -245,6 +253,11 @@ import {
 
 import { createUseSkillCommandFromAction } from "./skills.js";
 
+import {
+  createResolveHexCostReductionCommandFromAction,
+  createResolveTerrainCostReductionCommandFromAction,
+} from "./terrainCostReduction.js";
+
 import type { CommandFactory } from "./types.js";
 
 /**
@@ -308,4 +321,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [SPEND_MOVE_ON_CUMBERSOME_ACTION]: createSpendMoveOnCumbersomeCommandFromAction,
   // Heroes assault influence payment action
   [PAY_HEROES_ASSAULT_INFLUENCE_ACTION]: createPayHeroesAssaultInfluenceCommandFromAction,
+  // Terrain cost reduction actions (Druidic Paths)
+  [RESOLVE_HEX_COST_REDUCTION_ACTION]: createResolveHexCostReductionCommandFromAction,
+  [RESOLVE_TERRAIN_COST_REDUCTION_ACTION]: createResolveTerrainCostReductionCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/terrainCostReduction.ts
+++ b/packages/core/src/engine/commands/factories/terrainCostReduction.ts
@@ -1,0 +1,50 @@
+/**
+ * Terrain Cost Reduction Command Factories
+ *
+ * Factory functions that translate terrain cost reduction PlayerAction objects
+ * into executable Command objects.
+ *
+ * @module commands/factories/terrainCostReduction
+ */
+
+import type { CommandFactory } from "./types.js";
+import {
+  RESOLVE_HEX_COST_REDUCTION_ACTION,
+  RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+} from "@mage-knight/shared";
+import {
+  createResolveHexCostReductionCommand,
+  createResolveTerrainCostReductionCommand,
+} from "../terrainCostReductionCommands.js";
+
+/**
+ * Resolve hex cost reduction command factory.
+ * Creates a command to apply terrain cost reduction to a specific hex coordinate.
+ */
+export const createResolveHexCostReductionCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_HEX_COST_REDUCTION_ACTION) return null;
+  return createResolveHexCostReductionCommand({
+    playerId,
+    coordinate: action.coordinate,
+  });
+};
+
+/**
+ * Resolve terrain cost reduction command factory.
+ * Creates a command to apply terrain cost reduction to a terrain type.
+ */
+export const createResolveTerrainCostReductionCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_TERRAIN_COST_REDUCTION_ACTION) return null;
+  return createResolveTerrainCostReductionCommand({
+    playerId,
+    terrain: action.terrain,
+  });
+};

--- a/packages/core/src/engine/commands/index.ts
+++ b/packages/core/src/engine/commands/index.ts
@@ -221,6 +221,16 @@ export {
   BURN_MONASTERY_COMMAND,
 } from "./burnMonasteryCommand.js";
 
+// Terrain cost reduction commands (Druidic Paths)
+export {
+  createResolveHexCostReductionCommand,
+  createResolveTerrainCostReductionCommand,
+  type ResolveHexCostReductionCommandParams,
+  type ResolveTerrainCostReductionCommandParams,
+  RESOLVE_HEX_COST_REDUCTION_COMMAND,
+  RESOLVE_TERRAIN_COST_REDUCTION_COMMAND,
+} from "./terrainCostReductionCommands.js";
+
 // Discard for crystal commands (Savage Harvesting)
 export {
   createResolveDiscardForCrystalCommand,

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -14,6 +14,8 @@ import {
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
+  RESOLVE_HEX_COST_REDUCTION_ACTION,
+  RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
 } from "@mage-knight/shared";
 
 // Turn validators
@@ -74,6 +76,14 @@ import {
   validateCrystalJoyReclaimCard,
 } from "../crystalJoyReclaimValidators.js";
 
+// Terrain cost reduction validators (Druidic Paths)
+import {
+  validateHasPendingHexCostReduction,
+  validateHexCostReductionCoordinate,
+  validateHasPendingTerrainCostReduction,
+  validateTerrainCostReductionTerrain,
+} from "../terrainCostReductionValidators.js";
+
 export const choiceRegistry: Record<string, Validator[]> = {
   [RESOLVE_CHOICE_ACTION]: [
     validateIsPlayersTurn,
@@ -122,5 +132,15 @@ export const choiceRegistry: Record<string, Validator[]> = {
     validateIsPlayersTurn,
     validateHasPendingCrystalJoyReclaim,
     validateCrystalJoyReclaimCard,
+  ],
+  [RESOLVE_HEX_COST_REDUCTION_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingHexCostReduction,
+    validateHexCostReductionCoordinate,
+  ],
+  [RESOLVE_TERRAIN_COST_REDUCTION_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingTerrainCostReduction,
+    validateTerrainCostReductionTerrain,
   ],
 };

--- a/packages/core/src/engine/validators/terrainCostReductionValidators.ts
+++ b/packages/core/src/engine/validators/terrainCostReductionValidators.ts
@@ -1,0 +1,135 @@
+/**
+ * Terrain cost reduction validators (Druidic Paths)
+ *
+ * Validates RESOLVE_HEX_COST_REDUCTION and RESOLVE_TERRAIN_COST_REDUCTION actions.
+ * These require the player to have a pending terrain cost reduction choice
+ * and to select a valid coordinate or terrain type.
+ */
+
+import type { Validator, ValidationResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import {
+  RESOLVE_HEX_COST_REDUCTION_ACTION,
+  RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
+  hexKey,
+} from "@mage-knight/shared";
+import { valid, invalid } from "./types.js";
+import {
+  TERRAIN_COST_REDUCTION_REQUIRED,
+  TERRAIN_COST_REDUCTION_INVALID_COORDINATE,
+  TERRAIN_COST_REDUCTION_INVALID_TERRAIN,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+
+/**
+ * Validate that the player has a pending hex cost reduction choice
+ */
+export const validateHasPendingHexCostReduction: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTerrainCostReduction || player.pendingTerrainCostReduction.mode !== "hex") {
+    return invalid(
+      TERRAIN_COST_REDUCTION_REQUIRED,
+      "No pending hex cost reduction choice"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate that the chosen coordinate is in the available list
+ */
+export const validateHexCostReductionCoordinate: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_HEX_COST_REDUCTION_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTerrainCostReduction || player.pendingTerrainCostReduction.mode !== "hex") {
+    return valid(); // Let the other validator handle this
+  }
+
+  const selectedKey = hexKey(action.coordinate);
+  const availableKeys = player.pendingTerrainCostReduction.availableCoordinates.map(hexKey);
+
+  if (!availableKeys.includes(selectedKey)) {
+    return invalid(
+      TERRAIN_COST_REDUCTION_INVALID_COORDINATE,
+      `Invalid coordinate for cost reduction: (${action.coordinate.q}, ${action.coordinate.r})`
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate that the player has a pending terrain type cost reduction choice
+ */
+export const validateHasPendingTerrainCostReduction: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTerrainCostReduction || player.pendingTerrainCostReduction.mode !== "terrain") {
+    return invalid(
+      TERRAIN_COST_REDUCTION_REQUIRED,
+      "No pending terrain cost reduction choice"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate that the chosen terrain is in the available list
+ */
+export const validateTerrainCostReductionTerrain: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_TERRAIN_COST_REDUCTION_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTerrainCostReduction || player.pendingTerrainCostReduction.mode !== "terrain") {
+    return valid(); // Let the other validator handle this
+  }
+
+  if (!player.pendingTerrainCostReduction.availableTerrains.includes(action.terrain)) {
+    return invalid(
+      TERRAIN_COST_REDUCTION_INVALID_TERRAIN,
+      `Invalid terrain for cost reduction: ${action.terrain}`
+    );
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -255,6 +255,11 @@ export const CITY_NOT_FOUND = "CITY_NOT_FOUND" as const;
 export const MUST_INVITE_AT_LEAST_ONE = "MUST_INVITE_AT_LEAST_ONE" as const;
 export const INITIATOR_TOKEN_FLIPPED = "INITIATOR_TOKEN_FLIPPED" as const;
 
+// Terrain cost reduction validation codes (Druidic Paths)
+export const TERRAIN_COST_REDUCTION_REQUIRED = "TERRAIN_COST_REDUCTION_REQUIRED" as const;
+export const TERRAIN_COST_REDUCTION_INVALID_COORDINATE = "TERRAIN_COST_REDUCTION_INVALID_COORDINATE" as const;
+export const TERRAIN_COST_REDUCTION_INVALID_TERRAIN = "TERRAIN_COST_REDUCTION_INVALID_TERRAIN" as const;
+
 // Skill usage validation codes
 export const SKILL_NOT_LEARNED = "SKILL_NOT_LEARNED" as const;
 export const SKILL_NOT_FOUND = "SKILL_NOT_FOUND" as const;
@@ -471,6 +476,10 @@ export type ValidationErrorCode =
   | typeof CITY_NOT_FOUND
   | typeof MUST_INVITE_AT_LEAST_ONE
   | typeof INITIATOR_TOKEN_FLIPPED
+  // Terrain cost reduction validation (Druidic Paths)
+  | typeof TERRAIN_COST_REDUCTION_REQUIRED
+  | typeof TERRAIN_COST_REDUCTION_INVALID_COORDINATE
+  | typeof TERRAIN_COST_REDUCTION_INVALID_TERRAIN
   // Skill usage validation
   | typeof SKILL_NOT_LEARNED
   | typeof SKILL_NOT_FOUND

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -230,6 +230,23 @@ export interface PendingDiscardForCrystal {
 }
 
 /**
+ * Pending terrain cost reduction choice (Druidic Paths and similar effects).
+ * Player must choose a hex coordinate or terrain type to apply cost reduction.
+ */
+export interface PendingTerrainCostReduction {
+  /** Whether to pick a hex coordinate or terrain type */
+  readonly mode: "hex" | "terrain";
+  /** Available hex coordinates (for "hex" mode) */
+  readonly availableCoordinates: readonly HexCoord[];
+  /** Available terrain types (for "terrain" mode) */
+  readonly availableTerrains: readonly string[];
+  /** Cost reduction amount (negative, e.g., -1) */
+  readonly reduction: number;
+  /** Minimum cost after reduction */
+  readonly minimumCost: number;
+}
+
+/**
  * Track an attack that grants fame if it defeats at least one enemy.
  * Used by Axe Throw powered effect.
  */
@@ -421,6 +438,10 @@ export interface Player {
   readonly pendingCrystalJoyReclaim:
     | { readonly version: "basic" | "powered" }
     | undefined;
+
+  // Terrain cost reduction pending (Druidic Paths and similar effects)
+  // When set, the player must choose a hex coordinate or terrain type for cost reduction
+  readonly pendingTerrainCostReduction: PendingTerrainCostReduction | null;
 
   // Healing points accumulated this turn (cleared on combat entry per rulebook line 929)
   readonly healingPoints: number;


### PR DESCRIPTION
## Summary
- Implement command handlers for RESOLVE_HEX_COST_REDUCTION_ACTION and RESOLVE_TERRAIN_COST_REDUCTION_ACTION
- Create validators that check pending state and validate coordinate/terrain selections
- Register commands and validators in the dispatch registries
- Add PendingTerrainCostReduction state to Player type

## Changes
- Commands: Rewrote stub to follow CommandResult pattern with proper playerId threading via factory, pending state clearing, typed modifiers
- Factories: New terrainCostReduction.ts factory module registered in commandFactoryRegistry
- Validators: New terrainCostReductionValidators.ts with 4 validators
- Validation codes: Added TERRAIN_COST_REDUCTION_REQUIRED, TERRAIN_COST_REDUCTION_INVALID_COORDINATE, TERRAIN_COST_REDUCTION_INVALID_TERRAIN
- Player type: Added PendingTerrainCostReduction interface and field
- Tests: 18 unit tests covering commands and validators

## Test Plan
- [x] All 18 new tests pass
- [x] Full build succeeds
- [x] Lint clean (no new warnings)
- [x] All 1820 core + 48 server existing tests still pass

Closes #755