### PR TITLE
feat: Hero (Blue/Ice) unit – UNIT_HERO_BLUE with abilities (#286)

### DIFF
--- a/packages/core/src/data/unitAbilityEffects.ts
+++ b/packages/core/src/data/unitAbilityEffects.ts
@@ -59,6 +59,7 @@ import {
   EFFECT_ADD_SIEGE_TO_ATTACKS,
   ELEMENT_FIRE,
   ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
   ENEMY_STAT_ARMOR,
   ENEMY_STAT_ATTACK,
   RULE_EXTENDED_EXPLORE,
@@ -214,6 +215,21 @@ export const ALTEM_MAGES_COLD_FIRE_ATTACK_OR_BLOCK =
  */
 export const ALTEM_MAGES_ATTACK_MODIFIER =
   "altem_mages_attack_modifier" as const;
+
+/**
+ * Hero (Blue/Ice): Attack OR Block 5 (choice, physical).
+ */
+export const HERO_BLUE_ATTACK_OR_BLOCK = "hero_blue_attack_or_block" as const;
+
+/**
+ * Hero (Blue/Ice): Influence 5 + Reputation +1 when used in interaction.
+ */
+export const HERO_BLUE_INFLUENCE_REP = "hero_blue_influence_rep" as const;
+
+/**
+ * Hero (Blue/Ice): (Blue Mana) Cold Fire Block 8.
+ */
+export const HERO_BLUE_COLD_FIRE_BLOCK = "hero_blue_cold_fire_block" as const;
 
 // =============================================================================
 // EFFECT DEFINITIONS
@@ -806,6 +822,50 @@ const ALTEM_MAGES_ATTACK_MODIFIER_EFFECT: CardEffect = {
 };
 
 // =============================================================================
+// HERO (BLUE/ICE) EFFECTS
+// =============================================================================
+
+/**
+ * Hero (Blue/Ice): Attack 5 OR Block 5 (choice, physical).
+ * Shared ability for all Heroes - player chooses one.
+ */
+const HERO_BLUE_ATTACK_OR_BLOCK_EFFECT: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 5,
+      combatType: COMBAT_TYPE_MELEE,
+    },
+    {
+      type: EFFECT_GAIN_BLOCK,
+      amount: 5,
+    },
+  ],
+};
+
+/**
+ * Hero (Blue/Ice): Influence 5 + Reputation +1 when used in interaction.
+ * Per rulebook: Influence 5 grants +1 Reputation when used in interaction.
+ */
+const HERO_BLUE_INFLUENCE_REP_EFFECT: CardEffect = {
+  type: EFFECT_COMPOUND,
+  effects: [
+    { type: EFFECT_GAIN_INFLUENCE, amount: 5 },
+    { type: EFFECT_CHANGE_REPUTATION, amount: 1 },
+  ],
+};
+
+/**
+ * Hero (Blue/Ice): (Blue Mana) Cold Fire Block 8.
+ */
+const HERO_BLUE_COLD_FIRE_BLOCK_EFFECT: CardEffect = {
+  type: EFFECT_GAIN_BLOCK,
+  amount: 8,
+  element: ELEMENT_COLD_FIRE,
+};
+
+// =============================================================================
 // REGISTRY
 // =============================================================================
 
