### PR TITLE
fix: Fire Golems - correct ability structure and add Ranged Fire Attack 4 (red mana)

### DIFF
--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -871,7 +871,7 @@ describe("Unit Combat Abilities", () => {
 
   describe("Mana-powered abilities", () => {
     it("should allow free ability without mana source", () => {
-      // Fire Golems have Attack 3 Fire (free) at index 0
+      // Fire Golems have Attack 3 physical (free) at index 0 - Attack OR Block choice
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -886,7 +886,7 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 0, // Attack 3 Fire (free)
+        abilityIndex: 0, // Attack 3 physical (free)
       });
 
       // Should succeed
@@ -895,7 +895,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should reject powered ability without mana source", () => {
-      // Fire Golems have Attack 5 Fire (requires red mana) at index 2
+      // Fire Golems have Ranged Fire Attack 4 (requires red mana) at index 2
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -911,7 +911,7 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         // No manaSource provided
       });
 
@@ -925,7 +925,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should allow powered ability with mana token", () => {
-      // Fire Golems have Attack 5 Fire (requires red mana) at index 2
+      // Fire Golems have Ranged Fire Attack 4 (requires red mana) at index 2
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -941,12 +941,13 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
       });
 
-      // Should succeed
-      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(5);
+      // Should succeed - ranged fire attack adds to ranged pool
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(4);
+      expect(result.state.players[0].combatAccumulator.attack.rangedElements.fire).toBe(4);
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
       // Mana token should be consumed
       expect(result.state.players[0].pureMana.length).toBe(0);
@@ -981,7 +982,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should allow powered ability with mana die", () => {
-      // Fire Golems have Attack 5 Fire (requires red mana) at index 2
+      // Fire Golems have Ranged Fire Attack 4 (requires red mana) at index 2
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -1000,19 +1001,20 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         manaSource: { type: MANA_SOURCE_DIE, color: MANA_RED, dieId: "die_0" },
       });
 
-      // Should succeed
-      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(5);
+      // Should succeed - ranged fire attack
+      expect(result.state.players[0].combatAccumulator.attack.ranged).toBe(4);
+      expect(result.state.players[0].combatAccumulator.attack.rangedElements.fire).toBe(4);
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
       // Die should be in used list
       expect(result.state.players[0].usedDieIds).toContain("die_0");
     });
 
     it("should reject powered ability with wrong mana color", () => {
-      // Fire Golems need red mana, but we provide blue
+      // Fire Golems Ranged Fire Attack 4 needs red mana, but we provide blue
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -1028,7 +1030,7 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
       });
 
@@ -1039,7 +1041,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should reject powered ability when no mana available", () => {
-      // Fire Golems have Attack 5 Fire (requires red mana) at index 2
+      // Fire Golems have Ranged Fire Attack 4 (requires red mana) at index 2
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -1057,7 +1059,7 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
       });
 
@@ -1068,7 +1070,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should track mana used this turn for powered abilities", () => {
-      // Fire Golems have Attack 5 Fire (requires red mana) at index 2
+      // Fire Golems have Ranged Fire Attack 4 (requires red mana) at index 2
       const unit = createPlayerUnit(UNIT_FIRE_GOLEMS, "fire_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -1084,7 +1086,7 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "fire_golem_1",
-        abilityIndex: 2, // Attack 5 Fire (requires red mana)
+        abilityIndex: 2, // Ranged Fire Attack 4 (requires red mana)
         manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
       });
 

--- a/packages/shared/src/units/elite/fireGolems.ts
+++ b/packages/shared/src/units/elite/fireGolems.ts
@@ -1,8 +1,12 @@
 /**
  * Fire Golems unit definition
+ *
+ * Rulebook:
+ * - Ability 1: Attack OR Block 3 (choice, free, physical)
+ * - Ability 2: Ranged Fire Attack 4 (costs red mana)
  */
 
-import { ELEMENT_FIRE } from "../../elements.js";
+import { ELEMENT_FIRE, ELEMENT_PHYSICAL } from "../../elements.js";
 import { MANA_RED } from "../../ids.js";
 import { RESIST_PHYSICAL, RESIST_FIRE } from "../../enemies/index.js";
 import type { UnitDefinition } from "../types.js";
@@ -12,6 +16,7 @@ import {
   RECRUIT_SITE_MAGE_TOWER,
   UNIT_ABILITY_ATTACK,
   UNIT_ABILITY_BLOCK,
+  UNIT_ABILITY_RANGED_ATTACK,
 } from "../constants.js";
 import { UNIT_FIRE_GOLEMS } from "../ids.js";
 
@@ -25,12 +30,16 @@ export const FIRE_GOLEMS: UnitDefinition = {
   resistances: [RESIST_PHYSICAL, RESIST_FIRE],
   recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_MAGE_TOWER],
   abilities: [
-    // Base abilities (free)
-    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_FIRE },
-    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_FIRE },
-    // Powered abilities (require red mana)
-    { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_FIRE, manaCost: MANA_RED },
-    { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_FIRE, manaCost: MANA_RED },
+    // Ability 1: Attack OR Block 3 (choice, free, physical)
+    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
+    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_PHYSICAL },
+    // Ability 2: Ranged Fire Attack 4 (costs red mana)
+    {
+      type: UNIT_ABILITY_RANGED_ATTACK,
+      value: 4,
+      element: ELEMENT_FIRE,
+      manaCost: MANA_RED,
+    },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary
Fixes Fire Golems unit to match the rulebook: first ability is Attack OR Block 3 (choice, free, physical); second ability is Ranged Fire Attack 4 (costs red mana).

## Changes
- **packages/shared/src/units/elite/fireGolems.ts**
  - First ability: Attack 3 and Block 3 with **physical** element (was fire), free — represents "Attack OR Block 3" choice.
  - Second ability: **Ranged Fire Attack 4** with red mana cost (replaces the incorrect Attack 5 / Block 5 fire options).
- **packages/core/src/engine/__tests__/unitActivation.test.ts**
  - Updated Fire Golems tests: free ability at index 0 is Attack 3 physical; powered ability at index 2 is Ranged Fire Attack 4 (red mana). Assertions now expect `attack.ranged` and `rangedElements.fire` for the ranged ability.

## Test Plan
- `bun run test` (unitActivation tests cover free physical Attack 3 and red-mana Ranged Fire Attack 4).
- In-game: recruit Fire Golems, confirm two free options (Attack 3 / Block 3 physical) and one red-mana option (Ranged Fire Attack 4).

Closes #283

Made with [Cursor](https://cursor.com)