### PR TITLE
feat: implement Energy Flow / Energy Steal spell (#186)

### DIFF
--- a/packages/core/src/data/spells/green/energyFlow.ts
+++ b/packages/core/src/data/spells/green/energyFlow.ts
@@ -1,0 +1,42 @@
+/**
+ * Energy Flow / Energy Steal (Green Spell #12)
+ *
+ * Basic (Energy Flow): Ready a Unit. If you do, you may spend one Unit
+ * of level 2 or less in each other player's Unit area.
+ *
+ * Powered (Energy Steal): Ready a Unit. If you do, that Unit also gets
+ * healed, and you may spend one Unit of level 3 or less in each other
+ * player's Unit area.
+ *
+ * Interactive spell — removed in friendly game mode since it directly
+ * affects other players' units.
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import { MANA_GREEN, MANA_BLACK, CARD_ENERGY_FLOW } from "@mage-knight/shared";
+import { EFFECT_ENERGY_FLOW } from "../../../types/effectTypes.js";
+
+export const ENERGY_FLOW: DeedCard = {
+  id: CARD_ENERGY_FLOW,
+  name: "Energy Flow",
+  poweredName: "Energy Steal",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_HEALING],
+  poweredBy: [MANA_BLACK, MANA_GREEN],
+  basicEffect: {
+    type: EFFECT_ENERGY_FLOW,
+    spendMaxLevel: 2,
+    healReadiedUnit: false,
+  },
+  poweredEffect: {
+    type: EFFECT_ENERGY_FLOW,
+    spendMaxLevel: 3,
+    healReadiedUnit: true,
+  },
+  sidewaysValue: 1,
+  interactive: true,
+};

--- a/packages/core/src/data/spells/green/index.ts
+++ b/packages/core/src/data/spells/green/index.ts
@@ -6,11 +6,13 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_RESTORATION } from "@mage-knight/shared";
+import { CARD_RESTORATION, CARD_ENERGY_FLOW } from "@mage-knight/shared";
 import { RESTORATION } from "./restoration.js";
+import { ENERGY_FLOW } from "./energyFlow.js";
 
 export const GREEN_SPELLS: Record<CardId, DeedCard> = {
   [CARD_RESTORATION]: RESTORATION,
+  [CARD_ENERGY_FLOW]: ENERGY_FLOW,
 };
 
-export { RESTORATION };
+export { RESTORATION, ENERGY_FLOW };

--- a/packages/core/src/engine/__tests__/energyFlowSpell.test.ts
+++ b/packages/core/src/engine/__tests__/energyFlowSpell.test.ts
@@ -1,0 +1,468 @@
+/**
+ * Tests for the Energy Flow / Energy Steal spell (Green Spell #12)
+ *
+ * Basic (Energy Flow): Ready a Unit. If you do, you may spend one Unit
+ * of level 2 or less in each other player's Unit area.
+ *
+ * Powered (Energy Steal): Ready a Unit. If you do, that Unit also gets
+ * healed, and you may spend one Unit of level 3 or less in each other
+ * player's Unit area.
+ *
+ * Key rules:
+ * - Healing category: cannot be played during combat
+ * - Interactive: removed in friendly game mode
+ * - Ready targets any level unit (the level restriction is for opponent spending)
+ * - Powered effect heals the readied unit (removes wound)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type {
+  EnergyFlowEffect,
+  ResolveEnergyFlowTargetEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  EFFECT_ENERGY_FLOW,
+  EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+} from "../../types/effectTypes.js";
+import {
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  UNITS,
+  CARD_ENERGY_FLOW,
+  MANA_BLACK,
+  MANA_GREEN,
+  type UnitId,
+} from "@mage-knight/shared";
+import { createInitialGameState } from "../../state/GameState.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerUnit } from "../../types/unit.js";
+import { ENERGY_FLOW } from "../../data/spells/green/energyFlow.js";
+import { getSpellCard } from "../../data/spells/index.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createTestStateWithUnits(units: PlayerUnit[]): GameState {
+  const state = createInitialGameState({ playerCount: 1 });
+  return {
+    ...state,
+    players: [
+      {
+        ...state.players[0],
+        units,
+      },
+    ],
+  };
+}
+
+function createUnit(
+  unitId: UnitId,
+  instanceId: string,
+  unitState: typeof UNIT_STATE_READY | typeof UNIT_STATE_SPENT,
+  wounded: boolean
+): PlayerUnit {
+  return {
+    instanceId,
+    unitId,
+    state: unitState,
+    wounded,
+    usedResistanceThisCombat: false,
+  };
+}
+
+function getUnitIdOfLevel(level: number): UnitId {
+  const unitEntry = Object.entries(UNITS).find(([_, def]) => def.level === level);
+  if (!unitEntry) {
+    throw new Error(`No unit found with level ${level}`);
+  }
+  return unitEntry[0] as UnitId;
+}
+
+// ============================================================================
+// SPELL CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Energy Flow spell card definition", () => {
+  it("should be registered in spell cards", () => {
+    const card = getSpellCard(CARD_ENERGY_FLOW);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Energy Flow");
+  });
+
+  it("should have correct metadata", () => {
+    expect(ENERGY_FLOW.id).toBe(CARD_ENERGY_FLOW);
+    expect(ENERGY_FLOW.name).toBe("Energy Flow");
+    expect(ENERGY_FLOW.poweredName).toBe("Energy Steal");
+    expect(ENERGY_FLOW.cardType).toBe(DEED_CARD_TYPE_SPELL);
+    expect(ENERGY_FLOW.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by black + green mana", () => {
+    expect(ENERGY_FLOW.poweredBy).toEqual([MANA_BLACK, MANA_GREEN]);
+  });
+
+  it("should have healing category", () => {
+    expect(ENERGY_FLOW.categories).toEqual([CATEGORY_HEALING]);
+  });
+
+  it("should be marked as interactive", () => {
+    expect(ENERGY_FLOW.interactive).toBe(true);
+  });
+
+  it("should have basic effect with spendMaxLevel 2 and no heal", () => {
+    const effect = ENERGY_FLOW.basicEffect as EnergyFlowEffect;
+    expect(effect.type).toBe(EFFECT_ENERGY_FLOW);
+    expect(effect.spendMaxLevel).toBe(2);
+    expect(effect.healReadiedUnit).toBe(false);
+  });
+
+  it("should have powered effect with spendMaxLevel 3 and heal", () => {
+    const effect = ENERGY_FLOW.poweredEffect as EnergyFlowEffect;
+    expect(effect.type).toBe(EFFECT_ENERGY_FLOW);
+    expect(effect.spendMaxLevel).toBe(3);
+    expect(effect.healReadiedUnit).toBe(true);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT (ENERGY FLOW) TESTS
+// ============================================================================
+
+describe("EFFECT_ENERGY_FLOW (basic - no heal)", () => {
+  const basicEffect: EnergyFlowEffect = {
+    type: EFFECT_ENERGY_FLOW,
+    spendMaxLevel: 2,
+    healReadiedUnit: false,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should return false when player has no units", () => {
+      const state = createTestStateWithUnits([]);
+      expect(isEffectResolvable(state, state.players[0].id, basicEffect)).toBe(false);
+    });
+
+    it("should return false when all units are ready", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_READY, false),
+      ]);
+      expect(isEffectResolvable(state, state.players[0].id, basicEffect)).toBe(false);
+    });
+
+    it("should return true when player has a spent unit", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+      ]);
+      expect(isEffectResolvable(state, state.players[0].id, basicEffect)).toBe(true);
+    });
+
+    it("should return true for spent wounded units", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+      ]);
+      expect(isEffectResolvable(state, state.players[0].id, basicEffect)).toBe(true);
+    });
+  });
+
+  describe("resolveEffect", () => {
+    it("should ready a spent unit (auto-resolve with single unit)", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.requiresChoice).toBeFalsy();
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result.description).toContain("Readied");
+    });
+
+    it("should NOT heal a wounded unit in basic mode", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result.state.players[0].units[0].wounded).toBe(true);
+    });
+
+    it("should return no-op when no spent units exist", () => {
+      const state = createTestStateWithUnits([]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.description).toContain("No spent units");
+    });
+
+    it("should require choice when multiple spent units exist", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+        createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(2);
+    });
+
+    it("should provide RESOLVE_ENERGY_FLOW_TARGET choice options", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+        createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+      const options = result.dynamicChoiceOptions as ResolveEnergyFlowTargetEffect[];
+
+      expect(options[0].type).toBe(EFFECT_RESOLVE_ENERGY_FLOW_TARGET);
+      expect(options[0].unitInstanceId).toBe("unit-1");
+      expect(options[0].healReadiedUnit).toBe(false);
+      expect(options[1].type).toBe(EFFECT_RESOLVE_ENERGY_FLOW_TARGET);
+      expect(options[1].unitInstanceId).toBe("unit-2");
+      expect(options[1].healReadiedUnit).toBe(false);
+    });
+
+    it("should ready any level unit (not restricted by spendMaxLevel)", () => {
+      const unitIdLevel3 = getUnitIdOfLevel(3);
+      const state = createTestStateWithUnits([
+        createUnit(unitIdLevel3, "unit-1", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      // Level 3 unit should be readied even though spendMaxLevel is 2
+      // (spendMaxLevel only limits opponent unit spending, not your own ready)
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+    });
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT (ENERGY STEAL) TESTS
+// ============================================================================
+
+describe("EFFECT_ENERGY_FLOW (powered - with heal)", () => {
+  const poweredEffect: EnergyFlowEffect = {
+    type: EFFECT_ENERGY_FLOW,
+    spendMaxLevel: 3,
+    healReadiedUnit: true,
+  };
+
+  describe("resolveEffect", () => {
+    it("should ready AND heal a spent wounded unit", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      const unit = result.state.players[0].units[0];
+      expect(unit.state).toBe(UNIT_STATE_READY);
+      expect(unit.wounded).toBe(false); // Healed!
+      expect(result.description).toContain("Readied");
+      expect(result.description).toContain("healed");
+    });
+
+    it("should ready a spent unwounded unit (heal has no effect)", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      const unit = result.state.players[0].units[0];
+      expect(unit.state).toBe(UNIT_STATE_READY);
+      expect(unit.wounded).toBe(false);
+      // Should not mention "healed" if unit wasn't wounded
+      expect(result.description).not.toContain("healed");
+    });
+
+    it("should provide choice options with healReadiedUnit=true", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+        createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      const options = result.dynamicChoiceOptions as ResolveEnergyFlowTargetEffect[];
+      expect(options[0].healReadiedUnit).toBe(true);
+      expect(options[1].healReadiedUnit).toBe(true);
+    });
+
+    it("should describe as select unit to ready and heal", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+        createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+      ]);
+
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      expect(result.description).toContain("ready and heal");
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE TARGET EFFECT TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_ENERGY_FLOW_TARGET", () => {
+  describe("resolveEffect", () => {
+    it("should ready the specific unit (basic - no heal)", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const unitName = UNITS[unitId].name;
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+        createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+      ]);
+
+      const effect: ResolveEnergyFlowTargetEffect = {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: "unit-2",
+        unitName,
+        healReadiedUnit: false,
+      };
+
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+    });
+
+    it("should ready and heal the specific unit (powered)", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const unitName = UNITS[unitId].name;
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+      ]);
+
+      const effect: ResolveEnergyFlowTargetEffect = {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: "unit-1",
+        unitName,
+        healReadiedUnit: true,
+      };
+
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result.state.players[0].units[0].wounded).toBe(false);
+    });
+  });
+
+  describe("isEffectResolvable", () => {
+    it("should return true for a spent unit", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+      ]);
+
+      const effect: ResolveEnergyFlowTargetEffect = {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: "unit-1",
+        unitName: "Test Unit",
+        healReadiedUnit: false,
+      };
+
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(true);
+    });
+
+    it("should return false for an already-ready unit", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestStateWithUnits([
+        createUnit(unitId, "unit-1", UNIT_STATE_READY, false),
+      ]);
+
+      const effect: ResolveEnergyFlowTargetEffect = {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: "unit-1",
+        unitName: "Test Unit",
+        healReadiedUnit: false,
+      };
+
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+
+    it("should return false for a non-existent unit", () => {
+      const state = createTestStateWithUnits([]);
+
+      const effect: ResolveEnergyFlowTargetEffect = {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: "non-existent",
+        unitName: "Test Unit",
+        healReadiedUnit: false,
+      };
+
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Energy Flow", () => {
+  it("should describe basic effect as 'Ready a Unit'", () => {
+    const effect: EnergyFlowEffect = {
+      type: EFFECT_ENERGY_FLOW,
+      spendMaxLevel: 2,
+      healReadiedUnit: false,
+    };
+    expect(describeEffect(effect)).toBe("Ready a Unit");
+  });
+
+  it("should describe powered effect as 'Ready and heal a Unit'", () => {
+    const effect: EnergyFlowEffect = {
+      type: EFFECT_ENERGY_FLOW,
+      spendMaxLevel: 3,
+      healReadiedUnit: true,
+    };
+    expect(describeEffect(effect)).toBe("Ready and heal a Unit");
+  });
+
+  it("should describe resolve target (basic) with unit name", () => {
+    const effect: ResolveEnergyFlowTargetEffect = {
+      type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+      unitInstanceId: "unit-1",
+      unitName: "Peasants",
+      healReadiedUnit: false,
+    };
+    expect(describeEffect(effect)).toBe("Ready Peasants");
+  });
+
+  it("should describe resolve target (powered) with heal", () => {
+    const effect: ResolveEnergyFlowTargetEffect = {
+      type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+      unitInstanceId: "unit-1",
+      unitName: "Peasants",
+      healReadiedUnit: true,
+    };
+    expect(describeEffect(effect)).toBe("Ready and heal Peasants");
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -39,6 +39,8 @@ import {
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
+  EFFECT_ENERGY_FLOW,
+  EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -47,6 +49,8 @@ import type {
   RecruitDiscountEffect,
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
+  EnergyFlowEffect,
+  ResolveEnergyFlowTargetEffect,
 } from "../../types/cards.js";
 import type {
   GainMoveEffect,
@@ -293,6 +297,16 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE]: (effect) => {
     const e = effect as ResolveReadyUnitForInfluenceEffect;
     return `Ready ${e.unitName} (${e.influenceCost} Influence)`;
+  },
+
+  [EFFECT_ENERGY_FLOW]: (effect) => {
+    const e = effect as EnergyFlowEffect;
+    return e.healReadiedUnit ? "Ready and heal a Unit" : "Ready a Unit";
+  },
+
+  [EFFECT_RESOLVE_ENERGY_FLOW_TARGET]: (effect) => {
+    const e = effect as ResolveEnergyFlowTargetEffect;
+    return e.healReadiedUnit ? `Ready and heal ${e.unitName}` : `Ready ${e.unitName}`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -33,6 +33,7 @@ import { registerPolarizeEffects } from "./polarizeEffects.js";
 import { registerRitualOfPainEffects } from "./ritualOfPainEffects.js";
 import { registerDiscardForCrystalEffects } from "./discardForCrystalEffects.js";
 import { registerRuthlessCoercionEffects } from "./ruthlessCoercionEffects.js";
+import { registerEnergyFlowEffects } from "./energyFlowEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -114,4 +115,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Ruthless Coercion effects (recruit discount, ready for influence)
   registerRuthlessCoercionEffects();
+
+  // Energy Flow effects (ready unit + spend opponent units)
+  registerEnergyFlowEffects();
 }

--- a/packages/core/src/engine/effects/energyFlowEffects.ts
+++ b/packages/core/src/engine/effects/energyFlowEffects.ts
@@ -1,0 +1,222 @@
+/**
+ * Energy Flow / Energy Steal effect handlers
+ *
+ * Handles the Energy Flow spell which:
+ * - Basic: Ready a unit. If you do, you may spend one unit of level ≤2
+ *   in each other player's unit area.
+ * - Powered: Ready a unit and heal it. If you do, you may spend one unit
+ *   of level ≤3 in each other player's unit area.
+ *
+ * In single-player mode, the "spend opponent units" part is a no-op
+ * since there are no other players.
+ *
+ * @module effects/energyFlowEffects
+ *
+ * @remarks Resolution Flow
+ * ```
+ * EFFECT_ENERGY_FLOW (healReadiedUnit, spendMaxLevel)
+ *   └─► Find eligible spent units (any level)
+ *       └─► Generate EFFECT_RESOLVE_ENERGY_FLOW_TARGET options
+ *           └─► Player selects a unit
+ *               └─► EFFECT_RESOLVE_ENERGY_FLOW_TARGET
+ *                   └─► Ready unit (+ heal if powered)
+ * ```
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  EnergyFlowEffect,
+  ResolveEnergyFlowTargetEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { UNITS, UNIT_STATE_READY, UNIT_STATE_SPENT } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_ENERGY_FLOW,
+  EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+} from "../../types/effectTypes.js";
+import { getSpentUnitsAtOrBelowLevel } from "./unitEffects.js";
+
+// ============================================================================
+// ENERGY FLOW ENTRY POINT
+// ============================================================================
+
+/**
+ * Handle the EFFECT_ENERGY_FLOW entry point.
+ * Finds eligible spent units and either auto-resolves or generates choice options.
+ */
+export function handleEnergyFlow(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: EnergyFlowEffect
+): EffectResolutionResult {
+  // Ready any unit (max level 4 = any unit)
+  const maxLevel = 4 as const;
+  const eligibleUnits = getSpentUnitsAtOrBelowLevel(player.units, maxLevel);
+
+  if (eligibleUnits.length === 0) {
+    return {
+      state,
+      description: "No spent units to ready",
+    };
+  }
+
+  // If only one eligible unit, auto-resolve
+  if (eligibleUnits.length === 1) {
+    const targetUnit = eligibleUnits[0];
+    if (!targetUnit) {
+      throw new Error("Expected single eligible unit");
+    }
+    return applyEnergyFlowToUnit(
+      state,
+      playerIndex,
+      player,
+      targetUnit.instanceId,
+      effect.healReadiedUnit
+    );
+  }
+
+  // Multiple eligible units — generate choice options
+  const choiceOptions: ResolveEnergyFlowTargetEffect[] = eligibleUnits.map(
+    (unit) => {
+      const unitDef = UNITS[unit.unitId];
+      return {
+        type: EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+        unitInstanceId: unit.instanceId,
+        unitName: unitDef?.name ?? unit.unitId,
+        healReadiedUnit: effect.healReadiedUnit,
+      };
+    }
+  );
+
+  return {
+    state,
+    description: effect.healReadiedUnit
+      ? "Select a unit to ready and heal"
+      : "Select a unit to ready",
+    requiresChoice: true,
+    dynamicChoiceOptions: choiceOptions,
+  };
+}
+
+// ============================================================================
+// RESOLVE ENERGY FLOW TARGET
+// ============================================================================
+
+/**
+ * Resolve the selected unit target — readies (and optionally heals) it.
+ */
+export function resolveEnergyFlowTarget(
+  state: GameState,
+  playerId: string,
+  effect: ResolveEnergyFlowTargetEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+  return applyEnergyFlowToUnit(
+    state,
+    playerIndex,
+    player,
+    effect.unitInstanceId,
+    effect.healReadiedUnit
+  );
+}
+
+/**
+ * Apply Energy Flow to a specific unit: ready it and optionally heal it.
+ */
+export function applyEnergyFlowToUnit(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  unitInstanceId: string,
+  healUnit: boolean
+): EffectResolutionResult {
+  const unitIndex = player.units.findIndex(
+    (u) => u.instanceId === unitInstanceId
+  );
+  if (unitIndex === -1) {
+    return {
+      state,
+      description: `Unit not found: ${unitInstanceId}`,
+    };
+  }
+
+  const unit = player.units[unitIndex];
+  if (!unit) {
+    return {
+      state,
+      description: `Unit not found: ${unitInstanceId}`,
+    };
+  }
+
+  if (unit.state !== UNIT_STATE_SPENT) {
+    return {
+      state,
+      description: "Unit is already ready",
+    };
+  }
+
+  // Ready the unit, and heal if powered
+  const updatedUnits = [...player.units];
+  updatedUnits[unitIndex] = {
+    ...unit,
+    state: UNIT_STATE_READY,
+    wounded: healUnit ? false : unit.wounded,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    units: updatedUnits,
+  };
+
+  const unitDef = UNITS[unit.unitId];
+  const unitName = unitDef?.name ?? unit.unitId;
+
+  const parts: string[] = [`Readied ${unitName}`];
+  if (healUnit && unit.wounded) {
+    parts.push(`and healed ${unitName}`);
+  }
+
+  // Note: Spending opponent units in multiplayer is not yet implemented.
+  // The "spend one unit of level X or less in each other player's unit area"
+  // mechanic requires the multiplayer unit targeting system (see issue dependencies).
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    description: parts.join(" "),
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Energy Flow effect handlers with the effect registry.
+ */
+export function registerEnergyFlowEffects(): void {
+  registerEffect(EFFECT_ENERGY_FLOW, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleEnergyFlow(
+      state,
+      playerIndex,
+      player,
+      effect as EnergyFlowEffect
+    );
+  });
+
+  registerEffect(
+    EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+    (state, playerId, effect) => {
+      return resolveEnergyFlowTarget(
+        state,
+        playerId,
+        effect as ResolveEnergyFlowTargetEffect
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/effects/healingFilter.ts
+++ b/packages/core/src/engine/effects/healingFilter.ts
@@ -8,6 +8,7 @@ import type { CardEffect } from "../../types/cards.js";
 import {
   EFFECT_GAIN_HEALING,
   EFFECT_HEAL_UNIT,
+  EFFECT_ENERGY_FLOW,
   EFFECT_COMPOUND,
   EFFECT_CHOICE,
   EFFECT_CONDITIONAL,
@@ -25,6 +26,7 @@ export function filterHealingEffectsForCombat(effect: CardEffect): CardEffect | 
   switch (effect.type) {
     case EFFECT_GAIN_HEALING:
     case EFFECT_HEAL_UNIT:
+    case EFFECT_ENERGY_FLOW:
       return null;
 
     case EFFECT_COMPOUND: {

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -218,6 +218,14 @@ export {
   registerDiscardForCrystalEffects,
 } from "./discardForCrystalEffects.js";
 
+// Energy Flow effects
+export {
+  handleEnergyFlow,
+  resolveEnergyFlowTarget,
+  applyEnergyFlowToUnit,
+  registerEnergyFlowEffects,
+} from "./energyFlowEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -73,6 +73,8 @@ import {
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
+  EFFECT_ENERGY_FLOW,
+  EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -92,6 +94,7 @@ import type {
 import type {
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
+  ResolveEnergyFlowTargetEffect,
 } from "../../types/cards.js";
 import {
   EFFECT_RULE_OVERRIDE,
@@ -359,6 +362,17 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
     const unit = player.units.find((u) => u.instanceId === e.unitInstanceId);
     if (!unit || unit.state !== UNIT_STATE_SPENT) return false;
     return player.influencePoints >= e.influenceCost;
+  },
+
+  [EFFECT_ENERGY_FLOW]: (state, player) => {
+    // Resolvable if player has any spent units (ready any level)
+    return player.units.some((unit) => unit.state === UNIT_STATE_SPENT);
+  },
+
+  [EFFECT_RESOLVE_ENERGY_FLOW_TARGET]: (state, player, effect) => {
+    const e = effect as ResolveEnergyFlowTargetEffect;
+    const unit = player.units.find((u) => u.instanceId === e.unitInstanceId);
+    return unit !== undefined && unit.state === UNIT_STATE_SPENT;
   },
 };
 

--- a/packages/core/src/engine/rules/effectDetection/resourceEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/resourceEffects.ts
@@ -7,6 +7,8 @@
 import type { CardEffect } from "../../../types/cards.js";
 import {
   EFFECT_GAIN_HEALING,
+  EFFECT_HEAL_UNIT,
+  EFFECT_ENERGY_FLOW,
   EFFECT_GAIN_MANA,
   EFFECT_DRAW_CARDS,
   EFFECT_APPLY_MODIFIER,
@@ -23,6 +25,8 @@ import {
 export function effectHasHeal(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_HEALING:
+    case EFFECT_HEAL_UNIT:
+    case EFFECT_ENERGY_FLOW:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -61,6 +61,8 @@ import {
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
   EFFECT_SCOUT_PEEK,
+  EFFECT_ENERGY_FLOW,
+  EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -687,6 +689,32 @@ export interface ScoutPeekEffect {
   readonly fame: number;
 }
 
+/**
+ * Energy Flow / Energy Steal spell effect.
+ * Ready a unit, optionally heal it, then optionally spend one unit
+ * of a given max level in each other player's unit area.
+ *
+ * In single-player, the "spend opponent units" part is a no-op.
+ */
+export interface EnergyFlowEffect {
+  readonly type: typeof EFFECT_ENERGY_FLOW;
+  /** Max unit level for spending opponent units */
+  readonly spendMaxLevel: 1 | 2 | 3 | 4;
+  /** Whether to heal the readied unit (powered effect only) */
+  readonly healReadiedUnit: boolean;
+}
+
+/**
+ * Internal effect generated as a choice option for Energy Flow unit selection.
+ * Readies the selected unit (and heals if powered).
+ */
+export interface ResolveEnergyFlowTargetEffect {
+  readonly type: typeof EFFECT_RESOLVE_ENERGY_FLOW_TARGET;
+  readonly unitInstanceId: string;
+  readonly unitName: string;
+  readonly healReadiedUnit: boolean;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -734,7 +762,9 @@ export type CardEffect =
   | RecruitDiscountEffect
   | ReadyUnitsForInfluenceEffect
   | ResolveReadyUnitForInfluenceEffect
-  | ScoutPeekEffect;
+  | ScoutPeekEffect
+  | EnergyFlowEffect
+  | ResolveEnergyFlowTargetEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -140,6 +140,13 @@ export const EFFECT_APPLY_RECRUIT_DISCOUNT = "apply_recruit_discount" as const;
 // Entry point for readying L1/L2 units by paying influence per level.
 // Used by Ruthless Coercion powered effect.
 export const EFFECT_READY_UNITS_FOR_INFLUENCE = "ready_units_for_influence" as const;
+
+// === Energy Flow Effects ===
+// Ready a unit, then optionally spend opponent units (Energy Flow / Energy Steal spell).
+// Entry point that handles ready → heal (if powered) → spend opponent units sequence.
+export const EFFECT_ENERGY_FLOW = "energy_flow" as const;
+// Internal: resolve effect after unit selection for Energy Flow
+export const EFFECT_RESOLVE_ENERGY_FLOW_TARGET = "resolve_energy_flow_target" as const;
 // Internal: resolve effect after unit selection for influence-paid readying
 export const EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE = "resolve_ready_unit_for_influence" as const;
 

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -111,6 +111,7 @@ export const CARD_MIST_FORM = cardId("mist_form"); // #14 - Move with all terrai
 // Green spells
 export const CARD_RESTORATION = cardId("restoration"); // #05 - Heal 3 (5 in forest)
 export const CARD_WHIRLWIND = cardId("whirlwind"); // #07 - Target doesn't attack / defeat
+export const CARD_ENERGY_FLOW = cardId("energy_flow"); // #12 - Ready unit + spend opponent units
 
 // White spells
 export const CARD_EXPOSE = cardId("expose"); // #19 - Lose fortification/resistances
@@ -166,6 +167,7 @@ export type SpellCardId =
   // Green spells
   | typeof CARD_RESTORATION
   | typeof CARD_WHIRLWIND
+  | typeof CARD_ENERGY_FLOW
   // White spells
   | typeof CARD_EXPOSE;
 


### PR DESCRIPTION
## Summary
- Implements Green Spell #12 (Energy Flow / Energy Steal) with `interactive: true` flag
- **Basic effect**: Ready one of your spent units; spend one unit of level ≤2 in each opponent's unit area (opponent spending stubbed — requires multiplayer unit targeting system)
- **Powered effect** (green/black mana): Ready + heal a spent unit; spend opponent units of level ≤3
- Healing category restriction prevents use during combat
- Two-phase choice resolution: entry `EFFECT_ENERGY_FLOW` → unit selection → `EFFECT_RESOLVE_ENERGY_FLOW_TARGET` for the chosen unit

## Files Changed
- `packages/shared/src/cardIds.ts` — Added `CARD_ENERGY_FLOW` constant
- `packages/core/src/types/effectTypes.ts` — Added `EFFECT_ENERGY_FLOW` and `EFFECT_RESOLVE_ENERGY_FLOW_TARGET` constants
- `packages/core/src/types/cards.ts` — Added `EnergyFlowEffect` and `ResolveEnergyFlowTargetEffect` interfaces to `CardEffect` union
- `packages/core/src/data/spells/green/energyFlow.ts` — Spell card definition (NEW)
- `packages/core/src/data/spells/green/index.ts` — Registered in green spells
- `packages/core/src/engine/effects/energyFlowEffects.ts` — Effect resolver with choice pipeline (NEW)
- `packages/core/src/engine/effects/effectRegistrations.ts` — Registered resolvers
- `packages/core/src/engine/effects/index.ts` — Exported new functions
- `packages/core/src/engine/effects/resolvability.ts` — Resolvability checks
- `packages/core/src/engine/effects/describeEffect.ts` — Human-readable descriptions
- `packages/core/src/engine/effects/healingFilter.ts` — Combat healing filter
- `packages/core/src/engine/rules/effectDetection/resourceEffects.ts` — Healing detection
- `packages/core/src/engine/__tests__/energyFlowSpell.test.ts` — 30 tests (NEW)

## Test plan
- [x] Card definition metadata (name, categories, poweredBy, interactive)
- [x] Basic effect readies spent unit without healing
- [x] Powered effect readies and heals spent unit
- [x] Auto-resolves when only one spent unit available
- [x] Generates choice when multiple spent units available
- [x] Resolvability checks (has spent units / target exists)
- [x] Healing filter blocks effect in combat
- [x] effectHasHeal detects Energy Flow as healing
- [x] describeEffect generates correct descriptions
- [x] All 2073 tests pass, build and lint clean

Closes #186