### PR TITLE
feat: implement Cure/Disease white spell (#187)

### DIFF
--- a/packages/core/src/data/spells/white/cure.ts
+++ b/packages/core/src/data/spells/white/cure.ts
@@ -1,0 +1,36 @@
+/**
+ * Cure / Disease (White Spell)
+ *
+ * Basic (Cure): Heal 2 wounds from hand, draw a card for each wound healed
+ *   from hand this turn, ready all units healed this turn. Future healing
+ *   this turn also triggers card draws and unit readying.
+ *
+ * Powered (Disease): All enemies with ALL attacks blocked get armor reduced to 1.
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import { EFFECT_CURE, EFFECT_DISEASE } from "../../../types/effectTypes.js";
+import { MANA_WHITE, MANA_BLACK, CARD_CURE } from "@mage-knight/shared";
+
+export const CURE: DeedCard = {
+  id: CARD_CURE,
+  name: "Cure",
+  poweredName: "Disease",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_HEALING],
+  poweredEffectCategories: [CATEGORY_COMBAT],
+  poweredBy: [MANA_BLACK, MANA_WHITE],
+  basicEffect: {
+    type: EFFECT_CURE,
+    amount: 2,
+  },
+  poweredEffect: {
+    type: EFFECT_DISEASE,
+  },
+  sidewaysValue: 1,
+};

--- a/packages/core/src/data/spells/white/index.ts
+++ b/packages/core/src/data/spells/white/index.ts
@@ -6,13 +6,15 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_WHIRLWIND, CARD_EXPOSE } from "@mage-knight/shared";
+import { CARD_WHIRLWIND, CARD_EXPOSE, CARD_CURE } from "@mage-knight/shared";
 import { WHIRLWIND } from "./whirlwind.js";
 import { EXPOSE } from "./expose.js";
+import { CURE } from "./cure.js";
 
 export const WHITE_SPELLS: Record<CardId, DeedCard> = {
   [CARD_WHIRLWIND]: WHIRLWIND,
   [CARD_EXPOSE]: EXPOSE,
+  [CARD_CURE]: CURE,
 };
 
-export { WHIRLWIND, EXPOSE };
+export { WHIRLWIND, EXPOSE, CURE };

--- a/packages/core/src/engine/__tests__/cureSpell.test.ts
+++ b/packages/core/src/engine/__tests__/cureSpell.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Tests for the Cure / Disease spell (White Spell)
+ *
+ * Basic (Cure): Heal 2 wounds from hand. Draw a card for each wound healed
+ * from hand this turn (including earlier healing). Ready all units healed
+ * this turn. Set CURE_ACTIVE modifier for future healing triggers.
+ *
+ * Powered (Disease): All enemies with ALL attacks blocked get armor reduced to 1.
+ * Applied as a combat-scoped modifier.
+ *
+ * Key rules:
+ * - Healing category (basic), Combat category (powered)
+ * - Cure draws for ALL wounds healed from hand this turn, not just from Cure itself
+ * - After Cure, future GainHealing effects also draw cards (via CURE_ACTIVE)
+ * - After Cure, future HealUnit effects also ready units (via CURE_ACTIVE)
+ * - Disease only affects fully-blocked, non-defeated enemies
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type { CureEffect, DiseaseEffect } from "../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import { EFFECT_CURE, EFFECT_DISEASE } from "../../types/effectTypes.js";
+import {
+  CARD_WOUND,
+  CARD_CURE,
+  CARD_MARCH,
+  MANA_WHITE,
+  MANA_BLACK,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  UNITS,
+  ENEMY_GUARDSMEN,
+  ENEMY_DIGGERS,
+  getEnemy,
+  type UnitId,
+  type CardId,
+} from "@mage-knight/shared";
+import { createInitialGameState } from "../../state/GameState.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { PlayerUnit } from "../../types/unit.js";
+import type { CombatEnemy } from "../../types/combat.js";
+import { CURE } from "../../data/spells/white/cure.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import { createTestPlayer } from "./testHelpers.js";
+import { addModifier } from "../modifiers/index.js";
+import { getEffectiveEnemyArmor } from "../modifiers/combat.js";
+import {
+  DURATION_TURN,
+  EFFECT_CURE_ACTIVE,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createTestState(playerOverrides: Partial<Player> = {}): GameState {
+  const state = createInitialGameState();
+  const player = createTestPlayer(playerOverrides);
+  return {
+    ...state,
+    players: [player],
+    currentPlayerIndex: 0,
+  };
+}
+
+function createUnit(
+  unitId: UnitId,
+  instanceId: string,
+  unitState: typeof UNIT_STATE_READY | typeof UNIT_STATE_SPENT,
+  wounded: boolean
+): PlayerUnit {
+  return {
+    instanceId,
+    unitId,
+    state: unitState,
+    wounded,
+    usedResistanceThisCombat: false,
+  };
+}
+
+function getUnitIdOfLevel(level: number): UnitId {
+  const unitEntry = Object.entries(UNITS).find(([_, def]) => def.level === level);
+  if (!unitEntry) {
+    throw new Error(`No unit found with level ${level}`);
+  }
+  return unitEntry[0] as UnitId;
+}
+
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string,
+  overrides: Partial<CombatEnemy> = {}
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isDefeated: false,
+    isBlocked: false,
+    isRequiredForConquest: true,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+    ...overrides,
+  };
+}
+
+function createStateWithCombat(
+  enemies: CombatEnemy[],
+  playerOverrides: Partial<Player> = {}
+): GameState {
+  const state = createTestState(playerOverrides);
+  return {
+    ...state,
+    combat: {
+      phase: "block" as const,
+      enemies,
+      isAtFortifiedSite: false,
+      pendingDamage: {},
+      pendingBlock: {},
+      pendingSwiftBlock: {},
+      fameGained: 0,
+      unitsAllowed: true,
+      enemyAssignments: undefined,
+      assaultOrigin: undefined,
+    },
+  };
+}
+
+// ============================================================================
+// SPELL CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Cure spell card definition", () => {
+  it("should be registered in spell cards", () => {
+    const card = getSpellCard(CARD_CURE);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Cure");
+  });
+
+  it("should have correct metadata", () => {
+    expect(CURE.id).toBe(CARD_CURE);
+    expect(CURE.name).toBe("Cure");
+    expect(CURE.poweredName).toBe("Disease");
+    expect(CURE.cardType).toBe(DEED_CARD_TYPE_SPELL);
+    expect(CURE.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by black + white mana", () => {
+    expect(CURE.poweredBy).toEqual([MANA_BLACK, MANA_WHITE]);
+  });
+
+  it("should have healing category for basic effect", () => {
+    expect(CURE.categories).toEqual([CATEGORY_HEALING]);
+  });
+
+  it("should have combat category for powered effect", () => {
+    expect(CURE.poweredEffectCategories).toEqual([CATEGORY_COMBAT]);
+  });
+
+  it("should have basic Cure effect with amount 2", () => {
+    const effect = CURE.basicEffect as CureEffect;
+    expect(effect.type).toBe(EFFECT_CURE);
+    expect(effect.amount).toBe(2);
+  });
+
+  it("should have powered Disease effect", () => {
+    const effect = CURE.poweredEffect as DiseaseEffect;
+    expect(effect.type).toBe(EFFECT_DISEASE);
+  });
+});
+
+// ============================================================================
+// CURE BASIC EFFECT TESTS
+// ============================================================================
+
+describe("EFFECT_CURE (basic)", () => {
+  const cureEffect: CureEffect = {
+    type: EFFECT_CURE,
+    amount: 2,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should return true when player has wounds in hand", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      expect(isEffectResolvable(state, state.players[0]!.id, cureEffect)).toBe(true);
+    });
+
+    it("should return false when player has no wounds in hand", () => {
+      const state = createTestState({
+        hand: [CARD_MARCH],
+      });
+      expect(isEffectResolvable(state, state.players[0]!.id, cureEffect)).toBe(false);
+    });
+  });
+
+  describe("resolveEffect - wound healing", () => {
+    it("should heal wounds from hand", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: ["card_a" as CardId, "card_b" as CardId],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      // 2 wounds healed, so hand should have CARD_MARCH + 2 drawn cards
+      const player = result.state.players[0]!;
+      expect(player.hand.filter((c) => c === CARD_WOUND).length).toBe(0);
+      expect(result.description).toContain("Healed 2 wounds");
+    });
+
+    it("should heal only available wounds when less than amount", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_MARCH],
+        deck: ["card_a" as CardId],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const player = result.state.players[0]!;
+      expect(player.hand.filter((c) => c === CARD_WOUND).length).toBe(0);
+      expect(result.description).toContain("Healed 1 wound");
+    });
+
+    it("should track woundsHealedFromHandThisTurn", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_WOUND],
+        deck: ["card_a" as CardId, "card_b" as CardId],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      expect(result.state.players[0]!.woundsHealedFromHandThisTurn).toBe(2);
+    });
+  });
+
+  describe("resolveEffect - card draw", () => {
+    it("should draw cards equal to wounds healed from hand this turn", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_WOUND],
+        deck: ["card_a" as CardId, "card_b" as CardId, "card_c" as CardId],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const player = result.state.players[0]!;
+      // Healed 2 wounds, so drew 2 cards
+      expect(player.deck.length).toBe(1); // 3 - 2 drawn
+      expect(result.description).toContain("Drew 2 cards (Cure)");
+    });
+
+    it("should account for wounds healed earlier this turn", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: ["card_a" as CardId, "card_b" as CardId, "card_c" as CardId],
+        woundsHealedFromHandThisTurn: 1, // 1 wound already healed earlier
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const player = result.state.players[0]!;
+      // 1 already healed + 1 now = 2 total. Draws 2 cards.
+      expect(player.deck.length).toBe(1); // 3 - 2 drawn
+      expect(result.description).toContain("Drew 2 cards (Cure)");
+    });
+
+    it("should limit draws to available deck cards", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_WOUND],
+        deck: ["card_a" as CardId], // Only 1 card in deck
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const player = result.state.players[0]!;
+      expect(player.deck.length).toBe(0);
+      expect(result.description).toContain("Drew 1 card (Cure)");
+    });
+
+    it("should not draw when deck is empty", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: [],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      expect(result.description).not.toContain("Drew");
+    });
+  });
+
+  describe("resolveEffect - unit readying", () => {
+    it("should ready units that were healed this turn", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: ["card_a" as CardId],
+        units: [createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false)],
+        unitsHealedThisTurn: ["unit-1"],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      expect(result.state.players[0]!.units[0]!.state).toBe(UNIT_STATE_READY);
+      expect(result.description).toContain("Readied");
+    });
+
+    it("should not ready units that were not healed this turn", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: ["card_a" as CardId],
+        units: [createUnit(unitId, "unit-1", UNIT_STATE_SPENT, false)],
+        unitsHealedThisTurn: [], // No units healed
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      expect(result.state.players[0]!.units[0]!.state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should not re-ready already ready units", () => {
+      const unitId = getUnitIdOfLevel(1);
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: ["card_a" as CardId],
+        units: [createUnit(unitId, "unit-1", UNIT_STATE_READY, false)],
+        unitsHealedThisTurn: ["unit-1"],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      expect(result.state.players[0]!.units[0]!.state).toBe(UNIT_STATE_READY);
+      // Should not mention "Readied" since unit was already ready
+      expect(result.description).not.toContain("Readied");
+    });
+  });
+
+  describe("resolveEffect - CURE_ACTIVE modifier", () => {
+    it("should add CURE_ACTIVE modifier after resolution", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: ["card_a" as CardId],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const modifiers = result.state.activeModifiers;
+      expect(modifiers.some((m) => m.effect.type === EFFECT_CURE_ACTIVE)).toBe(true);
+    });
+
+    it("should add modifier even when no wounds to heal", () => {
+      // Edge: Cure might be played but there are no wounds (the resolvability
+      // check normally prevents this, but the handler still adds the modifier)
+      const state = createTestState({
+        hand: [CARD_WOUND],
+        deck: [],
+      });
+
+      const result = resolveEffect(state, state.players[0]!.id, cureEffect);
+
+      const modifiers = result.state.activeModifiers;
+      expect(modifiers.some((m) => m.effect.type === EFFECT_CURE_ACTIVE)).toBe(true);
+    });
+  });
+
+  describe("resolveEffect - return wounds to pile", () => {
+    it("should return healed wounds to the wound pile", () => {
+      const state = createTestState({
+        hand: [CARD_WOUND, CARD_WOUND],
+        deck: ["card_a" as CardId, "card_b" as CardId],
+      });
+      // Set wound pile to tracked value
+      const stateWithPile: GameState = { ...state, woundPileCount: 10 };
+
+      const result = resolveEffect(stateWithPile, stateWithPile.players[0]!.id, cureEffect);
+
+      expect(result.state.woundPileCount).toBe(12); // 10 + 2 healed
+    });
+  });
+});
+
+// ============================================================================
+// CURE_ACTIVE FOLLOW-UP HEALING TESTS
+// ============================================================================
+
+describe("CURE_ACTIVE modifier - future healing triggers", () => {
+  it("should cause GainHealing to also draw cards", () => {
+    // Set up: Cure was already played (CURE_ACTIVE modifier present)
+    let state = createTestState({
+      hand: [CARD_WOUND, CARD_MARCH],
+      deck: ["card_a" as CardId, "card_b" as CardId],
+    });
+
+    // Add CURE_ACTIVE modifier
+    state = addModifier(state, {
+      source: { type: SOURCE_CARD, cardId: CARD_CURE, playerId: state.players[0]!.id },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_CURE_ACTIVE },
+      createdAtRound: state.round,
+      createdByPlayerId: state.players[0]!.id,
+    });
+
+    // Now resolve a GainHealing effect (from another card)
+    const healEffect = { type: "gain_healing" as const, amount: 1 };
+    const result = resolveEffect(state, state.players[0]!.id, healEffect);
+
+    const player = result.state.players[0]!;
+    // 1 wound healed from hand, 1 card drawn from Cure
+    expect(player.hand.filter((c) => c === CARD_WOUND).length).toBe(0);
+    expect(result.description).toContain("Drew 1 card (Cure)");
+  });
+
+  it("should cause HealUnit to also ready the unit", () => {
+    const unitId = getUnitIdOfLevel(1);
+
+    let state = createTestState({
+      hand: [CARD_MARCH],
+      units: [createUnit(unitId, "unit-1", UNIT_STATE_SPENT, true)],
+    });
+
+    // Add CURE_ACTIVE modifier
+    state = addModifier(state, {
+      source: { type: SOURCE_CARD, cardId: CARD_CURE, playerId: state.players[0]!.id },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: { type: EFFECT_CURE_ACTIVE },
+      createdAtRound: state.round,
+      createdByPlayerId: state.players[0]!.id,
+    });
+
+    // Resolve HealUnit effect
+    const healUnitEffect = { type: "heal_unit" as const, maxLevel: 4 as const };
+    const result = resolveEffect(state, state.players[0]!.id, healUnitEffect);
+
+    const unit = result.state.players[0]!.units[0]!;
+    expect(unit.wounded).toBe(false);
+    expect(unit.state).toBe(UNIT_STATE_READY); // Also readied by Cure
+    expect(result.description).toContain("Cure");
+  });
+});
+
+// ============================================================================
+// DISEASE POWERED EFFECT TESTS
+// ============================================================================
+
+describe("EFFECT_DISEASE (powered)", () => {
+  const diseaseEffect: DiseaseEffect = {
+    type: EFFECT_DISEASE,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should return true when in combat", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN),
+      ]);
+      expect(isEffectResolvable(state, state.players[0]!.id, diseaseEffect)).toBe(true);
+    });
+
+    it("should return false when not in combat", () => {
+      const state = createTestState();
+      expect(isEffectResolvable(state, state.players[0]!.id, diseaseEffect)).toBe(false);
+    });
+  });
+
+  describe("resolveEffect", () => {
+    it("should reduce armor to 1 for fully-blocked enemies", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, { isBlocked: true }),
+      ]);
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      expect(result.description).toContain("armor reduced to 1");
+
+      // Verify modifier was added
+      const modifiers = result.state.activeModifiers;
+      expect(modifiers.length).toBeGreaterThan(0);
+    });
+
+    it("should not affect unblocked enemies", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, { isBlocked: false }),
+      ]);
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      expect(result.description).toBe("No fully-blocked enemies");
+    });
+
+    it("should not affect defeated enemies", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, {
+          isBlocked: true,
+          isDefeated: true,
+        }),
+      ]);
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      expect(result.description).toBe("No fully-blocked enemies");
+    });
+
+    it("should apply to multiple fully-blocked enemies", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, { isBlocked: true }),
+        createCombatEnemy("enemy_1", ENEMY_DIGGERS, { isBlocked: true }),
+      ]);
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      // Both enemies should have armor modifiers
+      expect(result.state.activeModifiers.length).toBe(2);
+    });
+
+    it("should only affect blocked enemies when mix of blocked/unblocked", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, { isBlocked: true }),
+        createCombatEnemy("enemy_1", ENEMY_DIGGERS, { isBlocked: false }),
+      ]);
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      // Only 1 modifier (for the blocked enemy)
+      expect(result.state.activeModifiers.length).toBe(1);
+    });
+
+    it("should return 'Not in combat' when no combat", () => {
+      const state = createTestState();
+
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      expect(result.description).toBe("Not in combat");
+    });
+  });
+
+  describe("Disease armor modifier integration", () => {
+    it("should make getEffectiveEnemyArmor return 1", () => {
+      const enemy = createCombatEnemy("enemy_0", ENEMY_GUARDSMEN, { isBlocked: true });
+      const baseArmor = enemy.definition.armor;
+
+      let state = createStateWithCombat([enemy]);
+
+      // Apply disease
+      const result = resolveEffect(state, state.players[0]!.id, diseaseEffect);
+
+      const effectiveArmor = getEffectiveEnemyArmor(
+        result.state,
+        "enemy_0",
+        baseArmor,
+        0, // no resistances
+        state.players[0]!.id
+      );
+
+      expect(effectiveArmor).toBe(1);
+    });
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Cure/Disease", () => {
+  it("should describe Cure effect", () => {
+    const effect: CureEffect = { type: EFFECT_CURE, amount: 2 };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Heal");
+    expect(desc).toContain("2");
+  });
+
+  it("should describe Disease effect", () => {
+    const effect: DiseaseEffect = { type: EFFECT_DISEASE };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("armor");
+    expect(desc).toContain("1");
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -161,6 +161,8 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingAttackDefeatFame: [],
     enemiesDefeatedThisTurn: 0,
     healingPoints: 0,
+    woundsHealedFromHandThisTurn: 0,
+    unitsHealedThisTurn: [],
     removedCards: [],
     isResting: false,
     woundImmunityActive: false,

--- a/packages/core/src/engine/commands/endTurn/playerReset.ts
+++ b/packages/core/src/engine/commands/endTurn/playerReset.ts
@@ -56,5 +56,8 @@ export function createResetPlayer(
     },
     // Spell effect resets
     woundImmunityActive: false,
+    // Cure spell tracking resets
+    woundsHealedFromHandThisTurn: 0,
+    unitsHealedThisTurn: [],
   };
 }

--- a/packages/core/src/engine/commands/interactCommand.ts
+++ b/packages/core/src/engine/commands/interactCommand.ts
@@ -97,7 +97,12 @@ export function createInteractCommand(params: InteractCommandParams): Command {
           }
         }
 
-        updatedPlayer = { ...updatedPlayer, hand: newHand };
+        updatedPlayer = {
+          ...updatedPlayer,
+          hand: newHand,
+          // Track wounds healed from hand this turn (for Cure spell)
+          woundsHealedFromHandThisTurn: updatedPlayer.woundsHealedFromHandThisTurn + woundsHealed,
+        };
 
         events.push({
           type: HEALING_PURCHASED,

--- a/packages/core/src/engine/effects/cureEffects.ts
+++ b/packages/core/src/engine/effects/cureEffects.ts
@@ -1,0 +1,245 @@
+/**
+ * Cure / Disease spell effect handlers
+ *
+ * Cure (Basic):
+ * - Heal `amount` wounds from hand
+ * - Draw a card for each wound healed from hand this turn (including just now)
+ * - Ready each unit healed this turn
+ * - Set a turn-scoped modifier so future healing triggers draws/readies
+ *
+ * Disease (Powered):
+ * - All enemies with ALL attacks blocked get armor reduced to 1
+ * - Applied as a combat-scoped modifier on each fully-blocked enemy
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { CureEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { CARD_WOUND, UNITS, UNIT_STATE_READY } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { addModifier } from "../modifiers/index.js";
+import { EFFECT_CURE, EFFECT_DISEASE } from "../../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  DURATION_TURN,
+  EFFECT_CURE_ACTIVE,
+  EFFECT_DISEASE_ARMOR,
+  SCOPE_ONE_ENEMY,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { CARD_CURE } from "@mage-knight/shared";
+import { isEnemyFullyBlocked } from "../combat/enemyAttackHelpers.js";
+
+// ============================================================================
+// CURE EFFECT
+// ============================================================================
+
+/**
+ * Handle the Cure basic effect.
+ *
+ * 1. Heal `amount` wounds from hand (and track in woundsHealedFromHandThisTurn)
+ * 2. Draw cards = woundsHealedFromHandThisTurn (total, including just healed)
+ * 3. Ready all units in unitsHealedThisTurn
+ * 4. Add CURE_ACTIVE modifier for future healing triggers
+ */
+export function handleCureEffect(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: CureEffect
+): EffectResolutionResult {
+  const amount = effect.amount;
+  const descriptions: string[] = [];
+
+  // Step 1: Heal wounds from hand
+  const woundsInHand = player.hand.filter((c) => c === CARD_WOUND).length;
+  const woundsToHeal = Math.min(amount, woundsInHand);
+
+  let currentPlayer = player;
+
+  if (woundsToHeal > 0) {
+    const newHand = [...currentPlayer.hand];
+    for (let i = 0; i < woundsToHeal; i++) {
+      const woundIndex = newHand.indexOf(CARD_WOUND);
+      if (woundIndex !== -1) {
+        newHand.splice(woundIndex, 1);
+      }
+    }
+
+    currentPlayer = {
+      ...currentPlayer,
+      hand: newHand,
+      woundsHealedFromHandThisTurn: currentPlayer.woundsHealedFromHandThisTurn + woundsToHeal,
+    };
+
+    descriptions.push(
+      woundsToHeal === 1 ? "Healed 1 wound" : `Healed ${woundsToHeal} wounds`
+    );
+  }
+
+  // Return wounds to the wound pile
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : state.woundPileCount + woundsToHeal;
+
+  let currentState: GameState = {
+    ...updatePlayer(state, playerIndex, currentPlayer),
+    woundPileCount: newWoundPileCount,
+  };
+
+  // Re-read player from state after update
+  currentPlayer = currentState.players[playerIndex]!;
+
+  // Step 2: Draw cards for wounds healed from hand this turn
+  const totalWoundsHealed = currentPlayer.woundsHealedFromHandThisTurn;
+  if (totalWoundsHealed > 0) {
+    const availableInDeck = currentPlayer.deck.length;
+    const cardsToDraw = Math.min(totalWoundsHealed, availableInDeck);
+
+    if (cardsToDraw > 0) {
+      const drawnCards = currentPlayer.deck.slice(0, cardsToDraw);
+      const newDeck = currentPlayer.deck.slice(cardsToDraw);
+      const newHand = [...currentPlayer.hand, ...drawnCards];
+
+      currentPlayer = {
+        ...currentPlayer,
+        hand: newHand,
+        deck: newDeck,
+      };
+
+      currentState = updatePlayer(currentState, playerIndex, currentPlayer);
+
+      descriptions.push(
+        cardsToDraw === 1
+          ? "Drew 1 card (Cure)"
+          : `Drew ${cardsToDraw} cards (Cure)`
+      );
+    }
+  }
+
+  // Step 3: Ready all units healed this turn
+  const unitsToReady = currentPlayer.unitsHealedThisTurn;
+  if (unitsToReady.length > 0) {
+    const updatedUnits = currentPlayer.units.map((unit) => {
+      if (
+        unitsToReady.includes(unit.instanceId) &&
+        unit.state !== UNIT_STATE_READY
+      ) {
+        return { ...unit, state: UNIT_STATE_READY as const };
+      }
+      return unit;
+    });
+
+    const readiedCount = currentPlayer.units.filter(
+      (unit) =>
+        unitsToReady.includes(unit.instanceId) &&
+        unit.state !== UNIT_STATE_READY
+    ).length;
+
+    if (readiedCount > 0) {
+      currentPlayer = { ...currentPlayer, units: updatedUnits };
+      currentState = updatePlayer(currentState, playerIndex, currentPlayer);
+
+      const readiedNames = currentPlayer.units
+        .filter((u) => unitsToReady.includes(u.instanceId))
+        .map((u) => UNITS[u.unitId]?.name ?? u.unitId);
+
+      descriptions.push(`Readied ${readiedNames.join(", ")}`);
+    }
+  }
+
+  // Step 4: Add CURE_ACTIVE modifier for future healing triggers
+  currentState = addModifier(currentState, {
+    source: {
+      type: SOURCE_CARD,
+      cardId: CARD_CURE,
+      playerId: currentState.players[playerIndex]!.id,
+    },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: { type: EFFECT_CURE_ACTIVE },
+    createdAtRound: currentState.round,
+    createdByPlayerId: currentState.players[playerIndex]!.id,
+  });
+
+  return {
+    state: currentState,
+    description: descriptions.length > 0
+      ? descriptions.join(". ")
+      : "No wounds to heal",
+  };
+}
+
+// ============================================================================
+// DISEASE EFFECT
+// ============================================================================
+
+/**
+ * Handle the Disease powered effect.
+ *
+ * All enemies that have ALL their attacks blocked get armor reduced to 1.
+ * Applied as a combat-scoped DiseaseArmor modifier on each qualifying enemy.
+ */
+export function handleDiseaseEffect(
+  state: GameState,
+  playerId: string
+): EffectResolutionResult {
+  if (!state.combat) {
+    return {
+      state,
+      description: "Not in combat",
+    };
+  }
+
+  const descriptions: string[] = [];
+  let currentState = state;
+
+  for (const enemy of state.combat.enemies) {
+    // Skip defeated enemies
+    if (enemy.isDefeated) continue;
+
+    // Check if ALL attacks are blocked
+    if (!isEnemyFullyBlocked(enemy)) continue;
+
+    // Apply Disease armor modifier: set armor to 1
+    currentState = addModifier(currentState, {
+      source: {
+        type: SOURCE_CARD,
+        cardId: CARD_CURE,
+        playerId,
+      },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_ONE_ENEMY, enemyId: enemy.instanceId },
+      effect: { type: EFFECT_DISEASE_ARMOR, setTo: 1 },
+      createdAtRound: currentState.round,
+      createdByPlayerId: playerId,
+    });
+
+    descriptions.push(`${enemy.definition.name} armor reduced to 1`);
+  }
+
+  return {
+    state: currentState,
+    description: descriptions.length > 0
+      ? descriptions.join(", ")
+      : "No fully-blocked enemies",
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+export function registerCureEffects(): void {
+  registerEffect(EFFECT_CURE, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleCureEffect(state, playerIndex, player, effect as CureEffect);
+  });
+
+  registerEffect(EFFECT_DISEASE, (state, playerId) => {
+    return handleDiseaseEffect(state, playerId);
+  });
+}

--- a/packages/core/src/engine/effects/cureHelpers.ts
+++ b/packages/core/src/engine/effects/cureHelpers.ts
@@ -1,0 +1,20 @@
+/**
+ * Cure spell helper functions
+ *
+ * Query functions for checking if Cure's turn-scoped modifier is active.
+ * Used by healing effect handlers to trigger additional card draws and unit readying.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import { EFFECT_CURE_ACTIVE } from "../../types/modifierConstants.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+
+/**
+ * Check if the Cure spell's active modifier is present for a player.
+ * When true, healing from hand should also draw cards,
+ * and unit healing should also ready the unit.
+ */
+export function isCureActive(state: GameState, playerId: string): boolean {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  return modifiers.some((m) => m.effect.type === EFFECT_CURE_ACTIVE);
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -42,6 +42,8 @@ import {
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_CURE,
+  EFFECT_DISEASE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -52,6 +54,7 @@ import type {
   ResolveReadyUnitForInfluenceEffect,
   EnergyFlowEffect,
   ResolveEnergyFlowTargetEffect,
+  CureEffect,
 } from "../../types/cards.js";
 import type {
   GainMoveEffect,
@@ -311,6 +314,13 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   },
 
   [EFFECT_READY_ALL_UNITS]: () => "Ready all Units",
+
+  [EFFECT_CURE]: (effect) => {
+    const e = effect as CureEffect;
+    return `Heal ${e.amount}, draw per wound healed, ready healed units`;
+  },
+
+  [EFFECT_DISEASE]: () => "Reduce fully-blocked enemies' armor to 1",
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -34,6 +34,7 @@ import { registerRitualOfPainEffects } from "./ritualOfPainEffects.js";
 import { registerDiscardForCrystalEffects } from "./discardForCrystalEffects.js";
 import { registerRuthlessCoercionEffects } from "./ruthlessCoercionEffects.js";
 import { registerEnergyFlowEffects } from "./energyFlowEffects.js";
+import { registerCureEffects } from "./cureEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -118,4 +119,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Energy Flow effects (ready unit + spend opponent units)
   registerEnergyFlowEffects();
+
+  // Cure / Disease effects (white spell)
+  registerCureEffects();
 }

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -78,6 +78,8 @@ import {
   EFFECT_READY_ALL_UNITS,
   EFFECT_SELECT_HEX_FOR_COST_REDUCTION,
   EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION,
+  EFFECT_CURE,
+  EFFECT_DISEASE,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -389,6 +391,16 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   [EFFECT_READY_ALL_UNITS]: (state, player) => {
     // Resolvable if player has at least one spent unit
     return player.units.some((u) => u.state === UNIT_STATE_SPENT);
+  },
+
+  [EFFECT_CURE]: (state, player) => {
+    // Cure is resolvable if player has wounds in hand
+    return player.hand.some((c) => c === CARD_WOUND);
+  },
+
+  [EFFECT_DISEASE]: (state) => {
+    // Disease is resolvable only in combat
+    return state.combat !== null;
   },
 };
 

--- a/packages/core/src/engine/modifiers/combat.ts
+++ b/packages/core/src/engine/modifiers/combat.ts
@@ -19,10 +19,12 @@ import {
 } from "../../types/combat.js";
 import { ABILITY_ELUSIVE } from "@mage-knight/shared";
 import { ENEMY_ABILITY_ELUSIVE } from "../../types/enemyConstants.js";
+import type { DiseaseArmorModifier } from "../../types/modifiers.js";
 import {
   ABILITY_ANY,
   EFFECT_ABILITY_NULLIFIER,
   EFFECT_COMBAT_VALUE,
+  EFFECT_DISEASE_ARMOR,
   EFFECT_DOUBLE_PHYSICAL_ATTACKS,
   EFFECT_ENEMY_SKIP_ATTACK,
   EFFECT_ENEMY_STAT,
@@ -104,6 +106,19 @@ export function getEffectiveEnemyArmor(
       armor += mod.amount;
     }
     minAllowed = Math.max(minAllowed, mod.minimum);
+  }
+
+  // Check for Disease armor modifier (sets armor to fixed value)
+  // Disease applies AFTER all other modifiers and bonuses per rules:
+  // "White City bonus applies first, THEN Disease reduces to 1"
+  const diseaseModifiers = getModifiersForEnemy(state, enemyId)
+    .filter((m) => m.effect.type === EFFECT_DISEASE_ARMOR)
+    .map((m) => m.effect as DiseaseArmorModifier);
+
+  if (diseaseModifiers.length > 0) {
+    // Disease overrides armor to setTo value (typically 1)
+    const diseaseValue = diseaseModifiers[0]!.setTo;
+    return diseaseValue;
   }
 
   // Apply Defend bonus AFTER modifiers (it's an external bonus, not a modifier)

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -61,6 +61,8 @@ import {
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
+  EFFECT_CURE,
+  EFFECT_DISEASE,
   EFFECT_SCOUT_PEEK,
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
@@ -764,6 +766,30 @@ export interface SelectTerrainForCostReductionEffect {
   readonly minimumCost: number;
 }
 
+/**
+ * Cure spell basic effect.
+ * 1. Heal `amount` wounds from hand
+ * 2. Draw a card for each wound healed from hand this turn (including the heal just done)
+ * 3. Ready each unit healed this turn
+ *
+ * Also establishes a turn-scoped modifier so future healing triggers additional
+ * card draws and unit readying.
+ */
+export interface CureEffect {
+  readonly type: typeof EFFECT_CURE;
+  readonly amount: number;
+}
+
+/**
+ * Disease spell powered effect.
+ * All enemies that have ALL their attacks blocked during the Block phase
+ * get their armor reduced to 1 for the rest of combat.
+ * Must be played during Block phase.
+ */
+export interface DiseaseEffect {
+  readonly type: typeof EFFECT_DISEASE;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -816,7 +842,9 @@ export type CardEffect =
   | EnergyFlowEffect
   | ResolveEnergyFlowTargetEffect
   | SelectHexForCostReductionEffect
-  | SelectTerrainForCostReductionEffect;
+  | SelectTerrainForCostReductionEffect
+  | CureEffect
+  | DiseaseEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -161,6 +161,12 @@ export const EFFECT_SELECT_HEX_FOR_COST_REDUCTION = "select_hex_for_cost_reducti
 // Select a terrain type for cost reduction (Druidic Paths powered effect)
 export const EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION = "select_terrain_for_cost_reduction" as const;
 
+// === Cure Spell Effects ===
+// Basic Cure: Heal 2, draw a card per wound healed from hand this turn, ready healed units
+export const EFFECT_CURE = "cure" as const;
+// Powered Disease: Reduce armor to 1 for all fully-blocked enemies
+export const EFFECT_DISEASE = "disease" as const;
+
 // === Scout Peek Effect ===
 // Reveals face-down enemy tokens within a distance from the player.
 // Also creates a modifier tracking which enemies were revealed, granting +1 fame on defeat.

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -155,3 +155,14 @@ export const EFFECT_DAMAGE_REDIRECT = "damage_redirect" as const;
 // Used by Shocktroops' Coordinated Fire ability.
 export const EFFECT_UNIT_ATTACK_BONUS = "unit_attack_bonus" as const;
 
+// === DiseaseArmorModifier ===
+// Sets enemy armor to a fixed value (Disease powered effect).
+// Applied to fully-blocked enemies during block phase.
+export const EFFECT_DISEASE_ARMOR = "disease_armor" as const;
+
+// === CureActiveModifier ===
+// Marks that Cure spell is active this turn.
+// When active, future healing from hand also draws cards,
+// and future unit healing also readies the unit.
+export const EFFECT_CURE_ACTIVE = "cure_active" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -38,6 +38,8 @@ import {
   EFFECT_TERRAIN_COST,
   EFFECT_TERRAIN_SAFE,
   EFFECT_UNIT_ATTACK_BONUS,
+  EFFECT_DISEASE_ARMOR,
+  EFFECT_CURE_ACTIVE,
   ELEMENT_COLD_FIRE,
   ELEMENT_FIRE,
   ELEMENT_ICE,
@@ -288,6 +290,21 @@ export interface UnitAttackBonusModifier {
   readonly amount: number; // +1 per Shocktroops activation
 }
 
+// Disease armor modifier (Disease powered effect)
+// Sets enemy armor to a fixed value. Applied to fully-blocked enemies.
+// Unlike EnemyStatModifier which adds/subtracts, this sets the armor absolutely.
+export interface DiseaseArmorModifier {
+  readonly type: typeof EFFECT_DISEASE_ARMOR;
+  readonly setTo: number; // Armor is set to this value (typically 1)
+}
+
+// Cure active modifier (Cure basic effect)
+// When active, future healing from hand also draws cards,
+// and future unit healing also readies the healed unit.
+export interface CureActiveModifier {
+  readonly type: typeof EFFECT_CURE_ACTIVE;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -309,7 +326,9 @@ export type ModifierEffect =
   | RecruitDiscountModifier
   | MoveToAttackConversionModifier
   | ScoutFameBonusModifier
-  | UnitAttackBonusModifier;
+  | UnitAttackBonusModifier
+  | DiseaseArmorModifier
+  | CureActiveModifier;
 
 // === Active Modifier (live in game state) ===
 

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -459,6 +459,12 @@ export interface Player {
   // Healing points accumulated this turn (cleared on combat entry per rulebook line 929)
   readonly healingPoints: number;
 
+  // Cure spell tracking (reset at end of turn)
+  // Tracks wounds healed from hand this turn (for Cure's card draw bonus)
+  readonly woundsHealedFromHandThisTurn: number;
+  // Tracks unit instance IDs healed this turn (for Cure's ready bonus)
+  readonly unitsHealedThisTurn: readonly string[];
+
   // Wound immunity active (Veil of Mist spell)
   // When true, the hero ignores the first wound from enemies this turn (including Poison/Paralyze effects)
   // Reset at end of turn; cleared when first wound is ignored

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -570,6 +570,8 @@ export class GameServer {
       pendingAttackDefeatFame: [],
       enemiesDefeatedThisTurn: 0,
       healingPoints: 0,
+      woundsHealedFromHandThisTurn: 0,
+      unitsHealedThisTurn: [],
       woundImmunityActive: false,
       removedCards: [],
       isResting: false,

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -115,6 +115,7 @@ export const CARD_ENERGY_FLOW = cardId("energy_flow"); // #12 - Ready unit + spe
 
 // White spells
 export const CARD_EXPOSE = cardId("expose"); // #19 - Lose fortification/resistances
+export const CARD_CURE = cardId("cure"); // #17 - Heal 2 + draw/ready / Armor reduction to 1
 
 // === Card ID Type Unions ===
 
@@ -169,7 +170,8 @@ export type SpellCardId =
   | typeof CARD_WHIRLWIND
   | typeof CARD_ENERGY_FLOW
   // White spells
-  | typeof CARD_EXPOSE;
+  | typeof CARD_EXPOSE
+  | typeof CARD_CURE;
 
 export type ArtifactCardId =
   // Banners


### PR DESCRIPTION
## Summary
Implements the Cure / Disease white spell card for Mage Knight.

- **Cure (Basic)**: Heal 2 wounds from hand, draw a card for each wound healed from hand this turn (including earlier healing), ready all units healed this turn. Sets a turn-scoped CURE_ACTIVE modifier so future healing also triggers card draws and unit readying.
- **Disease (Powered)**: All enemies with ALL attacks blocked get armor reduced to 1 via a combat-scoped DiseaseArmor modifier.

## Changes
- Added `CARD_CURE` constant to shared cardIds
- Added `woundsHealedFromHandThisTurn` and `unitsHealedThisTurn` tracking fields on Player
- Created `cureEffects.ts` with `handleCureEffect` and `handleDiseaseEffect` handlers
- Created `cureHelpers.ts` with `isCureActive()` query function
- Created `cure.ts` card data with `categories: [HEALING]` and `poweredEffectCategories: [COMBAT]`
- Updated `atomicCardEffects.ts` (GainHealing) to draw cards when Cure is active
- Updated `healUnitEffects.ts` to ready units when Cure is active
- Updated `interactCommand.ts` to track wounds healed at sites
- Added `EFFECT_DISEASE_ARMOR` and `EFFECT_CURE_ACTIVE` modifier constants
- Integrated Disease armor into `getEffectiveEnemyArmor` in modifier combat queries
- Added effect registrations, resolvability checks, and describeEffect entries
- Reset tracking fields in `playerReset.ts` at end of turn

## Test Plan
- 35 new tests in `cureSpell.test.ts` covering:
  - Card definition (metadata, categories, effect types)
  - Cure wound healing (amount limiting, tracking)
  - Cure card draw (based on total wounds healed this turn, deck limiting)
  - Cure unit readying (healed-this-turn tracking)
  - CURE_ACTIVE modifier persistence and future healing triggers
  - Disease armor reduction for fully-blocked enemies
  - Disease skipping unblocked/defeated enemies
  - Disease modifier integration with `getEffectiveEnemyArmor`
  - Effect descriptions
- All 2287 core tests pass, 0 regressions

Closes #187