### PR TITLE
fix: Ice Golems - rulebook ability structure (#290)

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -149,6 +149,12 @@ export const UTEM_SWORDSMEN_ATTACK_OR_BLOCK_WOUND = "utem_swordsmen_attack_or_bl
 export const UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK = "utem_crossbowmen_attack_or_block" as const;
 
 /**
+ * Ice Golems: Basic ability (free)
+ * Attack 3 OR Block 3 (Ice)
+ */
+export const ICE_GOLEMS_ATTACK_OR_BLOCK = "ice_golems_attack_or_block" as const;
+
+/**
  * Thugs: Free ability (combat only)
  * Attack 3 (Physical) + Reputation -1 (immediate)
  */
@@ -440,6 +446,27 @@ const UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK_EFFECT: CardEffect = {
 };
 
 /**
+ * Ice Golems' basic ability: Attack 3 OR Block 3 (Ice).
+ * Player chooses between gaining 3 Ice Attack (melee) or 3 Ice Block.
+ */
+const ICE_GOLEMS_ATTACK_OR_BLOCK_EFFECT: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 3,
+      combatType: COMBAT_TYPE_MELEE,
+      element: ELEMENT_ICE,
+    },
+    {
+      type: EFFECT_GAIN_BLOCK,
+      amount: 3,
+      element: ELEMENT_ICE,
+    },
+  ],
+};
+
+/**
  * Thugs' Attack ability effect.
  * Compound: Attack 3 Physical (melee) + Reputation -1 (immediate).
  * Per FAQ: reputation change is immediate, not at end of turn.
@@ -621,6 +648,7 @@ export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
   [SCOUTS_SCOUT_PEEK]: SCOUTS_SCOUT_PEEK_EFFECT,
   [SCOUTS_EXTENDED_MOVE]: SCOUTS_EXTENDED_MOVE_EFFECT,
   [UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK]: UTEM_CROSSBOWMEN_ATTACK_OR_BLOCK_EFFECT,
+  [ICE_GOLEMS_ATTACK_OR_BLOCK]: ICE_GOLEMS_ATTACK_OR_BLOCK_EFFECT,
   [THUGS_ATTACK]: THUGS_ATTACK_EFFECT,
   [THUGS_INFLUENCE]: THUGS_INFLUENCE_EFFECT,
   [SHOCKTROOPS_COORDINATED_FIRE]: SHOCKTROOPS_COORDINATED_FIRE_EFFECT,

--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -674,8 +674,8 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should return clear error for passive abilities like paralyze", () => {
-      // Ice Golems have Paralyze at index 4 (passive)
-      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
+      // Amotep Freezers have Paralyze at index 2 (passive)
+      const unit = createPlayerUnit(UNIT_AMOTEP_FREEZERS, "amotep_freezers_1");
       const player = createTestPlayer({
         units: [unit],
         commandTokens: 1,
@@ -688,8 +688,8 @@ describe("Unit Combat Abilities", () => {
 
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
-        unitInstanceId: "ice_golems_1",
-        abilityIndex: 4, // Paralyze (passive)
+        unitInstanceId: "amotep_freezers_1",
+        abilityIndex: 2, // Paralyze (passive)
       });
 
       // Unit should still be ready (action rejected)
@@ -953,7 +953,7 @@ describe("Unit Combat Abilities", () => {
     });
 
     it("should allow powered ability with mana crystal", () => {
-      // Ice Golems have Attack 5 Ice (requires blue mana) at index 2
+      // Ice Golems have Ice Attack 6 (requires blue mana) at index 1
       const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golem_1");
       const player = createTestPlayer({
         units: [unit],
@@ -969,12 +969,12 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "ice_golem_1",
-        abilityIndex: 2, // Attack 5 Ice (requires blue mana)
+        abilityIndex: 1, // Ice Attack 6 (requires blue mana)
         manaSource: { type: MANA_SOURCE_CRYSTAL, color: MANA_BLUE },
       });
 
       // Should succeed
-      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(5);
+      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(6);
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
       // Crystal should be consumed
       expect(result.state.players[0].crystals.blue).toBe(0);

--- a/packages/core/src/engine/__tests__/unitIceGolems.test.ts
+++ b/packages/core/src/engine/__tests__/unitIceGolems.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Ice Golems Unit Ability Tests
+ *
+ * Ice Golems have two abilities (rulebook):
+ * 1. Attack 3 OR Block 3 (Ice) - choice ability (free)
+ * 2. (Blue Mana) Ice Attack 6 - mana-powered attack
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import {
+  UNIT_ICE_GOLEMS,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CHOICE_REQUIRED,
+  ICE_GOLEMS,
+  MANA_BLUE,
+  MANA_SOURCE_CRYSTAL,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import { COMBAT_PHASE_ATTACK } from "../../types/combat.js";
+
+describe("Ice Golems Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(ICE_GOLEMS.name).toBe("Ice Golems");
+      expect(ICE_GOLEMS.level).toBe(3);
+      expect(ICE_GOLEMS.influence).toBe(8);
+      expect(ICE_GOLEMS.armor).toBe(4);
+    });
+
+    it("should have two abilities", () => {
+      expect(ICE_GOLEMS.abilities.length).toBe(2);
+    });
+
+    it("should have Attack 3 OR Block 3 as first ability (effect-based choice, no mana)", () => {
+      const ability = ICE_GOLEMS.abilities[0];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBeUndefined();
+      expect(ability?.displayName).toContain("Attack");
+      expect(ability?.displayName).toContain("Block");
+    });
+
+    it("should have Ice Attack 6 as second ability (blue mana)", () => {
+      const ability = ICE_GOLEMS.abilities[1];
+      expect(ability?.type).toBe("attack");
+      expect(ability?.value).toBe(6);
+      expect(ability?.manaCost).toBe(MANA_BLUE);
+    });
+  });
+
+  describe("Attack 3 OR Block 3 (Ability 0)", () => {
+    it("should present choice between Ice Attack 3 and Ice Block 3", () => {
+      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "ice_golems_1",
+        abilityIndex: 0,
+      });
+
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      const choiceEvent = result.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+    });
+
+    it("should grant Ice Attack 3 when attack option chosen", () => {
+      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "ice_golems_1",
+        abilityIndex: 0,
+      });
+
+      const choiceResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: 0 },
+      );
+
+      expect(
+        choiceResult.state.players[0].combatAccumulator.attack.normalElements.ice,
+      ).toBe(3);
+      expect(choiceResult.state.players[0].units[0].state).toBe(
+        UNIT_STATE_SPENT,
+      );
+    });
+
+    it("should grant Ice Block 3 when block option chosen", () => {
+      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "ice_golems_1",
+        abilityIndex: 0,
+      });
+
+      const choiceResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: 1 },
+      );
+
+      expect(choiceResult.state.players[0].combatAccumulator.block).toBe(3);
+      expect(choiceResult.state.players[0].units[0].state).toBe(
+        UNIT_STATE_SPENT,
+      );
+    });
+  });
+
+  describe("(Blue Mana) Ice Attack 6 (Ability 1)", () => {
+    it("should grant Ice Attack 6 when blue mana crystal used", () => {
+      const unit = createPlayerUnit(UNIT_ICE_GOLEMS, "ice_golems_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        crystals: { red: 0, blue: 1, green: 0, white: 0 },
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "ice_golems_1",
+        abilityIndex: 1,
+        manaSource: { type: MANA_SOURCE_CRYSTAL, color: MANA_BLUE },
+      });
+
+      expect(result.state.players[0].combatAccumulator.attack.normal).toBe(6);
+      expect(
+        result.state.players[0].combatAccumulator.attack.normalElements.ice,
+      ).toBe(6);
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      expect(result.state.players[0].crystals.blue).toBe(0);
+    });
+  });
+});

--- a/packages/shared/src/units/elite/iceGolems.ts
+++ b/packages/shared/src/units/elite/iceGolems.ts
@@ -1,5 +1,9 @@
 /**
  * Ice Golems unit definition
+ *
+ * Rulebook:
+ * - Attack OR Block 3 (choice ability, free)
+ * - (Blue Mana) Ice Attack 6 - mana-powered attack
  */
 
 import { ELEMENT_ICE } from "../../elements.js";
