### PR TITLE
feat: implement correct Shocktroops tactical abilities (#272)

### DIFF
--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -389,5 +389,6 @@ export function createUnitCombatState(
     paidHeroesAssaultInfluence: false,
     vampiricArmorBonus: {},
     paidThugsDamageInfluence: {},
+    damageRedirects: {},
   };
 }

--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -19,7 +19,8 @@ import {
   UNIT_THUGS,
   UNIT_FORESTERS,
   UNIT_CATAPULTS,
-  UNIT_SHOCKTROOPS,
+  UNIT_SAVAGE_MONKS,
+  UNIT_AMOTEP_FREEZERS,
   UNIT_HERBALIST,
   UNIT_UTEM_CROSSBOWMEN,
   UNIT_FIRE_GOLEMS,
@@ -27,7 +28,6 @@ import {
   UNIT_NORTHERN_MONKS,
   UNIT_RED_CAPE_MONKS,
   UNIT_GUARDIAN_GOLEMS,
-  UNIT_SAVAGE_MONKS,
   CARD_WOUND,
   UNIT_STATE_READY,
   UNIT_STATE_SPENT,
@@ -642,9 +642,9 @@ describe("Unit Combat Abilities", () => {
   });
 
   describe("Passive abilities", () => {
-    it("should return clear error for passive abilities like swift", () => {
-      // Shocktroops have Swift at index 1 (passive)
-      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+    it("should return clear error for passive abilities like paralyze (Amotep Freezers)", () => {
+      // Amotep Freezers have Paralyze at index 2 (passive)
+      const unit = createPlayerUnit(UNIT_AMOTEP_FREEZERS, "freezers_1");
       const player = createTestPlayer({
         units: [unit],
         commandTokens: 1,
@@ -657,8 +657,8 @@ describe("Unit Combat Abilities", () => {
 
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
-        unitInstanceId: "shocktroops_1",
-        abilityIndex: 1, // Swift (passive)
+        unitInstanceId: "freezers_1",
+        abilityIndex: 2, // Paralyze (passive)
       });
 
       // Unit should still be ready (action rejected)
@@ -673,9 +673,9 @@ describe("Unit Combat Abilities", () => {
       }
     });
 
-    it("should return clear error for passive abilities like brutal", () => {
-      // Shocktroops have Brutal at index 2 (passive)
-      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+    it("should return clear error for passive abilities like paralyze", () => {
+      // Ice Golems have Paralyze at index 4 (passive)
+      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
       const player = createTestPlayer({
         units: [unit],
         commandTokens: 1,
@@ -688,8 +688,8 @@ describe("Unit Combat Abilities", () => {
 
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
-        unitInstanceId: "shocktroops_1",
-        abilityIndex: 2, // Brutal (passive)
+        unitInstanceId: "ice_golems_1",
+        abilityIndex: 4, // Paralyze (passive)
       });
 
       // Unit should still be ready (action rejected)

--- a/packages/core/src/engine/__tests__/unitIceMages.test.ts
+++ b/packages/core/src/engine/__tests__/unitIceMages.test.ts
@@ -65,6 +65,7 @@ function createIceMagesCombatState(
     defendBonuses: {},
     paidHeroesAssaultInfluence: false,
     vampiricArmorBonus: {},
+    damageRedirects: {},
   };
 }
 

--- a/packages/core/src/engine/__tests__/unitIllusionists.test.ts
+++ b/packages/core/src/engine/__tests__/unitIllusionists.test.ts
@@ -86,6 +86,7 @@ function createIllusionistsCombatState(
     defendBonuses: {},
     paidHeroesAssaultInfluence: false,
     vampiricArmorBonus: {},
+    damageRedirects: {},
   };
 }
 

--- a/packages/core/src/engine/__tests__/unitShocktroops.test.ts
+++ b/packages/core/src/engine/__tests__/unitShocktroops.test.ts
@@ -1,0 +1,787 @@
+/**
+ * Shocktroops Unit Ability Tests
+ *
+ * Shocktroops have three abilities (all effect-based):
+ * 1. Coordinated Fire: Ranged Attack 1 + all units get +1 to all attacks this combat
+ * 2. Weaken Enemy: Target enemy gets -1 armor (min 1) and -1 attack (min 0)
+ * 3. Taunt + Reduce Attack: Target enemy gets -3 attack (min 0),
+ *    damage from that enemy must be assigned to this unit first (overrides Assassination)
+ *
+ * Key rules:
+ * - Ability 2 armor reduction minimum is 1 (not 0)
+ * - Ability 1 buff applies to all unit attack types (melee, ranged, siege)
+ * - Ability 2 usable in ranged phase despite being defensive
+ * - Damage redirect (Taunt) overrides Assassination
+ * - Damage redirect inactive if Shocktroops is wounded/destroyed
+ * - Attack reduction IS blocked by Arcane Immunity
+ * - Damage redirect is NOT blocked by Arcane Immunity (defensive ability)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+} from "./testHelpers.js";
+import {
+  UNIT_SHOCKTROOPS,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  UNIT_ACTIVATED,
+  CHOICE_REQUIRED,
+  ENEMY_GUARDSMEN,
+  ENEMY_GOLEMS,
+  ENEMY_SORCERERS,
+  ENEMY_ORC_TRACKER,
+  getEnemy,
+} from "@mage-knight/shared";
+import { SHOCKTROOPS } from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_ATTACK,
+  COMBAT_PHASE_ASSIGN_DAMAGE,
+  COMBAT_CONTEXT_STANDARD,
+  type CombatState,
+  type CombatEnemy,
+} from "../../types/combat.js";
+import {
+  getEffectiveEnemyArmor,
+  getEffectiveEnemyAttack,
+  getUnitAttackBonus,
+} from "../modifiers/index.js";
+import {
+  getDamageRedirectUnit,
+  isAssassinationActive,
+} from "../rules/combatTargeting.js";
+import { getDamageAssignmentOptions } from "../validActions/combatDamage.js";
+
+/**
+ * Create a combat state for Shocktroops tests
+ */
+function createShocktroopsCombatState(
+  phase: CombatState["phase"],
+  enemies: CombatEnemy[],
+  overrides: Partial<CombatState> = {}
+): CombatState {
+  return {
+    enemies,
+    phase,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+    damageRedirects: {},
+    ...overrides,
+  };
+}
+
+/**
+ * Create a combat enemy from an enemy ID
+ */
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isBlocked: false,
+    isDefeated: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+  };
+}
+
+describe("Shocktroops Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(SHOCKTROOPS.name).toBe("Shocktroops");
+      expect(SHOCKTROOPS.level).toBe(2);
+      expect(SHOCKTROOPS.influence).toBe(6);
+      expect(SHOCKTROOPS.armor).toBe(3);
+    });
+
+    it("should have three effect-based abilities", () => {
+      expect(SHOCKTROOPS.abilities.length).toBe(3);
+      for (const ability of SHOCKTROOPS.abilities) {
+        expect(ability.type).toBe("effect");
+      }
+    });
+
+    it("should have no mana costs (all free abilities)", () => {
+      for (const ability of SHOCKTROOPS.abilities) {
+        expect(ability.manaCost).toBeUndefined();
+      }
+    });
+  });
+
+  // ==========================================================================
+  // Ability 0: Coordinated Fire (Ranged Attack 1 + Unit Buff)
+  // ==========================================================================
+  describe("Coordinated Fire (Ability 0)", () => {
+    it("should add Ranged Attack 1 to combat accumulator", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      // Unit should be spent
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+
+      // Should have Ranged Attack 1 in accumulator
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(1);
+    });
+
+    it("should apply +1 unit attack bonus modifier for all units", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      // Should have +1 unit attack bonus active
+      const bonus = getUnitAttackBonus(result.state, "player1");
+      expect(bonus).toBe(1);
+    });
+
+    it("should stack unit attack bonus with multiple Shocktroops", () => {
+      const unit1 = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const unit2 = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_2");
+      const player = createTestPlayer({
+        units: [unit1, unit2],
+        commandTokens: 2,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Activate first Shocktroops
+      const result1 = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      // Activate second Shocktroops
+      const result2 = engine.processAction(result1.state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_2",
+        abilityIndex: 0,
+      });
+
+      // Should have +2 total bonus (stacked)
+      const bonus = getUnitAttackBonus(result2.state, "player1");
+      expect(bonus).toBe(2);
+
+      // Should have Ranged Attack 2 total (1 + 1)
+      expect(result2.state.players[0].combatAccumulator.attack.ranged).toBe(2);
+    });
+
+    it("should boost other unit's attack values via the bonus", () => {
+      // Create a Shocktroops and a regular attack unit
+      const shocktroops = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      // Use a second Shocktroops as the "other unit" since it has attack abilities
+      const otherUnit = {
+        ...createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_2"),
+      };
+      const player = createTestPlayer({
+        units: [shocktroops, otherUnit],
+        commandTokens: 2,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      // Activate first Shocktroops' coordinated fire
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      // Check the unit attack bonus is active
+      expect(getUnitAttackBonus(result.state, "player1")).toBe(1);
+    });
+
+    it("should work in attack phase too", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_ATTACK, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(1);
+      expect(getUnitAttackBonus(result.state, "player1")).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // Ability 1: Weaken Enemy (Reduce Armor by 1, Reduce Attack by 1)
+  // ==========================================================================
+  describe("Weaken Enemy (Ability 1)", () => {
+    it("should reduce enemy armor by 1 (minimum 1)", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Golems have armor 5
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      // Armor should be reduced by 1 (5 -> 4)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        result.state,
+        "enemy_0",
+        5, // base armor
+        1, // resistance count (physical)
+        "player1"
+      );
+      expect(effectiveArmor).toBe(4);
+    });
+
+    it("should enforce armor minimum of 1", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Create enemy with armor 1 to test minimum
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      // Even with -1, armor minimum is 1
+      const effectiveArmor = getEffectiveEnemyArmor(
+        result.state,
+        "enemy_0",
+        1, // base armor of 1
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(1); // min 1, not 0
+    });
+
+    it("should reduce enemy attack by 1 (minimum 0)", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Golems have attack 2
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      // Attack should be reduced by 1 (2 -> 1)
+      const effectiveAttack = getEffectiveEnemyAttack(
+        result.state,
+        "enemy_0",
+        2 // base attack
+      );
+      expect(effectiveAttack).toBe(1);
+    });
+
+    it("should be usable in ranged/siege phase", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should present choice when multiple enemies", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GOLEMS),
+        createCombatEnemy("enemy_1", ENEMY_GUARDSMEN),
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      // Should create pending choice
+      expect(activateResult.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = activateResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      // Resolve: select enemy_1
+      const choiceResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      });
+
+      // Only selected enemy should be weakened
+      const enemy0Armor = getEffectiveEnemyArmor(choiceResult.state, "enemy_0", 5, 1, "player1");
+      const enemy1Armor = getEffectiveEnemyArmor(choiceResult.state, "enemy_1", 7, 0, "player1");
+      expect(enemy0Armor).toBe(5); // Unchanged
+      expect(enemy1Armor).toBe(6); // Reduced by 1
+    });
+
+    it("should be blocked by Arcane Immunity", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Enemy Sorcerers have Arcane Immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_SORCERERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const sorcererDef = getEnemy(ENEMY_SORCERERS);
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 1,
+      });
+
+      // Armor should be unchanged (Arcane Immunity blocks)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        result.state,
+        "enemy_0",
+        sorcererDef.armor,
+        sorcererDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(sorcererDef.armor);
+    });
+  });
+
+  // ==========================================================================
+  // Ability 2: Taunt + Reduce Attack by 3
+  // ==========================================================================
+  describe("Taunt + Reduce Attack (Ability 2)", () => {
+    it("should reduce enemy attack by 3 (minimum 0)", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Guardsmen have attack 3
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GUARDSMEN)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Attack should be reduced by 3 (3 -> 0)
+      const effectiveAttack = getEffectiveEnemyAttack(
+        result.state,
+        "enemy_0",
+        3
+      );
+      expect(effectiveAttack).toBe(0);
+    });
+
+    it("should enforce attack minimum of 0", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Golems have attack 2 (< 3 reduction)
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Attack should be 0 (min 0), not negative
+      const effectiveAttack = getEffectiveEnemyAttack(
+        result.state,
+        "enemy_0",
+        2
+      );
+      expect(effectiveAttack).toBe(0);
+    });
+
+    it("should set damage redirect to the activating unit", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Should have damage redirect set
+      expect(result.state.combat?.damageRedirects["enemy_0"]).toBe("shocktroops_1");
+
+      // getDamageRedirectUnit should return the unit (even though unit is spent)
+      const redirectUnit = getDamageRedirectUnit(result.state, "player1", "enemy_0");
+      expect(redirectUnit).toBe("shocktroops_1");
+    });
+
+    it("should override Assassination with damage redirect", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Orc Tracker has Assassination
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_ORC_TRACKER)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Assassination should be overridden by damage redirect
+      expect(isAssassinationActive(result.state, "player1", result.state.combat!.enemies[0])).toBe(false);
+
+      // Damage redirect should be active
+      expect(getDamageRedirectUnit(result.state, "player1", "enemy_0")).toBe("shocktroops_1");
+    });
+
+    it("should make redirect inactive if unit is wounded", () => {
+      const woundedUnit = {
+        ...createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1"),
+        state: UNIT_STATE_SPENT as const,
+        wounded: true,
+      };
+      const player = createTestPlayer({
+        units: [woundedUnit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const combat = createShocktroopsCombatState(COMBAT_PHASE_ASSIGN_DAMAGE, enemies, {
+        damageRedirects: { enemy_0: "shocktroops_1" },
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat,
+      });
+
+      // Redirect should be inactive (unit is wounded)
+      const redirectUnit = getDamageRedirectUnit(state, "player1", "enemy_0");
+      expect(redirectUnit).toBeUndefined();
+    });
+
+    it("should show only redirect unit in damage assignment options", () => {
+      const shocktroops = {
+        ...createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1"),
+        state: UNIT_STATE_SPENT as const,
+      };
+      // Another unit that should NOT be targetable
+      const otherUnit = {
+        ...createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_2"),
+        state: UNIT_STATE_SPENT as const,
+      };
+      const player = createTestPlayer({
+        units: [shocktroops, otherUnit],
+        commandTokens: 2,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const combat = createShocktroopsCombatState(COMBAT_PHASE_ASSIGN_DAMAGE, enemies, {
+        damageRedirects: { enemy_0: "shocktroops_1" },
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat,
+      });
+
+      const options = getDamageAssignmentOptions(state, combat.enemies);
+
+      // Should have one option for the enemy
+      expect(options.length).toBe(1);
+      const option = options[0];
+
+      // Should have damageRedirectOnly flag
+      expect(option.damageRedirectOnly).toBe(true);
+
+      // Available units should only include the redirect unit
+      const assignableUnits = option.availableUnits.filter(u => u.canBeAssigned);
+      expect(assignableUnits.length).toBe(1);
+      expect(assignableUnits[0].unitInstanceId).toBe("shocktroops_1");
+    });
+
+    it("should allow targeting Arcane Immune enemy (attack reduction blocked but redirect works)", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Enemy Sorcerers have Arcane Immunity
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_SORCERERS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const sorcererDef = getEnemy(ENEMY_SORCERERS);
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Attack reduction should be blocked by Arcane Immunity
+      const effectiveAttack = getEffectiveEnemyAttack(
+        result.state,
+        "enemy_0",
+        sorcererDef.attack
+      );
+      expect(effectiveAttack).toBe(sorcererDef.attack); // Unchanged
+
+      // But damage redirect should still work (not blocked by AI)
+      expect(result.state.combat?.damageRedirects["enemy_0"]).toBe("shocktroops_1");
+    });
+
+    it("should present choice when multiple enemies", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [
+        createCombatEnemy("enemy_0", ENEMY_GOLEMS),
+        createCombatEnemy("enemy_1", ENEMY_GUARDSMEN),
+      ];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 2,
+      });
+
+      // Should create pending choice
+      expect(activateResult.state.players[0].pendingChoice).not.toBeNull();
+
+      // Resolve: select enemy_1
+      const choiceResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      });
+
+      // Only selected enemy should have attack reduced and redirect set
+      expect(choiceResult.state.combat?.damageRedirects["enemy_0"]).toBeUndefined();
+      expect(choiceResult.state.combat?.damageRedirects["enemy_1"]).toBe("shocktroops_1");
+
+      // Only enemy_1 should have reduced attack
+      expect(getEffectiveEnemyAttack(choiceResult.state, "enemy_0", 2)).toBe(2); // Unchanged
+      expect(getEffectiveEnemyAttack(choiceResult.state, "enemy_1", 3)).toBe(0); // 3 - 3 = 0
+    });
+  });
+
+  // ==========================================================================
+  // Cross-ability tests
+  // ==========================================================================
+  describe("Cross-ability interactions", () => {
+    it("should emit UNIT_ACTIVATED event for each ability", () => {
+      const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+      const state = createTestGameState({
+        players: [player],
+        combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "shocktroops_1",
+        abilityIndex: 0,
+      });
+
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+    });
+
+    it("should not require mana for any ability", () => {
+      const enemies = [createCombatEnemy("enemy_0", ENEMY_GOLEMS)];
+
+      // All abilities should work without mana
+      for (let i = 0; i < 3; i++) {
+        const freshUnit = createPlayerUnit(UNIT_SHOCKTROOPS, `shocktroops_${i}`);
+        const freshPlayer = createTestPlayer({
+          units: [freshUnit],
+          commandTokens: 1,
+          pureMana: [],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+        });
+        const freshState = createTestGameState({
+          players: [freshPlayer],
+          combat: createShocktroopsCombatState(COMBAT_PHASE_RANGED_SIEGE, enemies),
+        });
+
+        const result = engine.processAction(freshState, "player1", {
+          type: ACTIVATE_UNIT_ACTION,
+          unitInstanceId: `shocktroops_${i}`,
+          abilityIndex: i,
+        });
+
+        expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/unitSorcerers.test.ts
+++ b/packages/core/src/engine/__tests__/unitSorcerers.test.ts
@@ -81,6 +81,7 @@ function createSorcerersCombatState(
     defendBonuses: {},
     paidHeroesAssaultInfluence: false,
     vampiricArmorBonus: {},
+    damageRedirects: {},
   };
 }
 

--- a/packages/core/src/engine/effects/combatEffects.ts
+++ b/packages/core/src/engine/effects/combatEffects.ts
@@ -258,6 +258,23 @@ export function resolveCombatEnemyTarget(
     }
   }
 
+  // Handle damage redirect (Shocktroops' Taunt)
+  // NOT blocked by Arcane Immunity - it's a defensive ability on the player's side
+  if (effect.template.setDamageRedirectFromUnit && currentState.combat) {
+    const unitInstanceId = effect.template.setDamageRedirectFromUnit;
+    currentState = {
+      ...currentState,
+      combat: {
+        ...currentState.combat,
+        damageRedirects: {
+          ...currentState.combat.damageRedirects,
+          [effect.enemyInstanceId]: unitInstanceId,
+        },
+      },
+    };
+    descriptions.push(`Damage from ${effect.enemyName} redirected to unit`);
+  }
+
   return {
     state: currentState,
     description: descriptions.join("; ") || `Targeted ${effect.enemyName}`,

--- a/packages/core/src/engine/modifiers/index.ts
+++ b/packages/core/src/engine/modifiers/index.ts
@@ -37,7 +37,7 @@ export {
 } from "./terrain.js";
 
 // Unit effective values
-export { getEffectiveUnitResistances } from "./units.js";
+export { getEffectiveUnitResistances, getUnitAttackBonus } from "./units.js";
 
 // Card values
 export { getEffectiveSidewaysValue, isRuleActive, consumeMovementCardBonus } from "./cardValues.js";

--- a/packages/core/src/engine/validators/combatValidators/index.ts
+++ b/packages/core/src/engine/validators/combatValidators/index.ts
@@ -32,6 +32,7 @@ export {
   validateAssignDamageTargetEnemy,
   validateAttackTargets,
   validateAssassinationTarget,
+  validateDamageRedirectTarget,
 } from "./targetValidators.js";
 
 // Fortification validators

--- a/packages/core/src/engine/validators/registry/combatRegistry.ts
+++ b/packages/core/src/engine/validators/registry/combatRegistry.ts
@@ -62,6 +62,7 @@ import {
   validateHasSiegeAttack,
   validateOneCombatPerTurn,
   validateAssassinationTarget,
+  validateDamageRedirectTarget,
   // Incremental attack assignment validators
   validateAssignAttackInCombat,
   validateAssignAttackPhase,
@@ -162,6 +163,7 @@ export const combatRegistry: Record<string, Validator[]> = {
     validateAssignDamagePhase,
     validateAssignDamageTargetEnemy,
     validateAssassinationTarget,
+    validateDamageRedirectTarget,
     validateUnitCanReceiveDamage,
   ],
   // Incremental attack assignment actions

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -109,6 +109,8 @@ export const NOTHING_TO_UNASSIGN_BLOCK = "NOTHING_TO_UNASSIGN_BLOCK" as const;
 export const SUMMONER_HIDDEN = "SUMMONER_HIDDEN" as const;
 // Assassination ability validation codes
 export const ASSASSINATION_REQUIRES_HERO_TARGET = "ASSASSINATION_REQUIRES_HERO_TARGET" as const;
+// Damage redirect (Taunt) validation codes
+export const DAMAGE_REDIRECT_REQUIRES_UNIT_TARGET = "DAMAGE_REDIRECT_REQUIRES_UNIT_TARGET" as const;
 // Multi-attack validation codes
 export const INVALID_ATTACK_INDEX = "INVALID_ATTACK_INDEX" as const;
 export const ATTACK_ALREADY_BLOCKED = "ATTACK_ALREADY_BLOCKED" as const;
@@ -369,6 +371,7 @@ export type ValidationErrorCode =
   | typeof NOTHING_TO_UNASSIGN_BLOCK
   | typeof SUMMONER_HIDDEN
   | typeof ASSASSINATION_REQUIRES_HERO_TARGET
+  | typeof DAMAGE_REDIRECT_REQUIRES_UNIT_TARGET
   | typeof INVALID_ATTACK_INDEX
   | typeof ATTACK_ALREADY_BLOCKED
   | typeof ATTACK_DAMAGE_ALREADY_ASSIGNED

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -375,6 +375,15 @@ export interface CombatEnemyTargetTemplate {
    * Note: The bundled effect is NOT blocked by Arcane Immunity - it always resolves.
    */
   readonly bundledEffect?: CardEffect;
+  /**
+   * If set, establishes a damage redirect from this enemy to the specified unit.
+   * The unit instance ID is injected at resolution time by the activation command.
+   * Damage from this enemy must be assigned to the specified unit first,
+   * overriding Assassination. NOT blocked by Arcane Immunity (it's a defensive
+   * ability on the player's side, not a magical effect targeting the enemy).
+   * Used by Shocktroops' Taunt ability.
+   */
+  readonly setDamageRedirectFromUnit?: string;
 }
 
 /**

--- a/packages/core/src/types/combat.ts
+++ b/packages/core/src/types/combat.ts
@@ -182,6 +182,14 @@ export interface CombatState {
    * Payment is per-unit, per-combat. Resets when combat ends.
    */
   readonly paidThugsDamageInfluence: ThugsDamagePaymentMap;
+  /**
+   * Damage redirects from Shocktroops' Taunt ability.
+   * Maps enemy instance ID → unit instance ID that must receive damage first.
+   * When present, damage from that enemy MUST be assigned to the specified unit
+   * before any other target (including hero), overriding Assassination.
+   * If the unit is wounded/destroyed, the redirect becomes inactive.
+   */
+  readonly damageRedirects: DamageRedirectMap;
 }
 
 /**
@@ -227,6 +235,15 @@ export type VampiricArmorBonusMap = {
  */
 export type ThugsDamagePaymentMap = {
   readonly [unitInstanceId: string]: boolean;
+};
+
+/**
+ * Map of enemy instance IDs to the unit instance ID that must receive damage first.
+ * Set by Shocktroops' Taunt ability. Overrides Assassination.
+ * If the redirect target unit is wounded, the redirect is inactive.
+ */
+export type DamageRedirectMap = {
+  readonly [enemyInstanceId: string]: string;
 };
 
 // Options for special combat rules
@@ -295,6 +312,7 @@ export function createCombatState(
     paidHeroesAssaultInfluence: false,
     vampiricArmorBonus: {},
     paidThugsDamageInfluence: {},
+    damageRedirects: {},
   };
 
   // Only include enemyAssignments if provided (avoids exactOptionalPropertyTypes issues)

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -141,3 +141,17 @@ export const RULE_MOVE_CARDS_IN_COMBAT = "move_cards_in_combat" as const;
 // Grants +1 fame when defeating an enemy that was revealed by Scout ability this turn
 // Tracks which enemies were revealed via Scout peek
 export const EFFECT_SCOUT_FAME_BONUS = "scout_fame_bonus" as const;
+
+// === DamageRedirectModifier ===
+// Forces damage from a specific enemy to be assigned to a specific unit first.
+// Overrides Assassination ability. If the unit is wounded/destroyed before
+// damage assignment, the redirect is inactive and damage can go anywhere.
+// Used by Shocktroops' Taunt ability.
+export const EFFECT_DAMAGE_REDIRECT = "damage_redirect" as const;
+
+// === UnitAttackBonusModifier ===
+// Grants +N to all attacks (melee, ranged, siege) for units.
+// Scoped to SCOPE_OTHER_UNITS to exclude the unit that granted the bonus.
+// Used by Shocktroops' Coordinated Fire ability.
+export const EFFECT_UNIT_ATTACK_BONUS = "unit_attack_bonus" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -37,6 +37,7 @@ import {
   EFFECT_SIDEWAYS_VALUE,
   EFFECT_TERRAIN_COST,
   EFFECT_TERRAIN_SAFE,
+  EFFECT_UNIT_ATTACK_BONUS,
   ELEMENT_COLD_FIRE,
   ELEMENT_FIRE,
   ELEMENT_ICE,
@@ -279,6 +280,14 @@ export interface ScoutFameBonusModifier {
   readonly fame: number; // Fame per revealed enemy defeated (typically 1)
 }
 
+// Unit attack bonus modifier (Shocktroops Coordinated Fire)
+// Grants +N to all attacks (melee, ranged, siege) for targeted units.
+// Typically scoped to SCOPE_OTHER_UNITS to exclude the activating unit.
+export interface UnitAttackBonusModifier {
+  readonly type: typeof EFFECT_UNIT_ATTACK_BONUS;
+  readonly amount: number; // +1 per Shocktroops activation
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -299,7 +308,8 @@ export type ModifierEffect =
   | ColdToughnessBlockModifier
   | RecruitDiscountModifier
   | MoveToAttackConversionModifier
-  | ScoutFameBonusModifier;
+  | ScoutFameBonusModifier
+  | UnitAttackBonusModifier;
 
 // === Active Modifier (live in game state) ===
 

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -274,6 +274,8 @@ export interface DamageAssignmentOption {
   readonly unassignedDamage: number;
   /** Units available to absorb damage (empty if units not allowed in combat) */
   readonly availableUnits: readonly UnitDamageTarget[];
+  /** When true, damage MUST go to the redirect unit (Taunt). Hero cannot be targeted. */
+  readonly damageRedirectOnly?: boolean;
 }
 
 // ============================================================================

--- a/packages/shared/src/units/regular/index.ts
+++ b/packages/shared/src/units/regular/index.ts
@@ -38,7 +38,12 @@ export { UTEM_GUARDSMEN } from "./utemGuardsmen.js";
 export { UTEM_SWORDSMEN } from "./utemSwordsmen.js";
 export { GUARDIAN_GOLEMS } from "./guardianGolems.js";
 export { ILLUSIONISTS } from "./illusionists.js";
-export { SHOCKTROOPS } from "./shocktroops.js";
+export {
+  SHOCKTROOPS,
+  SHOCKTROOPS_COORDINATED_FIRE,
+  SHOCKTROOPS_WEAKEN_ENEMY,
+  SHOCKTROOPS_TAUNT,
+} from "./shocktroops.js";
 export { RED_CAPE_MONKS } from "./redCapeMonks.js";
 export { NORTHERN_MONKS } from "./northernMonks.js";
 export { SAVAGE_MONKS } from "./savageMonks.js";

--- a/packages/shared/src/units/regular/shocktroops.ts
+++ b/packages/shared/src/units/regular/shocktroops.ts
@@ -1,17 +1,24 @@
 /**
  * Shocktroops unit definition
+ *
+ * Abilities:
+ * 1. Ranged Attack 1 + all other units get +1 to all attacks this combat
+ * 2. Weaken Enemy: reduce target enemy armor by 1 and one attack by 1
+ * 3. Taunt + Reduce Attack: reduce enemy attack by 3, damage redirect to this unit
  */
 
-import { ELEMENT_PHYSICAL } from "../../elements.js";
 import type { UnitDefinition } from "../types.js";
 import {
   UNIT_TYPE_REGULAR,
   RECRUIT_SITE_KEEP,
-  UNIT_ABILITY_ATTACK,
-  UNIT_ABILITY_SWIFT,
-  UNIT_ABILITY_BRUTAL,
+  UNIT_ABILITY_EFFECT,
 } from "../constants.js";
 import { UNIT_SHOCKTROOPS } from "../ids.js";
+
+/** Effect IDs - referenced in core's unitAbilityEffects registry */
+export const SHOCKTROOPS_COORDINATED_FIRE = "shocktroops_coordinated_fire" as const;
+export const SHOCKTROOPS_WEAKEN_ENEMY = "shocktroops_weaken_enemy" as const;
+export const SHOCKTROOPS_TAUNT = "shocktroops_taunt" as const;
 
 export const SHOCKTROOPS: UnitDefinition = {
   id: UNIT_SHOCKTROOPS,
@@ -23,9 +30,21 @@ export const SHOCKTROOPS: UnitDefinition = {
   resistances: [],
   recruitSites: [RECRUIT_SITE_KEEP],
   abilities: [
-    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
-    { type: UNIT_ABILITY_SWIFT },
-    { type: UNIT_ABILITY_BRUTAL },
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: SHOCKTROOPS_COORDINATED_FIRE,
+      displayName: "Ranged Attack 1 + Buff Units",
+    },
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: SHOCKTROOPS_WEAKEN_ENEMY,
+      displayName: "Weaken Enemy",
+    },
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: SHOCKTROOPS_TAUNT,
+      displayName: "Taunt + Reduce Attack",
+    },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary
- Replaces all three incorrect Shocktroops abilities (Attack 3, Swift, Brutal) with correct tactical effect-based abilities
- Adds damage redirect system for Taunt mechanic
- Adds unit attack bonus modifier for Coordinated Fire buff

## Changes

### New Abilities
- **Coordinated Fire** (Ability 0): Ranged Attack 1 + all units get +1 to all attacks this combat
- **Weaken Enemy** (Ability 1): Target enemy gets -1 armor (min 1) and -1 attack (min 0)
- **Taunt + Reduce Attack** (Ability 2): Target enemy gets -3 attack (min 0), damage from that enemy must be assigned to this unit first

### New Systems
- **Damage redirect** (`damageRedirects` on CombatState): Maps enemy → unit for forced damage assignment. Overrides Assassination. Inactive if unit is wounded/destroyed
- **Unit attack bonus modifier** (`EFFECT_UNIT_ATTACK_BONUS`): Buffs all unit attacks (melee/ranged/siege) by N
- **`__ACTIVATING_UNIT__` placeholder**: Template placeholder replaced at activation time with actual unit instance ID

### Key Rules
- Attack reduction IS blocked by Arcane Immunity (modifier on enemy)
- Damage redirect is NOT blocked by Arcane Immunity (defensive ability on player's side)
- Armor reduction minimum is 1 (not 0)
- Coordinated Fire buff applies to all attack types including siege
- Multiple Shocktroops stack: second gets +1, other units get +2

### Files Modified
- `shared/src/units/regular/shocktroops.ts` — Unit definition with 3 effect-based abilities
- `core/src/data/unitAbilityEffects.ts` — 3 Shocktroops effect definitions
- `core/src/types/combat.ts` — `damageRedirects` field on CombatState
- `core/src/types/cards.ts` — `setDamageRedirectFromUnit` on CombatEnemyTargetTemplate
- `core/src/types/modifierConstants.ts` — New modifier type constants
- `core/src/types/modifiers.ts` — UnitAttackBonusModifier interface
- `core/src/engine/rules/combatTargeting.ts` — Damage redirect rules, Assassination override
- `core/src/engine/effects/combatEffects.ts` — Damage redirect resolution
- `core/src/engine/commands/units/activateUnitCommand.ts` — Placeholder replacement, attack bonus
- `core/src/engine/validators/` — Damage redirect validation
- `core/src/engine/validActions/combatDamage.ts` — Redirect-aware damage options
- `core/src/engine/modifiers/units.ts` — getUnitAttackBonus query

## Test Plan
- 24 new tests in `unitShocktroops.test.ts` covering all abilities and edge cases
- Updated passive ability tests (Shocktroops no longer has Swift/Brutal)
- Added `damageRedirects: {}` to all test combat state helpers

Closes #272