### PR TITLE
feat: implement Illusionists unit abilities

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -10,7 +10,7 @@
  * @module data/unitAbilityEffects
  */
 
-import { ABILITY_FORTIFIED, MANA_BLUE, MANA_GREEN } from "@mage-knight/shared";
+import { ABILITY_FORTIFIED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
 import type { CardEffect } from "../types/cards.js";
 import {
   EFFECT_SELECT_COMBAT_ENEMY,
@@ -28,6 +28,7 @@ import {
 import {
   DURATION_COMBAT,
   EFFECT_ABILITY_NULLIFIER,
+  EFFECT_ENEMY_SKIP_ATTACK,
   EFFECT_REMOVE_RESISTANCES,
   ELEMENT_ICE,
 } from "../types/modifierConstants.js";
@@ -77,6 +78,18 @@ export const HERBALIST_READY_UNIT = "herbalist_ready_unit" as const;
  * Gain a green mana token
  */
 export const HERBALIST_GAIN_MANA = "herbalist_gain_mana" as const;
+
+/**
+ * Illusionists: White mana ability
+ * Target unfortified, non-arcane-immune enemy does not attack this combat
+ */
+export const ILLUSIONISTS_CANCEL_ATTACK = "illusionists_cancel_attack" as const;
+
+/**
+ * Illusionists: Free ability
+ * Gain a white crystal
+ */
+export const ILLUSIONISTS_GAIN_WHITE_CRYSTAL = "illusionists_gain_white_crystal" as const;
 
 // =============================================================================
 // EFFECT DEFINITIONS
@@ -204,6 +217,41 @@ const HERBALIST_GAIN_MANA_EFFECT: CardEffect = {
   color: MANA_GREEN,
 };
 
+/**
+ * Illusionists' Cancel Attack ability effect.
+ * Targets an unfortified, non-arcane-immune enemy and cancels all their attacks.
+ * Uses EFFECT_ENEMY_SKIP_ATTACK modifier (same as Whirlwind spell).
+ *
+ * Key restrictions:
+ * - excludeFortified: Only unfortified enemies can be targeted
+ * - excludeArcaneImmune: Arcane Immunity blocks this magical effect
+ * - Can combo with Demolish (remove fortification first, then target)
+ * - Works against Multi-Attack enemies (cancels ALL attacks)
+ */
+const ILLUSIONISTS_CANCEL_ATTACK_EFFECT: CardEffect = {
+  type: EFFECT_SELECT_COMBAT_ENEMY,
+  excludeFortified: true,
+  excludeArcaneImmune: true,
+  template: {
+    modifiers: [
+      {
+        modifier: { type: EFFECT_ENEMY_SKIP_ATTACK },
+        duration: DURATION_COMBAT,
+        description: "Target enemy does not attack",
+      },
+    ],
+  },
+};
+
+/**
+ * Illusionists' Gain White Crystal ability effect.
+ * Grants one white crystal to the player's inventory.
+ */
+const ILLUSIONISTS_GAIN_WHITE_CRYSTAL_EFFECT: CardEffect = {
+  type: EFFECT_GAIN_CRYSTAL,
+  color: MANA_WHITE,
+};
+
 // =============================================================================
 // REGISTRY
 // =============================================================================
@@ -220,6 +268,8 @@ export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
   [ICE_MAGES_GAIN_MANA_CRYSTAL]: ICE_MAGES_GAIN_MANA_CRYSTAL_EFFECT,
   [HERBALIST_READY_UNIT]: HERBALIST_READY_UNIT_EFFECT,
   [HERBALIST_GAIN_MANA]: HERBALIST_GAIN_MANA_EFFECT,
+  [ILLUSIONISTS_CANCEL_ATTACK]: ILLUSIONISTS_CANCEL_ATTACK_EFFECT,
+  [ILLUSIONISTS_GAIN_WHITE_CRYSTAL]: ILLUSIONISTS_GAIN_WHITE_CRYSTAL_EFFECT,
 };
 
 /**

--- a/packages/core/src/engine/__tests__/unitIllusionists.test.ts
+++ b/packages/core/src/engine/__tests__/unitIllusionists.test.ts
@@ -1,0 +1,586 @@
+/**
+ * Illusionists Unit Ability Tests
+ *
+ * Illusionists have three abilities:
+ * 1. Influence 4 (free)
+ * 2. (White Mana) Cancel unfortified enemy's attack this combat
+ * 3. Gain white crystal (free, no combat required)
+ *
+ * Key rules:
+ * - Cancel Attack only targets unfortified enemies
+ * - Arcane Immunity blocks the cancel attack effect
+ * - Works against all attack types including Summon
+ * - Cancels ALL attacks from Multi-Attack enemies
+ * - Can combo with Demolish (remove fortification first, then cancel)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+} from "./testHelpers.js";
+import {
+  INVALID_ACTION,
+  UNIT_ILLUSIONISTS,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  UNIT_ACTIVATED,
+  CHOICE_REQUIRED,
+  MANA_SOURCE_TOKEN,
+  MANA_WHITE,
+  ENEMY_GUARDSMEN,
+  ENEMY_GOLEMS,
+  ENEMY_ORC_SKIRMISHERS,
+  ENEMY_SORCERERS,
+  ABILITY_FORTIFIED,
+  getEnemy,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_ATTACK,
+  COMBAT_CONTEXT_STANDARD,
+  type CombatState,
+  type CombatEnemy,
+} from "../../types/combat.js";
+import { doesEnemyAttackThisCombat, addModifier } from "../modifiers/index.js";
+import {
+  EFFECT_ABILITY_NULLIFIER,
+  DURATION_COMBAT,
+  SCOPE_ONE_ENEMY,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { ILLUSIONISTS } from "@mage-knight/shared";
+
+/**
+ * Create a combat state for Illusionists tests
+ */
+function createIllusionistsCombatState(
+  phase: "ranged_siege" | "attack",
+  enemies: CombatEnemy[],
+  isAtFortifiedSite = false
+): CombatState {
+  return {
+    enemies,
+    phase,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+  };
+}
+
+/**
+ * Create a combat enemy from an enemy ID
+ */
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isBlocked: false,
+    isDefeated: false,
+    isRequiredForConquest: true,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+  };
+}
+
+describe("Illusionists Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(ILLUSIONISTS.name).toBe("Illusionists");
+      expect(ILLUSIONISTS.level).toBe(2);
+      expect(ILLUSIONISTS.influence).toBe(7);
+      expect(ILLUSIONISTS.armor).toBe(2);
+    });
+
+    it("should have three abilities", () => {
+      expect(ILLUSIONISTS.abilities.length).toBe(3);
+    });
+
+    it("should have Influence 4 as first ability (free)", () => {
+      const ability = ILLUSIONISTS.abilities[0];
+      expect(ability?.type).toBe("influence");
+      expect(ability?.value).toBe(4);
+      expect(ability?.manaCost).toBeUndefined();
+    });
+
+    it("should have Cancel Enemy Attack as second ability (white mana)", () => {
+      const ability = ILLUSIONISTS.abilities[1];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBe(MANA_WHITE);
+      expect(ability?.displayName).toContain("Cancel");
+    });
+
+    it("should have Gain White Crystal as third ability (free, no combat required)", () => {
+      const ability = ILLUSIONISTS.abilities[2];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBeUndefined();
+      expect(ability?.requiresCombat).toBe(false);
+      expect(ability?.displayName).toContain("Crystal");
+    });
+  });
+
+  describe("Influence 4 Ability (Ability 0)", () => {
+    it("should add influence points when activated outside combat", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 0, // Influence 4
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(4);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should not require mana for influence ability", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 0,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(4);
+    });
+  });
+
+  describe("Cancel Enemy Attack (Ability 1 - White Mana)", () => {
+    it("should require white mana", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [], // No mana
+      });
+
+      // Golems are unfortified, no arcane immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+      });
+
+      // Should fail - no mana source provided
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should cancel unfortified enemy attack with white mana", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Golems are unfortified, no arcane immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Unit should be spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Mana token consumed
+      expect(result.state.players[0].pureMana.length).toBe(0);
+
+      // Enemy should not attack this combat
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(false);
+    });
+
+    it("should not allow targeting fortified enemies", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Guardsmen have ABILITY_FORTIFIED - should be excluded from targeting
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Enemy should still attack (not targetable)
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(true);
+    });
+
+    it("should not allow targeting Arcane Immune enemies", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Enemy Sorcerers have Arcane Immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_SORCERERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Enemy should still attack (not targetable)
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(true);
+    });
+
+    it("should cancel ALL attacks from Multi-Attack enemies", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Orc Skirmishers have 2 attacks (multi-attack, unfortified, no arcane immunity)
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_ORC_SKIRMISHERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Verify enemy has multiple attacks
+      const enemyDef = getEnemy(ENEMY_ORC_SKIRMISHERS);
+      expect(enemyDef.attacks!.length).toBeGreaterThan(1);
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Enemy should not attack at all (all attacks cancelled)
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(false);
+    });
+
+    it("should allow targeting with enemy selection when multiple valid targets", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Two unfortified enemies (Golems have no fortification or arcane immunity)
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GOLEMS),
+        createCombatEnemy("enemy_1", ENEMY_ORC_SKIRMISHERS),
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Activate - should create a pending choice
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      expect(activateResult.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = activateResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      // Resolve choice - select enemy_1
+      const choiceResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      });
+
+      // Only selected enemy should have attack cancelled
+      expect(doesEnemyAttackThisCombat(choiceResult.state, "enemy_0")).toBe(true);
+      expect(doesEnemyAttackThisCombat(choiceResult.state, "enemy_1")).toBe(false);
+    });
+
+    it("should only show unfortified enemies in choice when mixed fortified/unfortified", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Mix: one fortified (Guardsmen), one unfortified (Golems)
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN), // Fortified
+        createCombatEnemy("enemy_1", ENEMY_GOLEMS),     // Unfortified
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Should auto-resolve targeting the only valid target (Golems)
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Fortified enemy still attacks
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(true);
+
+      // Unfortified enemy attack cancelled
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_1")).toBe(false);
+    });
+
+    it("should reject when not in combat", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should work with Demolish combo (fortification removed first)", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      // Create a fortified enemy (Guardsmen have ABILITY_FORTIFIED)
+      const guardsmen = createCombatEnemy("enemy_0", ENEMY_GUARDSMEN);
+      expect(guardsmen.definition.abilities.includes(ABILITY_FORTIFIED)).toBe(true);
+
+      const enemies = [guardsmen];
+      const combat = createIllusionistsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies);
+
+      const state = createTestGameState({
+        players: [player],
+        combat,
+      });
+
+      // Apply a fortification nullifier modifier (simulating Demolish/Sorcerers was used)
+      const stateWithNullifier = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: "demolish" as never, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_ABILITY_NULLIFIER, ability: ABILITY_FORTIFIED },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Now activate Illusionists cancel attack on the de-fortified enemy
+      const result = engine.processAction(stateWithNullifier, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Enemy should not attack (fortification was removed, so Illusionists can target them)
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(false);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should work in attack phase", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createIllusionistsCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      expect(doesEnemyAttackThisCombat(result.state, "enemy_0")).toBe(false);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+  });
+
+  describe("Gain White Crystal (Ability 2)", () => {
+    it("should gain a white crystal when activated", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 2, // Gain White Crystal
+      });
+
+      expect(result.state.players[0].crystals.white).toBe(1);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should not require mana", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 2,
+      });
+
+      expect(result.state.players[0].crystals.white).toBe(1);
+    });
+
+    it("should work outside combat (requiresCombat: false)", () => {
+      const unit = createPlayerUnit(UNIT_ILLUSIONISTS, "illusionists_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "illusionists_1",
+        abilityIndex: 2,
+      });
+
+      // Should succeed outside combat
+      expect(result.state.players[0].crystals.white).toBe(1);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -376,6 +376,10 @@ export interface SelectCombatEnemyEffect {
   readonly includeDefeated?: boolean;
   /** If set, effect can only be used in this combat phase (e.g., Tornado = attack only) */
   readonly requiredPhase?: CombatPhase;
+  /** If true, exclude enemies that are currently fortified (after modifiers) */
+  readonly excludeFortified?: boolean;
+  /** If true, exclude enemies with Arcane Immunity from targeting */
+  readonly excludeArcaneImmune?: boolean;
 }
 
 /**

--- a/packages/shared/src/units/regular/illusionists.ts
+++ b/packages/shared/src/units/regular/illusionists.ts
@@ -1,8 +1,20 @@
 /**
  * Illusionists unit definition
+ *
+ * Abilities:
+ * 1. Influence 4 (free)
+ * 2. (White Mana) Cancel unfortified enemy's attack this combat
+ * 3. Gain white crystal (free)
+ *
+ * FAQ Notes:
+ * - Cancel Attack only works on unfortified enemies
+ * - Arcane Immunity blocks the cancel attack effect
+ * - Works against Summon Attacks (if used BEFORE token drawn)
+ * - Cancels ALL attacks from Multi-Attack enemies
+ * - Can combo with Demolish (remove fortification first, then cancel)
  */
 
-import { ELEMENT_PHYSICAL } from "../../elements.js";
+import { MANA_WHITE } from "../../ids.js";
 import { RESIST_PHYSICAL } from "../../enemies/index.js";
 import type { UnitDefinition } from "../types.js";
 import {
@@ -10,9 +22,13 @@ import {
   RECRUIT_SITE_MAGE_TOWER,
   RECRUIT_SITE_MONASTERY,
   UNIT_ABILITY_INFLUENCE,
-  UNIT_ABILITY_BLOCK,
+  UNIT_ABILITY_EFFECT,
 } from "../constants.js";
 import { UNIT_ILLUSIONISTS } from "../ids.js";
+
+// Effect IDs reference effects defined in core/src/data/unitAbilityEffects.ts
+const ILLUSIONISTS_CANCEL_ATTACK = "illusionists_cancel_attack";
+const ILLUSIONISTS_GAIN_WHITE_CRYSTAL = "illusionists_gain_white_crystal";
 
 export const ILLUSIONISTS: UnitDefinition = {
   id: UNIT_ILLUSIONISTS,
@@ -24,8 +40,22 @@ export const ILLUSIONISTS: UnitDefinition = {
   resistances: [RESIST_PHYSICAL],
   recruitSites: [RECRUIT_SITE_MAGE_TOWER, RECRUIT_SITE_MONASTERY],
   abilities: [
+    // Ability 1: Influence 4 (free)
     { type: UNIT_ABILITY_INFLUENCE, value: 4 },
-    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_PHYSICAL },
+    // Ability 2: Cancel unfortified enemy's attack (white mana, combat required)
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: ILLUSIONISTS_CANCEL_ATTACK,
+      displayName: "Cancel Enemy Attack",
+      manaCost: MANA_WHITE,
+    },
+    // Ability 3: Gain white crystal (free, no combat required)
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: ILLUSIONISTS_GAIN_WHITE_CRYSTAL,
+      displayName: "Gain White Crystal",
+      requiresCombat: false,
+    },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary

Implements the Illusionists unit with correct abilities per the Mage Knight rulebook, replacing the incorrect Block 3 placeholder.

### Abilities Implemented
1. **Influence 4** (free) - already correct, unchanged
2. **Cancel Enemy Attack** (white mana) - targets an unfortified, non-arcane-immune enemy; prevents all their attacks this combat
3. **Gain White Crystal** (free, no combat required) - adds a white crystal to inventory

### Key Mechanics
- Cancel Attack uses the existing EFFECT_ENEMY_SKIP_ATTACK modifier (same as Whirlwind spell)
- Target filtering ensures only unfortified enemies without Arcane Immunity can be targeted
- Works with Demolish combo: remove fortification first, then cancel the enemy's attack
- Cancels ALL attacks from Multi-Attack enemies (modifier is per-enemy, not per-attack)

## Changes

- packages/shared/src/units/regular/illusionists.ts - Updated unit definition with correct abilities
- packages/core/src/data/unitAbilityEffects.ts - Added Cancel Attack and Gain White Crystal effect definitions
- packages/core/src/types/cards.ts - Added excludeFortified and excludeArcaneImmune fields to SelectCombatEnemyEffect
- packages/core/src/engine/effects/combatEffects.ts - Updated enemy targeting to respect new filters
- packages/core/src/engine/effects/resolvability.ts - Updated resolvability checks for filtered targeting
- packages/core/src/engine/__tests__/unitIllusionists.test.ts - 20 comprehensive tests

## Test Plan

- [x] Influence 4 ability works (free)
- [x] Cancel Attack ability requires white mana
- [x] Cancel Attack only targets unfortified enemies
- [x] Cancel Attack blocked by Arcane Immunity
- [x] Cancel Attack prevents ALL attacks from Multi-Attack enemies
- [x] Gain White Crystal ability works (free)
- [x] Can combo with Demolish (remove fortification first)
- [x] Works in both ranged/siege and attack phases
- [x] All 1822 existing tests still pass

Closes #257