### PR TITLE
feat: implement Banner of Courage powered effect

### DIFF
--- a/packages/core/src/data/artifacts/bannerOfCourage.ts
+++ b/packages/core/src/data/artifacts/bannerOfCourage.ts
@@ -4,11 +4,38 @@
  *
  * Basic: Assign to a Unit. Once per Round (except combat), flip to Ready Unit.
  *        Flip face up at start of Round.
- * Powered: Ready all Units you control (anytime except combat).
+ * Powered: Ready all Units you control (anytime except combat). Destroy artifact.
+ *
+ * FAQ S1: You can use this Banner to ready the Unit even while it is wounded.
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import { EFFECT_NOOP, EFFECT_READY_ALL_UNITS } from "../../types/effectTypes.js";
+import { CARD_BANNER_OF_COURAGE, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
 
-// TODO: Implement Banner of Courage
-export const BANNER_OF_COURAGE_CARDS: Record<CardId, DeedCard> = {};
+const BANNER_OF_COURAGE: DeedCard = {
+  id: CARD_BANNER_OF_COURAGE,
+  name: "Banner of Courage",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_HEALING],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  // Basic effect: Assign to unit (requires banner system from #211)
+  // When attached, once per round (except combat), flip to ready the attached unit.
+  basicEffect: {
+    type: EFFECT_NOOP,
+  },
+  poweredEffect: {
+    type: EFFECT_READY_ALL_UNITS,
+  },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const BANNER_OF_COURAGE_CARDS: Record<CardId, DeedCard> = {
+  [CARD_BANNER_OF_COURAGE]: BANNER_OF_COURAGE,
+};

--- a/packages/core/src/engine/__tests__/bannerOfCourage.test.ts
+++ b/packages/core/src/engine/__tests__/bannerOfCourage.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Tests for Banner of Courage artifact
+ *
+ * Basic: Assign to a Unit. Once per Round (except combat), flip to Ready Unit.
+ *        (Requires banner system from #211 - basic effect is NOOP placeholder)
+ * Powered: Ready all Units you control (anytime except combat). Destroy artifact.
+ *
+ * FAQ S1: You can use this Banner to ready the Unit even while it is wounded.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveEffect, isEffectResolvable, describeEffect } from "../effects/index.js";
+import type { ReadyAllUnitsEffect } from "../../types/cards.js";
+import { EFFECT_READY_ALL_UNITS } from "../../types/effectTypes.js";
+import { BANNER_OF_COURAGE_CARDS } from "../../data/artifacts/bannerOfCourage.js";
+import {
+  CARD_BANNER_OF_COURAGE,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import type { UnitId } from "@mage-knight/shared";
+import { UNITS } from "@mage-knight/shared";
+import { DEED_CARD_TYPE_ARTIFACT, CATEGORY_HEALING } from "../../types/cards.js";
+import { createInitialGameState } from "../../state/GameState.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerUnit } from "../../types/unit.js";
+
+// Helper to create test game state with units
+function createTestStateWithUnits(units: PlayerUnit[]): GameState {
+  const state = createInitialGameState({ playerCount: 1 });
+  return {
+    ...state,
+    players: [
+      {
+        ...state.players[0],
+        units,
+      },
+    ],
+  };
+}
+
+// Helper to create a unit with specific state
+function createUnit(
+  unitId: UnitId,
+  instanceId: string,
+  state: typeof UNIT_STATE_READY | typeof UNIT_STATE_SPENT,
+  wounded: boolean
+): PlayerUnit {
+  return {
+    instanceId,
+    unitId,
+    state,
+    wounded,
+    usedResistanceThisCombat: false,
+  };
+}
+
+// Get unit IDs of different levels for testing
+function getUnitIdOfLevel(level: number): UnitId {
+  const unitEntry = Object.entries(UNITS).find(([_, def]) => def.level === level);
+  if (!unitEntry) {
+    throw new Error(`No unit found with level ${level}`);
+  }
+  return unitEntry[0] as UnitId;
+}
+
+describe("Banner of Courage", () => {
+  describe("Card Definition", () => {
+    it("should have correct card properties", () => {
+      const card = BANNER_OF_COURAGE_CARDS[CARD_BANNER_OF_COURAGE];
+      expect(card).toBeDefined();
+      expect(card.id).toBe(CARD_BANNER_OF_COURAGE);
+      expect(card.name).toBe("Banner of Courage");
+      expect(card.cardType).toBe(DEED_CARD_TYPE_ARTIFACT);
+      expect(card.categories).toEqual([CATEGORY_HEALING]);
+      expect(card.sidewaysValue).toBe(1);
+    });
+
+    it("should be powered by any basic mana color", () => {
+      const card = BANNER_OF_COURAGE_CARDS[CARD_BANNER_OF_COURAGE];
+      expect(card.poweredBy).toContain(MANA_RED);
+      expect(card.poweredBy).toContain(MANA_BLUE);
+      expect(card.poweredBy).toContain(MANA_GREEN);
+      expect(card.poweredBy).toContain(MANA_WHITE);
+    });
+
+    it("should be destroyed after powered effect", () => {
+      const card = BANNER_OF_COURAGE_CARDS[CARD_BANNER_OF_COURAGE];
+      expect(card.destroyOnPowered).toBe(true);
+    });
+
+    it("should have ready all units as powered effect", () => {
+      const card = BANNER_OF_COURAGE_CARDS[CARD_BANNER_OF_COURAGE];
+      expect(card.poweredEffect.type).toBe(EFFECT_READY_ALL_UNITS);
+    });
+  });
+
+  describe("Powered Effect - EFFECT_READY_ALL_UNITS", () => {
+    const effect: ReadyAllUnitsEffect = { type: EFFECT_READY_ALL_UNITS };
+
+    describe("isEffectResolvable", () => {
+      it("should return false when player has no units", () => {
+        const state = createTestStateWithUnits([]);
+        expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+      });
+
+      it("should return false when all units are already ready", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_READY, false),
+          createUnit(unitId, "unit-2", UNIT_STATE_READY, true),
+        ]);
+        expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+      });
+
+      it("should return true when player has spent units", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+        ]);
+        expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(true);
+      });
+
+      it("should return true when player has spent wounded units", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+        ]);
+        expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(true);
+      });
+    });
+
+    describe("resolveEffect", () => {
+      it("should ready all spent units", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+          createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+      });
+
+      it("should ready units of any level", () => {
+        const unitIdLevel1 = getUnitIdOfLevel(1);
+        const unitIdLevel2 = getUnitIdOfLevel(2);
+        const unitIdLevel3 = getUnitIdOfLevel(3);
+        const state = createTestStateWithUnits([
+          createUnit(unitIdLevel1, "unit-1", UNIT_STATE_SPENT, false),
+          createUnit(unitIdLevel2, "unit-2", UNIT_STATE_SPENT, false),
+          createUnit(unitIdLevel3, "unit-3", UNIT_STATE_SPENT, false),
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[2].state).toBe(UNIT_STATE_READY);
+      });
+
+      it("should work on wounded units (FAQ S1)", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true),
+          createUnit(unitId, "unit-2", UNIT_STATE_SPENT, true),
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        // Both should be readied
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+        // But wounds should remain
+        expect(result.state.players[0].units[0].wounded).toBe(true);
+        expect(result.state.players[0].units[1].wounded).toBe(true);
+      });
+
+      it("should not change ready units", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_READY, false),
+          createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+      });
+
+      it("should return no-op when no spent units exist", () => {
+        const state = createTestStateWithUnits([]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        expect(result.description).toContain("No spent units");
+      });
+
+      it("should include count in description", () => {
+        const unitId = getUnitIdOfLevel(1);
+        const state = createTestStateWithUnits([
+          createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false),
+          createUnit(unitId, "unit-2", UNIT_STATE_SPENT, false),
+          createUnit(unitId, "unit-3", UNIT_STATE_SPENT, true),
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        expect(result.description).toContain("3");
+      });
+
+      it("should handle mixed ready/spent/wounded states", () => {
+        const unitIdLevel1 = getUnitIdOfLevel(1);
+        const unitIdLevel2 = getUnitIdOfLevel(2);
+        const state = createTestStateWithUnits([
+          createUnit(unitIdLevel1, "unit-1", UNIT_STATE_READY, false), // ready, not wounded
+          createUnit(unitIdLevel1, "unit-2", UNIT_STATE_SPENT, false), // spent, not wounded
+          createUnit(unitIdLevel2, "unit-3", UNIT_STATE_SPENT, true), // spent, wounded
+          createUnit(unitIdLevel1, "unit-4", UNIT_STATE_READY, true), // ready, wounded
+        ]);
+
+        const result = resolveEffect(state, state.players[0].id, effect);
+
+        // Ready units stay ready
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[0].wounded).toBe(false);
+
+        // Spent units become ready
+        expect(result.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[1].wounded).toBe(false);
+
+        // Spent+wounded becomes ready+wounded
+        expect(result.state.players[0].units[2].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[2].wounded).toBe(true);
+
+        // Ready+wounded stays ready+wounded
+        expect(result.state.players[0].units[3].state).toBe(UNIT_STATE_READY);
+        expect(result.state.players[0].units[3].wounded).toBe(true);
+      });
+    });
+
+    describe("describeEffect", () => {
+      it("should describe as 'Ready all Units'", () => {
+        expect(describeEffect(effect)).toBe("Ready all Units");
+      });
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -41,6 +41,7 @@ import {
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+  EFFECT_READY_ALL_UNITS,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -308,6 +309,8 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     const e = effect as ResolveEnergyFlowTargetEffect;
     return e.healReadiedUnit ? `Ready and heal ${e.unitName}` : `Ready ${e.unitName}`;
   },
+
+  [EFFECT_READY_ALL_UNITS]: () => "Ready all Units",
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -163,6 +163,7 @@ export {
 // Unit effects
 export {
   handleReadyUnit,
+  handleReadyAllUnits,
   getSpentUnitsAtOrBelowLevel,
   registerUnitEffects,
 } from "./unitEffects.js";

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -75,6 +75,7 @@ import {
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+  EFFECT_READY_ALL_UNITS,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -373,6 +374,11 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
     const e = effect as ResolveEnergyFlowTargetEffect;
     const unit = player.units.find((u) => u.instanceId === e.unitInstanceId);
     return unit !== undefined && unit.state === UNIT_STATE_SPENT;
+  },
+
+  [EFFECT_READY_ALL_UNITS]: (state, player) => {
+    // Resolvable if player has at least one spent unit
+    return player.units.some((u) => u.state === UNIT_STATE_SPENT);
   },
 };
 

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -52,6 +52,7 @@ import {
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
   EFFECT_TRACK_ATTACK_DEFEAT_FAME,
+  EFFECT_READY_ALL_UNITS,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -278,6 +279,12 @@ const reverseHandlers: Partial<Record<EffectType, ReverseHandler>> = {
     // Enemy targeting effects modify combat state and modifiers, not player state directly.
     // The modifier removal would need to happen at GameState level, not player level.
     // For now, these effects should be considered non-reversible in practice.
+    return player;
+  },
+
+  [EFFECT_READY_ALL_UNITS]: (player) => {
+    // Cannot reliably reverse — we don't track which units were originally spent.
+    // Commands containing this effect should be non-reversible.
     return player;
   },
 

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -63,6 +63,7 @@ import {
   EFFECT_SCOUT_PEEK,
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
+  EFFECT_READY_ALL_UNITS,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -676,6 +677,16 @@ export interface ResolveReadyUnitForInfluenceEffect {
 }
 
 /**
+ * Ready all units controlled by the player.
+ * Unlike ReadyUnitEffect, this readies ALL spent units regardless of level.
+ * Wounded units are also readied (wound status unchanged).
+ * Used by Banner of Courage powered effect.
+ */
+export interface ReadyAllUnitsEffect {
+  readonly type: typeof EFFECT_READY_ALL_UNITS;
+}
+
+/**
  * Scout peek effect (Scouts unit ability).
  * Reveals face-down enemy tokens within a distance from the player.
  * Also creates a ScoutFameBonus modifier tracking which enemies were newly revealed,
@@ -762,6 +773,7 @@ export type CardEffect =
   | RecruitDiscountEffect
   | ReadyUnitsForInfluenceEffect
   | ResolveReadyUnitForInfluenceEffect
+  | ReadyAllUnitsEffect
   | ScoutPeekEffect
   | EnergyFlowEffect
   | ResolveEnergyFlowTargetEffect;

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -150,6 +150,11 @@ export const EFFECT_RESOLVE_ENERGY_FLOW_TARGET = "resolve_energy_flow_target" as
 // Internal: resolve effect after unit selection for influence-paid readying
 export const EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE = "resolve_ready_unit_for_influence" as const;
 
+// === Ready All Units Effect ===
+// Ready all units controlled by the player (regardless of level or wound status).
+// Used by Banner of Courage powered effect.
+export const EFFECT_READY_ALL_UNITS = "ready_all_units" as const;
+
 // === Scout Peek Effect ===
 // Reveals face-down enemy tokens within a distance from the player.
 // Also creates a modifier tracking which enemies were revealed, granting +1 fame on defeat.


### PR DESCRIPTION
## Summary
- Add `EFFECT_READY_ALL_UNITS` effect type that readies all spent units regardless of level
- Implement Banner of Courage card definition with powered effect (ready all units, destroy artifact)
- Works on wounded units per FAQ S1
- Powered by any basic mana color (red/blue/green/white)
- Basic effect (banner assignment to unit) is a NOOP placeholder pending #211 (banner system)

## Changes
- `effectTypes.ts` - New `EFFECT_READY_ALL_UNITS` constant
- `cards.ts` - New `ReadyAllUnitsEffect` interface added to `CardEffect` union
- `unitEffects.ts` - `handleReadyAllUnits()` resolver and effect registration
- `resolvability.ts` - Resolvability check (needs at least one spent unit)
- `describeEffect.ts` - Human-readable description
- `reverse.ts` - Non-reversible marker (can't track original spent states)
- `bannerOfCourage.ts` - Card definition with categories, mana colors, effects
- `bannerOfCourage.test.ts` - 16 tests covering card definition and powered effect

## Test Plan
- [x] Card definition properties (name, type, categories, poweredBy, destroyOnPowered)
- [x] Powered effect readies all spent units regardless of level
- [x] Works on wounded units (FAQ S1) - wounds preserved
- [x] No-op when no spent units exist
- [x] Mixed ready/spent/wounded states handled correctly
- [x] Resolvability checks (false when no units/all ready, true when spent exist)
- [x] Effect description returns "Ready all Units"
- [x] Build, lint, and all 2043 tests pass

Closes #215