### PR TITLE
feat: implement Invocation skill for Arythea (#316)

### DIFF
--- a/packages/core/src/engine/__tests__/skillInvocation.test.ts
+++ b/packages/core/src/engine/__tests__/skillInvocation.test.ts
@@ -1,0 +1,648 @@
+/**
+ * Tests for Invocation skill (Arythea)
+ *
+ * Skill effect: Once a turn, discard a card to gain a mana token.
+ * - Discard a Wound → gain red or black mana token
+ * - Discard a non-Wound → gain white or green mana token
+ * - Mana must be used immediately
+ * - Usable during combat (CATEGORY_SPECIAL)
+ * - Cannot interrupt other effects
+ *
+ * Key rules:
+ * - Once per turn usage
+ * - Wound cards are returned to wound pile (not discard pile)
+ * - Non-wound cards go to discard pile
+ * - Black mana during day only usable in Dungeon/Tomb
+ * - Works with Polarization (can convert gained mana before using)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  UNDO_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CARD_MARCH,
+  CARD_WOUND,
+  MANA_RED,
+  MANA_BLACK,
+  MANA_WHITE,
+  MANA_GREEN,
+  getSkillsFromValidActions,
+  TIME_OF_DAY_NIGHT,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_ARYTHEA_INVOCATION } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import { EFFECT_INVOCATION_RESOLVE } from "../../types/effectTypes.js";
+
+describe("Invocation skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate skill and create pending choice", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_ARYTHEA_INVOCATION,
+        })
+      );
+
+      // Should have a pending choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      expect(result.state.players[0].pendingChoice?.skillId).toBe(
+        SKILL_ARYTHEA_INVOCATION
+      );
+    });
+
+    it("should add skill to usedThisTurn cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      expect(
+        result.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_ARYTHEA_INVOCATION);
+    });
+
+    it("should reject if skill not learned", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if skill already used this turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_ARYTHEA_INVOCATION],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("choice options", () => {
+    it("should offer red and black mana for wound cards", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = result.state.players[0].pendingChoice?.options;
+      expect(options).toBeDefined();
+      expect(options).toHaveLength(2);
+
+      // Should have red and black options for wound
+      const colors = options?.map(
+        (o) => (o as { manaColor: string }).manaColor
+      );
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLACK);
+
+      // All options should be for wound card
+      for (const option of options ?? []) {
+        expect((option as { isWound: boolean }).isWound).toBe(true);
+        expect((option as { cardId: string }).cardId).toBe(CARD_WOUND);
+      }
+    });
+
+    it("should offer white and green mana for non-wound cards", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = result.state.players[0].pendingChoice?.options;
+      expect(options).toBeDefined();
+      expect(options).toHaveLength(2);
+
+      // Should have white and green options for non-wound
+      const colors = options?.map(
+        (o) => (o as { manaColor: string }).manaColor
+      );
+      expect(colors).toContain(MANA_WHITE);
+      expect(colors).toContain(MANA_GREEN);
+
+      // All options should be for non-wound card
+      for (const option of options ?? []) {
+        expect((option as { isWound: boolean }).isWound).toBe(false);
+        expect((option as { cardId: string }).cardId).toBe(CARD_MARCH);
+      }
+    });
+
+    it("should offer both wound and non-wound options when hand has both", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = result.state.players[0].pendingChoice?.options;
+      expect(options).toBeDefined();
+      // 2 for wound (red, black) + 2 for march (white, green) = 4
+      expect(options).toHaveLength(4);
+
+      const colors = options?.map(
+        (o) => (o as { manaColor: string }).manaColor
+      );
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLACK);
+      expect(colors).toContain(MANA_WHITE);
+      expect(colors).toContain(MANA_GREEN);
+    });
+
+    it("should deduplicate options for multiple copies of same card", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = result.state.players[0].pendingChoice?.options;
+      // Should only have 2 options (red, black) even with 3 wounds
+      expect(options).toHaveLength(2);
+    });
+
+    it("should use EFFECT_INVOCATION_RESOLVE type for all options", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = result.state.players[0].pendingChoice?.options;
+      for (const option of options ?? []) {
+        expect(option.type).toBe(EFFECT_INVOCATION_RESOLVE);
+      }
+    });
+  });
+
+  describe("wound discard → mana", () => {
+    it("should discard wound and gain red mana when choosing red option", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      // Find the red mana wound option
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const redWoundIndex = options.findIndex(
+        (o) =>
+          (o as { manaColor: string }).manaColor === MANA_RED &&
+          (o as { isWound: boolean }).isWound === true
+      );
+      expect(redWoundIndex).toBeGreaterThanOrEqual(0);
+
+      // Resolve the choice
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: redWoundIndex,
+      });
+
+      // Wound should be removed from hand
+      expect(afterResolve.state.players[0].hand).not.toContain(CARD_WOUND);
+      // Non-wound card should still be in hand
+      expect(afterResolve.state.players[0].hand).toContain(CARD_MARCH);
+      // Should have gained red mana token
+      expect(afterResolve.state.players[0].pureMana).toContainEqual(
+        expect.objectContaining({ color: MANA_RED })
+      );
+    });
+
+    it("should discard wound and gain black mana when choosing black option", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      // Find the black mana wound option
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const blackWoundIndex = options.findIndex(
+        (o) =>
+          (o as { manaColor: string }).manaColor === MANA_BLACK &&
+          (o as { isWound: boolean }).isWound === true
+      );
+      expect(blackWoundIndex).toBeGreaterThanOrEqual(0);
+
+      // Resolve the choice
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: blackWoundIndex,
+      });
+
+      // Wound should be removed from hand
+      expect(afterResolve.state.players[0].hand).not.toContain(CARD_WOUND);
+      // Should have gained black mana token
+      expect(afterResolve.state.players[0].pureMana).toContainEqual(
+        expect.objectContaining({ color: MANA_BLACK })
+      );
+    });
+
+    it("should return wound to wound pile (not discard pile)", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+        discard: [],
+      });
+      const initialWoundPileCount = 10;
+      const state = createTestGameState({
+        players: [player],
+        woundPileCount: initialWoundPileCount,
+      });
+
+      // Activate and choose wound → red
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const redWoundIndex = options.findIndex(
+        (o) =>
+          (o as { manaColor: string }).manaColor === MANA_RED &&
+          (o as { isWound: boolean }).isWound === true
+      );
+
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: redWoundIndex,
+      });
+
+      // Wound should NOT be in discard pile
+      expect(afterResolve.state.players[0].discard).not.toContain(CARD_WOUND);
+      // Wound pile count should increase
+      expect(afterResolve.state.woundPileCount).toBe(
+        initialWoundPileCount + 1
+      );
+    });
+  });
+
+  describe("non-wound discard → mana", () => {
+    it("should discard non-wound and gain white mana", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_MARCH],
+        pureMana: [],
+        discard: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      // Find the white mana option
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const whiteIndex = options.findIndex(
+        (o) =>
+          (o as { manaColor: string }).manaColor === MANA_WHITE &&
+          (o as { isWound: boolean }).isWound === false
+      );
+      expect(whiteIndex).toBeGreaterThanOrEqual(0);
+
+      // Resolve the choice
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: whiteIndex,
+      });
+
+      // Card should be in discard pile (not wound pile)
+      expect(afterResolve.state.players[0].hand).not.toContain(CARD_MARCH);
+      expect(afterResolve.state.players[0].discard).toContain(CARD_MARCH);
+      // Should have gained white mana token
+      expect(afterResolve.state.players[0].pureMana).toContainEqual(
+        expect.objectContaining({ color: MANA_WHITE })
+      );
+    });
+
+    it("should discard non-wound and gain green mana", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_MARCH],
+        pureMana: [],
+        discard: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      // Find the green mana option
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const greenIndex = options.findIndex(
+        (o) =>
+          (o as { manaColor: string }).manaColor === MANA_GREEN &&
+          (o as { isWound: boolean }).isWound === false
+      );
+      expect(greenIndex).toBeGreaterThanOrEqual(0);
+
+      // Resolve the choice
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: greenIndex,
+      });
+
+      // Card should be in discard pile
+      expect(afterResolve.state.players[0].discard).toContain(CARD_MARCH);
+      // Should have gained green mana token
+      expect(afterResolve.state.players[0].pureMana).toContainEqual(
+        expect.objectContaining({ color: MANA_GREEN })
+      );
+    });
+  });
+
+  describe("mana token source", () => {
+    it("should add mana token with skill source", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate and choose red mana from wound
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const afterResolve = engine.processAction(afterSkill.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // First option (red mana for wound)
+      });
+
+      const token = afterResolve.state.players[0].pureMana[0];
+      expect(token).toBeDefined();
+      expect(token?.source).toBe("skill");
+    });
+  });
+
+  describe("undo", () => {
+    it("should undo skill activation and clear pending choice", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      expect(afterSkill.state.players[0].pendingChoice).not.toBeNull();
+      expect(
+        afterSkill.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_ARYTHEA_INVOCATION);
+
+      // Undo
+      const afterUndo = engine.processAction(afterSkill.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Pending choice should be cleared
+      expect(afterUndo.state.players[0].pendingChoice).toBeNull();
+      // Cooldown should be removed
+      expect(
+        afterUndo.state.players[0].skillCooldowns.usedThisTurn
+      ).not.toContain(SKILL_ARYTHEA_INVOCATION);
+      // Hand should be unchanged
+      expect(afterUndo.state.players[0].hand).toContain(CARD_WOUND);
+      expect(afterUndo.state.players[0].hand).toContain(CARD_MARCH);
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill in valid actions when available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_ARYTHEA_INVOCATION,
+        })
+      );
+    });
+
+    it("should not show skill in valid actions when on cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_ARYTHEA_INVOCATION],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_ARYTHEA_INVOCATION,
+          })
+        );
+      }
+    });
+
+    it("should not show skill when hand is empty", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_ARYTHEA_INVOCATION,
+          })
+        );
+      }
+    });
+  });
+
+  describe("usable during combat", () => {
+    it("should show skill as available during combat (CATEGORY_SPECIAL)", () => {
+      // CATEGORY_SPECIAL skills are available both in and out of combat
+      // They don't have CATEGORY_COMBAT which would restrict to combat-only
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Verify skill is available outside combat
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_ARYTHEA_INVOCATION,
+        })
+      );
+    });
+  });
+
+  describe("night time", () => {
+    it("should offer black mana option at night", () => {
+      const player = createTestPlayer({
+        hero: Hero.Arythea,
+        skills: [SKILL_ARYTHEA_INVOCATION],
+        hand: [CARD_WOUND],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_ARYTHEA_INVOCATION,
+      });
+
+      const options = afterSkill.state.players[0].pendingChoice?.options ?? [];
+      const colors = options.map(
+        (o) => (o as { manaColor: string }).manaColor
+      );
+      expect(colors).toContain(MANA_BLACK);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -30,3 +30,9 @@ export {
   applyPowerOfPainEffect,
   removePowerOfPainEffect,
 } from "./powerOfPainEffect.js";
+
+export {
+  applyInvocationEffect,
+  removeInvocationEffect,
+  canActivateInvocation,
+} from "./invocationEffect.js";

--- a/packages/core/src/engine/commands/skills/invocationEffect.ts
+++ b/packages/core/src/engine/commands/skills/invocationEffect.ts
@@ -1,0 +1,192 @@
+/**
+ * Invocation skill effect handler (Arythea)
+ *
+ * Once per turn: Discard a card to gain a mana token.
+ * - Discard a Wound → gain red or black mana token
+ * - Discard a non-Wound → gain white or green mana token
+ * - Mana must be used immediately
+ *
+ * Implementation:
+ * - Builds pendingChoice options based on hand contents
+ * - Each option is an InvocationResolveEffect encoding the card + mana color
+ * - Resolution atomically discards the card and adds the mana token
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { Player } from "../../../types/player.js";
+import type { CardEffect } from "../../../types/cards.js";
+import type { CardId } from "@mage-knight/shared";
+import {
+  CARD_WOUND,
+  MANA_RED,
+  MANA_BLACK,
+  MANA_WHITE,
+  MANA_GREEN,
+} from "@mage-knight/shared";
+import { SKILL_ARYTHEA_INVOCATION } from "../../../data/skills/index.js";
+import { EFFECT_INVOCATION_RESOLVE } from "../../../types/effectTypes.js";
+import { getPlayerIndexByIdOrThrow } from "../../helpers/playerHelpers.js";
+import { getCard } from "../../helpers/cardLookup.js";
+
+/**
+ * Describes an Invocation option presented to the player.
+ */
+interface InvocationOption {
+  readonly cardId: CardId;
+  readonly isWound: boolean;
+  readonly manaColor: string;
+  readonly description: string;
+}
+
+/**
+ * Get the display name for a card.
+ */
+function getCardName(cardId: CardId): string {
+  const card = getCard(cardId);
+  return card ? card.name : String(cardId);
+}
+
+/**
+ * Build all valid Invocation options based on the player's hand.
+ *
+ * Wound cards → red or black mana (2 options per wound)
+ * Non-wound cards → white or green mana (2 options per non-wound card)
+ */
+function buildInvocationOptions(hand: readonly CardId[]): InvocationOption[] {
+  const options: InvocationOption[] = [];
+  const seenCards = new Set<string>();
+
+  for (const cardId of hand) {
+    // Deduplicate: only show one set of options per unique card ID
+    // (e.g., if player has 3 wounds, only show wound options once)
+    if (seenCards.has(cardId)) continue;
+    seenCards.add(cardId);
+
+    const isWound = cardId === CARD_WOUND;
+    const cardName = getCardName(cardId);
+
+    if (isWound) {
+      // Wound → red or black mana
+      options.push({
+        cardId,
+        isWound: true,
+        manaColor: MANA_RED,
+        description: `Discard ${cardName} → Red mana`,
+      });
+      options.push({
+        cardId,
+        isWound: true,
+        manaColor: MANA_BLACK,
+        description: `Discard ${cardName} → Black mana`,
+      });
+    } else {
+      // Non-wound → white or green mana
+      options.push({
+        cardId,
+        isWound: false,
+        manaColor: MANA_WHITE,
+        description: `Discard ${cardName} → White mana`,
+      });
+      options.push({
+        cardId,
+        isWound: false,
+        manaColor: MANA_GREEN,
+        description: `Discard ${cardName} → Green mana`,
+      });
+    }
+  }
+
+  return options;
+}
+
+/**
+ * Apply the Invocation skill effect.
+ *
+ * Creates a pending choice with all valid discard + mana gain options.
+ * Each option is an InvocationResolveEffect that atomically handles:
+ * 1. Removing the card from hand
+ * 2. Adding the mana token to pureMana
+ */
+export function applyInvocationEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  // Build options based on hand contents
+  const options = buildInvocationOptions(player.hand);
+
+  if (options.length === 0) {
+    // No valid options - shouldn't happen if validators work correctly
+    return state;
+  }
+
+  // Create pendingChoice with InvocationResolveEffect options
+  const choiceOptions: CardEffect[] = options.map((opt) => ({
+    type: EFFECT_INVOCATION_RESOLVE as typeof EFFECT_INVOCATION_RESOLVE,
+    cardId: opt.cardId,
+    isWound: opt.isWound,
+    manaColor: opt.manaColor,
+    description: opt.description,
+  }));
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice: {
+      cardId: null,
+      skillId: SKILL_ARYTHEA_INVOCATION,
+      unitInstanceId: null,
+      options: choiceOptions,
+    },
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return { ...state, players };
+}
+
+/**
+ * Remove Invocation effect for undo.
+ *
+ * Clears the pending choice if it's from Invocation.
+ */
+export function removeInvocationEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  // Clear pending choice if it's from Invocation
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice:
+      player.pendingChoice?.skillId === SKILL_ARYTHEA_INVOCATION
+        ? null
+        : player.pendingChoice,
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return { ...state, players };
+}
+
+/**
+ * Check if Invocation skill can be activated.
+ * Used by validActions to determine if the skill should be shown.
+ *
+ * Requirements:
+ * - Player must have at least one card in hand (wound or non-wound)
+ */
+export function canActivateInvocation(player: Player): boolean {
+  return player.hand.length > 0;
+}

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -30,6 +30,7 @@ import {
   SKILL_ARYTHEA_POLARIZATION,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_ARYTHEA_INVOCATION,
 } from "../../data/skills/index.js";
 import {
   applyWhoNeedsMagicEffect,
@@ -42,6 +43,8 @@ import {
   removePolarizationEffect,
   applyPowerOfPainEffect,
   removePowerOfPainEffect,
+  applyInvocationEffect,
+  removeInvocationEffect,
 } from "./skills/index.js";
 import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
 import {
@@ -96,6 +99,9 @@ function applyCustomSkillEffect(
     case SKILL_ARYTHEA_POWER_OF_PAIN:
       return applyPowerOfPainEffect(state, playerId);
 
+    case SKILL_ARYTHEA_INVOCATION:
+      return applyInvocationEffect(state, playerId);
+
     default:
       // Skill has no custom handler - will use generic effect resolution
       return state;
@@ -129,6 +135,9 @@ function removeCustomSkillEffect(
     case SKILL_ARYTHEA_POWER_OF_PAIN:
       return removePowerOfPainEffect(state, playerId);
 
+    case SKILL_ARYTHEA_INVOCATION:
+      return removeInvocationEffect(state, playerId);
+
     default:
       return state;
   }
@@ -144,6 +153,7 @@ function hasCustomHandler(skillId: SkillId): boolean {
     SKILL_TOVAK_I_FEEL_NO_PAIN,
     SKILL_ARYTHEA_POLARIZATION,
     SKILL_ARYTHEA_POWER_OF_PAIN,
+    SKILL_ARYTHEA_INVOCATION,
   ].includes(skillId);
 }
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -35,6 +35,7 @@ import { registerDiscardForCrystalEffects } from "./discardForCrystalEffects.js"
 import { registerRuthlessCoercionEffects } from "./ruthlessCoercionEffects.js";
 import { registerEnergyFlowEffects } from "./energyFlowEffects.js";
 import { registerCureEffects } from "./cureEffects.js";
+import { registerInvocationEffects } from "./invocationEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -122,4 +123,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Cure / Disease effects (white spell)
   registerCureEffects();
+
+  // Invocation effects (Arythea's Invocation skill)
+  registerInvocationEffects();
 }

--- a/packages/core/src/engine/effects/invocationEffects.ts
+++ b/packages/core/src/engine/effects/invocationEffects.ts
@@ -1,0 +1,110 @@
+/**
+ * Invocation Effect Resolution
+ *
+ * Handles the EFFECT_INVOCATION_RESOLVE effect for Arythea's Invocation skill.
+ * Atomically discards a card from hand and gains a mana token.
+ *
+ * @module effects/invocationEffects
+ *
+ * @remarks
+ * - Wound cards are returned to the wound pile (not discard pile)
+ * - Non-wound cards go to the discard pile
+ * - Mana token is added with MANA_TOKEN_SOURCE_SKILL source
+ *
+ * @example Resolution Flow
+ * ```
+ * Player activates Invocation skill
+ *   └─► applyInvocationEffect creates pendingChoice with INVOCATION_RESOLVE options
+ *       └─► Player selects option (card + mana color)
+ *           └─► resolveInvocation discards card, adds mana token
+ * ```
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, ManaToken } from "../../types/player.js";
+import type { InvocationResolveEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { MANA_TOKEN_SOURCE_SKILL } from "@mage-knight/shared";
+import { EFFECT_INVOCATION_RESOLVE } from "../../types/effectTypes.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+
+/**
+ * Resolve an Invocation effect - discard a card and gain a mana token.
+ *
+ * Wound cards are returned to the wound pile (unlimited supply).
+ * Non-wound cards go to the player's discard pile.
+ */
+export function resolveInvocation(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: InvocationResolveEffect
+): EffectResolutionResult {
+  const { cardId, isWound, manaColor } = effect;
+
+  // Step 1: Remove the card from hand
+  const handIndex = player.hand.indexOf(cardId);
+  if (handIndex === -1) {
+    return {
+      state,
+      description: `Card ${cardId} not found in hand`,
+    };
+  }
+
+  const updatedHand = [...player.hand];
+  updatedHand.splice(handIndex, 1);
+
+  // Step 2: Handle discard destination
+  let updatedDiscard = player.discard;
+  let updatedState = state;
+
+  if (isWound) {
+    // Wounds go back to the wound pile
+    const newWoundPileCount =
+      state.woundPileCount === null ? null : state.woundPileCount + 1;
+    updatedState = { ...state, woundPileCount: newWoundPileCount };
+  } else {
+    // Non-wound cards go to discard pile
+    updatedDiscard = [...player.discard, cardId];
+  }
+
+  // Step 3: Add mana token
+  const newToken: ManaToken = {
+    color: manaColor,
+    source: MANA_TOKEN_SOURCE_SKILL,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    hand: updatedHand,
+    discard: updatedDiscard,
+    pureMana: [...player.pureMana, newToken],
+  };
+
+  // Step 4: Apply player update to state
+  const players = [...updatedState.players];
+  players[playerIndex] = updatedPlayer;
+  updatedState = { ...updatedState, players };
+
+  return {
+    state: updatedState,
+    description: effect.description,
+  };
+}
+
+/**
+ * Register the Invocation effect handler with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerInvocationEffects(): void {
+  registerEffect(EFFECT_INVOCATION_RESOLVE, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return resolveInvocation(
+      state,
+      playerIndex,
+      player,
+      effect as InvocationResolveEffect
+    );
+  });
+}

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -24,6 +24,7 @@ import {
   SKILL_ARYTHEA_POLARIZATION,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_ARYTHEA_INVOCATION,
   SKILL_ARYTHEA_DARK_PATHS,
   SKILL_ARYTHEA_BURNING_POWER,
   SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
@@ -42,6 +43,7 @@ import {
 } from "../../types/combat.js";
 import { CARD_WOUND } from "@mage-knight/shared";
 import { canActivatePolarization } from "../commands/skills/polarizationEffect.js";
+import { canActivateInvocation } from "../commands/skills/invocationEffect.js";
 import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
 
 /**
@@ -55,6 +57,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_ARYTHEA_POLARIZATION,
   SKILL_ARYTHEA_RITUAL_OF_PAIN,
   SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_ARYTHEA_INVOCATION,
   SKILL_ARYTHEA_DARK_PATHS,
   SKILL_ARYTHEA_BURNING_POWER,
   SKILL_ARYTHEA_HOT_SWORDSMANSHIP,
@@ -96,6 +99,10 @@ function canActivateSkill(
     case SKILL_ARYTHEA_RITUAL_OF_PAIN:
       // Cannot use during combat
       return state.combat === null;
+
+    case SKILL_ARYTHEA_INVOCATION:
+      // Must have at least one card in hand to discard
+      return canActivateInvocation(player);
 
     default:
       // No special requirements

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -69,6 +69,7 @@ import {
   EFFECT_READY_ALL_UNITS,
   EFFECT_SELECT_HEX_FOR_COST_REDUCTION,
   EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION,
+  EFFECT_INVOCATION_RESOLVE,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -781,6 +782,28 @@ export interface CureEffect {
 }
 
 /**
+ * Invocation resolve effect (Arythea's Invocation skill).
+ *
+ * Atomic operation: discard a card from hand and gain a mana token.
+ * - Wound cards are returned to the wound pile (not discard pile)
+ * - Non-wound cards go to the discard pile
+ * - Mana token is added with MANA_TOKEN_SOURCE_SKILL
+ *
+ * Each option in the pendingChoice encodes the full operation.
+ */
+export interface InvocationResolveEffect {
+  readonly type: typeof EFFECT_INVOCATION_RESOLVE;
+  /** The card to discard from hand */
+  readonly cardId: CardId;
+  /** Whether the discarded card is a wound */
+  readonly isWound: boolean;
+  /** The mana color to gain */
+  readonly manaColor: ManaColor;
+  /** Human-readable description for UI */
+  readonly description: string;
+}
+
+/**
  * Disease spell powered effect.
  * All enemies that have ALL their attacks blocked during the Block phase
  * get their armor reduced to 1 for the rest of combat.
@@ -844,7 +867,8 @@ export type CardEffect =
   | SelectHexForCostReductionEffect
   | SelectTerrainForCostReductionEffect
   | CureEffect
-  | DiseaseEffect;
+  | DiseaseEffect
+  | InvocationResolveEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -167,6 +167,12 @@ export const EFFECT_CURE = "cure" as const;
 // Powered Disease: Reduce armor to 1 for all fully-blocked enemies
 export const EFFECT_DISEASE = "disease" as const;
 
+// === Invocation Effect ===
+// Atomic effect for Arythea's Invocation skill.
+// Discards a card from hand and gains a mana token in one atomic operation.
+// Wound cards → red or black mana. Non-wound cards → white or green mana.
+export const EFFECT_INVOCATION_RESOLVE = "invocation_resolve" as const;
+
 // === Scout Peek Effect ===
 // Reveals face-down enemy tokens within a distance from the player.
 // Also creates a modifier tracking which enemies were revealed, granting +1 fame on defeat.


### PR DESCRIPTION
## Summary
- Implement Arythea's Invocation skill: discard a card to gain a mana token
- Wound cards → red or black mana; non-wound cards → white or green mana
- Follows the Polarization custom handler pattern with pendingChoice

## Changes
- Add `EFFECT_INVOCATION_RESOLVE` effect type and `InvocationResolveEffect` interface
- Create `invocationEffect.ts` custom skill handler with apply/remove/canActivate
- Create `invocationEffects.ts` effect resolver (atomic discard + mana gain)
- Wire into `useSkillCommand.ts`, `skills/index.ts`, `effectRegistrations.ts`
- Add to `IMPLEMENTED_SKILLS` and `canActivateSkill` in `validActions/skills.ts`
- 21 tests covering all scenarios

## Implementation Notes
- Wound cards returned to wound pile (not discard pile)
- Non-wound cards go to discard pile
- Mana tokens have `MANA_TOKEN_SOURCE_SKILL` source
- Options are deduplicated (multiple wounds show one set of options)
- "Must use immediately" is a rulebook constraint enforced by players; the mana token is available in pureMana like any other skill-granted token

Closes #316