### PR TITLE
feat: implement Cold Toughness scaling block bonus

### DIFF
--- a/packages/core/src/data/basicActions/blue/tovak-cold-toughness.ts
+++ b/packages/core/src/data/basicActions/blue/tovak-cold-toughness.ts
@@ -1,12 +1,20 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_BASIC_ACTION } from "../../../types/cards.js";
-import { COMBAT_TYPE_MELEE } from "../../../types/effectTypes.js";
-import { ELEMENT_ICE } from "../../../types/modifierConstants.js";
+import { COMBAT_TYPE_MELEE, EFFECT_APPLY_MODIFIER } from "../../../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_COLD_TOUGHNESS_BLOCK,
+  ELEMENT_ICE,
+} from "../../../types/modifierConstants.js";
 import { MANA_BLUE, CARD_TOVAK_COLD_TOUGHNESS } from "@mage-knight/shared";
-import { attackWithElement, blockWithElement, choice } from "../helpers.js";
+import { attackWithElement, blockWithElement, choice, compound } from "../helpers.js";
 
 /**
  * Tovak's Cold Toughness (replaces Determination)
+ *
+ * Basic: Ice Attack 2 OR Ice Block 3
+ * Powered: Ice Block 5. +1 ice block per ability/attack color/resistance on blocked enemy.
+ *          Arcane Immunity negates the bonus (only base 5 applies).
  */
 export const TOVAK_COLD_TOUGHNESS: DeedCard = {
   id: CARD_TOVAK_COLD_TOUGHNESS,
@@ -18,6 +26,14 @@ export const TOVAK_COLD_TOUGHNESS: DeedCard = {
     attackWithElement(2, COMBAT_TYPE_MELEE, ELEMENT_ICE),
     blockWithElement(3, ELEMENT_ICE)
   ),
-  poweredEffect: blockWithElement(5, ELEMENT_ICE),
+  poweredEffect: compound(
+    blockWithElement(5, ELEMENT_ICE),
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: { type: EFFECT_COLD_TOUGHNESS_BLOCK },
+      duration: DURATION_COMBAT,
+      description: "+1 Ice Block per ability/color/resistance on blocked enemy",
+    }
+  ),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/coldToughnessIntegration.test.ts
+++ b/packages/core/src/engine/__tests__/coldToughnessIntegration.test.ts
@@ -1,0 +1,449 @@
+/**
+ * Cold Toughness Integration Tests
+ *
+ * Tests the full combat flow with Cold Toughness modifier active,
+ * verifying that the per-enemy block bonus is correctly applied
+ * during block resolution.
+ *
+ * Block efficiency rules (from elementalCalc.ts):
+ * - Physical attack: ALL block types are efficient
+ * - Fire attack: Ice and Cold Fire are efficient; Physical and Fire are halved
+ * - Ice attack: Fire and Cold Fire are efficient; Physical and Ice are halved
+ * - Cold Fire attack: Only Cold Fire is efficient; everything else is halved
+ *
+ * Cold Toughness bonus is ICE element block, so:
+ * - Efficient vs Physical and Fire attacks (full value)
+ * - Inefficient vs Ice and Cold Fire attacks (halved, rounded down)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState } from "./testHelpers.js";
+import { withBlockSources } from "./combatTestHelpers.js";
+import {
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  DECLARE_BLOCK_ACTION,
+  ENEMY_BLOCKED,
+  BLOCK_FAILED,
+  ELEMENT_PHYSICAL,
+  ELEMENT_COLD_FIRE,
+  ENEMY_HIGH_DRAGON,
+  ENEMY_DELPHANA_MASTERS,
+  ENEMY_DIGGERS,
+  ENEMY_SHADOW,
+} from "@mage-knight/shared";
+import { addModifier } from "../modifiers/index.js";
+import {
+  DURATION_COMBAT,
+  SCOPE_SELF,
+  SOURCE_CARD,
+  EFFECT_COLD_TOUGHNESS_BLOCK,
+} from "../../types/modifierConstants.js";
+import type { CardId } from "@mage-knight/shared";
+
+/**
+ * Helper to add Cold Toughness modifier to game state.
+ */
+function withColdToughnessModifier(
+  state: ReturnType<typeof createTestGameState>,
+  playerId: string = "player1"
+) {
+  return addModifier(state, {
+    source: { type: SOURCE_CARD, cardId: "cold_toughness" as CardId, playerId },
+    duration: DURATION_COMBAT,
+    scope: { type: SCOPE_SELF },
+    effect: { type: EFFECT_COLD_TOUGHNESS_BLOCK },
+    createdAtRound: 1,
+    createdByPlayerId: playerId,
+  });
+}
+
+describe("Cold Toughness Integration", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ==========================================================================
+  // Diggers: Physical attack 3, Fortified (+1 bonus)
+  // All block is efficient vs Physical, so ice bonus counts at full value.
+  // ==========================================================================
+
+  describe("Diggers (Physical attack, bonus = 1)", () => {
+    it("should add +1 ice bonus that is efficient vs physical attack", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // Diggers: Physical attack 3, Fortified. Bonus: 1 ice.
+      // 2 physical base (efficient vs Physical) + 1 ice bonus (also efficient vs Physical) = 3.
+      // Need 3. Should succeed.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_PHYSICAL, value: 2 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 3, // 2 physical + 1 ice bonus, all efficient vs Physical
+        })
+      );
+    });
+
+    it("should fail without Cold Toughness modifier (2 < 3)", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // No Cold Toughness modifier
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_PHYSICAL, value: 2 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: BLOCK_FAILED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 2,
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // FAQ Example: High Dragon
+  // Cold Fire attack 6, Brutal (+1), Fire Res (+1), Ice Res (+1), Cold Fire (+2) = 5 bonus
+  // Ice block is INEFFICIENT vs Cold Fire (halved, floored)
+  // ==========================================================================
+
+  describe("High Dragon (FAQ example, Cold Fire attack)", () => {
+    it("should add +5 ice bonus (halved vs Cold Fire) allowing block with Cold Fire base", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_HIGH_DRAGON],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // High Dragon: Cold Fire attack 6. Bonus: 5 ice.
+      // 4 cold_fire base (efficient vs Cold Fire) + 5 ice bonus (inefficient → floor(5/2) = 2).
+      // Total effective = 4 + 2 = 6. Need 6. Should succeed.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 4 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 6, // 4 cold_fire (efficient) + floor(5 ice / 2) = 4 + 2 = 6
+        })
+      );
+    });
+
+    it("should fail without Cold Toughness (4 cold_fire < 6 required)", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_HIGH_DRAGON],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // No modifier
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 4 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: BLOCK_FAILED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 4,
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // FAQ Example: Delphana Masters
+  // Cold Fire attack 5, Assassination (+1), Paralyze (+1), Fire Res (+1), Ice Res (+1),
+  // Cold Fire (+2) = 6 bonus
+  // ==========================================================================
+
+  describe("Delphana Masters (FAQ example, Cold Fire attack)", () => {
+    it("should add +6 ice bonus allowing block with small Cold Fire base", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DELPHANA_MASTERS],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // Delphana Masters: Cold Fire attack 5. Bonus: 6 ice.
+      // 2 cold_fire base (efficient) + 6 ice bonus (inefficient → floor(6/2) = 3).
+      // Total effective = 2 + 3 = 5. Need 5. Should succeed.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 2 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 5, // 2 cold_fire (efficient) + floor(6 ice / 2) = 2 + 3 = 5
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Arcane Immunity: Shadow
+  // Shadow: Elusive + Arcane Immunity, Cold Fire attack 4, no resistances
+  // Arcane Immunity negates the bonus entirely.
+  // ==========================================================================
+
+  describe("Arcane Immunity negation", () => {
+    it("should NOT add bonus for enemy with Arcane Immunity", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_SHADOW],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // Shadow: Cold Fire attack 4, Arcane Immunity → bonus is 0.
+      // Without bonus: Shadow would have Elusive + Arcane Immunity + Cold Fire = 4 bonus.
+      // But Arcane Immunity negates it entirely.
+      // 3 cold_fire base (efficient vs Cold Fire) = 3 effective. Need 4. Should fail.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 3 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: BLOCK_FAILED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 3, // No bonus despite modifier being active
+        })
+      );
+    });
+
+    it("should block Arcane Immune enemy with sufficient base block only", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_SHADOW],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // Shadow: Cold Fire attack 4. Need 4 cold_fire block (efficient).
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 4 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: ENEMY_BLOCKED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 4, // No bonus, just base block
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Elemental efficiency: bonus is ICE block
+  // ==========================================================================
+
+  describe("Elemental efficiency of Cold Toughness bonus", () => {
+    it("ice bonus is efficient vs physical attack (all block efficient vs physical)", () => {
+      let state = createTestGameState();
+
+      // Diggers: Physical attack 3, Fortified. Bonus: 1.
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // 2 physical + 1 ice bonus. All efficient vs Physical = 3 effective. Need 3.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_PHYSICAL, value: 2 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
+    });
+
+    it("ice bonus is inefficient vs cold fire attack (halved)", () => {
+      let state = createTestGameState();
+
+      // High Dragon: Cold Fire attack 6. Bonus: 5 ice.
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_HIGH_DRAGON],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // 3 cold_fire base (efficient, = 3) + 5 ice bonus (inefficient, floor(5/2) = 2) = 5.
+      // Need 6. Should fail (1 short because ice bonus is halved).
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 3 },
+      ]);
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      });
+
+      expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: BLOCK_FAILED,
+          enemyInstanceId: "enemy_0",
+          blockValue: 5, // 3 efficient + floor(5/2) = 5
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
+  // Multiple enemies: bonus varies per enemy
+  // ==========================================================================
+
+  describe("Multiple enemies with different bonuses", () => {
+    it("should calculate different bonus for each enemy", () => {
+      let state = createTestGameState();
+
+      // Enter combat with Diggers (bonus 1) and High Dragon (bonus 5)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_HIGH_DRAGON],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      state = withColdToughnessModifier(state);
+
+      // Block Diggers (enemy_0): Physical attack 3. Bonus 1 ice (efficient vs Physical).
+      // 2 physical + 1 ice bonus = 3 effective. Need 3.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_PHYSICAL, value: 2 },
+      ], "enemy_0");
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_0",
+      }).state;
+
+      expect(state.combat?.enemies[0].isBlocked).toBe(true);
+
+      // Block High Dragon (enemy_1): Cold Fire attack 6. Bonus 5 ice (inefficient vs Cold Fire).
+      // 4 cold_fire (efficient) + 5 ice bonus (floor(5/2) = 2) = 6 effective. Need 6.
+      state = withBlockSources(state, "player1", [
+        { element: ELEMENT_COLD_FIRE, value: 4 },
+      ], "enemy_1");
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: "enemy_1",
+      });
+
+      expect(result.state.combat?.enemies[1].isBlocked).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/combat/__tests__/coldToughnessHelpers.test.ts
+++ b/packages/core/src/engine/combat/__tests__/coldToughnessHelpers.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Cold Toughness Helper Unit Tests
+ *
+ * Tests for the bonus calculation logic independent of game state.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateColdToughnessBonus,
+  countAttackColors,
+  isCountableAbility,
+  getColdToughnessBlockBonus,
+} from "../coldToughnessHelpers.js";
+import type { CombatEnemy } from "../../../types/combat.js";
+import type { EnemyDefinition, EnemyAbilityType, Element } from "@mage-knight/shared";
+import {
+  ELEMENT_PHYSICAL,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  ABILITY_BRUTAL,
+  ABILITY_SWIFT,
+  ABILITY_POISON,
+  ABILITY_PARALYZE,
+  ABILITY_FORTIFIED,
+  ABILITY_UNFORTIFIED,
+  ABILITY_ELUSIVE,
+  ABILITY_ARCANE_IMMUNITY,
+  ABILITY_ASSASSINATION,
+  ABILITY_CUMBERSOME,
+  ABILITY_VAMPIRIC,
+  ABILITY_DEFEND,
+  RESIST_PHYSICAL,
+  RESIST_FIRE,
+  RESIST_ICE,
+  ENEMY_HIGH_DRAGON,
+  ENEMY_DELPHANA_MASTERS,
+  ENEMIES,
+} from "@mage-knight/shared";
+import { createTestGameState } from "../../__tests__/testHelpers.js";
+import { addModifier } from "../../modifiers/index.js";
+import {
+  DURATION_COMBAT,
+  SCOPE_SELF,
+  SOURCE_CARD,
+  EFFECT_COLD_TOUGHNESS_BLOCK,
+} from "../../../types/modifierConstants.js";
+import type { CardId } from "@mage-knight/shared";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createCombatEnemy(
+  definition: EnemyDefinition,
+  instanceId: string = "enemy_0"
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: definition.id,
+    definition,
+    isBlocked: false,
+    isDefeated: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+  };
+}
+
+function makeEnemy(
+  abilities: readonly EnemyAbilityType[],
+  attackElement: Element = ELEMENT_PHYSICAL,
+  resistances: readonly string[] = []
+): CombatEnemy {
+  return createCombatEnemy({
+    id: "test_enemy" as EnemyDefinition["id"],
+    name: "Test Enemy",
+    color: "green",
+    attack: 5,
+    attackElement,
+    armor: 5,
+    fame: 5,
+    resistances: resistances as EnemyDefinition["resistances"],
+    abilities,
+  });
+}
+
+// ============================================================================
+// countAttackColors
+// ============================================================================
+
+describe("countAttackColors", () => {
+  it("returns 0 for physical attack (no color icon)", () => {
+    expect(countAttackColors(ELEMENT_PHYSICAL)).toBe(0);
+  });
+
+  it("returns 1 for fire attack", () => {
+    expect(countAttackColors(ELEMENT_FIRE)).toBe(1);
+  });
+
+  it("returns 1 for ice attack", () => {
+    expect(countAttackColors(ELEMENT_ICE)).toBe(1);
+  });
+
+  it("returns 2 for cold fire attack (counts as both fire and ice)", () => {
+    expect(countAttackColors(ELEMENT_COLD_FIRE)).toBe(2);
+  });
+});
+
+// ============================================================================
+// isCountableAbility
+// ============================================================================
+
+describe("isCountableAbility", () => {
+  it("counts offensive abilities", () => {
+    expect(isCountableAbility(ABILITY_SWIFT)).toBe(true);
+    expect(isCountableAbility(ABILITY_BRUTAL)).toBe(true);
+    expect(isCountableAbility(ABILITY_POISON)).toBe(true);
+    expect(isCountableAbility(ABILITY_PARALYZE)).toBe(true);
+    expect(isCountableAbility(ABILITY_ASSASSINATION)).toBe(true);
+    expect(isCountableAbility(ABILITY_CUMBERSOME)).toBe(true);
+    expect(isCountableAbility(ABILITY_VAMPIRIC)).toBe(true);
+  });
+
+  it("counts defensive abilities (except Arcane Immunity)", () => {
+    expect(isCountableAbility(ABILITY_FORTIFIED)).toBe(true);
+    expect(isCountableAbility(ABILITY_UNFORTIFIED)).toBe(true);
+    expect(isCountableAbility(ABILITY_ELUSIVE)).toBe(true);
+    expect(isCountableAbility(ABILITY_DEFEND)).toBe(true);
+  });
+
+  it("does not count Arcane Immunity", () => {
+    expect(isCountableAbility(ABILITY_ARCANE_IMMUNITY)).toBe(false);
+  });
+});
+
+// ============================================================================
+// calculateColdToughnessBonus
+// ============================================================================
+
+describe("calculateColdToughnessBonus", () => {
+  it("returns 0 for enemy with Arcane Immunity", () => {
+    const enemy = makeEnemy(
+      [ABILITY_ARCANE_IMMUNITY, ABILITY_BRUTAL],
+      ELEMENT_FIRE,
+      [RESIST_FIRE, RESIST_ICE]
+    );
+    expect(calculateColdToughnessBonus(enemy)).toBe(0);
+  });
+
+  it("counts only abilities for physical-attack enemy with no resistances", () => {
+    const enemy = makeEnemy([ABILITY_BRUTAL], ELEMENT_PHYSICAL);
+    // 1 ability + 0 attack colors + 0 resistances = 1
+    expect(calculateColdToughnessBonus(enemy)).toBe(1);
+  });
+
+  it("counts abilities, resistances, and attack colors", () => {
+    const enemy = makeEnemy([ABILITY_BRUTAL], ELEMENT_FIRE, [RESIST_FIRE]);
+    // 1 ability + 1 attack color + 1 resistance = 3
+    expect(calculateColdToughnessBonus(enemy)).toBe(3);
+  });
+
+  // === FAQ Examples ===
+
+  it("High Dragon: Cold Fire, Brutal, Fire Res, Ice Res = 5 bonus", () => {
+    const highDragon = createCombatEnemy(ENEMIES[ENEMY_HIGH_DRAGON]);
+    // Cold Fire (+2) + Brutal (+1) + Fire Res (+1) + Ice Res (+1) = 5
+    expect(calculateColdToughnessBonus(highDragon)).toBe(5);
+  });
+
+  it("Delphana Masters: Cold Fire, Assassination, Paralyze, Fire Res, Ice Res = 6 bonus", () => {
+    const delphana = createCombatEnemy(ENEMIES[ENEMY_DELPHANA_MASTERS]);
+    // Cold Fire (+2) + Assassination (+1) + Paralyze (+1) + Fire Res (+1) + Ice Res (+1) = 6
+    expect(calculateColdToughnessBonus(delphana)).toBe(6);
+  });
+
+  it("basic enemy with no abilities or resistances and physical attack = 0", () => {
+    const enemy = makeEnemy([], ELEMENT_PHYSICAL);
+    expect(calculateColdToughnessBonus(enemy)).toBe(0);
+  });
+
+  it("enemy with ice attack and ice resistance = 2", () => {
+    const enemy = makeEnemy([], ELEMENT_ICE, [RESIST_ICE]);
+    // 0 abilities + 1 attack color + 1 resistance = 2
+    expect(calculateColdToughnessBonus(enemy)).toBe(2);
+  });
+
+  it("enemy with multiple abilities and resistances", () => {
+    const enemy = makeEnemy(
+      [ABILITY_SWIFT, ABILITY_BRUTAL, ABILITY_FORTIFIED],
+      ELEMENT_ICE,
+      [RESIST_PHYSICAL, RESIST_ICE]
+    );
+    // 3 abilities + 1 attack color + 2 resistances = 6
+    expect(calculateColdToughnessBonus(enemy)).toBe(6);
+  });
+});
+
+// ============================================================================
+// getColdToughnessBlockBonus (integration with modifier system)
+// ============================================================================
+
+describe("getColdToughnessBlockBonus", () => {
+  it("returns 0 when modifier is not active", () => {
+    const enemy = makeEnemy([ABILITY_BRUTAL], ELEMENT_FIRE, [RESIST_FIRE]);
+    const state = createTestGameState();
+    expect(getColdToughnessBlockBonus(state, "player1", enemy)).toBe(0);
+  });
+
+  it("returns bonus when Cold Toughness modifier is active", () => {
+    const enemy = makeEnemy([ABILITY_BRUTAL], ELEMENT_FIRE, [RESIST_FIRE]);
+    const baseState = createTestGameState();
+
+    // Add Cold Toughness modifier
+    const state = addModifier(baseState, {
+      source: { type: SOURCE_CARD, cardId: "cold_toughness" as CardId, playerId: "player1" },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_COLD_TOUGHNESS_BLOCK },
+      createdAtRound: 1,
+      createdByPlayerId: "player1",
+    });
+
+    // 1 ability + 1 attack color + 1 resistance = 3
+    expect(getColdToughnessBlockBonus(state, "player1", enemy)).toBe(3);
+  });
+
+  it("returns 0 for enemy with Arcane Immunity even when modifier is active", () => {
+    const enemy = makeEnemy(
+      [ABILITY_ARCANE_IMMUNITY, ABILITY_BRUTAL],
+      ELEMENT_FIRE,
+      [RESIST_FIRE]
+    );
+    const baseState = createTestGameState();
+
+    const state = addModifier(baseState, {
+      source: { type: SOURCE_CARD, cardId: "cold_toughness" as CardId, playerId: "player1" },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_COLD_TOUGHNESS_BLOCK },
+      createdAtRound: 1,
+      createdByPlayerId: "player1",
+    });
+
+    expect(getColdToughnessBlockBonus(state, "player1", enemy)).toBe(0);
+  });
+
+  it("returns 0 for a different player", () => {
+    const enemy = makeEnemy([ABILITY_BRUTAL], ELEMENT_FIRE);
+    const baseState = createTestGameState();
+
+    const state = addModifier(baseState, {
+      source: { type: SOURCE_CARD, cardId: "cold_toughness" as CardId, playerId: "player1" },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_COLD_TOUGHNESS_BLOCK },
+      createdAtRound: 1,
+      createdByPlayerId: "player1",
+    });
+
+    expect(getColdToughnessBlockBonus(state, "player2", enemy)).toBe(0);
+  });
+});

