### PR TITLE
fix: correct Utem Crossbowmen abilities

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -110,6 +110,12 @@ export const SCOUTS_SCOUT_PEEK = "scouts_scout_peek" as const;
  */
 export const SCOUTS_EXTENDED_MOVE = "scouts_extended_move" as const;
 
+/**
+ * Utem Crossbowmen: Basic ability (free)
+ * Attack 3 OR Block 3
+ */
+export const UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK = "utem_crossbowmen_attack_or_block" as const;
+
 // =============================================================================
 // EFFECT DEFINITIONS
 // =============================================================================
@@ -303,6 +309,25 @@ const SCOUTS_EXTENDED_MOVE_EFFECT: CardEffect = {
   ],
 };
 
+/**
+ * Utem Crossbowmen's basic ability: Attack 3 OR Block 3.
+ * Player chooses between gaining 3 Attack (melee, physical) or 3 Block (physical).
+ */
+const UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK_EFFECT: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 3,
+      combatType: COMBAT_TYPE_MELEE,
+    },
+    {
+      type: EFFECT_GAIN_BLOCK,
+      amount: 3,
+    },
+  ],
+};
+
 // =============================================================================
 // REGISTRY
 // =============================================================================
@@ -323,6 +348,7 @@ export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
   [ILLUSIONISTS_GAIN_WHITE_CRYSTAL]: ILLUSIONISTS_GAIN_WHITE_CRYSTAL_EFFECT,
   [SCOUTS_SCOUT_PEEK]: SCOUTS_SCOUT_PEEK_EFFECT,
   [SCOUTS_EXTENDED_MOVE]: SCOUTS_EXTENDED_MOVE_EFFECT,
+  [UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK]: UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK_EFFECT,
 };
 
 /**

--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -134,7 +134,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should allow ranged attack in ranged & siege phase", () => {
-      // Utem Crossbowmen have Ranged Attack 3 (ability index 1)
+      // Utem Crossbowmen have Ranged Attack 2 (ability index 1)
       const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
       const player = createTestPlayer({
         units: [unit],
@@ -149,16 +149,16 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "crossbow_1",
-        abilityIndex: 1, // Ranged Attack 3
+        abilityIndex: 1, // Ranged Attack 2
       });
 
       // Verify success - ranged attack added
-      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
     });
 
     it("should allow ranged attack in attack phase", () => {
-      // Utem Crossbowmen have Ranged Attack 3 (ability index 1)
+      // Utem Crossbowmen have Ranged Attack 2 (ability index 1)
       const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
       const player = createTestPlayer({
         units: [unit],
@@ -173,11 +173,11 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "crossbow_1",
-        abilityIndex: 1, // Ranged Attack 3
+        abilityIndex: 1, // Ranged Attack 2
       });
 
       // Verify success - ranged works in attack phase too
-      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(3);
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
     });
 

--- a/packages/core/src/engine/__tests__/unitUtemCrossbowmen.test.ts
+++ b/packages/core/src/engine/__tests__/unitUtemCrossbowmen.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Utem Crossbowmen Unit Ability Tests
+ *
+ * Utem Crossbowmen have two abilities:
+ * 1. Attack 3 OR Block 3 - choice ability (free, physical)
+ * 2. Ranged Attack 2 (free, physical)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  UNIT_UTEM_CROSSBOWMEN,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CHOICE_REQUIRED,
+  ENEMY_GUARDSMEN,
+  getEnemy,
+  UTEM_CROSSBOWMEN,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_ATTACK,
+  COMBAT_CONTEXT_STANDARD,
+  type CombatState,
+  type CombatEnemy,
+} from "../../types/combat.js";
+
+/**
+ * Create a combat state with customizable enemies for Crossbowmen tests
+ */
+function createCrossbowmenCombatState(
+  phase: "ranged_siege" | "attack",
+  enemies: CombatEnemy[],
+): CombatState {
+  return {
+    enemies,
+    phase,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+  };
+}
+
+function createCombatEnemy(instanceId: string, enemyId: string): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isBlocked: false,
+    isDefeated: false,
+    isRequiredForConquest: true,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+  };
+}
+
+describe("Utem Crossbowmen Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(UTEM_CROSSBOWMEN.name).toBe("Utem Crossbowmen");
+      expect(UTEM_CROSSBOWMEN.level).toBe(2);
+      expect(UTEM_CROSSBOWMEN.influence).toBe(6);
+      expect(UTEM_CROSSBOWMEN.armor).toBe(4);
+    });
+
+    it("should have two abilities", () => {
+      expect(UTEM_CROSSBOWMEN.abilities.length).toBe(2);
+    });
+
+    it("should have Attack 3 OR Block 3 as first ability (effect-based choice)", () => {
+      const ability = UTEM_CROSSBOWMEN.abilities[0];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBeUndefined();
+      expect(ability?.displayName).toContain("Attack");
+      expect(ability?.displayName).toContain("Block");
+    });
+
+    it("should have Ranged Attack 2 as second ability", () => {
+      const ability = UTEM_CROSSBOWMEN.abilities[1];
+      expect(ability?.type).toBe("ranged_attack");
+      expect(ability?.value).toBe(2);
+    });
+  });
+
+  describe("Attack OR Block 3 (Ability 0)", () => {
+    it("should present choice between Attack 3 and Block 3", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 0,
+      });
+
+      // Should create a pending choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = result.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+    });
+
+    it("should grant Attack 3 when attack option chosen", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      // Step 1: Activate ability
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 0,
+      });
+
+      // Step 2: Choose attack option (index 0)
+      const choiceResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        },
+      );
+
+      // Verify Attack 3 was added (physical = normal attack)
+      expect(
+        choiceResult.state.players[0].combatAccumulator.attack.normal,
+      ).toBe(3);
+
+      // Verify unit is spent
+      expect(choiceResult.state.players[0].units[0].state).toBe(
+        UNIT_STATE_SPENT,
+      );
+    });
+
+    it("should grant Block 3 when block option chosen", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      // Step 1: Activate ability
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 0,
+      });
+
+      // Step 2: Choose block option (index 1)
+      const choiceResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 1,
+        },
+      );
+
+      // Verify Block 3 was added (physical = normal block)
+      expect(choiceResult.state.players[0].combatAccumulator.block).toBe(3);
+
+      // Verify unit is spent
+      expect(choiceResult.state.players[0].units[0].state).toBe(
+        UNIT_STATE_SPENT,
+      );
+    });
+
+    it("should not require mana for choice ability", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 0,
+      });
+
+      // Should succeed and create a choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+    });
+  });
+
+  describe("Ranged Attack 2 (Ability 1)", () => {
+    it("should add Ranged Attack 2 in ranged & siege phase", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(
+          COMBAT_PHASE_RANGED_SIEGE,
+          enemies,
+        ),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 1,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should add Ranged Attack 2 in attack phase", () => {
+      const unit = createPlayerUnit(UNIT_UTEM_CROSSBOWMEN, "crossbow_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createCrossbowmenCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "crossbow_1",
+        abilityIndex: 1,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+  });
+});

