### PR TITLE
feat: Fireball/Firestorm fortification playability validation

### DIFF
--- a/packages/core/src/engine/__tests__/fireballFortification.test.ts
+++ b/packages/core/src/engine/__tests__/fireballFortification.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Fireball / Firestorm Fortification Playability Tests (#195)
+ *
+ * Tests that:
+ * - Fireball (basic: Ranged Fire Attack 5) cannot be played when all enemies are fortified
+ * - Firestorm (powered: Take Wound + Siege Fire Attack 8) CAN be played vs fortified enemies
+ * - Fireball basic CAN be played when at least one enemy is not fortified
+ * - Firestorm wound cost is always exactly 1 regardless of poison enemies
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  ENTER_COMBAT_ACTION,
+  PLAY_CARD_ACTION,
+  INVALID_ACTION,
+  ENEMY_DIGGERS,
+  ENEMY_PROWLERS,
+  ENEMY_ORC_WAR_BEASTS,
+  CARD_FIREBALL,
+  CARD_WOUND,
+  MANA_RED,
+  MANA_BLACK,
+  MANA_TOKEN_SOURCE_CARD,
+  MANA_SOURCE_TOKEN,
+  TIME_OF_DAY_NIGHT,
+} from "@mage-knight/shared";
+import { COMBAT_PHASE_RANGED_SIEGE } from "../../types/combat.js";
+import type { CardId } from "@mage-knight/shared";
+import type { ManaToken } from "../../types/player.js";
+
+/** Helper to create a mana token for tests */
+function manaToken(color: string): ManaToken {
+  return { color: color as ManaToken["color"], source: MANA_TOKEN_SOURCE_CARD };
+}
+
+describe("Fireball / Firestorm Fortification", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("Fireball basic (Ranged Fire Attack 5)", () => {
+    it("should NOT be playable when all enemies have ABILITY_FORTIFIED", () => {
+      let state = createTestGameState({
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat with Diggers (has ABILITY_FORTIFIED)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Try to play Fireball basic - should fail
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: false,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: expect.stringContaining("fortified"),
+        })
+      );
+    });
+
+    it("should NOT be playable when all enemies are fortified via site", () => {
+      let state = createTestGameState({
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat at fortified site with Prowlers (no ABILITY_FORTIFIED, but site grants it)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS],
+        isAtFortifiedSite: true,
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Try to play Fireball basic - should fail (site grants fortification)
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: false,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: expect.stringContaining("fortified"),
+        })
+      );
+    });
+
+    it("should be playable when at least one enemy is not fortified", () => {
+      let state = createTestGameState({
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat with both Diggers (fortified) and Prowlers (not fortified)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_PROWLERS],
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Play Fireball basic - should succeed (Prowlers are not fortified)
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: false,
+      });
+
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should be playable at fortified site when enemy has ABILITY_UNFORTIFIED", () => {
+      let state = createTestGameState({
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat at fortified site with Orc War Beasts (ABILITY_UNFORTIFIED)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_ORC_WAR_BEASTS],
+        isAtFortifiedSite: true,
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Play Fireball basic - should succeed (Orc War Beasts are unfortified)
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: false,
+      });
+
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should be playable against non-fortified enemies", () => {
+      let state = createTestGameState({
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat with Prowlers (not fortified)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS],
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Play Fireball basic - should succeed
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: false,
+      });
+
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("Firestorm powered (Take Wound + Siege Fire Attack 8)", () => {
+    it("should be playable when all enemies are fortified (has siege)", () => {
+      let state = createTestGameState({
+        timeOfDay: TIME_OF_DAY_NIGHT, // Night so black mana is usable
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            // Need mana tokens for powered spell: black + red
+            pureMana: [manaToken(MANA_BLACK), manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      // Enter combat with Diggers (fortified)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_RANGED_SIEGE);
+
+      // Play Firestorm (powered) - should succeed because it provides Siege Attack
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: true,
+      });
+
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: expect.stringContaining("fortified"),
+        })
+      );
+    });
+  });
+
+  describe("Firestorm wound cost", () => {
+    it("should take exactly 1 wound when powered", () => {
+      let state = createTestGameState({
+        timeOfDay: TIME_OF_DAY_NIGHT, // Night so black mana is usable
+        players: [
+          createTestPlayer({
+            hand: [CARD_FIREBALL],
+            pureMana: [manaToken(MANA_BLACK), manaToken(MANA_RED)],
+          }),
+        ],
+      });
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS],
+      }).state;
+
+      const handBefore = state.players[0]?.hand ?? [];
+      const woundsBefore = handBefore.filter(c => c === CARD_WOUND).length;
+
+      // Play Firestorm (powered) - must provide manaSources for spell powered
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_FIREBALL,
+        powered: true,
+        manaSources: [
+          { type: MANA_SOURCE_TOKEN, color: MANA_BLACK },
+          { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+        ],
+      });
+
+      // Verify no INVALID_ACTION was returned
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+
+      const handAfter = result.state.players[0]?.hand ?? [];
+      const woundsAfter = handAfter.filter((c: CardId) => c === CARD_WOUND).length;
+
+      // Should have exactly 1 more wound (casting cost)
+      expect(woundsAfter - woundsBefore).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/engine/rules/effectDetection/index.ts
+++ b/packages/core/src/engine/rules/effectDetection/index.ts
@@ -10,6 +10,7 @@ import type { CardEffect } from "../../../types/cards.js";
 // Combat effects
 export {
   effectHasRangedOrSiege,
+  effectIsRangedOnlyAttack,
   effectHasBlock,
   effectHasAttack,
 } from "./combatEffects.js";

