### PR TITLE
feat: implement Druidic Staff artifact (#112)

### DIFF
--- a/packages/core/src/data/artifacts/druidicStaff.ts
+++ b/packages/core/src/data/artifacts/druidicStaff.ts
@@ -3,15 +3,184 @@
  * Card #21 (308/377)
  *
  * Basic: Discard a card. Based on color get:
- *        White: Move up to 2 spaces to safe space
+ *        White: Move up to 2 revealed spaces to safe space (special movement)
  *        Blue: Get 2 crystals of one color
  *        Red: Ready level III or lower unit
  *        Green: Heal 3
- * Powered: Choose two options without discarding.
+ *        Artifact/no color: No effect (card is still discarded)
+ *
+ * Powered (any color, destroy): Choose two different options from above (no discard).
+ *
+ * FAQ S1: Cannot use white (movement) after the Action portion of your turn has begun.
+ * FAQ S2: White movement can pass through impassable terrain, rampaging enemies, fortified sites.
+ * FAQ S3: Cannot Ready a Unit (red) or Heal 3 (green) during Combat.
+ * FAQ S4: Choose two DIFFERENT options. Both resolve immediately (except Heal points banked).
+ * FAQ S5: During Combat, ONLY the blue option (crystals) is allowed.
+ * FAQ S6: Discarding an Artifact gives nothing (artifacts have no action color).
  */
 
-import type { DeedCard } from "../../types/cards.js";
+import type { DeedCard, CardEffect } from "../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  CATEGORY_SPECIAL,
+  CATEGORY_MOVEMENT,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_MOVE,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_GAIN_HEALING,
+  EFFECT_READY_UNIT,
+  EFFECT_CHOICE,
+  EFFECT_APPLY_MODIFIER,
+  CARD_COLOR_RED,
+  CARD_COLOR_BLUE,
+  CARD_COLOR_GREEN,
+  CARD_COLOR_WHITE,
+} from "../../types/effectTypes.js";
+import {
+  DURATION_TURN,
+  EFFECT_TERRAIN_COST,
+  EFFECT_RULE_OVERRIDE,
+  RULE_IGNORE_RAMPAGING_PROVOKE,
+  TERRAIN_ALL,
+} from "../../types/modifierConstants.js";
+import {
+  CARD_DRUIDIC_STAFF,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
+import { discardCostByColorAllowNoColor } from "../basicActions/helpers.js";
 
-// TODO: Implement Druidic Staff
-export const DRUIDIC_STAFF_CARDS: Record<CardId, DeedCard> = {};
+// === Individual Option Effects ===
+
+/**
+ * White option: Move up to 2 revealed spaces to a safe space.
+ * Can move through impassable terrain, rampaging enemies, and fortified sites.
+ * Does not provoke rampaging enemies.
+ *
+ * Implementation: Move 2 with all terrain costing 1 (each space = 1 move point),
+ * plus ignore rampaging provocation. The "safe space" end requirement is enforced
+ * by the movement system (player must end on a valid safe space).
+ */
+const whiteEffect: CardEffect = {
+  type: EFFECT_COMPOUND,
+  effects: [
+    { type: EFFECT_GAIN_MOVE, amount: 2 },
+    // All terrain costs 1 (each revealed space = 1 move point, including impassable)
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_TERRAIN_COST,
+        terrain: TERRAIN_ALL,
+        amount: 0,
+        minimum: 0,
+        replaceCost: 1,
+      },
+      duration: DURATION_TURN,
+      description: "All terrain costs 1",
+    },
+    // Does not provoke rampaging enemies
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_RULE_OVERRIDE,
+        rule: RULE_IGNORE_RAMPAGING_PROVOKE,
+      },
+      duration: DURATION_TURN,
+      description: "Does not provoke rampaging enemies",
+    },
+  ],
+};
+
+/**
+ * Blue option: Get 2 crystals of any one color.
+ * Player chooses the color, then gains 2 crystals of that color.
+ */
+const blueEffect: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    {
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_RED },
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_RED },
+      ],
+    },
+    {
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_BLUE },
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_BLUE },
+      ],
+    },
+    {
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_GREEN },
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_GREEN },
+      ],
+    },
+    {
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_WHITE },
+        { type: EFFECT_GAIN_CRYSTAL, color: MANA_WHITE },
+      ],
+    },
+  ],
+};
+
+/** Red option: Ready a unit of level 3 or lower. */
+const redEffect: CardEffect = { type: EFFECT_READY_UNIT, maxLevel: 3 };
+
+/** Green option: Heal 3. */
+const greenEffect: CardEffect = { type: EFFECT_GAIN_HEALING, amount: 3 };
+
+// === Powered Effect: Choose Two Different Options ===
+// Generate all 6 unique pairs of the 4 options as compound effects.
+// Each pair is a compound that resolves both effects in sequence.
+
+const poweredOptions: { label: string; effects: CardEffect[] }[] = [
+  { label: "White + Blue", effects: [whiteEffect, blueEffect] },
+  { label: "White + Red", effects: [whiteEffect, redEffect] },
+  { label: "White + Green", effects: [whiteEffect, greenEffect] },
+  { label: "Blue + Red", effects: [blueEffect, redEffect] },
+  { label: "Blue + Green", effects: [blueEffect, greenEffect] },
+  { label: "Red + Green", effects: [redEffect, greenEffect] },
+];
+
+const poweredEffect: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: poweredOptions.map(({ effects }) => ({
+    type: EFFECT_COMPOUND as typeof EFFECT_COMPOUND,
+    effects,
+  })),
+};
+
+// === Card Definition ===
+
+const DRUIDIC_STAFF: DeedCard = {
+  id: CARD_DRUIDIC_STAFF,
+  name: "Druidic Staff",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_HEALING, CATEGORY_SPECIAL, CATEGORY_MOVEMENT],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: discardCostByColorAllowNoColor(1, {
+    [CARD_COLOR_WHITE]: whiteEffect,
+    [CARD_COLOR_BLUE]: blueEffect,
+    [CARD_COLOR_RED]: redEffect,
+    [CARD_COLOR_GREEN]: greenEffect,
+  }),
+  poweredEffect,
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const DRUIDIC_STAFF_CARDS: Record<CardId, DeedCard> = {
+  [CARD_DRUIDIC_STAFF]: DRUIDIC_STAFF,
+};

