### PR TITLE
feat: implement Burning Shield / Exploding Shield spell

### DIFF
--- a/packages/core/src/data/spells/red/burningShield.ts
+++ b/packages/core/src/data/spells/red/burningShield.ts
@@ -1,0 +1,93 @@
+/**
+ * Burning Shield / Exploding Shield (Red Spell #08)
+ *
+ * Basic (Burning Shield):
+ *   Fire Block 4. If this card is used as part of a successful block,
+ *   you may use it during your Attack phase as Fire Attack 4.
+ *   Fire Attack bypasses Fire Resistance and Arcane Immunity.
+ *   Can target any enemy, not just the blocked one.
+ *
+ * Powered (Exploding Shield):
+ *   Fire Block 4. If this card is used as part of a successful block,
+ *   destroy the blocked enemy.
+ *   Fire Resistant/Arcane Immune enemies are NOT destroyed, but Fire Block still works.
+ *   Blocking ONE attack of a multi-attack enemy destroys the whole enemy.
+ *   Summoned monsters: destroying them grants no fame.
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_APPLY_MODIFIER,
+} from "../../../types/effectTypes.js";
+import {
+  MANA_RED,
+  MANA_BLACK,
+  CARD_BURNING_SHIELD,
+} from "@mage-knight/shared";
+import {
+  DURATION_COMBAT,
+  ELEMENT_FIRE,
+  EFFECT_BURNING_SHIELD_ACTIVE,
+} from "../../../types/modifierConstants.js";
+
+export const BURNING_SHIELD: DeedCard = {
+  id: CARD_BURNING_SHIELD,
+  name: "Burning Shield",
+  poweredName: "Exploding Shield",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_COMBAT],
+  poweredBy: [MANA_BLACK, MANA_RED],
+  basicEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // Fire Block 4
+      {
+        type: EFFECT_GAIN_BLOCK,
+        amount: 4,
+        element: ELEMENT_FIRE,
+      },
+      // Track that Burning Shield is active (basic mode = grants Fire Attack on successful block)
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_BURNING_SHIELD_ACTIVE,
+          mode: "attack",
+          blockValue: 4,
+          attackValue: 4,
+        },
+        duration: DURATION_COMBAT,
+        description: "On successful block: Fire Attack 4 in Attack phase",
+      },
+    ],
+  },
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // Fire Block 4
+      {
+        type: EFFECT_GAIN_BLOCK,
+        amount: 4,
+        element: ELEMENT_FIRE,
+      },
+      // Track that Exploding Shield is active (powered mode = destroys blocked enemy)
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_BURNING_SHIELD_ACTIVE,
+          mode: "destroy",
+          blockValue: 4,
+          attackValue: 0,
+        },
+        duration: DURATION_COMBAT,
+        description: "On successful block: destroy blocked enemy",
+      },
+    ],
+  },
+  sidewaysValue: 1,
+};

--- a/packages/core/src/data/spells/red/index.ts
+++ b/packages/core/src/data/spells/red/index.ts
@@ -12,12 +12,14 @@ import {
   CARD_TREMOR,
   CARD_MANA_MELTDOWN,
   CARD_DEMOLISH,
+  CARD_BURNING_SHIELD,
 } from "@mage-knight/shared";
 import { FIREBALL } from "./fireball.js";
 import { FLAME_WALL } from "./flameWall.js";
 import { TREMOR } from "./tremor.js";
 import { MANA_MELTDOWN } from "./manaMeltdown.js";
 import { DEMOLISH } from "./demolish.js";
+import { BURNING_SHIELD } from "./burningShield.js";
 
 export const RED_SPELLS: Record<CardId, DeedCard> = {
   [CARD_FIREBALL]: FIREBALL,
@@ -25,6 +27,7 @@ export const RED_SPELLS: Record<CardId, DeedCard> = {
   [CARD_TREMOR]: TREMOR,
   [CARD_MANA_MELTDOWN]: MANA_MELTDOWN,
   [CARD_DEMOLISH]: DEMOLISH,
+  [CARD_BURNING_SHIELD]: BURNING_SHIELD,
 };
 
-export { FIREBALL, FLAME_WALL, TREMOR, MANA_MELTDOWN, DEMOLISH };
+export { FIREBALL, FLAME_WALL, TREMOR, MANA_MELTDOWN, DEMOLISH, BURNING_SHIELD };

--- a/packages/core/src/engine/__tests__/burningShieldSpell.test.ts
+++ b/packages/core/src/engine/__tests__/burningShieldSpell.test.ts
@@ -1,0 +1,539 @@
+/**
+ * Burning Shield / Exploding Shield Spell Tests
+ *
+ * Tests for:
+ * - Card definition and registration
+ * - Basic (Burning Shield): Fire Block 4 + on successful block → Fire Attack 4
+ * - Powered (Exploding Shield): Fire Block 4 + on successful block → destroy enemy
+ * - Fire Resistance blocking powered destruction
+ * - Arcane Immunity blocking powered destruction
+ * - Modifier consumed after first successful block
+ * - Fame awarded / not awarded for summoned enemies
+ * - Integration with declareBlockCommand
+ */
+
+import { describe, it, expect } from "vitest";
+import type { GameState } from "../../state/GameState.js";
+import type { CombatEnemy } from "../../types/combat.js";
+import {
+  CARD_BURNING_SHIELD,
+  ENEMY_DIGGERS,
+  ENEMY_FIRE_MAGES,
+  ENEMY_SORCERERS,
+  ENEMY_WOLF_RIDERS,
+  ENEMY_BLOCKED,
+  getEnemy,
+} from "@mage-knight/shared";
+import { BURNING_SHIELD } from "../../data/spells/red/burningShield.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  MANA_RED,
+  MANA_BLACK,
+} from "@mage-knight/shared";
+import { resolveEffect, isEffectResolvable } from "../effects/index.js";
+import {
+  addModifier,
+} from "../modifiers/index.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_BURNING_SHIELD_ACTIVE,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import {
+  COMBAT_PHASE_BLOCK,
+  COMBAT_CONTEXT_STANDARD,
+} from "../../types/combat.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { applyBurningShieldOnBlock } from "../combat/burningShieldHelpers.js";
+import { createDeclareBlockCommand } from "../commands/combat/declareBlockCommand.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string,
+  overrides: Partial<CombatEnemy> = {}
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isDefeated: false,
+    isBlocked: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+    ...overrides,
+  };
+}
+
+function createStateWithCombat(
+  enemies: CombatEnemy[],
+  pendingBlock: Record<string, { physical: number; fire: number; ice: number; coldFire: number }> = {}
+): GameState {
+  const player = createTestPlayer({ id: "player1" });
+  const state = createTestGameState({ players: [player] });
+  return {
+    ...state,
+    combat: {
+      phase: COMBAT_PHASE_BLOCK,
+      enemies,
+      isAtFortifiedSite: false,
+      pendingDamage: {},
+      pendingBlock,
+      pendingSwiftBlock: {},
+      fameGained: 0,
+      woundsThisCombat: 0,
+      attacksThisPhase: 0,
+      unitsAllowed: true,
+      nightManaRules: false,
+      assaultOrigin: null,
+      combatHexCoord: null,
+      allDamageBlockedThisPhase: false,
+      discardEnemiesOnFailure: false,
+      combatContext: COMBAT_CONTEXT_STANDARD,
+      cumbersomeReductions: {},
+      usedDefend: {},
+      defendBonuses: {},
+      paidHeroesAssaultInfluence: false,
+      vampiricArmorBonus: {},
+      paidThugsDamageInfluence: {},
+      damageRedirects: {},
+    },
+    activeModifiers: [],
+  };
+}
+
+/**
+ * Add a Burning Shield modifier (basic mode) to the state
+ */
+function addBurningShieldModifier(state: GameState, mode: "attack" | "destroy"): GameState {
+  return addModifier(state, {
+    source: { type: SOURCE_CARD, cardId: CARD_BURNING_SHIELD, playerId: "player1" },
+    duration: DURATION_COMBAT,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_BURNING_SHIELD_ACTIVE,
+      mode,
+      blockValue: 4,
+      attackValue: mode === "attack" ? 4 : 0,
+    },
+    createdAtRound: 1,
+    createdByPlayerId: "player1",
+  });
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Burning Shield / Exploding Shield Spell", () => {
+  describe("card definition", () => {
+    it("should be registered in spell cards", () => {
+      const card = getSpellCard(CARD_BURNING_SHIELD);
+      expect(card).toBeDefined();
+      expect(card?.name).toBe("Burning Shield");
+    });
+
+    it("should have correct metadata", () => {
+      expect(BURNING_SHIELD.id).toBe(CARD_BURNING_SHIELD);
+      expect(BURNING_SHIELD.name).toBe("Burning Shield");
+      expect(BURNING_SHIELD.poweredName).toBe("Exploding Shield");
+      expect(BURNING_SHIELD.cardType).toBe(DEED_CARD_TYPE_SPELL);
+      expect(BURNING_SHIELD.sidewaysValue).toBe(1);
+    });
+
+    it("should be powered by black + red mana", () => {
+      expect(BURNING_SHIELD.poweredBy).toEqual([MANA_BLACK, MANA_RED]);
+    });
+
+    it("should have combat category", () => {
+      expect(BURNING_SHIELD.categories).toEqual([CATEGORY_COMBAT]);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT: BURNING SHIELD
+  // ============================================================================
+
+  describe("basic effect (Burning Shield)", () => {
+    const basicEffect = BURNING_SHIELD.basicEffect;
+
+    it("should grant Fire Block 4", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+
+      const result = resolveEffect(state, "player1", basicEffect);
+
+      // Should have Fire Block 4 in accumulator
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.combatAccumulator.block).toBe(4);
+      expect(player?.combatAccumulator.blockElements.fire).toBe(4);
+    });
+
+    it("should apply Burning Shield modifier for combat duration", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+
+      const result = resolveEffect(state, "player1", basicEffect);
+
+      // Should have active Burning Shield modifier
+      const modifiers = getModifiersForPlayer(result.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeDefined();
+      expect(shieldMod?.effect).toMatchObject({
+        type: EFFECT_BURNING_SHIELD_ACTIVE,
+        mode: "attack",
+        blockValue: 4,
+        attackValue: 4,
+      });
+      expect(shieldMod?.duration).toBe(DURATION_COMBAT);
+    });
+
+    it("should be resolvable in combat", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT: EXPLODING SHIELD
+  // ============================================================================
+
+  describe("powered effect (Exploding Shield)", () => {
+    const poweredEffect = BURNING_SHIELD.poweredEffect;
+
+    it("should grant Fire Block 4", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+
+      const result = resolveEffect(state, "player1", poweredEffect);
+
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.combatAccumulator.block).toBe(4);
+      expect(player?.combatAccumulator.blockElements.fire).toBe(4);
+    });
+
+    it("should apply Exploding Shield modifier with destroy mode", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+
+      const result = resolveEffect(state, "player1", poweredEffect);
+
+      const modifiers = getModifiersForPlayer(result.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeDefined();
+      expect(shieldMod?.effect).toMatchObject({
+        type: EFFECT_BURNING_SHIELD_ACTIVE,
+        mode: "destroy",
+        blockValue: 4,
+        attackValue: 0,
+      });
+    });
+  });
+
+  // ============================================================================
+  // ON-BLOCK-SUCCESS: BASIC (Fire Attack 4)
+  // ============================================================================
+
+  describe("on successful block - basic (Fire Attack 4)", () => {
+    it("should grant Fire Attack 4 to combat accumulator", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+      state = addBurningShieldModifier(state, "attack");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      expect(result).not.toBeNull();
+      const player = result!.state.players.find((p) => p.id === "player1");
+      expect(player?.combatAccumulator.attack.normal).toBe(4);
+      expect(player?.combatAccumulator.attack.normalElements.fire).toBe(4);
+    });
+
+    it("should consume the modifier after triggering", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+      state = addBurningShieldModifier(state, "attack");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      // Modifier should be removed
+      const modifiers = getModifiersForPlayer(result!.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeUndefined();
+    });
+
+    it("should not trigger on second block (modifier consumed)", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+        createCombatEnemy("enemy_1", ENEMY_WOLF_RIDERS),
+      ]);
+      state = addBurningShieldModifier(state, "attack");
+
+      // First block triggers
+      const enemy0 = state.combat!.enemies[0]!;
+      const result1 = applyBurningShieldOnBlock(state, "player1", enemy0);
+      expect(result1).not.toBeNull();
+
+      // Second block should not trigger (modifier consumed)
+      const enemy1 = result1!.state.combat!.enemies[1]!;
+      const result2 = applyBurningShieldOnBlock(result1!.state, "player1", enemy1);
+      expect(result2).toBeNull();
+    });
+
+    it("should return null when no modifier is active", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS),
+      ]);
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+      expect(result).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // ON-BLOCK-SUCCESS: POWERED (Destroy enemy)
+  // ============================================================================
+
+  describe("on successful block - powered (Destroy enemy)", () => {
+    it("should destroy the blocked enemy", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS),
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      expect(result).not.toBeNull();
+      expect(result!.state.combat?.enemies[0]?.isDefeated).toBe(true);
+    });
+
+    it("should award fame for destroyed enemy", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS), // 3 fame
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      const player = result!.state.players.find((p) => p.id === "player1");
+      expect(player?.fame).toBe(3);
+      expect(result!.state.combat?.fameGained).toBe(3);
+    });
+
+    it("should NOT destroy Fire Resistant enemies", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES), // Fire Resistant
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      // Enemy should NOT be defeated
+      expect(result).not.toBeNull();
+      expect(result!.state.combat?.enemies[0]?.isDefeated).toBe(false);
+    });
+
+    it("should NOT destroy Arcane Immune enemies", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_SORCERERS), // Arcane Immune
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      // Enemy should NOT be defeated
+      expect(result).not.toBeNull();
+      expect(result!.state.combat?.enemies[0]?.isDefeated).toBe(false);
+    });
+
+    it("should consume modifier even when enemy is Fire Resistant", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES),
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      // Modifier should still be consumed
+      const modifiers = getModifiersForPlayer(result!.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeUndefined();
+    });
+
+    it("should NOT award fame for summoned enemies", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_DIGGERS, {
+          summonedByInstanceId: "summoner_1",
+        }),
+      ]);
+      state = addBurningShieldModifier(state, "destroy");
+
+      const enemy = state.combat!.enemies[0]!;
+      const result = applyBurningShieldOnBlock(state, "player1", enemy);
+
+      // Enemy should be destroyed but no fame awarded
+      expect(result!.state.combat?.enemies[0]?.isDefeated).toBe(true);
+      const player = result!.state.players.find((p) => p.id === "player1");
+      expect(player?.fame).toBe(0);
+      expect(result!.state.combat?.fameGained).toBe(0);
+    });
+  });
+
+  // ============================================================================
+  // INTEGRATION: declareBlockCommand with Burning Shield
+  // ============================================================================
+
+  describe("integration with declareBlockCommand", () => {
+    it("should trigger basic Burning Shield on successful block", () => {
+      const enemy = createCombatEnemy("enemy_0", ENEMY_DIGGERS); // attack 3
+      let state = createStateWithCombat(
+        [enemy],
+        // Provide enough fire block to meet attack of 3
+        { enemy_0: { physical: 0, fire: 3, ice: 0, coldFire: 0 } }
+      );
+      state = addBurningShieldModifier(state, "attack");
+
+      const command = createDeclareBlockCommand({
+        playerId: "player1",
+        targetEnemyInstanceId: "enemy_0",
+        attackIndex: 0,
+      });
+
+      const result = command.execute(state);
+
+      // Block should succeed
+      expect(result.events.some((e) => e.type === ENEMY_BLOCKED)).toBe(true);
+
+      // Burning Shield should have triggered - Fire Attack 4 added
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.combatAccumulator.attack.normal).toBe(4);
+      expect(player?.combatAccumulator.attack.normalElements.fire).toBe(4);
+
+      // Modifier should be consumed
+      const modifiers = getModifiersForPlayer(result.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeUndefined();
+    });
+
+    it("should trigger powered Exploding Shield - destroy enemy on successful block", () => {
+      const enemy = createCombatEnemy("enemy_0", ENEMY_DIGGERS); // attack 3, fame 2
+      let state = createStateWithCombat(
+        [enemy],
+        { enemy_0: { physical: 0, fire: 3, ice: 0, coldFire: 0 } }
+      );
+      state = addBurningShieldModifier(state, "destroy");
+
+      const command = createDeclareBlockCommand({
+        playerId: "player1",
+        targetEnemyInstanceId: "enemy_0",
+        attackIndex: 0,
+      });
+
+      const result = command.execute(state);
+
+      // Block should succeed
+      expect(result.events.some((e) => e.type === ENEMY_BLOCKED)).toBe(true);
+
+      // Enemy should be destroyed
+      expect(result.state.combat?.enemies[0]?.isDefeated).toBe(true);
+
+      // Fame should be awarded
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.fame).toBe(2); // Diggers = 2 fame
+      expect(result.state.combat?.fameGained).toBe(2);
+    });
+
+    it("should NOT trigger Burning Shield on failed block", () => {
+      const enemy = createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS); // attack 4
+      let state = createStateWithCombat(
+        [enemy],
+        // Only 2 fire block - not enough for attack 4
+        { enemy_0: { physical: 0, fire: 2, ice: 0, coldFire: 0 } }
+      );
+      state = addBurningShieldModifier(state, "attack");
+
+      const command = createDeclareBlockCommand({
+        playerId: "player1",
+        targetEnemyInstanceId: "enemy_0",
+        attackIndex: 0,
+      });
+
+      const result = command.execute(state);
+
+      // Block should fail
+      expect(result.events.some((e) => e.type === ENEMY_BLOCKED)).toBe(false);
+
+      // Fire Attack should NOT be granted (block failed)
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.combatAccumulator.attack.normal).toBe(0);
+
+      // Modifier should still be active (not consumed on failed block)
+      const modifiers = getModifiersForPlayer(result.state, "player1");
+      const shieldMod = modifiers.find(
+        (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+      );
+      expect(shieldMod).toBeDefined();
+    });
+
+    it("should NOT destroy Fire Resistant enemy via Exploding Shield", () => {
+      const enemy = createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES); // Fire Resistant, attack 6
+      let state = createStateWithCombat(
+        [enemy],
+        // Enough fire block to meet the attack (fire vs fire = inefficient, need double)
+        { enemy_0: { physical: 0, fire: 12, ice: 0, coldFire: 0 } }
+      );
+      state = addBurningShieldModifier(state, "destroy");
+
+      const command = createDeclareBlockCommand({
+        playerId: "player1",
+        targetEnemyInstanceId: "enemy_0",
+        attackIndex: 0,
+      });
+
+      const result = command.execute(state);
+
+      // Block should succeed (fire block vs fire attack needs 2x, 12 >= 6*2)
+      expect(result.state.combat?.enemies[0]?.isBlocked).toBe(true);
+
+      // Enemy should NOT be destroyed (Fire Resistant)
+      expect(result.state.combat?.enemies[0]?.isDefeated).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/engine/combat/burningShieldHelpers.ts
+++ b/packages/core/src/engine/combat/burningShieldHelpers.ts
@@ -1,0 +1,162 @@
+/**
+ * Burning Shield / Exploding Shield on-block-success handling.
+ *
+ * When a block succeeds while the Burning Shield modifier is active:
+ * - Basic (mode "attack"): Grants Fire Attack 4 in Attack phase
+ * - Powered (mode "destroy"): Destroys the blocked enemy
+ *   (respects Fire Resistance and Arcane Immunity)
+ *
+ * The modifier is consumed (removed) after triggering.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent } from "@mage-knight/shared";
+import type { CombatEnemy } from "../../types/combat.js";
+import type { BurningShieldActiveModifier } from "../../types/modifiers.js";
+import { ABILITY_ARCANE_IMMUNITY, RESIST_FIRE } from "@mage-knight/shared";
+import { EFFECT_BURNING_SHIELD_ACTIVE, ELEMENT_FIRE } from "../../types/modifierConstants.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+import { removeModifier } from "../modifiers/lifecycle.js";
+
+/**
+ * Check for and apply Burning Shield effects after a successful block.
+ *
+ * @param state - Current game state (after block success)
+ * @param playerId - Player who blocked
+ * @param blockedEnemy - The enemy whose attack was blocked
+ * @returns Updated state and events, or null if no Burning Shield active
+ */
+export function applyBurningShieldOnBlock(
+  state: GameState,
+  playerId: string,
+  blockedEnemy: CombatEnemy
+): { state: GameState; events: GameEvent[] } | null {
+  // Find active Burning Shield modifier for this player
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const burningShieldMod = modifiers.find(
+    (m) => m.effect.type === EFFECT_BURNING_SHIELD_ACTIVE
+  );
+
+  if (!burningShieldMod) {
+    return null;
+  }
+
+  const effect = burningShieldMod.effect as BurningShieldActiveModifier;
+
+  // Remove the modifier (consumed on first successful block)
+  let updatedState = removeModifier(state, burningShieldMod.id);
+
+  if (effect.mode === "attack") {
+    // Basic: Grant Fire Attack 4 to the player's combat accumulator
+    return applyBurningShieldAttack(updatedState, playerId, effect.attackValue);
+  }
+
+  // Powered: Destroy the blocked enemy (respects resistances)
+  return applyExplodingShieldDestroy(updatedState, playerId, blockedEnemy);
+}
+
+/**
+ * Grant Fire Attack to player's combat accumulator.
+ * Fire Attack bypasses resistances (applied as fire element attack points).
+ */
+function applyBurningShieldAttack(
+  state: GameState,
+  playerId: string,
+  attackValue: number
+): { state: GameState; events: GameEvent[] } {
+  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  if (playerIndex === -1) {
+    return { state, events: [] };
+  }
+
+  const player = state.players[playerIndex]!;
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = {
+    ...player,
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      attack: {
+        ...player.combatAccumulator.attack,
+        normal: player.combatAccumulator.attack.normal + attackValue,
+        normalElements: {
+          ...player.combatAccumulator.attack.normalElements,
+          [ELEMENT_FIRE]:
+            player.combatAccumulator.attack.normalElements.fire + attackValue,
+        },
+      },
+    },
+  };
+
+  return {
+    state: { ...state, players: updatedPlayers },
+    events: [],
+  };
+}
+
+/**
+ * Destroy the blocked enemy if it doesn't have Fire Resistance or Arcane Immunity.
+ * Awards fame for destroyed enemy (except summoned enemies which grant no fame).
+ */
+function applyExplodingShieldDestroy(
+  state: GameState,
+  playerId: string,
+  blockedEnemy: CombatEnemy
+): { state: GameState; events: GameEvent[] } {
+  if (!state.combat) {
+    return { state, events: [] };
+  }
+
+  // Check Fire Resistance — enemy is NOT destroyed
+  if (blockedEnemy.definition.resistances.includes(RESIST_FIRE)) {
+    return { state, events: [] };
+  }
+
+  // Check Arcane Immunity — enemy is NOT destroyed
+  if (blockedEnemy.definition.abilities.includes(ABILITY_ARCANE_IMMUNITY)) {
+    return { state, events: [] };
+  }
+
+  // Destroy the enemy
+  const enemyIndex = state.combat.enemies.findIndex(
+    (e) => e.instanceId === blockedEnemy.instanceId
+  );
+  if (enemyIndex === -1) {
+    return { state, events: [] };
+  }
+
+  const updatedEnemies = state.combat.enemies.map((e, i) =>
+    i === enemyIndex ? { ...e, isDefeated: true } : e
+  );
+
+  // Award fame (summoned enemies grant no fame per rules)
+  const isSummoned = blockedEnemy.summonedByInstanceId !== undefined;
+  const fameValue = isSummoned ? 0 : blockedEnemy.definition.fame;
+
+  let updatedPlayers = state.players;
+  if (fameValue > 0) {
+    const playerIndex = state.players.findIndex((p) => p.id === playerId);
+    if (playerIndex !== -1) {
+      const player = state.players[playerIndex]!;
+      updatedPlayers = [...state.players];
+      updatedPlayers[playerIndex] = {
+        ...player,
+        fame: player.fame + fameValue,
+      };
+    }
+  }
+
+  const updatedState: GameState = {
+    ...state,
+    combat: {
+      ...state.combat,
+      enemies: updatedEnemies,
+      fameGained: state.combat.fameGained + fameValue,
+    },
+    players: updatedPlayers,
+  };
+
+  return {
+    state: updatedState,
+    events: [],
+  };
+}

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -178,3 +178,11 @@ export const EFFECT_TRANSFORM_ATTACKS_COLD_FIRE = "transform_attacks_cold_fire" 
 // Only affects attacks played AFTER activation (adds siege copy at accumulation time).
 export const EFFECT_ADD_SIEGE_TO_ATTACKS = "add_siege_to_attacks" as const;
 
