### PR TITLE
feat: implement Restoration/Rebirth forest conditional and unit readying

### DIFF
--- a/packages/core/src/data/spells/green/restoration.ts
+++ b/packages/core/src/data/spells/green/restoration.ts
@@ -1,10 +1,7 @@
 /**
  * Restoration / Rebirth (Green Spell #05)
  * Basic: Heal 3. If you are in a forest, Heal 5 instead.
- * Powered: Same + Ready up to 3 levels worth of Units (5 in forest)
- *
- * Note: Forest conditional and unit readying not yet implemented.
- * For now, just gives Heal 3 / Heal 5.
+ * Powered: Heal 3 (or 5 in forest) + Ready up to 3 levels worth of Units (5 in forest)
  */
 
 import type { DeedCard } from "../../../types/cards.js";
@@ -12,8 +9,15 @@ import {
   CATEGORY_HEALING,
   DEED_CARD_TYPE_SPELL,
 } from "../../../types/cards.js";
-import { MANA_GREEN, MANA_BLACK, CARD_RESTORATION } from "@mage-knight/shared";
+import { MANA_GREEN, MANA_BLACK, CARD_RESTORATION, TERRAIN_FOREST } from "@mage-knight/shared";
 import { heal } from "../helpers.js";
+import { ifOnTerrain, compound } from "../../effectHelpers.js";
+import { EFFECT_READY_UNITS_BUDGET } from "../../../types/effectTypes.js";
+import type { ReadyUnitsBudgetEffect } from "../../../types/cards.js";
+
+function readyUnitsBudget(totalLevels: number): ReadyUnitsBudgetEffect {
+  return { type: EFFECT_READY_UNITS_BUDGET, totalLevels };
+}
 
 export const RESTORATION: DeedCard = {
   id: CARD_RESTORATION,
@@ -22,7 +26,10 @@ export const RESTORATION: DeedCard = {
   cardType: DEED_CARD_TYPE_SPELL,
   categories: [CATEGORY_HEALING],
   poweredBy: [MANA_BLACK, MANA_GREEN],
-  basicEffect: heal(3),
-  poweredEffect: heal(5), // TODO: Add forest conditional and unit ready
+  basicEffect: ifOnTerrain(TERRAIN_FOREST, heal(5), heal(3)),
+  poweredEffect: compound([
+    ifOnTerrain(TERRAIN_FOREST, heal(5), heal(3)),
+    ifOnTerrain(TERRAIN_FOREST, readyUnitsBudget(5), readyUnitsBudget(3)),
+  ]),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/restoration.test.ts
+++ b/packages/core/src/engine/__tests__/restoration.test.ts
@@ -1,0 +1,589 @@
+/**
+ * Tests for Restoration / Rebirth spell
+ *
+ * Basic: Heal 3. If in a forest, Heal 5 instead.
+ * Powered: Heal 3 (or 5 in forest) + Ready up to 3 levels of Units (5 in forest)
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveEffect, isEffectResolvable, describeEffect } from "../effects/index.js";
+import type {
+  ReadyUnitsBudgetEffect,
+  ResolveReadyUnitBudgetEffect,
+  CompoundEffect,
+  NoopEffect,
+} from "../../types/cards.js";
+import {
+  EFFECT_READY_UNITS_BUDGET,
+  EFFECT_RESOLVE_READY_UNIT_BUDGET,
+  EFFECT_NOOP,
+  EFFECT_COMPOUND,
+  EFFECT_CONDITIONAL,
+} from "../../types/effectTypes.js";
+import {
+  CARD_WOUND,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  UNITS,
+  TERRAIN_FOREST,
+  TERRAIN_PLAINS,
+  hexKey,
+  type UnitId,
+} from "@mage-knight/shared";
+import type { PlayerUnit } from "../../types/unit.js";
+import { RESTORATION } from "../../data/spells/green/restoration.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createTestHex,
+} from "./testHelpers.js";
+import type { GameState } from "../../state/GameState.js";
+
+// Helper to create a unit with specific state
+function createUnit(
+  unitId: UnitId,
+  instanceId: string,
+  unitState: typeof UNIT_STATE_READY | typeof UNIT_STATE_SPENT,
+  wounded: boolean = false,
+): PlayerUnit {
+  return {
+    instanceId,
+    unitId,
+    state: unitState,
+    wounded,
+    usedResistanceThisCombat: false,
+  };
+}
+
+// Get unit IDs of different levels for testing
+function getUnitIdOfLevel(level: number): UnitId {
+  const unitEntry = Object.entries(UNITS).find(([_, def]) => def.level === level);
+  if (!unitEntry) {
+    throw new Error(`No unit found with level ${level}`);
+  }
+  return unitEntry[0] as UnitId;
+}
+
+// Create a state with the player at a specific terrain
+function createStateOnTerrain(
+  terrain: typeof TERRAIN_FOREST | typeof TERRAIN_PLAINS,
+  overrides: Partial<Parameters<typeof createTestPlayer>[0]> = {},
+): GameState {
+  const player = createTestPlayer({
+    position: { q: 0, r: 0 },
+    ...overrides,
+  });
+  return createTestGameState({
+    players: [player],
+    map: {
+      hexes: {
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, terrain),
+      },
+      tiles: [],
+      tileDeck: { countryside: [], core: [] },
+    },
+  });
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Restoration/Rebirth card definition", () => {
+  it("should have correct card metadata", () => {
+    expect(RESTORATION.name).toBe("Restoration");
+    expect(RESTORATION.poweredName).toBe("Rebirth");
+    expect(RESTORATION.categories).toContain("healing");
+    expect(RESTORATION.cardType).toBe("spell");
+  });
+
+  it("should have basic effect as terrain conditional", () => {
+    expect(RESTORATION.basicEffect.type).toBe(EFFECT_CONDITIONAL);
+  });
+
+  it("should have powered effect as compound of two conditionals", () => {
+    const powered = RESTORATION.poweredEffect;
+    expect(powered.type).toBe(EFFECT_COMPOUND);
+    const compound = powered as CompoundEffect;
+    expect(compound.effects).toHaveLength(2);
+    expect(compound.effects[0].type).toBe(EFFECT_CONDITIONAL);
+    expect(compound.effects[1].type).toBe(EFFECT_CONDITIONAL);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT: RESTORATION (Heal 3, or 5 in forest)
+// ============================================================================
+
+describe("Restoration basic effect (heal with forest conditional)", () => {
+  it("should heal 3 when not in a forest", () => {
+    const state = createStateOnTerrain(TERRAIN_PLAINS, {
+      hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.basicEffect);
+
+    // 4 wounds - 3 healed = 1 wound left
+    const woundsRemaining = result.state.players[0].hand.filter((c) => c === CARD_WOUND).length;
+    expect(woundsRemaining).toBe(1);
+  });
+
+  it("should heal 5 when in a forest", () => {
+    const state = createStateOnTerrain(TERRAIN_FOREST, {
+      hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.basicEffect);
+
+    // 6 wounds - 5 healed = 1 wound left
+    const woundsRemaining = result.state.players[0].hand.filter((c) => c === CARD_WOUND).length;
+    expect(woundsRemaining).toBe(1);
+  });
+
+  it("should only heal available wounds (not overcounting)", () => {
+    const state = createStateOnTerrain(TERRAIN_FOREST, {
+      hand: [CARD_WOUND, CARD_WOUND],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.basicEffect);
+
+    // Only 2 wounds to heal, heals 2 even though heal 5 offered
+    const woundsRemaining = result.state.players[0].hand.filter((c) => c === CARD_WOUND).length;
+    expect(woundsRemaining).toBe(0);
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT: REBIRTH (Heal + Ready units)
+// ============================================================================
+
+describe("Rebirth powered effect (heal + ready units)", () => {
+  it("should heal 3 when not in a forest (powered)", () => {
+    const state = createStateOnTerrain(TERRAIN_PLAINS, {
+      hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    // 4 wounds - 3 healed = 1 wound remaining
+    const woundsRemaining = result.state.players[0].hand.filter((c) => c === CARD_WOUND).length;
+    expect(woundsRemaining).toBe(1);
+  });
+
+  it("should heal 5 when in a forest (powered)", () => {
+    const state = createStateOnTerrain(TERRAIN_FOREST, {
+      hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    // 6 wounds - 5 healed = 1 wound remaining
+    const woundsRemaining = result.state.players[0].hand.filter((c) => c === CARD_WOUND).length;
+    expect(woundsRemaining).toBe(1);
+  });
+
+  it("should offer unit readying choices when player has spent units (not in forest)", () => {
+    const unitIdL1 = getUnitIdOfLevel(1);
+    const state = createStateOnTerrain(TERRAIN_PLAINS, {
+      hand: [],
+      units: [
+        createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+      ],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    // Should require a choice for unit readying
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toBeDefined();
+    // 1 unit option + Done
+    expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+    const unitOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+    expect(unitOption.type).toBe(EFFECT_RESOLVE_READY_UNIT_BUDGET);
+    expect(unitOption.unitInstanceId).toBe("u1");
+
+    const doneOption = result.dynamicChoiceOptions![1] as NoopEffect;
+    expect(doneOption.type).toBe(EFFECT_NOOP);
+  });
+
+  it("should have 5 level budget for unit readying in forest", () => {
+    const unitIdL1 = getUnitIdOfLevel(1);
+    const state = createStateOnTerrain(TERRAIN_FOREST, {
+      hand: [],
+      units: [
+        createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+      ],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    const unitOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+    // In forest, total budget is 5. L1 unit costs 1, so remaining is 4
+    expect(unitOption.remainingBudget).toBe(4);
+  });
+
+  it("should have 3 level budget for unit readying outside forest", () => {
+    const unitIdL1 = getUnitIdOfLevel(1);
+    const state = createStateOnTerrain(TERRAIN_PLAINS, {
+      hand: [],
+      units: [
+        createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+      ],
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    const unitOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+    // Not in forest, total budget is 3. L1 unit costs 1, so remaining is 2
+    expect(unitOption.remainingBudget).toBe(2);
+  });
+
+  it("should skip unit readying when no spent units", () => {
+    const state = createStateOnTerrain(TERRAIN_PLAINS, {
+      hand: [CARD_WOUND],
+      units: [], // No units at all
+    });
+    const result = resolveEffect(state, state.players[0].id, RESTORATION.poweredEffect);
+
+    // Should not require choice (healing resolves immediately, no units to ready)
+    expect(result.requiresChoice).toBeFalsy();
+  });
+});
+
+// ============================================================================
+// READY UNITS BUDGET EFFECT
+// ============================================================================
+
+describe("EFFECT_READY_UNITS_BUDGET", () => {
+  const effect: ReadyUnitsBudgetEffect = {
+    type: EFFECT_READY_UNITS_BUDGET,
+    totalLevels: 3,
+  };
+
+  describe("resolveEffect", () => {
+    it("should return no-op when no eligible units", () => {
+      const state = createStateOnTerrain(TERRAIN_PLAINS, { units: [] });
+      const result = resolveEffect(state, state.players[0].id, effect);
+      expect(result.description).toContain("No spent units");
+      expect(result.requiresChoice).toBeFalsy();
+    });
+
+    it("should present choice options including Done", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_SPENT)],
+      });
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(2); // 1 unit + Done
+      expect(result.dynamicChoiceOptions![0].type).toBe(EFFECT_RESOLVE_READY_UNIT_BUDGET);
+      expect(result.dynamicChoiceOptions![1].type).toBe(EFFECT_NOOP);
+    });
+
+    it("should exclude units that exceed budget", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const unitIdL4 = getUnitIdOfLevel(4);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL4, "u2", UNIT_STATE_SPENT), // L4 > budget of 3
+        ],
+      });
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.requiresChoice).toBe(true);
+      // Only L1 unit + Done (L4 exceeds budget of 3)
+      expect(result.dynamicChoiceOptions).toHaveLength(2);
+      const unitOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+      expect(unitOption.unitInstanceId).toBe("u1");
+    });
+
+    it("should include multiple eligible units", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u2", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u3", UNIT_STATE_SPENT),
+        ],
+      });
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.requiresChoice).toBe(true);
+      // 3 unit options + Done
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+    });
+
+    it("should skip already-ready units", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_READY),
+          createUnit(unitIdL1, "u2", UNIT_STATE_SPENT),
+        ],
+      });
+      const result = resolveEffect(state, state.players[0].id, effect);
+
+      expect(result.requiresChoice).toBe(true);
+      // Only u2 (spent) + Done
+      expect(result.dynamicChoiceOptions).toHaveLength(2);
+      const unitOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+      expect(unitOption.unitInstanceId).toBe("u2");
+    });
+  });
+
+  describe("isEffectResolvable", () => {
+    it("should return false when no units", () => {
+      const state = createStateOnTerrain(TERRAIN_PLAINS, { units: [] });
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+
+    it("should return false when all units are ready", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_READY)],
+      });
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+
+    it("should return false when spent units exceed budget", () => {
+      const unitIdL4 = getUnitIdOfLevel(4);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL4, "u1", UNIT_STATE_SPENT)],
+      });
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+
+    it("should return true when eligible spent unit exists", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_SPENT)],
+      });
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(true);
+    });
+  });
+
+  describe("describeEffect", () => {
+    it("should describe the budget", () => {
+      const desc = describeEffect(effect);
+      expect(desc).toContain("3");
+      expect(desc).toContain("levels");
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE READY UNIT BUDGET EFFECT
+// ============================================================================
+
+describe("EFFECT_RESOLVE_READY_UNIT_BUDGET", () => {
+  describe("resolveEffect", () => {
+    it("should ready the selected unit", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_SPENT)],
+      });
+      const resolveEffect_ = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      } as ResolveReadyUnitBudgetEffect;
+
+      const result = resolveEffect(state, state.players[0].id, resolveEffect_);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result.description).toContain("Readied");
+    });
+
+    it("should preserve wound status when readying", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_SPENT, true)],
+      });
+      const resolveEffect_ = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      } as ResolveReadyUnitBudgetEffect;
+
+      const result = resolveEffect(state, state.players[0].id, resolveEffect_);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result.state.players[0].units[0].wounded).toBe(true);
+    });
+
+    it("should chain with remaining options when budget remains", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u2", UNIT_STATE_SPENT),
+        ],
+      });
+      const resolveEffect_ = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2, // After readying u1, 2 levels left
+      } as ResolveReadyUnitBudgetEffect;
+
+      const result = resolveEffect(state, state.players[0].id, resolveEffect_);
+
+      // u1 readied
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      // Should offer u2 + Done
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(2);
+      const nextOption = result.dynamicChoiceOptions![0] as ResolveReadyUnitBudgetEffect;
+      expect(nextOption.unitInstanceId).toBe("u2");
+      expect(nextOption.remainingBudget).toBe(1); // 2 - 1 (L1 unit)
+    });
+
+    it("should not chain when budget is exhausted", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u2", UNIT_STATE_SPENT),
+        ],
+      });
+      const resolveEffect_ = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 0, // No budget left after this
+      } as ResolveReadyUnitBudgetEffect;
+
+      const result = resolveEffect(state, state.players[0].id, resolveEffect_);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      // Should NOT chain
+      expect(result.requiresChoice).toBeFalsy();
+    });
+
+    it("should not chain when remaining units exceed remaining budget", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const unitIdL3 = getUnitIdOfLevel(3);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL3, "u2", UNIT_STATE_SPENT), // L3, won't fit in budget of 1
+        ],
+      });
+      const resolveEffect_ = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 1, // Only 1 level left, L3 won't fit
+      } as ResolveReadyUnitBudgetEffect;
+
+      const result = resolveEffect(state, state.players[0].id, resolveEffect_);
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      // Should NOT chain (L3 unit can't fit in remaining budget of 1)
+      expect(result.requiresChoice).toBeFalsy();
+    });
+
+    it("should allow readying multiple units up to 3 levels total", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [
+          createUnit(unitIdL1, "u1", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u2", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u3", UNIT_STATE_SPENT),
+          createUnit(unitIdL1, "u4", UNIT_STATE_SPENT),
+        ],
+      });
+
+      // Ready first unit (budget 3 -> 2)
+      const effect1: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      };
+      const result1 = resolveEffect(state, state.players[0].id, effect1);
+      expect(result1.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      expect(result1.requiresChoice).toBe(true);
+
+      // Ready second unit (budget 2 -> 1)
+      const effect2: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u2",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 1,
+      };
+      const result2 = resolveEffect(result1.state, result1.state.players[0].id, effect2);
+      expect(result2.state.players[0].units[1].state).toBe(UNIT_STATE_READY);
+      expect(result2.requiresChoice).toBe(true);
+
+      // Ready third unit (budget 1 -> 0)
+      const effect3: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u3",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 0,
+      };
+      const result3 = resolveEffect(result2.state, result2.state.players[0].id, effect3);
+      expect(result3.state.players[0].units[2].state).toBe(UNIT_STATE_READY);
+      // Budget exhausted, no more chaining
+      expect(result3.requiresChoice).toBeFalsy();
+
+      // u4 should still be spent
+      expect(result3.state.players[0].units[3].state).toBe(UNIT_STATE_SPENT);
+    });
+  });
+
+  describe("isEffectResolvable", () => {
+    it("should return true for spent unit", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_SPENT)],
+      });
+      const effect: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      };
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(true);
+    });
+
+    it("should return false for already-ready unit", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const state = createStateOnTerrain(TERRAIN_PLAINS, {
+        units: [createUnit(unitIdL1, "u1", UNIT_STATE_READY)],
+      });
+      const effect: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      };
+      expect(isEffectResolvable(state, state.players[0].id, effect)).toBe(false);
+    });
+  });
+
+  describe("describeEffect", () => {
+    it("should describe the unit being readied", () => {
+      const unitIdL1 = getUnitIdOfLevel(1);
+      const effect: ResolveReadyUnitBudgetEffect = {
+        type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+        unitInstanceId: "u1",
+        unitName: UNITS[unitIdL1].name,
+        unitLevel: 1,
+        remainingBudget: 2,
+      };
+      const desc = describeEffect(effect);
+      expect(desc).toContain(UNITS[unitIdL1].name);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -42,6 +42,8 @@ import {
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_READY_UNITS_BUDGET,
+  EFFECT_RESOLVE_READY_UNIT_BUDGET,
   EFFECT_CURE,
   EFFECT_DISEASE,
   COMBAT_TYPE_RANGED,
@@ -52,6 +54,8 @@ import type {
   RecruitDiscountEffect,
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
+  ReadyUnitsBudgetEffect,
+  ResolveReadyUnitBudgetEffect,
   EnergyFlowEffect,
   ResolveEnergyFlowTargetEffect,
   CureEffect,
@@ -314,6 +318,16 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   },
 
   [EFFECT_READY_ALL_UNITS]: () => "Ready all Units",
+
+  [EFFECT_READY_UNITS_BUDGET]: (effect) => {
+    const e = effect as ReadyUnitsBudgetEffect;
+    return `Ready Units (up to ${e.totalLevels} levels)`;
+  },
+
+  [EFFECT_RESOLVE_READY_UNIT_BUDGET]: (effect) => {
+    const e = effect as ResolveReadyUnitBudgetEffect;
+    return `Ready ${e.unitName}`;
+  },
 
   [EFFECT_CURE]: (effect) => {
     const e = effect as CureEffect;

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -36,6 +36,7 @@ import { registerRuthlessCoercionEffects } from "./ruthlessCoercionEffects.js";
 import { registerEnergyFlowEffects } from "./energyFlowEffects.js";
 import { registerCureEffects } from "./cureEffects.js";
 import { registerInvocationEffects } from "./invocationEffects.js";
+import { registerReadyUnitsBudgetEffects } from "./readyUnitsBudgetEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -126,4 +127,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Invocation effects (Arythea's Invocation skill)
   registerInvocationEffects();
+
+  // Ready units budget effects (Restoration/Rebirth spell)
+  registerReadyUnitsBudgetEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -232,6 +232,11 @@ export {
   registerEnergyFlowEffects,
 } from "./energyFlowEffects.js";
 
+// Ready units budget effects (Restoration/Rebirth spell)
+export {
+  registerReadyUnitsBudgetEffects,
+} from "./readyUnitsBudgetEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/readyUnitsBudgetEffects.ts
+++ b/packages/core/src/engine/effects/readyUnitsBudgetEffects.ts
@@ -1,0 +1,196 @@
+/**
+ * Ready Units Budget effect handlers
+ *
+ * Handles the Restoration/Rebirth spell's unit readying effect:
+ * - EFFECT_READY_UNITS_BUDGET: Entry point for readying spent units up to a total level budget
+ * - EFFECT_RESOLVE_READY_UNIT_BUDGET: Apply ready to one unit and chain with remaining budget
+ *
+ * @module effects/readyUnitsBudgetEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  ReadyUnitsBudgetEffect,
+  ResolveReadyUnitBudgetEffect,
+  CardEffect,
+  NoopEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { UNITS, UNIT_STATE_READY, UNIT_STATE_SPENT } from "@mage-knight/shared";
+import type { PlayerUnit } from "../../types/unit.js";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_READY_UNITS_BUDGET,
+  EFFECT_RESOLVE_READY_UNIT_BUDGET,
+  EFFECT_NOOP,
+} from "../../types/effectTypes.js";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Get spent units whose level fits within the remaining budget.
+ */
+function getEligibleUnitsForBudget(
+  units: readonly PlayerUnit[],
+  remainingBudget: number,
+): PlayerUnit[] {
+  return units.filter((unit) => {
+    if (unit.state !== UNIT_STATE_SPENT) return false;
+    const unitDef = UNITS[unit.unitId];
+    if (!unitDef) return false;
+    return unitDef.level <= remainingBudget;
+  });
+}
+
+// ============================================================================
+// READY UNITS BUDGET (Entry Point)
+// ============================================================================
+
+/**
+ * Handle EFFECT_READY_UNITS_BUDGET entry point.
+ * Finds eligible spent units and generates choice options including a "Done" option.
+ */
+function handleReadyUnitsBudget(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: ReadyUnitsBudgetEffect,
+): EffectResolutionResult {
+  const eligible = getEligibleUnitsForBudget(player.units, effect.totalLevels);
+
+  if (eligible.length === 0) {
+    return {
+      state,
+      description: "No spent units to ready",
+    };
+  }
+
+  // Generate choice options: one per eligible unit + "Done" option
+  const unitOptions: ResolveReadyUnitBudgetEffect[] = eligible.map((unit) => {
+    const unitDef = UNITS[unit.unitId];
+    const level = unitDef?.level ?? 1;
+    return {
+      type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+      unitInstanceId: unit.instanceId,
+      unitName: unitDef?.name ?? unit.unitId,
+      unitLevel: level,
+      remainingBudget: effect.totalLevels - level,
+    };
+  });
+
+  const doneOption: NoopEffect = { type: EFFECT_NOOP };
+
+  return {
+    state,
+    description: `Select units to ready (${effect.totalLevels} levels available)`,
+    requiresChoice: true,
+    dynamicChoiceOptions: [...unitOptions, doneOption] as CardEffect[],
+  };
+}
+
+// ============================================================================
+// RESOLVE READY UNIT BUDGET TARGET
+// ============================================================================
+
+/**
+ * Handle EFFECT_RESOLVE_READY_UNIT_BUDGET - readies the selected unit,
+ * then chains back to present remaining options with updated budget.
+ */
+function handleResolveReadyUnitBudget(
+  state: GameState,
+  playerId: string,
+  effect: ResolveReadyUnitBudgetEffect,
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  // Find the unit
+  const unitIndex = player.units.findIndex((u) => u.instanceId === effect.unitInstanceId);
+  if (unitIndex === -1) {
+    return { state, description: `Unit not found: ${effect.unitInstanceId}` };
+  }
+
+  const unit = player.units[unitIndex];
+  if (!unit || unit.state !== UNIT_STATE_SPENT) {
+    return { state, description: "Unit is not spent" };
+  }
+
+  // Ready the unit
+  const updatedUnits = [...player.units];
+  updatedUnits[unitIndex] = { ...unit, state: UNIT_STATE_READY };
+
+  const updatedPlayer: Player = {
+    ...player,
+    units: updatedUnits,
+  };
+
+  const stateAfterReady = updatePlayer(state, playerIndex, updatedPlayer);
+
+  // Check if we can ready more units with the remaining budget
+  if (effect.remainingBudget > 0) {
+    const remainingEligible = getEligibleUnitsForBudget(
+      updatedPlayer.units,
+      effect.remainingBudget,
+    );
+
+    if (remainingEligible.length > 0) {
+      // Generate new choice options for remaining units
+      const unitOptions: ResolveReadyUnitBudgetEffect[] = remainingEligible.map((u) => {
+        const unitDef = UNITS[u.unitId];
+        const level = unitDef?.level ?? 1;
+        return {
+          type: EFFECT_RESOLVE_READY_UNIT_BUDGET,
+          unitInstanceId: u.instanceId,
+          unitName: unitDef?.name ?? u.unitId,
+          unitLevel: level,
+          remainingBudget: effect.remainingBudget - level,
+        };
+      });
+
+      const doneOption: NoopEffect = { type: EFFECT_NOOP };
+
+      return {
+        state: stateAfterReady,
+        description: `Readied ${effect.unitName}`,
+        requiresChoice: true,
+        dynamicChoiceOptions: [...unitOptions, doneOption] as CardEffect[],
+      };
+    }
+  }
+
+  return {
+    state: stateAfterReady,
+    description: `Readied ${effect.unitName}`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all ready units budget effect handlers with the effect registry.
+ */
+export function registerReadyUnitsBudgetEffects(): void {
+  registerEffect(EFFECT_READY_UNITS_BUDGET, (state, playerId, effect) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleReadyUnitsBudget(
+      state,
+      playerIndex,
+      player,
+      effect as ReadyUnitsBudgetEffect,
+    );
+  });
+
+  registerEffect(EFFECT_RESOLVE_READY_UNIT_BUDGET, (state, playerId, effect) => {
+    return handleResolveReadyUnitBudget(
+      state,
+      playerId,
+      effect as ResolveReadyUnitBudgetEffect,
+    );
+  });
+}

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -76,6 +76,8 @@ import {
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_READY_UNITS_BUDGET,
+  EFFECT_RESOLVE_READY_UNIT_BUDGET,
   EFFECT_SELECT_HEX_FOR_COST_REDUCTION,
   EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION,
   EFFECT_CURE,
@@ -100,6 +102,8 @@ import type {
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
   ResolveEnergyFlowTargetEffect,
+  ReadyUnitsBudgetEffect,
+  ResolveReadyUnitBudgetEffect,
 } from "../../types/cards.js";
 import {
   EFFECT_RULE_OVERRIDE,
@@ -391,6 +395,23 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   [EFFECT_READY_ALL_UNITS]: (state, player) => {
     // Resolvable if player has at least one spent unit
     return player.units.some((u) => u.state === UNIT_STATE_SPENT);
+  },
+
+  [EFFECT_READY_UNITS_BUDGET]: (state, player, effect) => {
+    const e = effect as ReadyUnitsBudgetEffect;
+    // Resolvable if player has spent units with level <= totalLevels
+    return player.units.some((unit) => {
+      if (unit.state !== UNIT_STATE_SPENT) return false;
+      const unitDef = UNITS[unit.unitId];
+      return unitDef !== undefined && unitDef.level <= e.totalLevels;
+    });
+  },
+
+  [EFFECT_RESOLVE_READY_UNIT_BUDGET]: (state, player, effect) => {
+    const e = effect as ResolveReadyUnitBudgetEffect;
+    // Resolvable if the unit exists and is spent
+    const unit = player.units.find((u) => u.instanceId === e.unitInstanceId);
+    return unit !== undefined && unit.state === UNIT_STATE_SPENT;
   },
 
   [EFFECT_CURE]: (state, player) => {

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -61,6 +61,8 @@ import {
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
+  EFFECT_READY_UNITS_BUDGET,
+  EFFECT_RESOLVE_READY_UNIT_BUDGET,
   EFFECT_CURE,
   EFFECT_DISEASE,
   EFFECT_SCOUT_PEEK,
@@ -708,6 +710,33 @@ export interface ReadyAllUnitsEffect {
 }
 
 /**
+ * Ready units up to a total level budget (free, no influence cost).
+ * Used by Restoration/Rebirth powered spell effect.
+ *
+ * Resolution:
+ * 1. Find eligible spent units where level <= remaining budget
+ * 2. Present choices: one per eligible unit + "Done" option
+ * 3. On selection: ready unit, deduct level from budget, re-present remaining choices
+ * 4. On "Done": complete resolution
+ */
+export interface ReadyUnitsBudgetEffect {
+  readonly type: typeof EFFECT_READY_UNITS_BUDGET;
+  readonly totalLevels: number; // Budget of unit levels (e.g., 3 or 5)
+}
+
+/**
+ * Internal effect generated as a choice option for budget-based unit readying.
+ * Readies the selected unit and chains back with remaining budget.
+ */
+export interface ResolveReadyUnitBudgetEffect {
+  readonly type: typeof EFFECT_RESOLVE_READY_UNIT_BUDGET;
+  readonly unitInstanceId: string;
+  readonly unitName: string;
+  readonly unitLevel: number; // Level of the selected unit
+  readonly remainingBudget: number; // Budget remaining after readying this unit
+}
+
+/**
  * Scout peek effect (Scouts unit ability).
  * Reveals face-down enemy tokens within a distance from the player.
  * Also creates a ScoutFameBonus modifier tracking which enemies were newly revealed,
@@ -861,6 +890,8 @@ export type CardEffect =
   | ReadyUnitsForInfluenceEffect
   | ResolveReadyUnitForInfluenceEffect
   | ReadyAllUnitsEffect
+  | ReadyUnitsBudgetEffect
+  | ResolveReadyUnitBudgetEffect
   | ScoutPeekEffect
   | EnergyFlowEffect
   | ResolveEnergyFlowTargetEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -173,6 +173,13 @@ export const EFFECT_DISEASE = "disease" as const;
 // Wound cards → red or black mana. Non-wound cards → white or green mana.
 export const EFFECT_INVOCATION_RESOLVE = "invocation_resolve" as const;
 
+// === Ready Units Budget Effect ===
+// Entry point for readying spent units up to a total level budget (no influence cost).
+// Used by Restoration/Rebirth powered spell effect.
+export const EFFECT_READY_UNITS_BUDGET = "ready_units_budget" as const;
+// Internal: resolve effect after unit selection for budget-based readying
+export const EFFECT_RESOLVE_READY_UNIT_BUDGET = "resolve_ready_unit_budget" as const;
+
 // === Scout Peek Effect ===
 // Reveals face-down enemy tokens within a distance from the player.
 // Also creates a modifier tracking which enemies were revealed, granting +1 fame on defeat.


### PR DESCRIPTION
## Summary
- Implement forest terrain conditional for Restoration basic effect (Heal 3, or Heal 5 in forest)
- Fix powered effect to Heal 3/5 (was incorrectly Heal 5 always) plus ready units
- Add new `EFFECT_READY_UNITS_BUDGET` effect type for readying spent units up to a total level budget
- Powered effect: ready up to 3 levels of units (or 5 in forest), free of cost

## Changes
- **`restoration.ts`**: Updated spell definition with `ifOnTerrain` conditional for both basic and powered effects, compound powered effect with heal + ready units budget
- **`effectTypes.ts`**: Added `EFFECT_READY_UNITS_BUDGET` and `EFFECT_RESOLVE_READY_UNIT_BUDGET` constants
- **`cards.ts`**: Added `ReadyUnitsBudgetEffect` and `ResolveReadyUnitBudgetEffect` interfaces to the `CardEffect` union
- **`readyUnitsBudgetEffects.ts`** (new): Effect resolver following the iterative selection pattern (like Ruthless Coercion), with budget tracking instead of influence cost
- **`effectRegistrations.ts`**: Registered new effect handlers
- **`resolvability.ts`**: Added resolvability checks for new effects
- **`describeEffect.ts`**: Added human-readable descriptions for new effects
- **`restoration.test.ts`** (new): 31 tests covering basic heal, forest conditional, powered heal, unit readying with budget tracking, chaining, and edge cases

Closes #191