--- a/packages/shared/src/units/regular/utemCrossbowmen.ts
+++ b/packages/shared/src/units/regular/utemCrossbowmen.ts
@@ -1,5 +1,9 @@
 /**
  * Utem Crossbowmen unit definition
+ *
+ * Abilities:
+ * 1. Attack 3 OR Block 3 - choice ability (free)
+ * 2. Ranged Attack 2 (free)
  */
 
 import { ELEMENT_PHYSICAL } from "../../elements.js";
@@ -8,10 +12,13 @@ import {
   UNIT_TYPE_REGULAR,
   RECRUIT_SITE_VILLAGE,
   RECRUIT_SITE_KEEP,
-  UNIT_ABILITY_ATTACK,
+  UNIT_ABILITY_EFFECT,
   UNIT_ABILITY_RANGED_ATTACK,
 } from "../constants.js";
 import { UNIT_UTEM_CROSSBOWMEN } from "../ids.js";
+
+// Effect ID references effect defined in core/src/data/unitAbilityEffects.ts
+const UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK = "utem_crossbowmen_attack_or_block";
 
 export const UTEM_CROSSBOWMEN: UnitDefinition = {
   id: UNIT_UTEM_CROSSBOWMEN,
@@ -23,8 +30,14 @@ export const UTEM_CROSSBOWMEN: UnitDefinition = {
   resistances: [],
   recruitSites: [RECRUIT_SITE_VILLAGE, RECRUIT_SITE_KEEP],
   abilities: [
-    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
-    { type: UNIT_ABILITY_RANGED_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
+    // Basic: Attack 3 OR Block 3 (choice, no mana cost)
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK,
+      displayName: "Attack 3 OR Block 3",
+    },
+    // Ranged Attack 2 (free)
+    { type: UNIT_ABILITY_RANGED_ATTACK, value: 2, element: ELEMENT_PHYSICAL },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary
- Changed first ability from Attack 3 to **Attack 3 OR Block 3** choice (effect-based, following Ice Mages pattern)
- Fixed Ranged Attack value from **3 to 2** per rulebook
- Added dedicated test file with 10 tests covering both abilities

## Changes
- `packages/shared/src/units/regular/utemCrossbowmen.ts` — Updated unit definition: first ability now uses `UNIT_ABILITY_EFFECT` with choice, second ability value corrected to 2
- `packages/core/src/data/unitAbilityEffects.ts` — Added `UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK` effect (ChoiceEffect with Attack 3 melee / Block 3 physical)
- `packages/core/src/engine/__tests__/unitUtemCrossbowmen.test.ts` — New test file: definition checks, choice resolution for both options, ranged attack in both phases
- `packages/core/src/engine/__tests__/unitActivation.test.ts` — Updated existing ranged attack tests to expect value 2

Closes #274