--- a/packages/core/src/data/basicActions/helpers.ts
+++ b/packages/core/src/data/basicActions/helpers.ts
@@ -206,6 +206,30 @@ export function discardCostByColor(
 }
 
 /**
+ * Discard as cost with color-dependent follow-up effect,
+ * but also allows discarding cards with no action color (artifacts, spells).
+ * Cards with no color are discarded but produce no effect.
+ * Used by Druidic Staff basic effect.
+ */
+export function discardCostByColorAllowNoColor(
+  count: number,
+  thenEffectByColor: Record<BasicCardColor, CardEffect>,
+  optional: boolean = false,
+  filterWounds: boolean = true
+): CardEffect {
+  return {
+    type: EFFECT_DISCARD_COST,
+    count,
+    optional,
+    thenEffect: { type: EFFECT_NOOP },
+    colorMatters: true,
+    thenEffectByColor,
+    filterWounds,
+    allowNoColor: true,
+  };
+}
+
+/**
  * Discard-for-crystal effect (Savage Harvesting).
  * Allows discarding a non-wound card to gain a crystal matching the card's color.
  * For artifacts, the player chooses the crystal color.

--- a/packages/core/src/engine/__tests__/druidicStaff.test.ts
+++ b/packages/core/src/engine/__tests__/druidicStaff.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Tests for Druidic Staff artifact.
+ *
+ * Basic: Discard a card → effect depends on card color
+ * Powered (destroy): Choose 2 different options from the 4 color effects
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  PLAY_CARD_ACTION,
+  RESOLVE_DISCARD_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  INVALID_ACTION,
+  CARD_DRUIDIC_STAFF,
+  CARD_RAGE,
+  CARD_CRYSTALLIZE,
+  CARD_PROMISE,
+  CARD_MARCH,
+  CARD_WOUND,
+  MANA_SOURCE_TOKEN,
+  MANA_RED,
+  MANA_TOKEN_SOURCE_CARD,
+  CARD_RUBY_RING,
+} from "@mage-knight/shared";
+
+describe("Druidic Staff", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ============================================================
+  // Basic Effect: Discard a card for color-dependent effect
+  // ============================================================
+
+  describe("basic effect (discard for color)", () => {
+    it("discarding a white card grants move points", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_PROMISE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0].pendingDiscard).toBeTruthy();
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_PROMISE],
+      });
+
+      // White: Move up to 2 (grants 2 move points + terrain modifiers)
+      expect(discardResult.state.players[0].movePoints).toBe(2);
+    });
+
+    it("discarding a blue card creates a crystal color choice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_CRYSTALLIZE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_CRYSTALLIZE],
+      });
+
+      // Blue: Choose crystal color (should have pending choice with 4 options)
+      expect(discardResult.state.players[0].pendingChoice).toBeTruthy();
+      expect(discardResult.state.players[0].pendingChoice?.options).toHaveLength(4);
+
+      // Resolve choice (pick red crystals = index 0)
+      const choiceResult = engine.processAction(discardResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      });
+
+      expect(choiceResult.state.players[0].crystals.red).toBe(2);
+    });
+
+    it("discarding a blue card and choosing green crystals gives 2 green crystals", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_CRYSTALLIZE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_CRYSTALLIZE],
+      });
+
+      // Choose green crystals (index 2)
+      const choiceResult = engine.processAction(discardResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 2,
+      });
+
+      expect(choiceResult.state.players[0].crystals.green).toBe(2);
+    });
+
+    it("discarding a red card readies a spent unit", () => {
+      // Need to import unit types
+      const { UNIT_STATE_SPENT, UNIT_STATE_READY, UNITS } = require("@mage-knight/shared");
+
+      // Find a level 1-3 unit
+      const unitEntries = Object.entries(UNITS) as [string, { level: number; name: string }][];
+      const eligibleUnit = unitEntries.find(([, u]) => u.level <= 3);
+      if (!eligibleUnit) {
+        throw new Error("No level 1-3 unit found for test");
+      }
+
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_RAGE],
+        units: [
+          {
+            unitId: eligibleUnit[0],
+            instanceId: "unit-1",
+            state: UNIT_STATE_SPENT,
+            wounded: false,
+            level: eligibleUnit[1].level,
+          },
+        ],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_RAGE],
+      });
+
+      // Red: Ready unit - with only one eligible unit, auto-resolves
+      expect(discardResult.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+    });
+
+    it("discarding a green card heals wounds", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_MARCH, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_MARCH],
+      });
+
+      // Green: Heal 3 (removes up to 3 wound cards)
+      const woundsInHand = discardResult.state.players[0].hand.filter(
+        (c: string) => c === CARD_WOUND
+      ).length;
+      expect(woundsInHand).toBe(0); // All 3 wounds healed
+    });
+
+    it("discarding an artifact gives no effect", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_RUBY_RING],
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0].pendingDiscard).toBeTruthy();
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_RUBY_RING],
+      });
+
+      // Artifact has no action color → no effect
+      // Card should be discarded but no move/crystal/heal/ready
+      expect(discardResult.state.players[0].movePoints).toBe(0);
+      expect(discardResult.state.players[0].crystals.red).toBe(0);
+      expect(discardResult.state.players[0].pendingChoice).toBeNull();
+      // Ruby Ring should be in discard pile
+      expect(discardResult.state.players[0].discard).toContain(CARD_RUBY_RING);
+    });
+
+    it("eligible cards include both action cards and artifacts", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_RAGE, CARD_RUBY_RING, CARD_WOUND],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const validActions = getValidActions(playResult.state, "player1");
+      expect(validActions.mode).toBe("pending_discard_cost");
+      // Action cards and artifacts are eligible
+      expect(validActions.discardCost.availableCardIds).toContain(CARD_RAGE);
+      expect(validActions.discardCost.availableCardIds).toContain(CARD_RUBY_RING);
+      // Wounds are NOT eligible
+      expect(validActions.discardCost.availableCardIds).not.toContain(CARD_WOUND);
+    });
+
+    it("cannot discard wound cards", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_WOUND, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: false,
+      });
+
+      const discardResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_DISCARD_ACTION,
+        cardIds: [CARD_WOUND],
+      });
+
+      expect(discardResult.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+  });
+
+  // ============================================================
+  // Powered Effect: Choose two different options
+  // ============================================================
+
+  describe("powered effect (choose two options)", () => {
+    it("creates a choice with 6 combination options", () => {
+      const { UNIT_STATE_SPENT, UNITS } = require("@mage-knight/shared");
+      const unitEntries = Object.entries(UNITS) as [string, { level: number; name: string }][];
+      const eligibleUnit = unitEntries.find(([, u]) => u.level <= 3);
+      if (!eligibleUnit) throw new Error("No level 1-3 unit found");
+
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+        units: [
+          {
+            unitId: eligibleUnit[0],
+            instanceId: "unit-1",
+            state: UNIT_STATE_SPENT,
+            wounded: false,
+            level: eligibleUnit[1].level,
+          },
+        ],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Should have pending choice with 6 options (C(4,2) = 6 pairs)
+      // All 6 are resolvable because player has wounds (green) and spent units (red)
+      expect(playResult.state.players[0].pendingChoice).toBeTruthy();
+      expect(playResult.state.players[0].pendingChoice?.options).toHaveLength(6);
+    });
+
+    it("choosing blue + green gives crystals and healing", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_WOUND, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Blue + Green is option index 4 (0: W+B, 1: W+R, 2: W+G, 3: B+R, 4: B+G, 5: R+G)
+      const choiceResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 4,
+      });
+
+      // Blue part creates a crystal color sub-choice
+      expect(choiceResult.state.players[0].pendingChoice).toBeTruthy();
+
+      // Choose blue crystals (index 1)
+      const crystalResult = engine.processAction(choiceResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      });
+
+      // Should have 2 blue crystals and wounds healed
+      expect(crystalResult.state.players[0].crystals.blue).toBe(2);
+      const woundsLeft = crystalResult.state.players[0].hand.filter(
+        (c: string) => c === CARD_WOUND
+      ).length;
+      expect(woundsLeft).toBe(0); // Both wounds healed (heal 3, had 2)
+    });
+
+    it("choosing red + green readies a unit and heals", () => {
+      const { UNIT_STATE_SPENT, UNIT_STATE_READY, UNITS } = require("@mage-knight/shared");
+
+      const unitEntries = Object.entries(UNITS) as [string, { level: number; name: string }][];
+      const eligibleUnit = unitEntries.find(([, u]) => u.level <= 3);
+      if (!eligibleUnit) throw new Error("No level 1-3 unit found");
+
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+        units: [
+          {
+            unitId: eligibleUnit[0],
+            instanceId: "unit-1",
+            state: UNIT_STATE_SPENT,
+            wounded: false,
+            level: eligibleUnit[1].level,
+          },
+        ],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Red + Green is option index 5
+      const choiceResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 5,
+      });
+
+      // Unit should be readied
+      expect(choiceResult.state.players[0].units[0].state).toBe(UNIT_STATE_READY);
+      // Wound should be healed
+      const woundsLeft = choiceResult.state.players[0].hand.filter(
+        (c: string) => c === CARD_WOUND
+      ).length;
+      expect(woundsLeft).toBe(0);
+    });
+
+    it("choosing white + blue grants move and crystal choice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // White + Blue is option index 0
+      const choiceResult = engine.processAction(playResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      });
+
+      // Move 2 should be granted
+      expect(choiceResult.state.players[0].movePoints).toBe(2);
+      // Crystal choice should be pending
+      expect(choiceResult.state.players[0].pendingChoice).toBeTruthy();
+      expect(choiceResult.state.players[0].pendingChoice?.options).toHaveLength(4);
+
+      // Choose white crystals (index 3)
+      const crystalResult = engine.processAction(choiceResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 3,
+      });
+
+      expect(crystalResult.state.players[0].crystals.white).toBe(2);
+    });
+
+    it("artifact is destroyed after powered use", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Artifact should be in removedCards (destroyed), not discard
+      expect(playResult.state.players[0].removedCards).toContain(CARD_DRUIDIC_STAFF);
+      expect(playResult.state.players[0].discard).not.toContain(CARD_DRUIDIC_STAFF);
+    });
+
+    it("does not require discarding a card for powered effect", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DRUIDIC_STAFF],
+        pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DRUIDIC_STAFF,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_RED },
+      });
+
+      // Should go straight to choice, not pendingDiscard
+      expect(playResult.state.players[0].pendingDiscard).toBeNull();
+      expect(playResult.state.players[0].pendingChoice).toBeTruthy();
+    });
+  });
+});

--- a/packages/core/src/engine/commands/playCardCommand.ts
+++ b/packages/core/src/engine/commands/playCardCommand.ts
@@ -233,6 +233,18 @@ export function createPlayCardCommand(params: PlayCardCommandParams): Command {
             movementBonusAppliedAmount > 0
           );
 
+          // Handle artifact destruction for choice-based powered effects
+          if (isPowered && card.destroyOnPowered) {
+            const destructionResult = handleArtifactDestruction(
+              updatedState,
+              params.playerId,
+              params.cardId
+            );
+            updatedState = destructionResult.state;
+            const events = [...(choiceResult.events || []), ...destructionResult.events];
+            return { ...choiceResult, state: updatedState, events };
+          }
+
           return { ...choiceResult, state: updatedState };
         }
 

--- a/packages/core/src/engine/effects/discardEffects.ts
+++ b/packages/core/src/engine/effects/discardEffects.ts
@@ -150,13 +150,20 @@ export function applyDiscardCard(
 export function getCardsEligibleForDiscardCost(
   hand: readonly CardId[],
   filterWounds: boolean,
-  colorMatters: boolean = false
+  colorMatters: boolean = false,
+  allowNoColor: boolean = false
 ): CardId[] {
   const baseCards = filterWounds
     ? hand.filter((cardId) => cardId !== CARD_WOUND)
     : [...hand];
 
   if (!colorMatters) {
+    return baseCards;
+  }
+
+  // When allowNoColor is true, non-action cards (artifacts, spells) are eligible
+  // but will resolve to no effect. Otherwise, only action cards with color are eligible.
+  if (allowNoColor) {
     return baseCards;
   }
 
@@ -187,6 +194,7 @@ export function handleDiscardCostEffect(
 
   const filterWounds = effect.filterWounds ?? true;
   const colorMatters = effect.colorMatters ?? false;
+  const allowNoColor = effect.allowNoColor ?? false;
 
   if (colorMatters) {
     if (!effect.thenEffectByColor) {
@@ -200,7 +208,8 @@ export function handleDiscardCostEffect(
   const eligibleCards = getCardsEligibleForDiscardCost(
     player.hand,
     filterWounds,
-    colorMatters
+    colorMatters,
+    allowNoColor
   );
 
   // Check if player has enough cards to discard
@@ -221,6 +230,7 @@ export function handleDiscardCostEffect(
       colorMatters,
       filterWounds,
       ...(effect.thenEffectByColor ? { thenEffectByColor: effect.thenEffectByColor } : {}),
+      ...(allowNoColor ? { allowNoColor } : {}),
     },
   };
 

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -101,13 +101,14 @@ export function getDiscardCostOptions(
     return undefined;
   }
 
-  const { sourceCardId, count, optional, filterWounds, colorMatters } = player.pendingDiscard;
+  const { sourceCardId, count, optional, filterWounds, colorMatters, allowNoColor } = player.pendingDiscard;
 
   // Get eligible cards from hand
   const availableCardIds = getCardsEligibleForDiscardCost(
     player.hand,
     filterWounds,
-    colorMatters ?? false
+    colorMatters ?? false,
+    allowNoColor ?? false
   );
 
   return {

--- a/packages/core/src/engine/validators/discardValidators.ts
+++ b/packages/core/src/engine/validators/discardValidators.ts
@@ -61,7 +61,7 @@ export const validateDiscardSelection: Validator = (
     return valid(); // Let the other validator handle this
   }
 
-  const { count, optional, filterWounds, colorMatters } = player.pendingDiscard;
+  const { count, optional, filterWounds, colorMatters, allowNoColor } = player.pendingDiscard;
   const cardIds = action.cardIds;
 
   // If skipping (empty cardIds), must be optional
@@ -87,7 +87,8 @@ export const validateDiscardSelection: Validator = (
   const eligibleCards = getCardsEligibleForDiscardCost(
     player.hand,
     filterWounds,
-    colorMatters ?? false
+    colorMatters ?? false,
+    allowNoColor ?? false
   );
   for (const cardId of cardIds) {
     if (!eligibleCards.includes(cardId)) {

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -537,6 +537,9 @@ export interface DiscardCostEffect {
   readonly thenEffectByColor?: Partial<Record<BasicCardColor, CardEffect>>;
   /** If true, wounds cannot be discarded (default: true per standard rules) */
   readonly filterWounds?: boolean;
