### PR TITLE
fix: Amotep Gunners - correct abilities per rulebook (#280)

### DIFF
--- a/packages/shared/src/units/elite/amotepGunners.ts
+++ b/packages/shared/src/units/elite/amotepGunners.ts
@@ -1,16 +1,22 @@
 /**
  * Amotep Gunners unit definition
+ *
+ * Rulebook abilities:
+ * - Ability 1: Attack OR Block 5 (choice, free, physical)
+ * - Ability 2: Ranged Fire Attack 6 (costs red mana)
  */
 
-import { ELEMENT_PHYSICAL } from "../../elements.js";
+import { ELEMENT_FIRE, ELEMENT_PHYSICAL } from "../../elements.js";
 import type { UnitDefinition } from "../types.js";
 import {
   UNIT_TYPE_ELITE,
   RECRUIT_SITE_KEEP,
   RECRUIT_SITE_CITY,
+  UNIT_ABILITY_ATTACK,
+  UNIT_ABILITY_BLOCK,
   UNIT_ABILITY_RANGED_ATTACK,
-  UNIT_ABILITY_SIEGE_ATTACK,
 } from "../constants.js";
+import { MANA_RED } from "../../ids.js";
 import { UNIT_AMOTEP_GUNNERS } from "../ids.js";
 
 export const AMOTEP_GUNNERS: UnitDefinition = {
@@ -23,8 +29,16 @@ export const AMOTEP_GUNNERS: UnitDefinition = {
   resistances: [],
   recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_CITY],
   abilities: [
-    { type: UNIT_ABILITY_RANGED_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
-    { type: UNIT_ABILITY_SIEGE_ATTACK, value: 3, element: ELEMENT_PHYSICAL },
+    // Ability 1: Attack OR Block 5 (choice, free, physical)
+    { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_PHYSICAL },
+    { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_PHYSICAL },
+    // Ability 2: Ranged Fire Attack 6 (costs red mana)
+    {
+      type: UNIT_ABILITY_RANGED_ATTACK,
+      value: 6,
+      element: ELEMENT_FIRE,
+      manaCost: MANA_RED,
+    },
   ],
   copies: 2,
 };


### PR DESCRIPTION
## Summary
Fixes Amotep Gunners unit abilities to match the Mage Knight rulebook.

## Changes
- **Ability 1**: Replaced incorrect Ranged Attack 3 (Physical) and Siege Attack 3 (Physical) with Attack OR Block 5 (choice, free, physical)
- **Ability 2**: Replaced Siege Attack 3 with Ranged Fire Attack 6 (costs red mana)
- Added unit tests for all three abilities (Attack 5, Block 5, Ranged Fire Attack 6)

## Test Plan
- `bun test ./packages/core/src/engine/__tests__/unitActivation.test.ts` - All 66 tests pass including 4 new Amotep Gunners tests
- Verify in-game: recruit Amotep Gunners, enter combat, activate Attack 5 or Block 5 (free), activate Ranged Fire Attack 6 (requires red mana)

Closes #280

Made with [Cursor](https://cursor.com)