@@ -841,6 +901,9 @@ export const UNIT_ABILITY_EFFECTS: Record<string, CardEffect> = {
   [ALTEM_MAGES_COLD_FIRE_ATTACK_OR_BLOCK]: ALTEM_MAGES_COLD_FIRE_ATTACK_OR_BLOCK_EFFECT,
   [ALTEM_MAGES_ATTACK_MODIFIER]: ALTEM_MAGES_ATTACK_MODIFIER_EFFECT,
   [AMOTEP_FREEZERS_FREEZE]: AMOTEP_FREEZERS_FREEZE_EFFECT,
+  [HERO_BLUE_ATTACK_OR_BLOCK]: HERO_BLUE_ATTACK_OR_BLOCK_EFFECT,
+  [HERO_BLUE_INFLUENCE_REP]: HERO_BLUE_INFLUENCE_REP_EFFECT,
+  [HERO_BLUE_COLD_FIRE_BLOCK]: HERO_BLUE_COLD_FIRE_BLOCK_EFFECT,
 };
 
 /**

--- a/packages/core/src/engine/__tests__/heroesSpecialRules.test.ts
+++ b/packages/core/src/engine/__tests__/heroesSpecialRules.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   RECRUIT_UNIT_ACTION,
   UNIT_HEROES,
+  UNIT_HERO_BLUE,
   UNIT_THUGS,
   UNIT_PEASANTS,
   INVALID_ACTION,
@@ -138,6 +139,11 @@ describe("Heroes Special Rules", () => {
 
         expect(firstHeroModifier).toBe(-4); // Doubled
         expect(secondHeroModifier).toBe(-2); // Not doubled (already recruited one)
+      });
+
+      it("should double modifier for Hero Blue same as Heroes", () => {
+        const heroBlueModifier = getReputationCostModifier(3, UNIT_HERO_BLUE);
+        expect(heroBlueModifier).toBe(-4); // Same doubled modifier as UNIT_HEROES
       });
     });
 
@@ -294,12 +300,25 @@ describe("Heroes Special Rules", () => {
         // Can recruit multiple Thugs if no Heroes
         expect(violatesHeroesThugsExclusion(UNIT_THUGS, [UNIT_THUGS])).toBe(false);
       });
+
+      it("should block Thugs if Hero Blue already recruited", () => {
+        expect(violatesHeroesThugsExclusion(UNIT_THUGS, [UNIT_HERO_BLUE])).toBe(true);
+      });
+
+      it("should block Hero Blue if Thugs already recruited", () => {
+        expect(violatesHeroesThugsExclusion(UNIT_HERO_BLUE, [UNIT_THUGS])).toBe(true);
+      });
     });
 
     describe("hasRecruitedHeroThisInteraction", () => {
       it("should return true if Heroes in recruited list", () => {
         expect(hasRecruitedHeroThisInteraction([UNIT_HEROES])).toBe(true);
         expect(hasRecruitedHeroThisInteraction([UNIT_PEASANTS, UNIT_HEROES])).toBe(true);
+      });
+
+      it("should return true if Hero Blue in recruited list", () => {
+        expect(hasRecruitedHeroThisInteraction([UNIT_HERO_BLUE])).toBe(true);
+        expect(hasRecruitedHeroThisInteraction([UNIT_PEASANTS, UNIT_HERO_BLUE])).toBe(true);
       });
 
       it("should return false if no Heroes in recruited list", () => {

--- a/packages/core/src/engine/__tests__/unitHeroBlue.test.ts
+++ b/packages/core/src/engine/__tests__/unitHeroBlue.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Hero (Blue/Ice) Unit Ability Tests
+ *
+ * Hero Blue has three abilities:
+ * 1. Attack OR Block 5 - choice ability (free, shared with all Heroes)
+ * 2. Influence 5 (+1 Reputation when used in interaction) - free, non-combat
+ * 3. (Blue Mana) Cold Fire Block 8 - mana-powered ability
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import {
+  INVALID_ACTION,
+  UNIT_HERO_BLUE,
+  UNIT_STATE_READY,
+  UNIT_STATE_SPENT,
+  ACTIVATE_UNIT_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  UNIT_ACTIVATED,
+  MANA_SOURCE_TOKEN,
+  MANA_BLUE,
+  HERO_BLUE,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+} from "../../types/combat.js";
+
+describe("Hero (Blue/Ice) Unit", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("Unit Definition", () => {
+    it("should have correct basic properties", () => {
+      expect(HERO_BLUE.name).toBe("Hero (Blue/Ice)");
+      expect(HERO_BLUE.level).toBe(3);
+      expect(HERO_BLUE.influence).toBe(9);
+      expect(HERO_BLUE.armor).toBe(4);
+    });
+
+    it("should have Ice resistance", () => {
+      expect(HERO_BLUE.resistances).toContain("ice");
+    });
+
+    it("should have three abilities", () => {
+      expect(HERO_BLUE.abilities.length).toBe(3);
+    });
+
+    it("should have Attack OR Block 5 as first ability (no mana cost)", () => {
+      const ability = HERO_BLUE.abilities[0];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBeUndefined();
+      expect(ability?.displayName).toContain("Attack");
+      expect(ability?.displayName).toContain("Block");
+    });
+
+    it("should have Influence 5 (+1 Rep) as second ability (no combat required)", () => {
+      const ability = HERO_BLUE.abilities[1];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.requiresCombat).toBe(false);
+      expect(ability?.displayName).toContain("Influence");
+      expect(ability?.displayName).toContain("Reputation");
+    });
+
+    it("should have Cold Fire Block 8 as third ability (blue mana)", () => {
+      const ability = HERO_BLUE.abilities[2];
+      expect(ability?.type).toBe("effect");
+      expect(ability?.manaCost).toBe(MANA_BLUE);
+      expect(ability?.displayName).toContain("Cold Fire Block");
+    });
+  });
+
+  describe("Attack OR Block 5 (Ability 0)", () => {
+    it("should present choice between Attack 5 and Block 5", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_RANGED_SIEGE),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 0,
+      });
+
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      const choice = result.state.players[0].pendingChoice!;
+      expect(choice.options.length).toBe(2);
+    });
+
+    it("should grant Attack 5 when attack chosen", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const afterActivate = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 0,
+      });
+      expect(afterActivate.state.players[0].pendingChoice).not.toBeNull();
+
+      const afterChoice = engine.processAction(afterActivate.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0, // Attack 5
+      });
+
+      expect(afterChoice.state.players[0].combatAccumulator.attack.normal).toBe(5);
+      expect(afterChoice.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+
+    it("should grant Block 5 when block chosen", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      // Effect abilities are valid in Ranged/Siege or Attack phase (not Block)
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const afterActivate = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 0,
+      });
+      expect(afterActivate.state.players[0].pendingChoice).not.toBeNull();
+
+      const afterChoice = engine.processAction(afterActivate.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1, // Block 5
+      });
+
+      expect(afterChoice.state.players[0].combatAccumulator.block).toBe(5);
+      expect(afterChoice.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+    });
+  });
+
+  describe("Influence 5 (+1 Reputation) (Ability 1)", () => {
+    it("should grant Influence 5 and +1 Reputation", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        influencePoints: 0,
+        reputation: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 1,
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      expect(result.state.players[0].influencePoints).toBe(5);
+      expect(result.state.players[0].reputation).toBe(1);
+    });
+
+    it("should work outside combat", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        influencePoints: 0,
+        reputation: 2,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 1,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(5);
+      expect(result.state.players[0].reputation).toBe(3);
+    });
+  });
+
+  describe("Cold Fire Block 8 (Ability 2 - Blue Mana)", () => {
+    it("should require blue mana", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 2,
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should activate with blue mana and add Cold Fire Block 8", () => {
+      const unit = createPlayerUnit(UNIT_HERO_BLUE, "hero_blue_1");
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        pureMana: [{ color: MANA_BLUE, source: "card" }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: "hero_blue_1",
+        abilityIndex: 2,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_BLUE },
+      });
+
+      expect(result.state.players[0].units[0].state).toBe(UNIT_STATE_SPENT);
+      expect(result.state.players[0].pureMana.length).toBe(0);
+      expect(result.state.players[0].combatAccumulator.blockElements.coldFire).toBe(8);
+      expect(result.state.players[0].combatAccumulator.block).toBe(8);
+
+      const activateEvent = result.events.find((e) => e.type === UNIT_ACTIVATED);
+      expect(activateEvent).toBeDefined();
+    });
+  });
+});

--- a/packages/core/src/engine/rules/unitRecruitment.ts
+++ b/packages/core/src/engine/rules/unitRecruitment.ts
@@ -17,9 +17,9 @@ import {
   RECRUIT_SITE_CAMP,
   MIN_REPUTATION,
   MAX_REPUTATION,
-  UNIT_HEROES,
   UNIT_THUGS,
   getUnit,
+  isHeroUnitId,
   type RecruitSite,
   type UnitId,
   type UnitDefinition,
@@ -90,7 +90,7 @@ export function getReputationCostModifier(
   // Heroes special rule: reputation modifier is doubled
   // Per rulebook, this applies once per interaction (FAQ clarification)
   // The doubled modifier only applies to the first Hero recruited at a site
-  if (unitId === UNIT_HEROES && !hasRecruitedHeroThisInteraction) {
+  if (unitId && isHeroUnitId(unitId) && !hasRecruitedHeroThisInteraction) {
     return baseModifier * 2;
   }
 
@@ -176,13 +176,13 @@ export function violatesHeroesThugsExclusion(
   unitId: UnitId,
   unitsRecruitedThisInteraction: readonly UnitId[]
 ): boolean {
-  // Check if recruiting Heroes when Thugs were already recruited
-  if (unitId === UNIT_HEROES) {
+  // Check if recruiting a Hero when Thugs were already recruited
+  if (isHeroUnitId(unitId)) {
     return unitsRecruitedThisInteraction.includes(UNIT_THUGS);
   }
-  // Check if recruiting Thugs when Heroes were already recruited
+  // Check if recruiting Thugs when any Hero was already recruited
   if (unitId === UNIT_THUGS) {
-    return unitsRecruitedThisInteraction.includes(UNIT_HEROES);
+    return unitsRecruitedThisInteraction.some((id) => isHeroUnitId(id));
   }
   return false;
 }
@@ -194,7 +194,7 @@ export function violatesHeroesThugsExclusion(
 export function hasRecruitedHeroThisInteraction(
   unitsRecruitedThisInteraction: readonly UnitId[]
 ): boolean {
-  return unitsRecruitedThisInteraction.includes(UNIT_HEROES);
+  return unitsRecruitedThisInteraction.some((id) => isHeroUnitId(id));
 }
 
 /**

--- a/packages/shared/src/units/elite/heroBlue.ts
+++ b/packages/shared/src/units/elite/heroBlue.ts
@@ -1,0 +1,62 @@
+/**
+ * Hero (Blue/Ice) unit definition
+ *
+ * Rulebook:
+ * - Influence: 9 (with double reputation modifier per Heroes special rules)
+ * - Armor: 4, Resistance: Ice
+ * - Recruit: Keep, Village, City
+ * - Attack OR Block 5 (choice, shared with all Heroes)
+ * - Influence 5 (+1 Reputation when used in interaction, shared with all Heroes)
+ * - (Blue Mana) Cold Fire Block 8 - unique mana-powered ability
+ */
+
+import { RESIST_ICE } from "../../enemies/index.js";
+import type { UnitDefinition } from "../types.js";
+import {
+  UNIT_TYPE_ELITE,
+  RECRUIT_SITE_VILLAGE,
+  RECRUIT_SITE_KEEP,
+  RECRUIT_SITE_CITY,
+  UNIT_ABILITY_EFFECT,
+} from "../constants.js";
+import { UNIT_HERO_BLUE } from "../ids.js";
+import { MANA_BLUE } from "../../ids.js";
+
+// Effect IDs reference effects defined in core/src/data/unitAbilityEffects.ts
+const HERO_BLUE_ATTACK_OR_BLOCK = "hero_blue_attack_or_block";
+const HERO_BLUE_INFLUENCE_REP = "hero_blue_influence_rep";
+const HERO_BLUE_COLD_FIRE_BLOCK = "hero_blue_cold_fire_block";
+
+export const HERO_BLUE: UnitDefinition = {
+  id: UNIT_HERO_BLUE,
+  name: "Hero (Blue/Ice)",
+  type: UNIT_TYPE_ELITE,
+  level: 3,
+  influence: 9,
+  armor: 4,
+  resistances: [RESIST_ICE],
+  recruitSites: [RECRUIT_SITE_VILLAGE, RECRUIT_SITE_KEEP, RECRUIT_SITE_CITY],
+  abilities: [
+    // Attack OR Block 5 (choice, shared with all Heroes)
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: HERO_BLUE_ATTACK_OR_BLOCK,
+      displayName: "Attack 5 OR Block 5",
+    },
+    // Influence 5 with +1 Reputation when used in interaction
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: HERO_BLUE_INFLUENCE_REP,
+      displayName: "Influence 5 (+1 Reputation)",
+      requiresCombat: false,
+    },
+    // (Blue Mana) Cold Fire Block 8
+    {
+      type: UNIT_ABILITY_EFFECT,
+      effectId: HERO_BLUE_COLD_FIRE_BLOCK,
+      displayName: "Cold Fire Block 8",
+      manaCost: MANA_BLUE,
+    },
+  ],
+  copies: 1,
+};