@@ -11,10 +15,11 @@ import {
   RECRUIT_SITE_KEEP,
   RECRUIT_SITE_MAGE_TOWER,
   UNIT_ABILITY_ATTACK,
-  UNIT_ABILITY_BLOCK,
-  UNIT_ABILITY_PARALYZE,
+  UNIT_ABILITY_EFFECT,
 } from "../constants.js";
 import { UNIT_ICE_GOLEMS } from "../ids.js";
+
+const ICE_GOLEMS_ATTACK_OR_BLOCK = "ice_golems_attack_or_block";
 
 export const ICE_GOLEMS: UnitDefinition = {
   id: UNIT_ICE_GOLEMS,
@@ -26,14 +31,14 @@ export const ICE_GOLEMS: UnitDefinition = {
   resistances: [RESIST_PHYSICAL, RESIST_ICE],
   recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_MAGE_TOWER],
   abilities: [
-    // Base abilities (free)
-    { type: UNIT_ABILITY_ATTACK, value: 3, element: ELEMENT_ICE },
-    { type: UNIT_ABILITY_BLOCK, value: 3, element: ELEMENT_ICE },
-    // Powered abilities (require blue mana)
-    { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_ICE, manaCost: MANA_BLUE },
-    { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_ICE, manaCost: MANA_BLUE },
-    // Passive
-    { type: UNIT_ABILITY_PARALYZE },
+    // Attack 3 OR Block 3 (Ice) - choice, no mana cost
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: ICE_GOLEMS_ATTACK_OR_BLOCK,
+      displayName: "Attack 3 OR Block 3",
+    },
+    // (Blue Mana) Ice Attack 6
+    { type: UNIT_ABILITY_ATTACK, value: 6, element: ELEMENT_ICE, manaCost: MANA_BLUE },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary
Align Ice Golems unit with rulebook: single Attack OR Block 3 (choice), Blue mana Ice Attack 6, and remove incorrect Paralyze.

## Changes
- **Remove** incorrect Paralyze ability
- **Replace** separate Attack 3 + Block 3 with a single **choice ability** (Attack 3 OR Block 3, Ice) using `UNIT_ABILITY_EFFECT` + `ice_golems_attack_or_block` effect
- **Add** Blue mana-powered **Ice Attack 6** (was wrongly implemented as Attack 5 + Block 5)
- **Core**: Add `ICE_GOLEMS_ATTACK_OR_BLOCK` effect and `ICE_GOLEMS_ATTACK_OR_BLOCK_EFFECT` in `unitAbilityEffects.ts`
- **Tests**: Paralyze test now uses Amotep Freezers (which have Paralyze); Ice Golems mana test updated to ability index 1, value 6
- **New**: `unitIceGolems.test.ts` — unit definition, choice ability (Attack/Block options), and Blue mana Ice Attack 6

## Test Plan
- `bun run test` in `packages/core` (unitIceGolems, unitActivation)
- Manually: recruit Ice Golems, activate choice ability and resolve Attack or Block; activate Ice Attack 6 with blue mana

Closes #290

Made with [Cursor](https://cursor.com)