### PR TITLE
feat: add enemy scaling for Flame Wave powered effect

### DIFF
--- a/packages/core/src/data/spells/helpers.ts
+++ b/packages/core/src/data/spells/helpers.ts
@@ -76,3 +76,6 @@ export function heal(amount: number): CardEffect {
 export function choice(options: readonly CardEffect[]): CardEffect {
   return { type: EFFECT_CHOICE, options };
 }
+
+// Re-export scaling helpers from effectHelpers for spell definitions
+export { fireAttackPerEnemy, fireBlockPerEnemy } from "../effectHelpers.js";

--- a/packages/core/src/data/spells/red/flameWall.ts
+++ b/packages/core/src/data/spells/red/flameWall.ts
@@ -1,10 +1,7 @@
 /**
  * Flame Wall / Flame Wave (Red Spell #10)
  * Basic (Flame Wall): Fire Attack 5, or Fire Block 7
- * Powered (Flame Wave): Same choice, +2 per enemy
- *
- * Note: The scaling powered effect is not yet implemented.
- * For now, powered just gives the base values.
+ * Powered (Flame Wave): Fire Attack 5 OR Fire Block 7, +2 per enemy
  */
 
 import type { DeedCard } from "../../../types/cards.js";
@@ -13,7 +10,7 @@ import {
   DEED_CARD_TYPE_SPELL,
 } from "../../../types/cards.js";
 import { MANA_RED, MANA_BLACK, CARD_FLAME_WALL } from "@mage-knight/shared";
-import { fireAttack, fireBlock, choice } from "../helpers.js";
+import { fireAttack, fireBlock, choice, fireAttackPerEnemy, fireBlockPerEnemy } from "../helpers.js";
 
 export const FLAME_WALL: DeedCard = {
   id: CARD_FLAME_WALL,
@@ -23,6 +20,9 @@ export const FLAME_WALL: DeedCard = {
   categories: [CATEGORY_COMBAT],
   poweredBy: [MANA_BLACK, MANA_RED],
   basicEffect: choice([fireAttack(5), fireBlock(7)]),
-  poweredEffect: choice([fireAttack(5), fireBlock(7)]), // TODO: Add scaling
+  poweredEffect: choice([
+    fireAttackPerEnemy(5, 2),
+    fireBlockPerEnemy(7, 2),
+  ]),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/effects/scalingEvaluator.ts
+++ b/packages/core/src/engine/effects/scalingEvaluator.ts
@@ -16,6 +16,7 @@ import type { UnitFilter } from "../../types/scaling.js";
 import type { PlayerUnit } from "../../types/unit.js";
 import { CARD_WOUND, UNIT_STATE_READY, UNIT_STATE_SPENT } from "@mage-knight/shared";
 import { getPlayerById } from "../helpers/playerHelpers.js";
+import { isEnemyAssignedToPlayer } from "../helpers/cooperativeAssaultHelpers.js";
 
 /**
  * Evaluates a scaling factor and returns the count to multiply by.
@@ -35,9 +36,13 @@ export function evaluateScalingFactor(
 
   switch (factor.type) {
     case SCALING_PER_ENEMY: {
-      // Count undefeated enemies in current combat
+      // Count undefeated, non-summoned enemies assigned to this player
       if (!state.combat) return 0;
-      return state.combat.enemies.filter((e) => !e.isDefeated).length;
+      return state.combat.enemies.filter((e) =>
+        !e.isDefeated &&
+        !e.summonedByInstanceId &&
+        isEnemyAssignedToPlayer(state.combat?.enemyAssignments, playerId, e.instanceId)
+      ).length;
     }
 
     case SCALING_PER_WOUND_IN_HAND: {


### PR DESCRIPTION
## Summary
- Updated Flame Wall/Flame Wave spell powered effect to scale +2 per enemy token (Fire Attack 5+2/enemy, Fire Block 7+2/enemy)
- Improved `SCALING_PER_ENEMY` evaluator to exclude summoned monsters from enemy count
- Added cooperative assault support: only counts enemies assigned to the current player

## Changes
- `packages/core/src/data/spells/red/flameWall.ts` — Use `fireAttackPerEnemy(5, 2)` and `fireBlockPerEnemy(7, 2)` for powered effect
- `packages/core/src/data/spells/helpers.ts` — Re-export scaling helpers for spell definitions
- `packages/core/src/engine/effects/scalingEvaluator.ts` — Filter out summoned enemies and respect cooperative assault assignments in `SCALING_PER_ENEMY`
- `packages/core/src/engine/__tests__/scalingEffects.test.ts` — Added tests for summoned enemy exclusion, cooperative assault filtering, and FLAME_WALL real card integration

Closes #196