--- a/packages/core/src/engine/combat/coldToughnessHelpers.ts
+++ b/packages/core/src/engine/combat/coldToughnessHelpers.ts
@@ -1,0 +1,109 @@
+/**
+ * Cold Toughness block bonus calculation helpers.
+ *
+ * Tovak's Cold Toughness powered effect grants +1 ice block per ability,
+ * attack color, and resistance depicted on the enemy token being blocked.
+ * Arcane Immunity negates the bonus entirely (only base 5 applies).
+ *
+ * @module combat/coldToughnessHelpers
+ */
+
+import type { Element, EnemyAbilityType } from "@mage-knight/shared";
+import {
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  ABILITY_ARCANE_IMMUNITY,
+} from "@mage-knight/shared";
+import type { CombatEnemy } from "../../types/combat.js";
+import type { GameState } from "../../state/GameState.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+import { EFFECT_COLD_TOUGHNESS_BLOCK } from "../../types/modifierConstants.js";
+
+/**
+ * Count the attack color icons on an enemy token.
+ *
+ * - Physical attack: 0 (no color icon)
+ * - Fire attack: 1
+ * - Ice attack: 1
+ * - Cold Fire attack: 2 (counts as both fire and ice)
+ */
+export function countAttackColors(attackElement: Element): number {
+  switch (attackElement) {
+    case ELEMENT_COLD_FIRE:
+      return 2;
+    case ELEMENT_FIRE:
+    case ELEMENT_ICE:
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Check if an ability counts toward the Cold Toughness bonus.
+ * All abilities count except Arcane Immunity (which negates the bonus entirely).
+ */
+export function isCountableAbility(ability: EnemyAbilityType): boolean {
+  return ability !== ABILITY_ARCANE_IMMUNITY;
+}
+
+/**
+ * Calculate Cold Toughness scaling block bonus for a specific enemy.
+ *
+ * Counts:
+ * - Each ability on the token (except Arcane Immunity)
+ * - Each attack color (Cold Fire = 2, Fire/Ice = 1, Physical = 0)
+ * - Each resistance (Physical, Fire, Ice)
+ *
+ * Returns 0 if enemy has Arcane Immunity.
+ *
+ * @param enemy - The combat enemy being blocked
+ * @returns The bonus block value (+1 per counted feature)
+ */
+export function calculateColdToughnessBonus(enemy: CombatEnemy): number {
+  const definition = enemy.definition;
+
+  // Arcane Immunity negates the bonus entirely
+  if (definition.abilities.includes(ABILITY_ARCANE_IMMUNITY)) {
+    return 0;
+  }
+
+  let bonus = 0;
+
+  // Count abilities (all except Arcane Immunity, which we already checked)
+  for (const ability of definition.abilities) {
+    if (isCountableAbility(ability)) {
+      bonus++;
+    }
+  }
+
+  // Count attack colors
+  bonus += countAttackColors(definition.attackElement);
+
+  // Count resistances
+  bonus += definition.resistances.length;
+
+  return bonus;
+}
+
+/**
+ * Check if Cold Toughness block modifier is active for a player and return
+ * the bonus for a specific enemy.
+ *
+ * @returns The per-enemy bonus, or 0 if modifier not active
+ */
+export function getColdToughnessBlockBonus(
+  state: GameState,
+  playerId: string,
+  enemy: CombatEnemy
+): number {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const hasColdToughness = modifiers.some(
+    (m) => m.effect.type === EFFECT_COLD_TOUGHNESS_BLOCK
+  );
+
+  if (!hasColdToughness) return 0;
+
+  return calculateColdToughnessBonus(enemy);
+}

--- a/packages/core/src/engine/commands/combat/declareBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareBlockCommand.ts
@@ -33,6 +33,7 @@ import {
 } from "../../combat/enemyAttackHelpers.js";
 import { getCumbersomeReducedAttack } from "../../combat/cumbersomeHelpers.js";
 import { isSwiftActive } from "../../combat/swiftHelpers.js";
+import { getColdToughnessBlockBonus } from "../../combat/coldToughnessHelpers.js";
 
 export const DECLARE_BLOCK_COMMAND = "DECLARE_BLOCK" as const;
 
@@ -178,10 +179,17 @@ export function createDeclareBlockCommand(
 
       // Convert pendingBlock to BlockSource[] format for calculation
       const baseBlockSources = pendingBlockToBlockSources(pendingBlock);
+
+      // Add Cold Toughness per-enemy bonus as an ice block source (before efficiency calc)
+      const coldToughnessBonus = getColdToughnessBlockBonus(state, params.playerId, enemy);
+      const sourcesWithBonus = coldToughnessBonus > 0
+        ? [...baseBlockSources, { element: ELEMENT_ICE as Element, value: coldToughnessBonus }]
+        : baseBlockSources;
+
       const swiftActive = isSwiftActive(state, params.playerId, enemy);
       const blockSources = swiftActive
-        ? appendSwiftDoubleSources(baseBlockSources, pendingSwiftBlock)
-        : baseBlockSources;
+        ? appendSwiftDoubleSources(sourcesWithBonus, pendingSwiftBlock)
+        : sourcesWithBonus;
 
       // Calculate final block value including elemental efficiency and combat modifiers
       // Use the attack's element for block efficiency calculation

--- a/packages/core/src/engine/validActions/combatBlock.ts
+++ b/packages/core/src/engine/validActions/combatBlock.ts
@@ -45,6 +45,7 @@ import {
   isCumbersomeActive,
   getCumbersomeReduction,
 } from "../combat/cumbersomeHelpers.js";
+import { getColdToughnessBlockBonus } from "../combat/coldToughnessHelpers.js";
 
 // ============================================================================
 // Block Allocation Computation
@@ -136,9 +137,16 @@ export function computeEnemyBlockState(
 
   // Calculate effective block value after elemental efficiency
   const baseBlockSources = pendingBlockToBlockSources(rawPending);
-  const blockSources = swiftActive
-    ? appendSwiftDoubleSources(baseBlockSources, rawSwiftPending)
+
+  // Add Cold Toughness per-enemy bonus as an ice block source (before efficiency calc)
+  const coldToughnessBonus = getColdToughnessBlockBonus(state, playerId, enemy);
+  const sourcesWithBonus = coldToughnessBonus > 0
+    ? [...baseBlockSources, { element: "ice" as Element, value: coldToughnessBonus }]
     : baseBlockSources;
+
+  const blockSources = swiftActive
+    ? appendSwiftDoubleSources(sourcesWithBonus, rawSwiftPending)
+    : sourcesWithBonus;
 
   const effectiveBlock = calculateTotalBlock(blockSources, enemy.definition.attackElement);
 

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -115,3 +115,8 @@ export const EFFECT_DOUBLE_PHYSICAL_ATTACKS = "double_physical_attacks" as const
 // Removes physical resistance from enemies (Sword of Justice powered)
 // Does not affect Arcane Immune enemies
 export const EFFECT_REMOVE_PHYSICAL_RESISTANCE = "remove_physical_resistance" as const;
+
+// === ColdToughnessBlockModifier ===
+// Grants +1 ice block per ability/attack color/resistance on blocked enemy (Tovak)
+// Arcane Immunity on the enemy negates the bonus entirely
+export const EFFECT_COLD_TOUGHNESS_BLOCK = "cold_toughness_block" as const;

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -28,6 +28,7 @@ import {
   EFFECT_ENEMY_STAT,
   EFFECT_REMOVE_PHYSICAL_RESISTANCE,
   EFFECT_REMOVE_RESISTANCES,
+  EFFECT_COLD_TOUGHNESS_BLOCK,
   EFFECT_MOVEMENT_CARD_BONUS,
   EFFECT_RULE_OVERRIDE,
   EFFECT_SIDEWAYS_VALUE,
@@ -233,6 +234,13 @@ export interface RemovePhysicalResistanceModifier {
   readonly type: typeof EFFECT_REMOVE_PHYSICAL_RESISTANCE;
 }
 
+// Cold Toughness scaling block modifier (Tovak)
+// Grants +1 ice block per ability/attack color/resistance on blocked enemy.
+// Arcane Immunity on the enemy negates the bonus entirely.
+export interface ColdToughnessBlockModifier {
+  readonly type: typeof EFFECT_COLD_TOUGHNESS_BLOCK;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -249,7 +257,8 @@ export type ModifierEffect =
   | TerrainProhibitionModifier
   | GrantResistancesModifier
   | DoublePhysicalAttacksModifier
-  | RemovePhysicalResistanceModifier;
+  | RemovePhysicalResistanceModifier
+  | ColdToughnessBlockModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary

Implements the scaling block bonus for Tovak's Cold Toughness card (powered effect).

Closes #134

- **Powered effect**: Ice Block 5 + per-enemy bonus (+1 ice block per ability, attack color, and resistance on blocked enemy)
- **Arcane Immunity**: Negates the bonus entirely (only base 5 applies)
- **Architecture**: Uses a combat modifier (`ColdToughnessBlockModifier`) so the bonus is calculated at block time based on which enemy is being blocked, not at card play time

### How it works

1. Card played → grants base Ice Block 5 + applies `EFFECT_COLD_TOUGHNESS_BLOCK` modifier
2. Block preview (validActions) → checks modifier, calculates per-enemy bonus as ice block source
3. Block resolution (declareBlock) → same calculation, bonus added before elemental efficiency

### FAQ Examples verified

| Enemy | Features | Bonus |
|-------|----------|-------|
| High Dragon | Cold Fire (+2), Brutal (+1), Fire Res (+1), Ice Res (+1) | +5 |
| Delphana Masters | Cold Fire (+2), Assassination (+1), Paralyze (+1), Fire Res (+1), Ice Res (+1) | +6 |
| Diggers | Fortified (+1) | +1 |
| Shadow (Arcane Immune) | Negated | +0 |

## Test plan

- [x] Unit tests for bonus calculation logic (19 tests)
- [x] Integration tests for full combat block flow (10 tests)
- [x] FAQ enemy examples (High Dragon, Delphana Masters)
- [x] Arcane Immunity negation
- [x] Elemental efficiency (ice bonus halved vs Cold Fire/Ice attacks, efficient vs Physical/Fire)
- [x] Multiple enemies with different bonuses
- [x] Full test suite passes (1891 tests, 0 failures)
- [x] Build and lint pass