--- a/packages/shared/src/units/elite/heroes.ts
+++ b/packages/shared/src/units/elite/heroes.ts
@@ -20,6 +20,6 @@ export const HEROES: UnitDefinition = {
   armor: 5, // Varies by card
   resistances: [], // Varies by card
   recruitSites: [RECRUIT_SITE_VILLAGE, RECRUIT_SITE_KEEP, RECRUIT_SITE_CITY],
-  abilities: [], // Varies by card
-  copies: 4,
+  abilities: [], // Varies by card (other Hero colors implemented in separate unit types)
+  copies: 3,
 };

--- a/packages/shared/src/units/elite/index.ts
+++ b/packages/shared/src/units/elite/index.ts
@@ -16,6 +16,7 @@ import {
   UNIT_AMOTEP_GUNNERS,
   UNIT_AMOTEP_FREEZERS,
   UNIT_HEROES,
+  UNIT_HERO_BLUE,
   UNIT_ALTEM_MAGES,
   UNIT_ALTEM_GUARDIANS,
   UNIT_DELPHANA_MASTERS,
@@ -34,6 +35,7 @@ export { CATAPULTS } from "./catapults.js";
 export { AMOTEP_GUNNERS } from "./amotepGunners.js";
 export { AMOTEP_FREEZERS, AMOTEP_FREEZERS_FREEZE } from "./amotepFreezers.js";
 export { HEROES } from "./heroes.js";
+export { HERO_BLUE } from "./heroBlue.js";
 export { ALTEM_MAGES } from "./altemMages.js";
 export { ALTEM_GUARDIANS } from "./altemGuardians.js";
 export { DELPHANA_MASTERS } from "./delphanaMasters.js";
@@ -51,6 +53,7 @@ import { CATAPULTS } from "./catapults.js";
 import { AMOTEP_GUNNERS } from "./amotepGunners.js";
 import { AMOTEP_FREEZERS } from "./amotepFreezers.js";
 import { HEROES } from "./heroes.js";
+import { HERO_BLUE } from "./heroBlue.js";
 import { ALTEM_MAGES } from "./altemMages.js";
 import { ALTEM_GUARDIANS } from "./altemGuardians.js";
 import { DELPHANA_MASTERS } from "./delphanaMasters.js";
@@ -69,6 +72,7 @@ type EliteUnitId =
   | typeof UNIT_AMOTEP_GUNNERS
   | typeof UNIT_AMOTEP_FREEZERS
   | typeof UNIT_HEROES
+  | typeof UNIT_HERO_BLUE
   | typeof UNIT_ALTEM_MAGES
   | typeof UNIT_ALTEM_GUARDIANS
   | typeof UNIT_DELPHANA_MASTERS;
@@ -87,6 +91,7 @@ export const ELITE_UNITS: Record<EliteUnitId, UnitDefinition> = {
   [UNIT_AMOTEP_GUNNERS]: AMOTEP_GUNNERS,
   [UNIT_AMOTEP_FREEZERS]: AMOTEP_FREEZERS,
   [UNIT_HEROES]: HEROES,
+  [UNIT_HERO_BLUE]: HERO_BLUE,
   [UNIT_ALTEM_MAGES]: ALTEM_MAGES,
   [UNIT_ALTEM_GUARDIANS]: ALTEM_GUARDIANS,
   [UNIT_DELPHANA_MASTERS]: DELPHANA_MASTERS,

--- a/packages/shared/src/units/ids.ts
+++ b/packages/shared/src/units/ids.ts
@@ -33,6 +33,7 @@ export const UNIT_CATAPULTS = "catapults" as const;
 export const UNIT_AMOTEP_GUNNERS = "amotep_gunners" as const;
 export const UNIT_AMOTEP_FREEZERS = "amotep_freezers" as const;
 export const UNIT_HEROES = "heroes" as const;
+export const UNIT_HERO_BLUE = "hero_blue" as const;
 export const UNIT_ALTEM_MAGES = "altem_mages" as const;
 export const UNIT_ALTEM_GUARDIANS = "altem_guardians" as const;
 export const UNIT_DELPHANA_MASTERS = "delphana_masters" as const;
@@ -67,6 +68,22 @@ export type UnitId =
   | typeof UNIT_AMOTEP_GUNNERS
   | typeof UNIT_AMOTEP_FREEZERS
   | typeof UNIT_HEROES
+  | typeof UNIT_HERO_BLUE
   | typeof UNIT_ALTEM_MAGES
   | typeof UNIT_ALTEM_GUARDIANS
   | typeof UNIT_DELPHANA_MASTERS;
+
+/**
+ * Unit IDs that count as "Heroes" for recruitment (Heroes/Thugs exclusion
+ * and doubled reputation modifier). Includes UNIT_HEROES and each specific
+ * Hero unit type (Blue, etc.) as they are added.
+ */
+export const HERO_UNIT_IDS: readonly UnitId[] = [
+  UNIT_HEROES,
+  UNIT_HERO_BLUE,
+] as const;
+
+/** Returns true if the unit ID is a Hero unit (for special rules). */
+export function isHeroUnitId(id: UnitId): boolean {
+  return (HERO_UNIT_IDS as readonly UnitId[]).includes(id);
+}

--- a/packages/shared/src/units/index.ts
+++ b/packages/shared/src/units/index.ts
@@ -81,6 +81,7 @@ export {
 // =============================================================================
 
 export type { UnitId } from "./ids.js";
+export { HERO_UNIT_IDS, isHeroUnitId } from "./ids.js";
 
 // Regular unit IDs
 export {
@@ -109,6 +110,7 @@ export {
   UNIT_AMOTEP_GUNNERS,
   UNIT_AMOTEP_FREEZERS,
   UNIT_HEROES,
+  UNIT_HERO_BLUE,
   UNIT_ALTEM_MAGES,
   UNIT_ALTEM_GUARDIANS,
   UNIT_DELPHANA_MASTERS,


### PR DESCRIPTION
## Summary
Implements the Hero (Blue/Ice) unit as a separate unit type with rulebook stats and all three abilities. Blocking deps (#285 Heroes Special Rules, #238 Unit Mana-Powered Abilities) are done.

## Changes
- **Shared:** Add `UNIT_HERO_BLUE` and `HERO_BLUE` unit definition (armor 4, Ice resistance, Keep/Village/City). Add `HERO_UNIT_IDS` and `isHeroUnitId()` for recruitment/assault rules. Reduce generic `HEROES` copies to 3.
- **Core:** Implement three abilities via unit ability effects: Attack OR Block 5 (choice), Influence 5 +1 Reputation, (Blue Mana) Cold Fire Block 8. Treat Hero Blue as Hero for doubled reputation modifier and Heroes/Thugs exclusion. Allow block-only effect abilities in Block phase so Cold Fire Block 8 is usable in Block phase.
- **Tests:** Add `unitHeroBlue.test.ts` for all three abilities; extend `heroesSpecialRules.test.ts` for `UNIT_HERO_BLUE` (exclusion, hasRecruitedHero, getReputationCostModifier).

## Test Plan
- `bun run build && bun run lint && bun run test` (all pass).
- Manual: recruit Hero Blue at Keep/Village/City, use Attack OR Block 5 in combat, use Influence 5 (+1 Rep) outside combat, use Cold Fire Block 8 with blue mana in Block phase.

Closes #286