+  /** If true, cards with no action color (artifacts, spells) can be discarded for no effect.
+   *  Used by Druidic Staff where discarding an artifact gives nothing. */
+  readonly allowNoColor?: boolean;
 }
 
 /**

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -197,6 +197,8 @@ export interface PendingDiscard {
   readonly thenEffectByColor?: Partial<Record<BasicCardColor, CardEffect>>;
   /** If true, wounds cannot be selected (default: true) */
   readonly filterWounds: boolean;
+  /** If true, cards with no action color can be discarded (gives no effect). Used by Druidic Staff. */
+  readonly allowNoColor?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Implements Druidic Staff artifact card (Card #21)
- **Basic effect**: Discard a card from hand; based on discarded card's color: White grants Move 2 (special movement through impassable terrain), Blue grants 2 crystals of chosen color, Red readies a level 3 or lower unit, Green heals 3. Discarding artifacts/spells gives no effect.
- **Powered effect** (any mana, destroy artifact): Choose two different options from the four color effects without discarding
- Adds `allowNoColor` flag to discard-as-cost system so artifacts/spells can be discarded with no follow-up effect
- Fixes artifact destruction for choice-based powered effects (previously skipped when effect created a pending choice)

## Test plan

- [x] Basic: White card discard grants 2 move points
- [x] Basic: Blue card discard creates crystal color choice (4 options), resolving gives 2 crystals
- [x] Basic: Red card discard readies a spent unit (auto-resolves with single unit)
- [x] Basic: Green card discard heals 3 wounds
- [x] Basic: Artifact discard gives no effect (card still discarded)
- [x] Basic: Eligible cards include action cards and artifacts, but not wounds
- [x] Basic: Cannot discard wound cards
- [x] Powered: Creates choice with 6 combination options (when all are resolvable)
- [x] Powered: Blue+Green gives crystals and healing
- [x] Powered: Red+Green readies unit and heals
- [x] Powered: White+Blue grants move and crystal choice
- [x] Powered: Artifact is destroyed (moved to removedCards) after powered use
- [x] Powered: Does not require discarding a card
- [x] Build, lint, and all 2772 tests pass

Closes #112