--- a/packages/core/src/engine/validators/playCardValidators.ts
+++ b/packages/core/src/engine/validators/playCardValidators.ts
@@ -18,6 +18,7 @@ import {
   CARD_NOT_PLAYABLE,
   CARD_NOT_PLAYABLE_IN_PHASE,
   CARD_EFFECT_NOT_RESOLVABLE,
+  RANGED_ATTACK_ALL_FORTIFIED,
 } from "./validationCodes.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
 import type { CardEffectKind } from "../helpers/cardCategoryHelpers.js";
@@ -27,6 +28,7 @@ import {
   isCombatEffectAllowed,
   isHealingOnlyInCombat,
   isNormalEffectAllowed,
+  isRangedAttackUnusable,
   isWoundCardId,
 } from "../rules/cardPlay.js";
 import { isRuleActive } from "../modifiers/index.js";
@@ -170,6 +172,14 @@ export function validateCardPlayableInContext(
       return invalid(
         CARD_NOT_PLAYABLE_IN_PHASE,
         `Card cannot be played in ${phase} phase`
+      );
+    }
+
+    // Ranged-only attacks cannot be played when all enemies are fortified
+    if (context.effect && isRangedAttackUnusable(context.effect, state, playerId, state.combat)) {
+      return invalid(
+        RANGED_ATTACK_ALL_FORTIFIED,
+        "Ranged attacks cannot target fortified enemies"
       );
     }
 

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -97,6 +97,7 @@ export const INVALID_ATTACK_TYPE = "INVALID_ATTACK_TYPE" as const;
 export const DAMAGE_NOT_ASSIGNED = "DAMAGE_NOT_ASSIGNED" as const;
 export const FORTIFIED_NEEDS_SIEGE = "FORTIFIED_NEEDS_SIEGE" as const;
 export const NO_SIEGE_ATTACK_ACCUMULATED = "NO_SIEGE_ATTACK_ACCUMULATED" as const;
+export const RANGED_ATTACK_ALL_FORTIFIED = "RANGED_ATTACK_ALL_FORTIFIED" as const;
 export const ALREADY_COMBATTED = "ALREADY_COMBATTED" as const;
 // Incremental attack assignment validation codes
 export const INSUFFICIENT_ATTACK = "INSUFFICIENT_ATTACK" as const;
@@ -363,6 +364,7 @@ export type ValidationErrorCode =
   | typeof DAMAGE_NOT_ASSIGNED
   | typeof FORTIFIED_NEEDS_SIEGE
   | typeof NO_SIEGE_ATTACK_ACCUMULATED
+  | typeof RANGED_ATTACK_ALL_FORTIFIED
   | typeof ALREADY_COMBATTED
   | typeof INSUFFICIENT_ATTACK
   | typeof NOTHING_TO_UNASSIGN


### PR DESCRIPTION
## Summary
- Added validator to prevent Fireball (basic: Ranged Fire Attack 5) from being played when all enemies are fortified in Ranged/Siege phase
- Firestorm (powered: Siege Fire Attack 8) is unaffected since siege bypasses fortification
- ValidActions also updated to hide Fireball basic from playable cards when all enemies are fortified

## Changes
- `effectDetection/combatEffects.ts`: New `effectIsRangedOnlyAttack()` detection function
- `rules/cardPlay.ts`: New `isRangedAttackUnusable()` rule checking enemy fortification state
- `validators/playCardValidators.ts`: Added fortification check in `validateCardPlayableInContext`
- `validActions/cards/combat.ts`: Filter ranged-only cards when all enemies are fortified
- `validationCodes.ts`: New `RANGED_ATTACK_ALL_FORTIFIED` code
- New test file with 7 tests covering all scenarios

## Test Plan
- [x] Fireball basic blocked when all enemies have ABILITY_FORTIFIED (Diggers)
- [x] Fireball basic blocked when all enemies are fortified via site
- [x] Fireball basic allowed when at least one enemy is not fortified (mixed)
- [x] Fireball basic allowed at fortified site with ABILITY_UNFORTIFIED enemy (Orc War Beasts)
- [x] Fireball basic allowed against non-fortified enemies
- [x] Firestorm powered allowed vs fortified enemies (has siege)
- [x] Firestorm wound cost is exactly 1 (verified by test)

Closes #195