### PR TITLE
feat: implement Pure Magic mana-payment-driven effect selection

### DIFF
--- a/packages/core/src/data/advancedActions/blue/pure-magic.ts
+++ b/packages/core/src/data/advancedActions/blue/pure-magic.ts
@@ -6,7 +6,7 @@ import {
   DEED_CARD_TYPE_ADVANCED_ACTION,
 } from "../../../types/cards.js";
 import { MANA_BLUE, CARD_PURE_MAGIC } from "@mage-knight/shared";
-import { attack, block, move, influence, choice } from "../helpers.js";
+import { EFFECT_PURE_MAGIC } from "../../../types/effectTypes.js";
 
 export const PURE_MAGIC: DeedCard = {
   id: CARD_PURE_MAGIC,
@@ -16,8 +16,7 @@ export const PURE_MAGIC: DeedCard = {
   categories: [CATEGORY_MOVEMENT, CATEGORY_INFLUENCE, CATEGORY_COMBAT],
   // Basic: When you play this, pay a mana. If you paid green, Move 4. If you paid white, Influence 4. If you paid blue, Block 4. If you paid red, Attack 4.
   // Powered: When you play this, pay a mana. If you paid green, Move 7. If you paid white, Influence 7. If you paid blue, Block 7. If you paid red, Attack 7.
-  // TODO: Implement mana-color-dependent effect
-  basicEffect: choice(move(4), influence(4), block(4), attack(4)),
-  poweredEffect: choice(move(7), influence(7), block(7), attack(7)),
+  basicEffect: { type: EFFECT_PURE_MAGIC, value: 4 },
+  poweredEffect: { type: EFFECT_PURE_MAGIC, value: 7 },
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/pureMagic.test.ts
+++ b/packages/core/src/engine/__tests__/pureMagic.test.ts
@@ -1,0 +1,549 @@
+/**
+ * Tests for Pure Magic advanced action card
+ *
+ * Pure Magic:
+ * - Basic: Pay a mana. Green → Move 4. White → Influence 4. Blue → Block 4. Red → Attack 4.
+ * - Powered (Blue): Pay a mana. Green → Move 7. White → Influence 7. Blue → Block 7. Red → Attack 7.
+ *
+ * Key mechanics:
+ * - Effect is determined by color of mana paid (not a free choice)
+ * - Blue/Red mana → Block/Attack → only payable during combat
+ * - Green/White mana → Move/Influence → always available
+ * - Gold mana is wild and substitutes for any basic color (day only)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import {
+  PLAY_CARD_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CHOICE_REQUIRED,
+  CARD_PURE_MAGIC,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_GOLD,
+  MANA_SOURCE_TOKEN,
+} from "@mage-knight/shared";
+import { COMBAT_PHASE_BLOCK, COMBAT_PHASE_ATTACK } from "../../types/combat.js";
+
+describe("Pure Magic Advanced Action", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  /**
+   * Create a state with Pure Magic in hand and the given mana tokens
+   */
+  function createStateWithPureMagic(
+    playerOverrides: Partial<Parameters<typeof createTestPlayer>[0]> = {}
+  ) {
+    const player = createTestPlayer({
+      hand: [CARD_PURE_MAGIC],
+      ...playerOverrides,
+    });
+    return createTestGameState({ players: [player] });
+  }
+
+  /**
+   * Create a combat state with Pure Magic in hand
+   */
+  function createCombatStateWithPureMagic(
+    phase: typeof COMBAT_PHASE_BLOCK | typeof COMBAT_PHASE_ATTACK,
+    playerOverrides: Partial<Parameters<typeof createTestPlayer>[0]> = {}
+  ) {
+    const player = createTestPlayer({
+      hand: [CARD_PURE_MAGIC],
+      ...playerOverrides,
+    });
+    return createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(phase),
+    });
+  }
+
+  describe("Basic effect - non-combat", () => {
+    it("should present green and white mana options when both tokens available", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_GREEN, source: "card" },
+          { color: MANA_WHITE, source: "card" },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      // Should have a pending choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+
+      const choiceEvent = result.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      if (choiceEvent && choiceEvent.type === CHOICE_REQUIRED) {
+        // Should have 2 options: green → Move 4, white → Influence 4
+        // (blue/red not available outside combat)
+        expect(choiceEvent.options).toHaveLength(2);
+      }
+    });
+
+    it("should grant Move 4 when paying green mana", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [{ color: MANA_GREEN, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      // Should auto-resolve since only one option
+      // Or present choice - let's check
+      if (playResult.state.players[0].pendingChoice) {
+        // Single option - resolve it
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        // Green mana should be consumed
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        // Should have gained Move 4
+        expect(choiceResult.state.players[0].movePoints).toBe(4);
+        expect(choiceResult.state.players[0].pendingChoice).toBeNull();
+      } else {
+        // Auto-resolved
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].movePoints).toBe(4);
+      }
+    });
+
+    it("should grant Influence 4 when paying white mana", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [{ color: MANA_WHITE, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].influencePoints).toBe(4);
+        expect(choiceResult.state.players[0].pendingChoice).toBeNull();
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].influencePoints).toBe(4);
+      }
+    });
+
+    it("should NOT offer blue/red mana options outside combat", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_RED, source: "card" },
+          { color: MANA_BLUE, source: "card" },
+          { color: MANA_GREEN, source: "card" },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      // Only green is valid outside combat, so it auto-resolves (single option)
+      // Green mana consumed, Move 4 granted
+      expect(result.state.players[0].pendingChoice).toBeNull();
+      expect(result.state.players[0].movePoints).toBe(4);
+      // Only green token consumed, blue and red remain
+      expect(result.state.players[0].pureMana).toHaveLength(2);
+    });
+
+    it("should handle no available mana tokens", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      // Card should resolve with no effect (no mana to pay)
+      expect(result.state.players[0].pendingChoice).toBeNull();
+    });
+  });
+
+  describe("Basic effect - in combat", () => {
+    it("should offer all four color options in combat when all tokens available", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_ATTACK, {
+        pureMana: [
+          { color: MANA_RED, source: "card" },
+          { color: MANA_BLUE, source: "card" },
+          { color: MANA_GREEN, source: "card" },
+          { color: MANA_WHITE, source: "card" },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+
+      const choiceEvent = result.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      if (choiceEvent && choiceEvent.type === CHOICE_REQUIRED) {
+        expect(choiceEvent.options).toHaveLength(4);
+      }
+    });
+
+    it("should grant Block 4 when paying blue mana in combat", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_BLOCK, {
+        pureMana: [{ color: MANA_BLUE, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].combatAccumulator.block).toBe(4);
+        expect(choiceResult.state.players[0].pendingChoice).toBeNull();
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].combatAccumulator.block).toBe(4);
+      }
+    });
+
+    it("should grant Attack 4 when paying red mana in combat", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_ATTACK, {
+        pureMana: [{ color: MANA_RED, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].combatAccumulator.attack.normal).toBe(4);
+        expect(choiceResult.state.players[0].pendingChoice).toBeNull();
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].combatAccumulator.attack.normal).toBe(4);
+      }
+    });
+  });
+
+  describe("Powered effect", () => {
+    it("should grant Move 7 when paying green mana (powered)", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_BLUE, source: "card" }, // for powering
+          { color: MANA_GREEN, source: "card" }, // for effect
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        // Blue token spent for powering, green token spent for effect
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].movePoints).toBe(7);
+        expect(choiceResult.state.players[0].pendingChoice).toBeNull();
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].movePoints).toBe(7);
+      }
+    });
+
+    it("should grant Influence 7 when paying white mana (powered)", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_BLUE, source: "card" }, // for powering
+          { color: MANA_WHITE, source: "card" }, // for effect
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].influencePoints).toBe(7);
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].influencePoints).toBe(7);
+      }
+    });
+
+    it("should grant Attack 7 when paying red mana in combat (powered)", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_ATTACK, {
+        pureMana: [
+          { color: MANA_BLUE, source: "card" }, // for powering
+          { color: MANA_RED, source: "card" }, // for effect
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].combatAccumulator.attack.normal).toBe(7);
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].combatAccumulator.attack.normal).toBe(7);
+      }
+    });
+
+    it("should grant Block 7 when paying blue mana in combat (powered)", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_BLOCK, {
+        pureMana: [
+          { color: MANA_BLUE, source: "card" }, // for powering
+          { color: MANA_BLUE, source: "card" }, // for effect
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+      });
+
+      // Blue mana used for powering, remaining blue for block
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        // Both blue tokens spent
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(0);
+        expect(choiceResult.state.players[0].combatAccumulator.block).toBe(7);
+      } else {
+        expect(playResult.state.players[0].pureMana).toHaveLength(0);
+        expect(playResult.state.players[0].combatAccumulator.block).toBe(7);
+      }
+    });
+  });
+
+  describe("Gold mana (wild)", () => {
+    it("should allow gold mana as substitute for green (Move) outside combat", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [{ color: MANA_GOLD, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      // Should present gold → Move and gold → Influence options
+      expect(playResult.state.players[0].pendingChoice).not.toBeNull();
+
+      const choiceEvent = playResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      if (choiceEvent && choiceEvent.type === CHOICE_REQUIRED) {
+        // Gold can be Move or Influence outside combat (not Block/Attack)
+        expect(choiceEvent.options).toHaveLength(2);
+      }
+    });
+
+    it("should allow gold mana for all four options in combat", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_ATTACK, {
+        pureMana: [{ color: MANA_GOLD, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0].pendingChoice).not.toBeNull();
+
+      const choiceEvent = playResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      if (choiceEvent && choiceEvent.type === CHOICE_REQUIRED) {
+        // Gold can substitute for all four colors in combat
+        expect(choiceEvent.options).toHaveLength(4);
+      }
+    });
+
+    it("should not duplicate options when player has both basic and gold mana", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_GREEN, source: "card" },
+          { color: MANA_GOLD, source: "card" },
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0].pendingChoice).not.toBeNull();
+
+      const choiceEvent = playResult.events.find((e) => e.type === CHOICE_REQUIRED);
+      expect(choiceEvent).toBeDefined();
+
+      if (choiceEvent && choiceEvent.type === CHOICE_REQUIRED) {
+        // Green → Move (from green token) + Gold → Influence (gold fills white gap)
+        // Should NOT duplicate Move option
+        expect(choiceEvent.options).toHaveLength(2);
+      }
+    });
+  });
+
+  describe("Mana consumption", () => {
+    it("should consume exactly 1 mana token when paying for effect", () => {
+      const state = createStateWithPureMagic({
+        pureMana: [
+          { color: MANA_GREEN, source: "card" },
+          { color: MANA_GREEN, source: "card" },
+        ],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        // Only 1 green token should be consumed, 1 remains
+        expect(choiceResult.state.players[0].pureMana).toHaveLength(1);
+        expect(choiceResult.state.players[0].pureMana[0]?.color).toBe(MANA_GREEN);
+      }
+    });
+  });
+
+  describe("Effects are NOT elemental", () => {
+    it("should produce non-elemental attack (no fire/ice resistance)", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_ATTACK, {
+        pureMana: [{ color: MANA_RED, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        // Attack should be physical (normal), not elemental
+        const acc = choiceResult.state.players[0].combatAccumulator;
+        expect(acc.attack.normal).toBe(4);
+        expect(acc.attack.normalElements.physical).toBe(4);
+        expect(acc.attack.normalElements.fire).toBe(0);
+        expect(acc.attack.normalElements.ice).toBe(0);
+      }
+    });
+
+    it("should produce non-elemental block", () => {
+      const state = createCombatStateWithPureMagic(COMBAT_PHASE_BLOCK, {
+        pureMana: [{ color: MANA_BLUE, source: "card" }],
+      });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_PURE_MAGIC,
+        powered: false,
+      });
+
+      if (playResult.state.players[0].pendingChoice) {
+        const choiceResult = engine.processAction(playResult.state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        });
+
+        const acc = choiceResult.state.players[0].combatAccumulator;
+        expect(acc.block).toBe(4);
+        expect(acc.blockElements.physical).toBe(4);
+        expect(acc.blockElements.fire).toBe(0);
+        expect(acc.blockElements.ice).toBe(0);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -50,6 +50,7 @@ import {
   EFFECT_RESOLVE_MANA_MELTDOWN_CHOICE,
   EFFECT_MANA_RADIANCE,
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
+  EFFECT_PURE_MAGIC,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -354,6 +355,11 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_RESOLVE_MANA_RADIANCE_COLOR]: (effect) => {
     const e = effect as ResolveManaRadianceColorEffect;
     return `All players: wound per ${e.color} crystal, gain 2 ${e.color} crystals`;
+  },
+
+  [EFFECT_PURE_MAGIC]: (effect) => {
+    const e = effect as import("../../types/cards.js").PureMagicEffect;
+    return `Pay mana: Green=Move ${e.value}, White=Influence ${e.value}, Blue=Block ${e.value}, Red=Attack ${e.value}`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -40,6 +40,7 @@ import { registerReadyUnitsBudgetEffects } from "./readyUnitsBudgetEffects.js";
 import { registerWoundActivatingUnitEffects } from "./woundActivatingUnitEffects.js";
 import { registerManaMeltdownEffects } from "./manaMeltdownEffects.js";
 import { registerAltemMagesEffects } from "./altemMagesEffects.js";
+import { registerPureMagicEffects } from "./pureMagicEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -142,4 +143,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Altem Mages effects (Cold Fire Attack/Block with mana scaling)
   registerAltemMagesEffects();
+
+  // Pure Magic effects (mana-color-driven effect selection)
+  registerPureMagicEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -257,6 +257,11 @@ export {
   registerAltemMagesEffects,
 } from "./altemMagesEffects.js";
 
+// Pure Magic effects (mana-color-driven effect selection)
+export {
+  registerPureMagicEffects,
+} from "./pureMagicEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/pureMagicEffects.ts
+++ b/packages/core/src/engine/effects/pureMagicEffects.ts
@@ -1,0 +1,153 @@
+/**
+ * Pure Magic Effect Handler
+ *
+ * Generates dynamic choice options where the player pays a basic mana token
+ * and the color determines the effect:
+ * - Green → Move
+ * - White → Influence
+ * - Blue → Block (combat only)
+ * - Red → Attack (combat only)
+ *
+ * The handler checks the player's available mana tokens at resolution time
+ * and generates compound effects (pay mana + gain effect) for each viable color.
+ *
+ * @module effects/pureMagicEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { PureMagicEffect, CardEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_PURE_MAGIC,
+  EFFECT_COMPOUND,
+  EFFECT_PAY_MANA,
+  EFFECT_GAIN_MOVE,
+  EFFECT_GAIN_INFLUENCE,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_MELEE,
+} from "../../types/effectTypes.js";
+import { MANA_GREEN, MANA_WHITE, MANA_BLUE, MANA_RED, MANA_GOLD } from "@mage-knight/shared";
+import type { ManaColor } from "@mage-knight/shared";
+import { countManaTokens } from "./manaPaymentEffects.js";
+import { canUseGoldAsWild } from "../rules/mana.js";
+
+/**
+ * Handle the EFFECT_PURE_MAGIC entry point.
+ *
+ * Generates dynamic choices based on available mana tokens and combat state:
+ * - Green mana → Move {value} (always available)
+ * - White mana → Influence {value} (always available)
+ * - Blue mana → Block {value} (combat only)
+ * - Red mana → Attack {value} (combat only)
+ *
+ * Gold mana tokens are wild and can substitute for any basic color,
+ * so each gold token adds options for all eligible basic colors.
+ */
+function handlePureMagic(
+  state: GameState,
+  playerId: string,
+  effect: PureMagicEffect
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+  const value = effect.value;
+  const inCombat = state.combat !== null;
+  const goldIsWild = canUseGoldAsWild(state);
+
+  // Check which basic colors the player has tokens for
+  const hasGreen = countManaTokens(player, MANA_GREEN) >= 1;
+  const hasWhite = countManaTokens(player, MANA_WHITE) >= 1;
+  const hasBlue = countManaTokens(player, MANA_BLUE) >= 1;
+  const hasRed = countManaTokens(player, MANA_RED) >= 1;
+  const hasGold = goldIsWild && countManaTokens(player, MANA_GOLD) >= 1;
+
+  const options: CardEffect[] = [];
+
+  // Helper to create a compound option: pay mana + gain effect
+  function addOption(payColor: ManaColor, gainEffect: CardEffect) {
+    options.push({
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_PAY_MANA, colors: [payColor], amount: 1 },
+        gainEffect,
+      ],
+    });
+  }
+
+  // Green → Move (always available outside/inside combat)
+  if (hasGreen) {
+    addOption(MANA_GREEN, { type: EFFECT_GAIN_MOVE, amount: value });
+  }
+
+  // White → Influence (always available outside/inside combat)
+  if (hasWhite) {
+    addOption(MANA_WHITE, { type: EFFECT_GAIN_INFLUENCE, amount: value });
+  }
+
+  // Blue → Block (combat only)
+  if (hasBlue && inCombat) {
+    addOption(MANA_BLUE, { type: EFFECT_GAIN_BLOCK, amount: value });
+  }
+
+  // Red → Attack (combat only)
+  if (hasRed && inCombat) {
+    addOption(MANA_RED, {
+      type: EFFECT_GAIN_ATTACK,
+      amount: value,
+      combatType: COMBAT_TYPE_MELEE,
+    });
+  }
+
+  // Gold is wild — can substitute for any basic color
+  if (hasGold) {
+    // Green → Move
+    if (!hasGreen) {
+      addOption(MANA_GOLD, { type: EFFECT_GAIN_MOVE, amount: value });
+    }
+    // White → Influence
+    if (!hasWhite) {
+      addOption(MANA_GOLD, { type: EFFECT_GAIN_INFLUENCE, amount: value });
+    }
+    // Blue → Block (combat only)
+    if (!hasBlue && inCombat) {
+      addOption(MANA_GOLD, { type: EFFECT_GAIN_BLOCK, amount: value });
+    }
+    // Red → Attack (combat only)
+    if (!hasRed && inCombat) {
+      addOption(MANA_GOLD, {
+        type: EFFECT_GAIN_ATTACK,
+        amount: value,
+        combatType: COMBAT_TYPE_MELEE,
+      });
+    }
+  }
+
+  if (options.length === 0) {
+    return {
+      state,
+      description: "No mana available to pay for Pure Magic",
+    };
+  }
+
+  return {
+    state,
+    description: "Choose mana color to pay for Pure Magic",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Pure Magic effect handlers with the effect registry.
+ */
+export function registerPureMagicEffects(): void {
+  registerEffect(EFFECT_PURE_MAGIC, (state, playerId, effect) => {
+    return handlePureMagic(state, playerId, effect as PureMagicEffect);
+  });
+}

--- a/packages/core/src/engine/rules/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/combatEffects.ts
@@ -14,6 +14,7 @@ import {
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
+  EFFECT_PURE_MAGIC,
 } from "../../../types/effectTypes.js";
 import {
   COMBAT_TYPE_RANGED,
@@ -60,6 +61,7 @@ export function effectHasBlock(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_BLOCK:
     case EFFECT_TERRAIN_BASED_BLOCK:
+    case EFFECT_PURE_MAGIC: // Pure Magic can provide Block (via blue mana)
       return true;
 
     case EFFECT_CHOICE:
@@ -93,6 +95,7 @@ export function effectHasBlock(effect: CardEffect): boolean {
 export function effectHasAttack(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
+    case EFFECT_PURE_MAGIC: // Pure Magic can provide Attack (via red mana)
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/engine/rules/effectDetection/movementEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/movementEffects.ts
@@ -14,6 +14,7 @@ import {
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
+  EFFECT_PURE_MAGIC,
 } from "../../../types/effectTypes.js";
 
 /**
@@ -22,6 +23,7 @@ import {
 export function effectHasMove(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_MOVE:
+    case EFFECT_PURE_MAGIC: // Pure Magic can provide Move (via green mana)
       return true;
 
     case EFFECT_CHOICE:
@@ -82,6 +84,7 @@ export function effectIsMoveOnly(effect: CardEffect): boolean {
 export function effectHasInfluence(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_INFLUENCE:
+    case EFFECT_PURE_MAGIC: // Pure Magic can provide Influence (via white mana)
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -78,6 +78,7 @@ import {
   EFFECT_MANA_RADIANCE,
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
   EFFECT_ALTEM_MAGES_COLD_FIRE,
+  EFFECT_PURE_MAGIC,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -921,6 +922,18 @@ export interface AltemMagesColdFireEffect {
   readonly boostPerMana: number;
 }
 
+/**
+ * Pure Magic mana-payment-driven effect.
+ * Player pays 1 basic mana token and the color determines the effect:
+ * Green → Move, White → Influence, Blue → Block, Red → Attack.
+ * Blue/Red are only available during combat.
+ * Value differs between basic and powered modes.
+ */
+export interface PureMagicEffect {
+  readonly type: typeof EFFECT_PURE_MAGIC;
+  readonly value: number;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -984,7 +997,8 @@ export type CardEffect =
   | ResolveManaMeltdownChoiceEffect
   | ManaRadianceEffect
   | ResolveManaRadianceColorEffect
-  | AltemMagesColdFireEffect;
+  | AltemMagesColdFireEffect
+  | PureMagicEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -209,3 +209,10 @@ export const EFFECT_SCOUT_PEEK = "scout_peek" as const;
 // blue (+2), red (+2), or both (+4) mana tokens.
 // Generates choices based on available mana at resolution time.
 export const EFFECT_ALTEM_MAGES_COLD_FIRE = "altem_mages_cold_fire" as const;
+
+// === Pure Magic Effect ===
+// Pay a basic mana token → effect determined by color paid:
+// Green → Move, White → Influence, Blue → Block, Red → Attack.
+// Blue/Red only available during combat (Block/Attack are combat actions).
+// Values differ between basic (4) and powered (7) modes.
+export const EFFECT_PURE_MAGIC = "pure_magic" as const;


### PR DESCRIPTION
## Summary
- Implemented the correct Pure Magic mechanic where the player pays a basic mana token and the color determines the effect
- Green → Move 4/7, White → Influence 4/7, Blue → Block 4/7, Red → Attack 4/7
- Blue/Red mana options only available during combat (Block/Attack are combat actions)
- Gold mana serves as wild, substituting for any basic color
- Basic effect uses value 4, powered (blue mana) effect uses value 7

## Changes
- Added `EFFECT_PURE_MAGIC` effect type constant and `PureMagicEffect` interface
- Created `pureMagicEffects.ts` handler that generates dynamic compound choices (pay mana + gain effect)
- Updated Pure Magic card data to use the new effect type instead of free choice
- Registered new effect handler in the effect registry
- Added `EFFECT_PURE_MAGIC` to effect detection functions (move, influence, block, attack) for card playability
- Added effect description for UI display
- Added 18 tests covering all mana-color-to-effect mappings, combat restrictions, powered mode, gold wildcard, and non-elemental effects

Closes #155