+// === BurningShieldActiveModifier ===
+// Marks that Burning Shield/Exploding Shield spell is active this combat.
+// When a block is successfully declared against any enemy, triggers a bonus:
+// - Basic (mode "attack"): grants Fire Attack 4 in Attack phase
+// - Powered (mode "destroy"): destroys the blocked enemy (respects Fire/Arcane resistances)
+// The modifier fires ONCE on the first successful block, then is consumed.
+export const EFFECT_BURNING_SHIELD_ACTIVE = "burning_shield_active" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -43,6 +43,7 @@ import {
   EFFECT_CURE_ACTIVE,
   EFFECT_TRANSFORM_ATTACKS_COLD_FIRE,
   EFFECT_ADD_SIEGE_TO_ATTACKS,
+  EFFECT_BURNING_SHIELD_ACTIVE,
   ELEMENT_COLD_FIRE,
   ELEMENT_FIRE,
   ELEMENT_ICE,
@@ -324,6 +325,18 @@ export interface AddSiegeToAttacksModifier {
   readonly type: typeof EFFECT_ADD_SIEGE_TO_ATTACKS;
 }
 
+// Burning Shield active modifier (Burning Shield / Exploding Shield spell)
+// Tracks that the spell is active during this combat's Block phase.
+// On first successful block, triggers a bonus based on mode:
+// - "attack": grants Fire Attack 4 in Attack phase
+// - "destroy": destroys the blocked enemy (respects Fire/Arcane resistances, no fame for summoned)
+export interface BurningShieldActiveModifier {
+  readonly type: typeof EFFECT_BURNING_SHIELD_ACTIVE;
+  readonly mode: "attack" | "destroy";
+  readonly blockValue: number; // The block value (4 for both basic and powered)
+  readonly attackValue: number; // Fire Attack value if mode is "attack" (4)
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -349,7 +362,8 @@ export type ModifierEffect =
   | DiseaseArmorModifier
   | CureActiveModifier
   | TransformAttacksColdFireModifier
-  | AddSiegeToAttacksModifier;
+  | AddSiegeToAttacksModifier
+  | BurningShieldActiveModifier;
 
 // === Active Modifier (live in game state) ===
 

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -104,6 +104,7 @@ export const CARD_FLAME_WALL = cardId("flame_wall"); // #10 - Fire Attack 5 or F
 export const CARD_TREMOR = cardId("tremor"); // #11 - Target/All Armor reduction
 export const CARD_MANA_MELTDOWN = cardId("mana_meltdown"); // #109 - Random crystal loss / Color wound + gain crystals
 export const CARD_DEMOLISH = cardId("demolish"); // #12 - Ignore fortification + Armor -1 / Destroy enemy + Armor -1
+export const CARD_BURNING_SHIELD = cardId("burning_shield"); // #08 - Fire Block 4 + conditional Fire Attack 4 / Fire Block 4 + destroy blocked enemy
 
 // Blue spells
 export const CARD_SNOWSTORM = cardId("snowstorm"); // #15 - Ice Ranged Attack 5 / Siege Ice Attack 8
@@ -166,6 +167,7 @@ export type SpellCardId =
   | typeof CARD_TREMOR
   | typeof CARD_MANA_MELTDOWN
   | typeof CARD_DEMOLISH
+  | typeof CARD_BURNING_SHIELD
   // Blue spells
   | typeof CARD_SNOWSTORM
   | typeof CARD_CHILL


### PR DESCRIPTION
## Summary
- Implements Burning Shield (basic) and Exploding Shield (powered) red spell (#194)
- Basic: Fire Block 4 + on successful block, grants Fire Attack 4 in Attack phase
- Powered: Fire Block 4 + on successful block, destroys the blocked enemy (respects Fire Resistance and Arcane Immunity)
- Modifier is consumed after first successful block trigger
- Awards fame for destroyed enemies (summoned enemies grant no fame)

## Implementation
- Added `CARD_BURNING_SHIELD` constant to shared package
- Added `EFFECT_BURNING_SHIELD_ACTIVE` modifier type with "attack" and "destroy" modes
- Spell uses CompoundEffect (GainBlock + ApplyModifier) for declarative card definition
- Hook in `declareBlockCommand` checks for active modifier on successful block
- `burningShieldHelpers.ts` handles both basic (fire attack grant) and powered (enemy destruction) logic

## Test plan
- [x] Card definition and registration (metadata, mana cost, categories)
- [x] Basic effect grants Fire Block 4 and applies modifier
- [x] Powered effect grants Fire Block 4 and applies destroy-mode modifier
- [x] Basic on-block-success: grants Fire Attack 4 to combat accumulator
- [x] Powered on-block-success: destroys enemy and awards fame
- [x] Fire Resistant enemies are NOT destroyed
- [x] Arcane Immune enemies are NOT destroyed
- [x] Modifier consumed after first successful block (no double trigger)
- [x] No trigger on failed block (modifier preserved)
- [x] Summoned enemies grant no fame when destroyed
- [x] Full integration tests with declareBlockCommand

Closes #194