### PR TITLE
feat: implement Heroic Tale recruitment bonus per unit

### DIFF
--- a/packages/core/src/data/advancedActions/white/heroic-tale.ts
+++ b/packages/core/src/data/advancedActions/white/heroic-tale.ts
@@ -1,7 +1,8 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_INFLUENCE, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_WHITE, CARD_HEROIC_TALE } from "@mage-knight/shared";
-import { influence } from "../helpers.js";
+import { influence, compound } from "../helpers.js";
+import { EFFECT_APPLY_RECRUITMENT_BONUS } from "../../../types/effectTypes.js";
 
 export const HEROIC_TALE: DeedCard = {
   id: CARD_HEROIC_TALE,
@@ -10,9 +11,14 @@ export const HEROIC_TALE: DeedCard = {
   poweredBy: [MANA_WHITE],
   categories: [CATEGORY_INFLUENCE],
   // Basic: Influence 3. Reputation +1 for each Unit you recruit this turn.
+  basicEffect: compound(
+    influence(3),
+    { type: EFFECT_APPLY_RECRUITMENT_BONUS, reputationPerRecruit: 1, famePerRecruit: 0 },
+  ),
   // Powered: Influence 6. Fame +1 and Reputation +1 for each Unit you recruit this turn.
-  // TODO: Implement recruitment bonus modifier
-  basicEffect: influence(3),
-  poweredEffect: influence(6),
+  poweredEffect: compound(
+    influence(6),
+    { type: EFFECT_APPLY_RECRUITMENT_BONUS, reputationPerRecruit: 1, famePerRecruit: 1 },
+  ),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/heroicTale.test.ts
+++ b/packages/core/src/engine/__tests__/heroicTale.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Tests for Heroic Tale card
+ *
+ * Basic: Influence 3. Reputation +1 for each Unit you recruit this turn.
+ * Powered (White): Influence 6. Fame +1 and Reputation +1 for each Unit you recruit this turn.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolveEffect, isEffectResolvable, describeEffect } from "../effects/index.js";
+import type {
+  ApplyRecruitmentBonusEffect,
+  CompoundEffect,
+} from "../../types/cards.js";
+import {
+  EFFECT_APPLY_RECRUITMENT_BONUS,
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_INFLUENCE,
+} from "../../types/effectTypes.js";
+import {
+  EFFECT_RECRUITMENT_BONUS,
+} from "../../types/modifierConstants.js";
+import type { UnitRecruitmentBonusModifier } from "../../types/modifiers.js";
+import {
+  UNITS,
+  type UnitId,
+} from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import {
+  createRecruitUnitCommand,
+  resetUnitInstanceCounter,
+} from "../commands/units/recruitUnitCommand.js";
+import { getActiveRecruitmentBonus } from "../rules/unitRecruitment.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { HEROIC_TALE } from "../../data/advancedActions/white/heroic-tale.js";
+
+// Get a level-1 unit ID for testing
+function getUnitIdOfLevel(level: number): UnitId {
+  const unitEntry = Object.entries(UNITS).find(([_, def]) => def.level === level);
+  if (!unitEntry) {
+    throw new Error(`No unit found with level ${level}`);
+  }
+  return unitEntry[0] as UnitId;
+}
+
+// Helper to create a state with units in the offer
+function createRecruitState(
+  numUnitsInOffer: number = 1,
+  influencePoints: number = 20,
+): GameState {
+  resetUnitInstanceCounter();
+  const unitId = getUnitIdOfLevel(1);
+  const unitIds = Array.from({ length: numUnitsInOffer }, () => unitId);
+  const player = createTestPlayer({ influencePoints });
+  return createTestGameState({
+    players: [player],
+    offers: {
+      units: unitIds,
+      advancedActions: [],
+      spells: [],
+    } as GameState["offers"],
+  });
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Heroic Tale card definition", () => {
+  it("should have correct categories", () => {
+    expect(HEROIC_TALE.categories).toContain("influence");
+  });
+
+  it("should have basic effect as compound of influence(3) + recruitment bonus", () => {
+    const basic = HEROIC_TALE.basicEffect;
+    expect(basic.type).toBe(EFFECT_COMPOUND);
+    const compound = basic as CompoundEffect;
+    expect(compound.effects).toHaveLength(2);
+    expect(compound.effects[0].type).toBe(EFFECT_GAIN_INFLUENCE);
+    expect(compound.effects[1].type).toBe(EFFECT_APPLY_RECRUITMENT_BONUS);
+
+    const bonus = compound.effects[1] as ApplyRecruitmentBonusEffect;
+    expect(bonus.reputationPerRecruit).toBe(1);
+    expect(bonus.famePerRecruit).toBe(0);
+  });
+
+  it("should have powered effect as compound of influence(6) + recruitment bonus with fame", () => {
+    const powered = HEROIC_TALE.poweredEffect;
+    expect(powered.type).toBe(EFFECT_COMPOUND);
+    const compound = powered as CompoundEffect;
+    expect(compound.effects).toHaveLength(2);
+    expect(compound.effects[0].type).toBe(EFFECT_GAIN_INFLUENCE);
+    expect(compound.effects[1].type).toBe(EFFECT_APPLY_RECRUITMENT_BONUS);
+
+    const bonus = compound.effects[1] as ApplyRecruitmentBonusEffect;
+    expect(bonus.reputationPerRecruit).toBe(1);
+    expect(bonus.famePerRecruit).toBe(1);
+  });
+});
+
+// ============================================================================
+// EFFECT_APPLY_RECRUITMENT_BONUS TESTS
+// ============================================================================
+
+describe("EFFECT_APPLY_RECRUITMENT_BONUS", () => {
+  const basicEffect: ApplyRecruitmentBonusEffect = {
+    type: EFFECT_APPLY_RECRUITMENT_BONUS,
+    reputationPerRecruit: 1,
+    famePerRecruit: 0,
+  };
+
+  const poweredEffect: ApplyRecruitmentBonusEffect = {
+    type: EFFECT_APPLY_RECRUITMENT_BONUS,
+    reputationPerRecruit: 1,
+    famePerRecruit: 1,
+  };
+
+  describe("resolveEffect", () => {
+    it("should add a recruitment bonus modifier for basic effect", () => {
+      const state = createRecruitState();
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.state.activeModifiers).toHaveLength(1);
+      const modifier = result.state.activeModifiers[0];
+      expect(modifier.effect.type).toBe(EFFECT_RECRUITMENT_BONUS);
+      const bonusEffect = modifier.effect as UnitRecruitmentBonusModifier;
+      expect(bonusEffect.reputationPerRecruit).toBe(1);
+      expect(bonusEffect.famePerRecruit).toBe(0);
+    });
+
+    it("should add a recruitment bonus modifier for powered effect", () => {
+      const state = createRecruitState();
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      expect(result.state.activeModifiers).toHaveLength(1);
+      const modifier = result.state.activeModifiers[0];
+      expect(modifier.effect.type).toBe(EFFECT_RECRUITMENT_BONUS);
+      const bonusEffect = modifier.effect as UnitRecruitmentBonusModifier;
+      expect(bonusEffect.reputationPerRecruit).toBe(1);
+      expect(bonusEffect.famePerRecruit).toBe(1);
+    });
+
+    it("should set modifier duration to turn", () => {
+      const state = createRecruitState();
+      const result = resolveEffect(state, state.players[0].id, basicEffect);
+
+      expect(result.state.activeModifiers[0].duration).toBe("turn");
+    });
+
+    it("should include a description", () => {
+      const state = createRecruitState();
+      const result = resolveEffect(state, state.players[0].id, poweredEffect);
+
+      expect(result.description).toContain("Reputation");
+      expect(result.description).toContain("Fame");
+      expect(result.description).toContain("per unit recruited");
+    });
+  });
+
+  describe("isEffectResolvable", () => {
+    it("should always be resolvable", () => {
+      const state = createRecruitState();
+      expect(isEffectResolvable(state, state.players[0].id, basicEffect)).toBe(true);
+    });
+  });
+
+  describe("describeEffect", () => {
+    it("should describe basic effect (reputation only)", () => {
+      const desc = describeEffect(basicEffect);
+      expect(desc).toContain("Reputation");
+      expect(desc).toContain("per unit recruited");
+    });
+
+    it("should describe powered effect (reputation + fame)", () => {
+      const desc = describeEffect(poweredEffect);
+      expect(desc).toContain("Reputation");
+      expect(desc).toContain("Fame");
+    });
+  });
+});
+
+// ============================================================================
+// INTEGRATION: RECRUITMENT BONUS + RECRUITMENT COMMAND
+// ============================================================================
+
+describe("Recruitment bonus integration with recruitUnitCommand", () => {
+  const basicBonusEffect: ApplyRecruitmentBonusEffect = {
+    type: EFFECT_APPLY_RECRUITMENT_BONUS,
+    reputationPerRecruit: 1,
+    famePerRecruit: 0,
+  };
+
+  const poweredBonusEffect: ApplyRecruitmentBonusEffect = {
+    type: EFFECT_APPLY_RECRUITMENT_BONUS,
+    reputationPerRecruit: 1,
+    famePerRecruit: 1,
+  };
+
+  function applyBonusAndRecruit(
+    bonusEffect: ApplyRecruitmentBonusEffect,
+    numUnits: number = 1,
+  ): { initialState: GameState; finalState: GameState } {
+    resetUnitInstanceCounter();
+    const state = createRecruitState(numUnits);
+    const playerId = state.players[0].id;
+
+    // Apply the recruitment bonus modifier
+    const bonusResult = resolveEffect(state, playerId, bonusEffect);
+    let currentState = bonusResult.state;
+    const initialState = currentState;
+
+    // Recruit units
+    for (let i = 0; i < numUnits; i++) {
+      const unitId = currentState.offers.units[0];
+      const unitDef = UNITS[unitId];
+      const command = createRecruitUnitCommand({
+        playerId,
+        unitId,
+        influenceSpent: unitDef.influence,
+      });
+      const result = command.execute(currentState);
+      currentState = result.state;
+    }
+
+    return { initialState, finalState: currentState };
+  }
+
+  describe("basic effect (reputation only)", () => {
+    it("should grant +1 reputation on single recruitment", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(basicBonusEffect, 1);
+      const initialRep = initialState.players[0].reputation;
+      expect(finalState.players[0].reputation).toBe(initialRep + 1);
+    });
+
+    it("should grant +2 reputation on two recruitments", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(basicBonusEffect, 2);
+      const initialRep = initialState.players[0].reputation;
+      expect(finalState.players[0].reputation).toBe(initialRep + 2);
+    });
+
+    it("should not grant fame on basic effect", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(basicBonusEffect, 1);
+      expect(finalState.players[0].fame).toBe(initialState.players[0].fame);
+    });
+  });
+
+  describe("powered effect (reputation + fame)", () => {
+    it("should grant +1 reputation and +1 fame on single recruitment", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(poweredBonusEffect, 1);
+      const initialRep = initialState.players[0].reputation;
+      const initialFame = initialState.players[0].fame;
+      expect(finalState.players[0].reputation).toBe(initialRep + 1);
+      expect(finalState.players[0].fame).toBe(initialFame + 1);
+    });
+
+    it("should grant +2 reputation and +2 fame on two recruitments", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(poweredBonusEffect, 2);
+      const initialRep = initialState.players[0].reputation;
+      const initialFame = initialState.players[0].fame;
+      expect(finalState.players[0].reputation).toBe(initialRep + 2);
+      expect(finalState.players[0].fame).toBe(initialFame + 2);
+    });
+
+    it("should grant +3 reputation and +3 fame on three recruitments", () => {
+      const { initialState, finalState } = applyBonusAndRecruit(poweredBonusEffect, 3);
+      const initialRep = initialState.players[0].reputation;
+      const initialFame = initialState.players[0].fame;
+      expect(finalState.players[0].reputation).toBe(initialRep + 3);
+      expect(finalState.players[0].fame).toBe(initialFame + 3);
+    });
+  });
+
+  describe("modifier persistence", () => {
+    it("should NOT consume the modifier after recruitment", () => {
+      const state = createRecruitState(2);
+      const playerId = state.players[0].id;
+
+      // Apply the bonus modifier
+      const bonusResult = resolveEffect(state, playerId, basicBonusEffect);
+      let currentState = bonusResult.state;
+
+      // Verify modifier exists
+      expect(getActiveRecruitmentBonus(currentState, playerId)).not.toBeNull();
+
+      // Recruit first unit
+      const unitId = currentState.offers.units[0];
+      const unitDef = UNITS[unitId];
+      const command1 = createRecruitUnitCommand({
+        playerId,
+        unitId,
+        influenceSpent: unitDef.influence,
+      });
+      const result1 = command1.execute(currentState);
+      currentState = result1.state;
+
+      // Modifier should still be active
+      expect(getActiveRecruitmentBonus(currentState, playerId)).not.toBeNull();
+
+      // Recruit second unit
+      const unitId2 = currentState.offers.units[0];
+      const unitDef2 = UNITS[unitId2];
+      const command2 = createRecruitUnitCommand({
+        playerId,
+        unitId: unitId2,
+        influenceSpent: unitDef2.influence,
+      });
+      const result2 = command2.execute(currentState);
+      currentState = result2.state;
+
+      // Modifier should still be active
+      expect(getActiveRecruitmentBonus(currentState, playerId)).not.toBeNull();
+    });
+  });
+
+  describe("undo support", () => {
+    it("should restore reputation and fame on undo", () => {
+      resetUnitInstanceCounter();
+      const state = createRecruitState(1);
+      const playerId = state.players[0].id;
+
+      // Apply the powered bonus modifier
+      const bonusResult = resolveEffect(state, playerId, poweredBonusEffect);
+      const stateWithBonus = bonusResult.state;
+      const initialRep = stateWithBonus.players[0].reputation;
+      const initialFame = stateWithBonus.players[0].fame;
+
+      // Recruit a unit
+      const unitId = stateWithBonus.offers.units[0];
+      const unitDef = UNITS[unitId];
+      const command = createRecruitUnitCommand({
+        playerId,
+        unitId,
+        influenceSpent: unitDef.influence,
+      });
+      const executed = command.execute(stateWithBonus);
+
+      // Verify bonuses were applied
+      expect(executed.state.players[0].reputation).toBe(initialRep + 1);
+      expect(executed.state.players[0].fame).toBe(initialFame + 1);
+
+      // Undo the command
+      const undone = command.undo(executed.state);
+
+      // Reputation and fame should be restored
+      expect(undone.state.players[0].reputation).toBe(initialRep);
+      expect(undone.state.players[0].fame).toBe(initialFame);
+    });
+  });
+
+  describe("no bonus without modifier", () => {
+    it("should not change reputation or fame when recruiting without modifier", () => {
+      resetUnitInstanceCounter();
+      const state = createRecruitState(1);
+      const playerId = state.players[0].id;
+      const initialRep = state.players[0].reputation;
+      const initialFame = state.players[0].fame;
+
+      // Recruit without any bonus modifier
+      const unitId = state.offers.units[0];
+      const unitDef = UNITS[unitId];
+      const command = createRecruitUnitCommand({
+        playerId,
+        unitId,
+        influenceSpent: unitDef.influence,
+      });
+      const result = command.execute(state);
+
+      // No bonuses applied
+      expect(result.state.players[0].reputation).toBe(initialRep);
+      expect(result.state.players[0].fame).toBe(initialFame);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -51,6 +51,7 @@ import {
   EFFECT_MANA_RADIANCE,
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
   EFFECT_PURE_MAGIC,
+  EFFECT_APPLY_RECRUITMENT_BONUS,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -66,6 +67,7 @@ import type {
   CureEffect,
   ResolveManaMeltdownChoiceEffect,
   ResolveManaRadianceColorEffect,
+  ApplyRecruitmentBonusEffect,
 } from "../../types/cards.js";
 import type {
   GainMoveEffect,
@@ -360,6 +362,18 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_PURE_MAGIC]: (effect) => {
     const e = effect as import("../../types/cards.js").PureMagicEffect;
     return `Pay mana: Green=Move ${e.value}, White=Influence ${e.value}, Blue=Block ${e.value}, Red=Attack ${e.value}`;
+  },
+
+  [EFFECT_APPLY_RECRUITMENT_BONUS]: (effect) => {
+    const e = effect as ApplyRecruitmentBonusEffect;
+    const parts: string[] = [];
+    if (e.reputationPerRecruit !== 0) {
+      parts.push(`Reputation +${e.reputationPerRecruit}`);
+    }
+    if (e.famePerRecruit > 0) {
+      parts.push(`Fame +${e.famePerRecruit}`);
+    }
+    return `${parts.join(" and ")} per unit recruited this turn`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -41,6 +41,7 @@ import { registerWoundActivatingUnitEffects } from "./woundActivatingUnitEffects
 import { registerManaMeltdownEffects } from "./manaMeltdownEffects.js";
 import { registerAltemMagesEffects } from "./altemMagesEffects.js";
 import { registerPureMagicEffects } from "./pureMagicEffects.js";
+import { registerHeroicTaleEffects } from "./heroicTaleEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -146,4 +147,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Pure Magic effects (mana-color-driven effect selection)
   registerPureMagicEffects();
+
+  // Heroic Tale effects (recruitment bonus modifier)
+  registerHeroicTaleEffects();
 }

--- a/packages/core/src/engine/effects/heroicTaleEffects.ts
+++ b/packages/core/src/engine/effects/heroicTaleEffects.ts
@@ -1,0 +1,78 @@
+/**
+ * Heroic Tale effect handlers
+ *
+ * Handles Heroic Tale card effects:
+ * - EFFECT_APPLY_RECRUITMENT_BONUS: Grants a turn-scoped modifier that gives
+ *   reputation and/or fame per unit recruited this turn.
+ *
+ * @module effects/heroicTaleEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { ApplyRecruitmentBonusEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { UnitRecruitmentBonusModifier } from "../../types/modifiers.js";
+import { registerEffect } from "./effectRegistry.js";
+import { addModifier } from "../modifiers/lifecycle.js";
+import { EFFECT_APPLY_RECRUITMENT_BONUS } from "../../types/effectTypes.js";
+import {
+  EFFECT_RECRUITMENT_BONUS,
+  DURATION_TURN,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { CARD_HEROIC_TALE } from "@mage-knight/shared";
+
+// ============================================================================
+// RECRUITMENT BONUS EFFECT
+// ============================================================================
+
+/**
+ * Handle EFFECT_APPLY_RECRUITMENT_BONUS - adds a turn-scoped modifier that grants
+ * reputation and/or fame each time a unit is recruited for the rest of the turn.
+ */
+function handleApplyRecruitmentBonus(
+  state: GameState,
+  playerId: string,
+  effect: ApplyRecruitmentBonusEffect,
+): EffectResolutionResult {
+  const newState = addModifier(state, {
+    source: { type: SOURCE_CARD, cardId: CARD_HEROIC_TALE, playerId },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_RECRUITMENT_BONUS,
+      reputationPerRecruit: effect.reputationPerRecruit,
+      famePerRecruit: effect.famePerRecruit,
+    } satisfies UnitRecruitmentBonusModifier,
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  const parts: string[] = [];
+  if (effect.reputationPerRecruit !== 0) {
+    parts.push(`Reputation +${effect.reputationPerRecruit}`);
+  }
+  if (effect.famePerRecruit > 0) {
+    parts.push(`Fame +${effect.famePerRecruit}`);
+  }
+  const bonusDesc = parts.join(" and ");
+
+  return {
+    state: newState,
+    description: `${bonusDesc} per unit recruited this turn`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all Heroic Tale effect handlers with the effect registry.
+ */
+export function registerHeroicTaleEffects(): void {
+  registerEffect(EFFECT_APPLY_RECRUITMENT_BONUS, (state, playerId, effect) => {
+    return handleApplyRecruitmentBonus(state, playerId, effect as ApplyRecruitmentBonusEffect);
+  });
+}

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -262,6 +262,11 @@ export {
   registerPureMagicEffects,
 } from "./pureMagicEffects.js";
 
+// Heroic Tale effects (recruitment bonus modifier)
+export {
+  registerHeroicTaleEffects,
+} from "./heroicTaleEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -71,6 +71,7 @@ import {
   EFFECT_PLACE_SKILL_IN_CENTER,
   EFFECT_DISCARD_FOR_CRYSTAL,
   EFFECT_APPLY_RECRUIT_DISCOUNT,
+  EFFECT_APPLY_RECRUITMENT_BONUS,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
   EFFECT_ENERGY_FLOW,
@@ -360,6 +361,9 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Recruit discount is always resolvable (adds a modifier)
   [EFFECT_APPLY_RECRUIT_DISCOUNT]: () => true,
+
+  // Recruitment bonus is always resolvable (adds a modifier)
+  [EFFECT_APPLY_RECRUITMENT_BONUS]: () => true,
 
   // Terrain cost reduction selection is always resolvable (sets pending state)
   [EFFECT_SELECT_HEX_FOR_COST_REDUCTION]: () => true,

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -79,6 +79,7 @@ import {
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
   EFFECT_ALTEM_MAGES_COLD_FIRE,
   EFFECT_PURE_MAGIC,
+  EFFECT_APPLY_RECRUITMENT_BONUS,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -923,6 +924,18 @@ export interface AltemMagesColdFireEffect {
 }
 
 /**
+ * Apply a recruitment bonus modifier that triggers on each unit recruited this turn.
+ * Used by Heroic Tale:
+ * - Basic: Rep +1 per recruit
+ * - Powered: Rep +1 AND Fame +1 per recruit
+ */
+export interface ApplyRecruitmentBonusEffect {
+  readonly type: typeof EFFECT_APPLY_RECRUITMENT_BONUS;
+  readonly reputationPerRecruit: number;
+  readonly famePerRecruit: number;
+}
+
+/**
  * Pure Magic mana-payment-driven effect.
  * Player pays 1 basic mana token and the color determines the effect:
  * Green → Move, White → Influence, Blue → Block, Red → Attack.
@@ -998,7 +1011,8 @@ export type CardEffect =
   | ManaRadianceEffect
   | ResolveManaRadianceColorEffect
   | AltemMagesColdFireEffect
-  | PureMagicEffect;
+  | PureMagicEffect
+  | ApplyRecruitmentBonusEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -216,3 +216,8 @@ export const EFFECT_ALTEM_MAGES_COLD_FIRE = "altem_mages_cold_fire" as const;
 // Blue/Red only available during combat (Block/Attack are combat actions).
 // Values differ between basic (4) and powered (7) modes.
 export const EFFECT_PURE_MAGIC = "pure_magic" as const;
+
+// === Recruitment Bonus Effect ===
+// Adds a turn-scoped modifier that grants reputation and/or fame per unit recruited.
+// Used by Heroic Tale (basic: Rep+1 per recruit, powered: Rep+1 + Fame+1 per recruit).
+export const EFFECT_APPLY_RECRUITMENT_BONUS = "apply_recruitment_bonus" as const;

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -178,6 +178,12 @@ export const EFFECT_TRANSFORM_ATTACKS_COLD_FIRE = "transform_attacks_cold_fire" 
 // Only affects attacks played AFTER activation (adds siege copy at accumulation time).
 export const EFFECT_ADD_SIEGE_TO_ATTACKS = "add_siege_to_attacks" as const;
 
+// === UnitRecruitmentBonusModifier ===
+// Grants reputation and/or fame bonuses each time a unit is recruited this turn.
+// Does NOT get consumed — applies to every recruitment for the rest of the turn.
+// Used by Heroic Tale card.
+export const EFFECT_RECRUITMENT_BONUS = "recruitment_bonus" as const;
+
 // === BurningShieldActiveModifier ===
 // Marks that Burning Shield/Exploding Shield spell is active this combat.
 // When a block is successfully declared against any enemy, triggers a bonus:

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -28,6 +28,7 @@ import {
   EFFECT_TERRAIN_PROHIBITION,
   EFFECT_ENEMY_STAT,
   EFFECT_RECRUIT_DISCOUNT,
+  EFFECT_RECRUITMENT_BONUS,
   EFFECT_REMOVE_PHYSICAL_RESISTANCE,
   EFFECT_REMOVE_RESISTANCES,
   EFFECT_COLD_TOUGHNESS_BLOCK,
@@ -337,6 +338,15 @@ export interface BurningShieldActiveModifier {
   readonly attackValue: number; // Fire Attack value if mode is "attack" (4)
 }
 
+// Unit recruitment bonus modifier (Heroic Tale)
+// Grants reputation and/or fame each time a unit is recruited this turn.
+// Unlike RecruitDiscountModifier, this is NOT consumed — it triggers on every recruitment.
+export interface UnitRecruitmentBonusModifier {
+  readonly type: typeof EFFECT_RECRUITMENT_BONUS;
+  readonly reputationPerRecruit: number; // Reputation gained per recruitment (e.g., 1)
+  readonly famePerRecruit: number; // Fame gained per recruitment (e.g., 0 for basic, 1 for powered)
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -363,7 +373,8 @@ export type ModifierEffect =
   | CureActiveModifier
   | TransformAttacksColdFireModifier
   | AddSiegeToAttacksModifier
-  | BurningShieldActiveModifier;
+  | BurningShieldActiveModifier
+  | UnitRecruitmentBonusModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- Implements the Heroic Tale advanced action card's missing recruitment bonus mechanics
- Basic effect: Influence 3 + Rep +1 for each unit recruited this turn
- Powered effect (White mana): Influence 6 + Rep +1 and Fame +1 for each unit recruited this turn
- Uses a turn-scoped modifier that persists and triggers on every recruitment (not consumed)

## Changes
- Added `UnitRecruitmentBonusModifier` to the modifier system
- Added `ApplyRecruitmentBonusEffect` to the card effect system
- Created `heroicTaleEffects.ts` effect handler that creates the turn-scoped modifier
- Integrated bonus application into `recruitUnitCommand` with full undo support
- Updated Heroic Tale card definition to use compound effects
- 19 tests covering card definition, effect resolution, and integration

## Test plan
- [x] Basic effect grants Rep +1 per recruitment
- [x] Powered effect grants Rep +1 and Fame +1 per recruitment
- [x] Bonus triggers on every recruitment (not consumed after first use)
- [x] Multiple recruitments in one turn accumulate bonuses correctly
- [x] Modifier has turn duration and expires properly
- [x] Undo correctly restores reputation, fame, and level-up state
- [x] No bonus applied when modifier is not active
- [x] All 2717 core tests + 48 server tests pass

Closes #156