### PR TITLE
fix: Amotep Freezers — correct abilities (Attack OR Block 5 + Freeze)

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -12,6 +12,7 @@
 
 import {
   ABILITY_FORTIFIED,
+  AMOTEP_FREEZERS_FREEZE,
   MANA_BLUE,
   MANA_GREEN,
   MANA_RED,
@@ -360,6 +361,35 @@ const ILLUSIONISTS_CANCEL_ATTACK_EFFECT: CardEffect = {
 const ILLUSIONISTS_GAIN_WHITE_CRYSTAL_EFFECT: CardEffect = {
   type: EFFECT_GAIN_CRYSTAL,
   color: MANA_WHITE,
+};
+
+/**
+ * Amotep Freezers' Freeze ability (blue mana).
+ * Target enemy does not attack this combat and gets Armor -3 (min 1).
+ * No effect on Ice Resistant enemies (excludeResistance: RESIST_ICE).
+ */
+const AMOTEP_FREEZERS_FREEZE_EFFECT: CardEffect = {
+  type: EFFECT_SELECT_COMBAT_ENEMY,
+  excludeResistance: RESIST_ICE,
+  template: {
+    modifiers: [
+      {
+        modifier: { type: EFFECT_ENEMY_SKIP_ATTACK },
+        duration: DURATION_COMBAT,
+        description: "Target enemy does not attack",
+      },
+      {
+        modifier: {
+          type: EFFECT_ENEMY_STAT,
+          stat: ENEMY_STAT_ARMOR,
+          amount: -3,
+          minimum: 1,
+        },
+        duration: DURATION_COMBAT,
+        description: "Target enemy gets Armor -3",
+      },
+    ],
+  },
 };
 
 /**
@@ -762,6 +792,7 @@ export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
   [ALTEM_MAGES_GAIN_TWO_MANA]: ALTEM_MAGES_GAIN_TWO_MANA_EFFECT,
   [ALTEM_MAGES_COLD_FIRE_ATTACK_OR_BLOCK]: ALTEM_MAGES_COLD_FIRE_ATTACK_OR_BLOCK_EFFECT,
   [ALTEM_MAGES_ATTACK_MODIFIER]: ALTEM_MAGES_ATTACK_MODIFIER_EFFECT,
+  [AMOTEP_FREEZERS_FREEZE]: AMOTEP_FREEZERS_FREEZE_EFFECT,
 };
 
 /**

--- a/packages/core/src/engine/__tests__/unitActivation.test.ts
+++ b/packages/core/src/engine/__tests__/unitActivation.test.ts
@@ -643,9 +643,9 @@ describe("Unit Combat Abilities", () => {
     });
   });
 
-  describe("Passive abilities", () => {
-    it("should return clear error for passive abilities like paralyze (Amotep Freezers)", () => {
-      // Amotep Freezers have Paralyze at index 2 (passive)
+  describe("Amotep Freezers", () => {
+    it("should reject Freeze ability (index 2) when blue mana is unavailable", () => {
+      // Amotep Freezers: ability 2 is Freeze (blue mana) — requires blue mana
       const unit = createPlayerUnit(UNIT_AMOTEP_FREEZERS, "freezers_1");
       const player = createTestPlayer({
         units: [unit],
@@ -660,23 +660,20 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "freezers_1",
-        abilityIndex: 2, // Paralyze (passive)
+        abilityIndex: 2, // Freeze (requires blue mana)
       });
 
-      // Unit should still be ready (action rejected)
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
-
-      // Check for invalid action event with helpful message
       const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
       expect(invalidEvent).toBeDefined();
       if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
-        expect(invalidEvent.reason).toContain("passive");
-        expect(invalidEvent.reason).toContain("automatically");
+        expect(invalidEvent.reason).toContain("blue");
+        expect(invalidEvent.reason).toMatch(/mana|Requires/);
       }
     });
 
-    it("should return clear error for passive abilities like paralyze", () => {
-      // Amotep Freezers have Paralyze at index 2 (passive)
+    it("should reject Freeze ability when effect has no valid targets", () => {
+      // Freeze requires combat with a targetable enemy (non-ice-resistant)
       const unit = createPlayerUnit(UNIT_AMOTEP_FREEZERS, "amotep_freezers_1");
       const player = createTestPlayer({
         units: [unit],
@@ -691,18 +688,14 @@ describe("Unit Combat Abilities", () => {
       const result = engine.processAction(state, "player1", {
         type: ACTIVATE_UNIT_ACTION,
         unitInstanceId: "amotep_freezers_1",
-        abilityIndex: 2, // Paralyze (passive)
+        abilityIndex: 2, // Freeze
       });
 
-      // Unit should still be ready (action rejected)
       expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
-
-      // Check for invalid action event with helpful message
       const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
       expect(invalidEvent).toBeDefined();
       if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
-        expect(invalidEvent.reason).toContain("passive");
-        expect(invalidEvent.reason).toContain("automatically");
+        expect(invalidEvent.reason).toMatch(/mana|target|resolv/);
       }
     });
   });

--- a/packages/shared/src/units/elite/amotepFreezers.ts
+++ b/packages/shared/src/units/elite/amotepFreezers.ts
@@ -1,18 +1,27 @@
 /**
  * Amotep Freezers unit definition
+ *
+ * Rulebook abilities:
+ * - Ability 1: Attack OR Block 5 (choice, free, physical)
+ * - Ability 2: Freeze (blue mana) — target enemy does not attack this combat
+ *   and gets Armor -3 (min 1). No effect on Ice Resistant enemies.
  */
 
-import { ELEMENT_ICE } from "../../elements.js";
+import { ELEMENT_PHYSICAL } from "../../elements.js";
 import type { UnitDefinition } from "../types.js";
 import {
   UNIT_TYPE_ELITE,
   RECRUIT_SITE_KEEP,
   RECRUIT_SITE_CITY,
-  UNIT_ABILITY_RANGED_ATTACK,
-  UNIT_ABILITY_SIEGE_ATTACK,
-  UNIT_ABILITY_PARALYZE,
+  UNIT_ABILITY_ATTACK,
+  UNIT_ABILITY_BLOCK,
+  UNIT_ABILITY_EFFECT,
 } from "../constants.js";
+import { MANA_BLUE } from "../../ids.js";
 import { UNIT_AMOTEP_FREEZERS } from "../ids.js";
+
+/** Effect ID for Freeze: target enemy skip attack + Armor -3 (min 1), no effect vs Ice Resistant */
+export const AMOTEP_FREEZERS_FREEZE = "amotep_freezers_freeze" as const;
 
 export const AMOTEP_FREEZERS: UnitDefinition = {
   id: UNIT_AMOTEP_FREEZERS,
@@ -24,9 +33,16 @@ export const AMOTEP_FREEZERS: UnitDefinition = {
   resistances: [],
   recruitSites: [RECRUIT_SITE_KEEP, RECRUIT_SITE_CITY],
   abilities: [
-    { type: UNIT_ABILITY_RANGED_ATTACK, value: 3, element: ELEMENT_ICE },
-    { type: UNIT_ABILITY_SIEGE_ATTACK, value: 3, element: ELEMENT_ICE },
-    { type: UNIT_ABILITY_PARALYZE },
+    // Ability 1: Attack OR Block 5 (choice, free, physical)
+    { type: UNIT_ABILITY_ATTACK, value: 5, element: ELEMENT_PHYSICAL },
+    { type: UNIT_ABILITY_BLOCK, value: 5, element: ELEMENT_PHYSICAL },
+    // Ability 2: Freeze (blue mana) — skip attack + Armor -3, no effect on Ice Resistant
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: AMOTEP_FREEZERS_FREEZE,
+      displayName: "Freeze enemy",
+      manaCost: MANA_BLUE,
+    },
   ],
   copies: 2,
 };

--- a/packages/shared/src/units/elite/index.ts
+++ b/packages/shared/src/units/elite/index.ts
@@ -32,7 +32,7 @@ export { ICE_GOLEMS } from "./iceGolems.js";
 export { SORCERERS } from "./sorcerers.js";
 export { CATAPULTS } from "./catapults.js";
 export { AMOTEP_GUNNERS } from "./amotepGunners.js";
-export { AMOTEP_FREEZERS } from "./amotepFreezers.js";
+export { AMOTEP_FREEZERS, AMOTEP_FREEZERS_FREEZE } from "./amotepFreezers.js";
 export { HEROES } from "./heroes.js";
 export { ALTEM_MAGES } from "./altemMages.js";
 export { ALTEM_GUARDIANS } from "./altemGuardians.js";


### PR DESCRIPTION
## Summary
Fixes Amotep Freezers unit to match rulebook: Attack OR Block 5 (choice, free) and Freeze (blue mana) instead of incorrect Ranged/Siege/Paralyze.

## Changes
- **shared**: Replace Ranged Attack 3, Siege Attack 3, Paralyze with Attack OR Block 5 (two abilities) and Freeze effect (blue mana, `effectId`).
- **core**: Add `AMOTEP_FREEZERS_FREEZE` effect: `EFFECT_SELECT_COMBAT_ENEMY` with `excludeResistance: RESIST_ICE`, template = skip attack + Armor -3 (min 1) for this combat.
- **tests**: Replace two "passive ability (Paralyze)" tests with Amotep Freezers tests that Freeze requires blue mana and valid targets.

## Acceptance criteria addressed
- Remove wrong Ranged Attack 3, Siege Attack 3, Paralyze
- Ability 1: Attack OR Block 5 (choice, free, physical)
- Ability 2: Costs blue mana; target enemy; skip attack this combat; Armor -3 (min 1); no effect on Ice Resistant

## Test plan
- `cd packages/core && bun test unitActivation` — Amotep Freezers tests pass.
- `bun run build` in shared + core succeeds.

Closes #279