### PR TITLE
feat: implement Night Sharpshooting skill (Tovak)

### DIFF
--- a/packages/core/src/data/skills/tovak/nightSharpshooting.ts
+++ b/packages/core/src/data/skills/tovak/nightSharpshooting.ts
@@ -5,15 +5,17 @@
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_COMBAT } from "../../../types/cards.js";
+import { ifNightOrUnderground, rangedAttack } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_TOVAK_NIGHT_SHARPSHOOTING = "tovak_night_sharpshooting" as SkillId;
 
 export const nightSharpshooting: SkillDefinition = {
   id: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
-    name: "Night Sharpshooting",
-    heroId: "tovak",
-    description: "Ranged Attack 1 (Day) or Ranged Attack 2 (Night)",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_COMBAT],
+  name: "Night Sharpshooting",
+  heroId: "tovak",
+  description: "Ranged Attack 1 (Day) or Ranged Attack 2 (Night)",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  effect: ifNightOrUnderground(rangedAttack(2), rangedAttack(1)),
+  categories: [CATEGORY_COMBAT],
 };

--- a/packages/core/src/engine/__tests__/skillNightSharpshooting.test.ts
+++ b/packages/core/src/engine/__tests__/skillNightSharpshooting.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Tests for Night Sharpshooting skill (Tovak)
+ *
+ * Skill effect: Ranged Attack 1 (day) or Ranged Attack 2 (night).
+ * Dungeons/Tombs count as night for this skill.
+ * Only usable during the ranged/siege or attack phase of combat.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+  getSkillsFromValidActions,
+  ENEMY_PROWLERS,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_TOVAK_NIGHT_SHARPSHOOTING } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+  createCombatState,
+} from "../../types/combat.js";
+
+describe("Night Sharpshooting skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate during ranged/siege phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+        })
+      );
+    });
+
+    it("should grant Ranged Attack 1 during the day", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({
+        players: [player],
+        combat,
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(1);
+    });
+
+    it("should grant Ranged Attack 2 during the night", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({
+        players: [player],
+        combat,
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
+    });
+
+    it("should grant Ranged Attack 2 in dungeon during the day", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatState([ENEMY_PROWLERS], false, {
+        nightManaRules: true,
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat,
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(2);
+    });
+
+    it("should activate during attack phase and grant ranged attack", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+        })
+      );
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(1);
+    });
+
+    it("should reject if not in ranged/siege or attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill during ranged/siege phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+        })
+      );
+    });
+
+    it("should show skill during attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+        })
+      );
+    });
+
+    it("should not show skill when not in ranged/siege or attack phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_NIGHT_SHARPSHOOTING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_TOVAK_NIGHT_SHARPSHOOTING,
+          })
+        );
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -31,6 +31,7 @@ import {
   SKILL_BRAEVALAR_THUNDERSTORM,
   SKILL_BRAEVALAR_SECRET_WAYS,
   SKILL_NOROWAS_DAY_SHARPSHOOTING,
+  SKILL_TOVAK_NIGHT_SHARPSHOOTING,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -60,6 +61,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_BRAEVALAR_THUNDERSTORM,
   SKILL_BRAEVALAR_SECRET_WAYS,
   SKILL_NOROWAS_DAY_SHARPSHOOTING,
+  SKILL_TOVAK_NIGHT_SHARPSHOOTING,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN]);
@@ -132,7 +134,7 @@ export function getSkillOptions(
     }
 
     // Ranged/siege attack skills are only available during ranged/siege or attack phase
-    const rangedSkills = [SKILL_NOROWAS_DAY_SHARPSHOOTING, SKILL_ARYTHEA_BURNING_POWER, SKILL_GOLDYX_FREEZING_POWER];
+    const rangedSkills = [SKILL_NOROWAS_DAY_SHARPSHOOTING, SKILL_TOVAK_NIGHT_SHARPSHOOTING, SKILL_ARYTHEA_BURNING_POWER, SKILL_GOLDYX_FREEZING_POWER];
     if (rangedSkills.includes(skillId)) {
       if (
         !state.combat ||

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -30,6 +30,7 @@ import {
   SKILL_TOVAK_SHIELD_MASTERY,
   SKILL_TOVAK_I_FEEL_NO_PAIN,
   SKILL_NOROWAS_DAY_SHARPSHOOTING,
+  SKILL_TOVAK_NIGHT_SHARPSHOOTING,
   SKILL_ARYTHEA_BURNING_POWER,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_GOLDYX_FREEZING_POWER,
@@ -165,7 +166,7 @@ export const validateRangedSkillInRangedPhase: Validator = (state, _playerId, ac
   const useSkillAction = action as UseSkillAction;
 
   // Skills that provide ranged/siege attacks can only be used in ranged/siege or attack phase
-  const rangedSkills = [SKILL_NOROWAS_DAY_SHARPSHOOTING, SKILL_ARYTHEA_BURNING_POWER, SKILL_GOLDYX_FREEZING_POWER];
+  const rangedSkills = [SKILL_NOROWAS_DAY_SHARPSHOOTING, SKILL_TOVAK_NIGHT_SHARPSHOOTING, SKILL_ARYTHEA_BURNING_POWER, SKILL_GOLDYX_FREEZING_POWER];
 
   if (rangedSkills.includes(useSkillAction.skillId)) {
     if (


### PR DESCRIPTION
## Summary
Implement the Night Sharpshooting skill for Tovak. This conditional combat skill grants Ranged Attack 1 during the day or Ranged Attack 2 at night (including dungeons/tombs).

## Changes
- Added conditional effect to Night Sharpshooting skill definition using `ifNightOrUnderground(rangedAttack(2), rangedAttack(1))`
- Registered skill in `IMPLEMENTED_SKILLS` set for ValidActions
- Added skill to ranged phase restrictions in both validators and ValidActions
- Added test coverage for day, night, dungeon, phase validation, and valid actions

Closes #301