### PR TITLE
feat: Refreshing Walk combat context - move only in combat

### DIFF
--- a/packages/core/src/data/advancedActions/green/refreshing-walk.ts
+++ b/packages/core/src/data/advancedActions/green/refreshing-walk.ts
@@ -5,7 +5,7 @@ import {
   DEED_CARD_TYPE_ADVANCED_ACTION,
 } from "../../../types/cards.js";
 import { MANA_GREEN, CARD_REFRESHING_WALK } from "@mage-knight/shared";
-import { move, heal, compound } from "../helpers.js";
+import { move, heal, compound, ifInCombat } from "../helpers.js";
 
 export const REFRESHING_WALK: DeedCard = {
   id: CARD_REFRESHING_WALK,
@@ -14,9 +14,8 @@ export const REFRESHING_WALK: DeedCard = {
   poweredBy: [MANA_GREEN],
   categories: [CATEGORY_MOVEMENT, CATEGORY_HEALING],
   // Basic: Move 2 and Heal 1. If played during combat, Move 2 only.
+  basicEffect: ifInCombat(move(2), compound(move(2), heal(1))),
   // Powered: Move 4 and Heal 2. If played during combat, Move 4 only.
-  // TODO: Implement combat context check
-  basicEffect: compound(move(2), heal(1)),
-  poweredEffect: compound(move(4), heal(2)),
+  poweredEffect: ifInCombat(move(4), compound(move(4), heal(2))),
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/advancedActions/helpers.ts
+++ b/packages/core/src/data/advancedActions/helpers.ts
@@ -22,7 +22,7 @@
  * ```
  */
 
-import type { CardEffect } from "../../types/cards.js";
+import type { CardEffect, ConditionalEffect } from "../../types/cards.js";
 import {
   EFFECT_GAIN_ATTACK,
   EFFECT_GAIN_BLOCK,
@@ -32,6 +32,7 @@ import {
   EFFECT_GAIN_CRYSTAL,
   EFFECT_CHOICE,
   EFFECT_COMPOUND,
+  EFFECT_CONDITIONAL,
   EFFECT_CHANGE_REPUTATION,
   EFFECT_TAKE_WOUND,
   COMBAT_TYPE_MELEE,
@@ -41,6 +42,7 @@ import {
 } from "../../types/effectTypes.js";
 import type { BasicManaColor, Element } from "@mage-knight/shared";
 import { ELEMENT_FIRE, ELEMENT_ICE } from "../../types/modifierConstants.js";
+import { CONDITION_IN_COMBAT } from "../../types/conditions.js";
 
 export { discardCost, discardCostByColor } from "../basicActions/helpers.js";
 
@@ -205,6 +207,29 @@ export function changeReputation(amount: number): CardEffect {
  */
 export function takeWound(amount: number): CardEffect {
   return { type: EFFECT_TAKE_WOUND, amount };
+}
+
+/**
+ * Creates a conditional effect that branches on whether the player is in combat.
+ *
+ * @param thenEffect - Effect when in combat
+ * @param elseEffect - Effect when not in combat
+ * @returns A ConditionalEffect with an in-combat condition
+ */
+export function ifInCombat(
+  thenEffect: CardEffect,
+  elseEffect?: CardEffect
+): ConditionalEffect {
+  const base = {
+    type: EFFECT_CONDITIONAL,
+    condition: { type: CONDITION_IN_COMBAT },
+    thenEffect,
+  } as const;
+
+  if (elseEffect !== undefined) {
+    return { ...base, elseEffect };
+  }
+  return base;
 }
 
 // Re-export element constants for convenience

--- a/packages/core/src/engine/rules/effectDetection/index.ts
+++ b/packages/core/src/engine/rules/effectDetection/index.ts
@@ -17,6 +17,7 @@ export {
 // Movement effects
 export {
   effectHasMove,
+  effectIsMoveOnly,
   effectHasInfluence,
 } from "./movementEffects.js";
 

--- a/packages/core/src/engine/rules/effectDetection/movementEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/movementEffects.ts
@@ -8,6 +8,7 @@ import type { CardEffect } from "../../../types/cards.js";
 import {
   EFFECT_GAIN_MOVE,
   EFFECT_GAIN_INFLUENCE,
+  EFFECT_NOOP,
   EFFECT_CHOICE,
   EFFECT_COMPOUND,
   EFFECT_CONDITIONAL,
@@ -42,6 +43,33 @@ export function effectHasMove(effect: CardEffect): boolean {
             effectHasMove(next)
           )
         : effectHasMove(effect.thenEffect);
+
+    default:
+      return false;
+  }
+}
+
+/**
+ * Check if an effect provides ONLY move points (no other combat-relevant effects).
+ * Used to determine if a card's combat-filtered effect needs move to be useful.
+ */
+export function effectIsMoveOnly(effect: CardEffect): boolean {
+  switch (effect.type) {
+    case EFFECT_GAIN_MOVE:
+      return true;
+
+    case EFFECT_NOOP:
+      return true;
+
+    case EFFECT_COMPOUND:
+      return effect.effects.every(eff => effectIsMoveOnly(eff));
+
+    case EFFECT_CONDITIONAL:
+      return effectIsMoveOnly(effect.thenEffect) &&
+        (!effect.elseEffect || effectIsMoveOnly(effect.elseEffect));
+
+    case EFFECT_CHOICE:
+      return effect.options.every(opt => effectIsMoveOnly(opt));
 
     default:
       return false;

--- a/packages/core/src/engine/validActions/cards/combat.ts
+++ b/packages/core/src/engine/validActions/cards/combat.ts
@@ -23,7 +23,7 @@ import { describeEffect } from "../../effects/describeEffect.js";
 import { isEffectResolvable } from "../../effects/index.js";
 import { getCard } from "./index.js";
 import { canPayForSpellBasic, findPayableManaColor } from "./manaPayment.js";
-import { isCombatEffectAllowed, getCombatEffectContext, type CombatEffectContext } from "../../rules/cardPlay.js";
+import { isCombatEffectAllowed, getCombatEffectContext, shouldExcludeMoveOnlyEffect, type CombatEffectContext } from "../../rules/cardPlay.js";
 import { getSidewaysOptionsForValue } from "../../rules/sideways.js";
 import { getEffectiveSidewaysValue, isRuleActive } from "../../modifiers/index.js";
 import { RULE_WOUNDS_PLAYABLE_SIDEWAYS } from "../../../types/modifierConstants.js";
@@ -92,14 +92,29 @@ export function getPlayableCardsForCombat(
 
     const basicContext = getCombatEffectContext(card, "basic");
     const poweredContext = getCombatEffectContext(card, "powered");
-    const playability = getCardPlayabilityForPhase(card, combat.phase, basicContext, poweredContext);
+
+    // Exclude move-only effects when move isn't useful in combat
+    const basicExcluded = basicContext.effect
+      ? shouldExcludeMoveOnlyEffect(basicContext.effect, state, player.id, combat)
+      : false;
+    const poweredExcluded = poweredContext.effect
+      ? shouldExcludeMoveOnlyEffect(poweredContext.effect, state, player.id, combat)
+      : false;
+    const adjustedBasicContext: CombatEffectContext = basicExcluded
+      ? { effect: null, allowAnyPhase: false }
+      : basicContext;
+    const adjustedPoweredContext: CombatEffectContext = poweredExcluded
+      ? { effect: null, allowAnyPhase: false }
+      : poweredContext;
+
+    const playability = getCardPlayabilityForPhase(card, combat.phase, adjustedBasicContext, adjustedPoweredContext);
 
     // Check resolvability - effect must actually be able to do something
-    const basicIsResolvable = basicContext.effect
-      ? isEffectResolvable(state, player.id, basicContext.effect)
+    const basicIsResolvable = adjustedBasicContext.effect
+      ? isEffectResolvable(state, player.id, adjustedBasicContext.effect)
       : false;
-    const poweredIsResolvable = poweredContext.effect
-      ? isEffectResolvable(state, player.id, poweredContext.effect)
+    const poweredIsResolvable = adjustedPoweredContext.effect
+      ? isEffectResolvable(state, player.id, adjustedPoweredContext.effect)
       : false;
 
     // For spells, basic effect also requires mana (the spell's color)


### PR DESCRIPTION
## Summary
- Implement combat-conditional effect for Refreshing Walk: Move+Heal outside combat, Move only during combat
- Add `ifInCombat` helper to advanced actions helpers for clean card definitions
- Add `effectIsMoveOnly` detection and `isMoveUsefulInCombat` rule to filter move-only cards from combat valid actions when move isn't useful
- Move-only effects are now only offered during combat when facing Cumbersome enemies (extensible for future Agility modifier)

## Changes
- **Card definition**: Use `ifInCombat(move(X), compound(move(X), heal(Y)))` pattern instead of plain `compound(move(X), heal(Y))`
- **Advanced actions helpers**: Add `ifInCombat` helper function with `ConditionalEffect` support
- **Effect detection**: Add `effectIsMoveOnly` to detect effects that only provide move points
- **Card play rules**: Add `isMoveUsefulInCombat` and `shouldExcludeMoveOnlyEffect` rule functions
- **Combat valid actions**: Integrate move-only exclusion so cards like Refreshing Walk aren't shown during combat when move is useless
- **Tests**: 11 test cases covering combat/non-combat scenarios, Cumbersome enemy interactions, and Power of Crystals behavior

Closes #149