### PR TITLE
feat: implement Banner of Command artifact

### DIFF
--- a/packages/core/src/data/artifacts/bannerOfCommand.ts
+++ b/packages/core/src/data/artifacts/bannerOfCommand.ts
@@ -5,10 +5,42 @@
  * Basic: Influence 4. If recruited Unit this turn, may assign this instead
  *        of Command token. Put face down when spent, face up when ready.
  * Powered: Fame +2. Recruit any Unit from offer for free.
+ *          If at Command limit, must disband first. Destroy artifact.
+ *
+ * FAQ S2: Permissible to play Banner → use Influence to recruit → assign Banner to Unit.
+ * FAQ S3: No location restrictions — don't need to be at a site with Locals.
+ * FAQ S4: Strong effect works in Combat.
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_BANNER,
+  CATEGORY_INFLUENCE,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import { EFFECT_COMPOUND, EFFECT_FREE_RECRUIT } from "../../types/effectTypes.js";
+import { CARD_BANNER_OF_COMMAND, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
+import { influence, fame } from "../effectHelpers.js";
 
-// TODO: Implement Banner of Command
-export const BANNER_OF_COMMAND_CARDS: Record<CardId, DeedCard> = {};
+const BANNER_OF_COMMAND: DeedCard = {
+  id: CARD_BANNER_OF_COMMAND,
+  name: "Banner of Command",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_BANNER, CATEGORY_INFLUENCE],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: influence(4),
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      fame(2),
+      { type: EFFECT_FREE_RECRUIT },
+    ],
+  },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const BANNER_OF_COMMAND_CARDS: Record<CardId, DeedCard> = {
+  [CARD_BANNER_OF_COMMAND]: BANNER_OF_COMMAND,
+};

--- a/packages/core/src/engine/__tests__/bannerOfCommand.test.ts
+++ b/packages/core/src/engine/__tests__/bannerOfCommand.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Tests for Banner of Command artifact
+ *
+ * Basic: Influence 4. If recruited Unit this turn, may assign this instead
+ *        of Command token. (Banner assignment uses existing banner system.)
+ * Powered: Fame +2. Recruit any Unit from offer for free. Destroy artifact.
+ *
+ * FAQ S2: Can play banner, recruit with its influence, assign to unit in same turn.
+ * FAQ S3: No location restrictions.
+ * FAQ S4: Works in combat.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { resolveEffect, isEffectResolvable, describeEffect, resetFreeRecruitInstanceCounter } from "../effects/index.js";
+import { BANNER_OF_COMMAND_CARDS } from "../../data/artifacts/bannerOfCommand.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+import { getCard } from "../helpers/cardLookup.js";
+import { isBannerArtifact } from "../rules/banners.js";
+import {
+  CARD_BANNER_OF_COMMAND,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  UNIT_PEASANTS,
+  UNIT_FORESTERS,
+  UNIT_UTEM_CROSSBOWMEN,
+} from "@mage-knight/shared";
+import type { UnitId } from "@mage-knight/shared";
+import type { FreeRecruitEffect, ResolveFreeRecruitTargetEffect } from "../../types/cards.js";
+import {
+  DEED_CARD_TYPE_ARTIFACT,
+  CATEGORY_BANNER,
+  CATEGORY_INFLUENCE,
+} from "../../types/cards.js";
+import {
+  EFFECT_GAIN_INFLUENCE,
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_FAME,
+  EFFECT_FREE_RECRUIT,
+  EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+} from "../../types/effectTypes.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { createPlayerUnit } from "../../types/unit.js";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+function createStateWithUnitOffer(
+  unitOffer: UnitId[],
+  playerOverrides: Partial<Player> = {}
+): GameState {
+  const player = createTestPlayer({
+    hand: [CARD_BANNER_OF_COMMAND],
+    commandTokens: 2,
+    ...playerOverrides,
+  });
+  return createTestGameState({
+    players: [player],
+    offers: {
+      units: unitOffer,
+      advancedActions: { cards: [] },
+      spells: { cards: [] },
+      commonSkills: [],
+      monasteryAdvancedActions: [],
+    },
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Banner of Command", () => {
+  beforeEach(() => {
+    resetFreeRecruitInstanceCounter();
+  });
+
+  // --------------------------------------------------------------------------
+  // Card Definition
+  // --------------------------------------------------------------------------
+  describe("Card Definition", () => {
+    it("should have correct card properties", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card).toBeDefined();
+      expect(card.id).toBe(CARD_BANNER_OF_COMMAND);
+      expect(card.name).toBe("Banner of Command");
+      expect(card.cardType).toBe(DEED_CARD_TYPE_ARTIFACT);
+      expect(card.sidewaysValue).toBe(1);
+    });
+
+    it("should have banner and influence categories", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card.categories).toContain(CATEGORY_BANNER);
+      expect(card.categories).toContain(CATEGORY_INFLUENCE);
+    });
+
+    it("should be identified as a banner artifact", () => {
+      const card = getCard(CARD_BANNER_OF_COMMAND);
+      expect(card).not.toBeNull();
+      expect(isBannerArtifact(card!)).toBe(true);
+    });
+
+    it("should be powered by any basic mana color", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card.poweredBy).toContain(MANA_RED);
+      expect(card.poweredBy).toContain(MANA_BLUE);
+      expect(card.poweredBy).toContain(MANA_GREEN);
+      expect(card.poweredBy).toContain(MANA_WHITE);
+    });
+
+    it("should be destroyed after powered effect", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card.destroyOnPowered).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Basic Effect — Influence 4
+  // --------------------------------------------------------------------------
+  describe("Basic Effect — Influence 4", () => {
+    it("should have Influence 4 as basic effect", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card.basicEffect.type).toBe(EFFECT_GAIN_INFLUENCE);
+      if (card.basicEffect.type === EFFECT_GAIN_INFLUENCE) {
+        expect(card.basicEffect.amount).toBe(4);
+      }
+    });
+
+    it("should grant 4 influence when resolved", () => {
+      const state = createStateWithUnitOffer([UNIT_PEASANTS]);
+      const player = state.players[0]!;
+      expect(player.influencePoints).toBe(0);
+
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND]!;
+      const result = resolveEffect(state, player.id, card.basicEffect);
+
+      expect(result.state.players[0]!.influencePoints).toBe(4);
+      expect(result.description).toContain("4");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Powered Effect — Fame +2, Free Recruit
+  // --------------------------------------------------------------------------
+  describe("Powered Effect", () => {
+    it("should be a compound of Fame +2 and Free Recruit", () => {
+      const card = BANNER_OF_COMMAND_CARDS[CARD_BANNER_OF_COMMAND];
+      expect(card.poweredEffect.type).toBe(EFFECT_COMPOUND);
+      if (card.poweredEffect.type === EFFECT_COMPOUND) {
+        expect(card.poweredEffect.effects).toHaveLength(2);
+        expect(card.poweredEffect.effects[0]!.type).toBe(EFFECT_GAIN_FAME);
+        expect(card.poweredEffect.effects[1]!.type).toBe(EFFECT_FREE_RECRUIT);
+      }
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Free Recruit Effect
+  // --------------------------------------------------------------------------
+  describe("EFFECT_FREE_RECRUIT", () => {
+    const effect: FreeRecruitEffect = { type: EFFECT_FREE_RECRUIT };
+
+    describe("isEffectResolvable", () => {
+      it("should return false when no units in offer", () => {
+        const state = createStateWithUnitOffer([]);
+        expect(isEffectResolvable(state, state.players[0]!.id, effect)).toBe(false);
+      });
+
+      it("should return false when at command limit", () => {
+        const state = createStateWithUnitOffer([UNIT_PEASANTS], {
+          commandTokens: 1,
+          units: [createPlayerUnit(UNIT_PEASANTS, "unit_1")],
+        });
+        expect(isEffectResolvable(state, state.players[0]!.id, effect)).toBe(false);
+      });
+
+      it("should return true when units available and has command slots", () => {
+        const state = createStateWithUnitOffer([UNIT_PEASANTS], {
+          commandTokens: 2,
+          units: [],
+        });
+        expect(isEffectResolvable(state, state.players[0]!.id, effect)).toBe(true);
+      });
+    });
+
+    describe("resolveEffect — single unit", () => {
+      it("should auto-resolve when only one unit in offer", () => {
+        const state = createStateWithUnitOffer([UNIT_PEASANTS], {
+          commandTokens: 2,
+          units: [],
+        });
+
+        const result = resolveEffect(state, state.players[0]!.id, effect);
+
+        // Should NOT require a choice (auto-resolved)
+        expect(result.requiresChoice).toBeFalsy();
+        // Player should have the unit
+        expect(result.state.players[0]!.units).toHaveLength(1);
+        expect(result.state.players[0]!.units[0]!.unitId).toBe(UNIT_PEASANTS);
+        // Unit should be removed from offer
+        expect(result.state.offers.units).not.toContain(UNIT_PEASANTS);
+        // Player flags should be updated
+        expect(result.state.players[0]!.hasRecruitedUnitThisTurn).toBe(true);
+        expect(result.state.players[0]!.hasTakenActionThisTurn).toBe(true);
+        // No influence deducted (free!)
+        expect(result.state.players[0]!.influencePoints).toBe(0);
+      });
+    });
+
+    describe("resolveEffect — multiple units", () => {
+      it("should present choice when multiple units available", () => {
+        const state = createStateWithUnitOffer(
+          [UNIT_PEASANTS, UNIT_FORESTERS, UNIT_UTEM_CROSSBOWMEN],
+          { commandTokens: 2, units: [] }
+        );
+
+        const result = resolveEffect(state, state.players[0]!.id, effect);
+
+        expect(result.requiresChoice).toBe(true);
+        expect(result.dynamicChoiceOptions).toHaveLength(3);
+        // Each option should be a RESOLVE_FREE_RECRUIT_TARGET
+        for (const opt of result.dynamicChoiceOptions!) {
+          expect(opt.type).toBe(EFFECT_RESOLVE_FREE_RECRUIT_TARGET);
+        }
+      });
+    });
+
+    describe("resolveEffect — RESOLVE_FREE_RECRUIT_TARGET", () => {
+      it("should recruit the selected unit for free", () => {
+        const state = createStateWithUnitOffer(
+          [UNIT_PEASANTS, UNIT_FORESTERS],
+          { commandTokens: 2, units: [] }
+        );
+
+        const targetEffect: ResolveFreeRecruitTargetEffect = {
+          type: EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+          unitId: UNIT_FORESTERS,
+          unitName: "Foresters",
+        };
+
+        const result = resolveEffect(state, state.players[0]!.id, targetEffect);
+
+        // Foresters recruited
+        expect(result.state.players[0]!.units).toHaveLength(1);
+        expect(result.state.players[0]!.units[0]!.unitId).toBe(UNIT_FORESTERS);
+        // Foresters removed from offer, Peasants remain
+        expect(result.state.offers.units).not.toContain(UNIT_FORESTERS);
+        expect(result.state.offers.units).toContain(UNIT_PEASANTS);
+        // No influence spent
+        expect(result.state.players[0]!.influencePoints).toBe(0);
+      });
+    });
+
+    describe("edge cases", () => {
+      it("should handle empty offer gracefully", () => {
+        const state = createStateWithUnitOffer([], {
+          commandTokens: 2,
+          units: [],
+        });
+
+        const result = resolveEffect(state, state.players[0]!.id, effect);
+
+        expect(result.requiresChoice).toBeFalsy();
+        expect(result.description).toContain("No units");
+      });
+
+      it("should block recruitment when at command limit", () => {
+        const state = createStateWithUnitOffer([UNIT_PEASANTS], {
+          commandTokens: 1,
+          units: [createPlayerUnit(UNIT_PEASANTS, "existing_unit")],
+        });
+
+        const result = resolveEffect(state, state.players[0]!.id, effect);
+
+        expect(result.requiresChoice).toBeFalsy();
+        expect(result.description).toContain("command limit");
+        expect(result.state.players[0]!.units).toHaveLength(1); // unchanged
+      });
+
+      it("should track unit in unitsRecruitedThisInteraction", () => {
+        const state = createStateWithUnitOffer([UNIT_PEASANTS], {
+          commandTokens: 2,
+          units: [],
+        });
+
+        const result = resolveEffect(state, state.players[0]!.id, effect);
+
+        expect(result.state.players[0]!.unitsRecruitedThisInteraction).toContain(
+          UNIT_PEASANTS
+        );
+      });
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // describeEffect
+  // --------------------------------------------------------------------------
+  describe("describeEffect", () => {
+    it("should describe EFFECT_FREE_RECRUIT", () => {
+      const effect: FreeRecruitEffect = { type: EFFECT_FREE_RECRUIT };
+      expect(describeEffect(effect)).toBe("Recruit any Unit for free");
+    });
+
+    it("should describe EFFECT_RESOLVE_FREE_RECRUIT_TARGET", () => {
+      const effect: ResolveFreeRecruitTargetEffect = {
+        type: EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+        unitId: UNIT_PEASANTS,
+        unitName: "Peasants",
+      };
+      expect(describeEffect(effect)).toBe("Recruit Peasants for free");
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -52,6 +52,8 @@ import {
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
   EFFECT_PURE_MAGIC,
   EFFECT_APPLY_RECRUITMENT_BONUS,
+  EFFECT_FREE_RECRUIT,
+  EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -374,6 +376,13 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
       parts.push(`Fame +${e.famePerRecruit}`);
     }
     return `${parts.join(" and ")} per unit recruited this turn`;
+  },
+
+  [EFFECT_FREE_RECRUIT]: () => "Recruit any Unit for free",
+
+  [EFFECT_RESOLVE_FREE_RECRUIT_TARGET]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveFreeRecruitTargetEffect;
+    return `Recruit ${e.unitName} for free`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -42,6 +42,7 @@ import { registerManaMeltdownEffects } from "./manaMeltdownEffects.js";
 import { registerAltemMagesEffects } from "./altemMagesEffects.js";
 import { registerPureMagicEffects } from "./pureMagicEffects.js";
 import { registerHeroicTaleEffects } from "./heroicTaleEffects.js";
+import { registerFreeRecruitEffects } from "./freeRecruitEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -150,4 +151,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Heroic Tale effects (recruitment bonus modifier)
   registerHeroicTaleEffects();
+
+  // Free recruit effects (Banner of Command, Call to Glory)
+  registerFreeRecruitEffects();
 }

--- a/packages/core/src/engine/effects/freeRecruitEffects.ts
+++ b/packages/core/src/engine/effects/freeRecruitEffects.ts
@@ -1,0 +1,192 @@
+/**
+ * Free Recruitment Effect Handlers
+ *
+ * Handles effects that recruit units from the offer for free:
+ * - EFFECT_FREE_RECRUIT: Entry point, presents available units
+ * - EFFECT_RESOLVE_FREE_RECRUIT_TARGET: Executes the free recruitment
+ *
+ * Used by Banner of Command powered effect and Call to Glory spell.
+ * No location restrictions — works anywhere, even in combat.
+ *
+ * @module effects/freeRecruitEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { ResolveFreeRecruitTargetEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { UnitId } from "@mage-knight/shared";
+import { UNITS } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_FREE_RECRUIT,
+  EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+} from "../../types/effectTypes.js";
+import { createPlayerUnit } from "../../types/unit.js";
+import { removeUnitFromOffer } from "../../data/unitDeckSetup.js";
+
+// Instance counter for free-recruited units (separate from normal recruit)
+let freeRecruitInstanceCounter = 0;
+
+/**
+ * Reset the instance counter (for testing)
+ */
+export function resetFreeRecruitInstanceCounter(): void {
+  freeRecruitInstanceCounter = 0;
+}
+
+// ============================================================================
+// FREE RECRUIT ENTRY POINT
+// ============================================================================
+
+/**
+ * Handle the EFFECT_FREE_RECRUIT entry point.
+ * Finds available units in the offer and generates choice options.
+ *
+ * No location restrictions — this works anywhere.
+ * Command limit is NOT checked here; the player must have already
+ * disbanded a unit if at the limit before playing the powered effect.
+ */
+export function handleFreeRecruit(
+  state: GameState,
+  playerIndex: number,
+  player: Player
+): EffectResolutionResult {
+  const availableUnits = state.offers.units;
+
+  if (availableUnits.length === 0) {
+    return {
+      state,
+      description: "No units available in the offer",
+    };
+  }
+
+  // Check command limit: player must have a free command slot
+  if (player.units.length >= player.commandTokens) {
+    return {
+      state,
+      description: "At command limit — must disband a unit first",
+    };
+  }
+
+  // If only one unit available, auto-resolve
+  if (availableUnits.length === 1) {
+    const unitId = availableUnits[0]!;
+    return applyFreeRecruit(state, playerIndex, player, unitId);
+  }
+
+  // Multiple units — generate choice options
+  const choiceOptions: ResolveFreeRecruitTargetEffect[] = availableUnits.map(
+    (unitId) => {
+      const unitDef = UNITS[unitId];
+      return {
+        type: EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+        unitId,
+        unitName: unitDef?.name ?? unitId,
+      };
+    }
+  );
+
+  return {
+    state,
+    description: "Select a unit to recruit for free",
+    requiresChoice: true,
+    dynamicChoiceOptions: choiceOptions,
+  };
+}
+
+// ============================================================================
+// RESOLVE FREE RECRUIT TARGET
+// ============================================================================
+
+/**
+ * Resolves the selected unit target — recruits the unit for free.
+ */
+export function resolveFreeRecruitTarget(
+  state: GameState,
+  playerId: string,
+  effect: ResolveFreeRecruitTargetEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+  return applyFreeRecruit(state, playerIndex, player, effect.unitId);
+}
+
+/**
+ * Apply the free recruitment — add unit to player, remove from offer.
+ * No influence cost, no reputation changes, no special rules bypass needed
+ * (free recruitment inherently skips all cost calculations).
+ */
+export function applyFreeRecruit(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  unitId: UnitId
+): EffectResolutionResult {
+  // Verify unit is in the offer
+  if (!state.offers.units.includes(unitId)) {
+    return {
+      state,
+      description: `Unit ${unitId} is not in the offer`,
+    };
+  }
+
+  // Create new unit instance
+  const instanceId = `free_unit_${++freeRecruitInstanceCounter}`;
+  const newUnit = createPlayerUnit(unitId, instanceId);
+
+  // Update player: add unit, mark action taken and recruited
+  const updatedPlayer: Player = {
+    ...player,
+    units: [...player.units, newUnit],
+    hasTakenActionThisTurn: true,
+    hasRecruitedUnitThisTurn: true,
+    unitsRecruitedThisInteraction: [
+      ...player.unitsRecruitedThisInteraction,
+      unitId,
+    ],
+  };
+
+  // Remove unit from offer
+  const updatedOffer = removeUnitFromOffer(unitId, state.offers.units);
+  const updatedOffers = {
+    ...state.offers,
+    units: updatedOffer,
+  };
+
+  const updatedState: GameState = {
+    ...updatePlayer(state, playerIndex, updatedPlayer),
+    offers: updatedOffers,
+  };
+
+  const unitDef = UNITS[unitId];
+  const unitName = unitDef?.name ?? unitId;
+
+  return {
+    state: updatedState,
+    description: `Recruited ${unitName} for free`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register free recruit effect handlers with the effect registry.
+ */
+export function registerFreeRecruitEffects(): void {
+  registerEffect(EFFECT_FREE_RECRUIT, (state, playerId) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleFreeRecruit(state, playerIndex, player);
+  });
+
+  registerEffect(EFFECT_RESOLVE_FREE_RECRUIT_TARGET, (state, playerId, effect) => {
+    return resolveFreeRecruitTarget(
+      state,
+      playerId,
+      effect as ResolveFreeRecruitTargetEffect
+    );
+  });
+}

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -267,6 +267,15 @@ export {
   registerHeroicTaleEffects,
 } from "./heroicTaleEffects.js";
 
+// Free recruit effects (Banner of Command, Call to Glory)
+export {
+  handleFreeRecruit,
+  resolveFreeRecruitTarget,
+  applyFreeRecruit,
+  registerFreeRecruitEffects,
+  resetFreeRecruitInstanceCounter,
+} from "./freeRecruitEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -87,6 +87,8 @@ import {
   EFFECT_RESOLVE_MANA_MELTDOWN_CHOICE,
   EFFECT_MANA_RADIANCE,
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
+  EFFECT_FREE_RECRUIT,
+  EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -443,6 +445,15 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Mana Radiance color resolution is always resolvable
   [EFFECT_RESOLVE_MANA_RADIANCE_COLOR]: () => true,
+
+  // Free recruit is resolvable if there are units in the offer and player has command slots
+  [EFFECT_FREE_RECRUIT]: (state, player) => {
+    if (state.offers.units.length === 0) return false;
+    return player.units.length < player.commandTokens;
+  },
+
+  // Free recruit target resolution is always resolvable (unit validated at resolution time)
+  [EFFECT_RESOLVE_FREE_RECRUIT_TARGET]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -5,6 +5,7 @@
 import type {
   CardId,
   SkillId,
+  UnitId,
   ManaColor,
   BasicManaColor,
   Element,
@@ -80,6 +81,8 @@ import {
   EFFECT_ALTEM_MAGES_COLD_FIRE,
   EFFECT_PURE_MAGIC,
   EFFECT_APPLY_RECRUITMENT_BONUS,
+  EFFECT_FREE_RECRUIT,
+  EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -947,6 +950,28 @@ export interface PureMagicEffect {
   readonly value: number;
 }
 
+/**
+ * Free recruit effect entry point.
+ * Presents the units offer for the player to pick a unit for free.
+ * No location restrictions (works anywhere, even in combat).
+ * If at command limit, the player must disband a unit first (handled externally).
+ *
+ * Used by Banner of Command powered effect and Call to Glory spell.
+ */
+export interface FreeRecruitEffect {
+  readonly type: typeof EFFECT_FREE_RECRUIT;
+}
+
+/**
+ * Internal effect generated as a choice option for free recruitment unit selection.
+ * Recruits the selected unit for free (0 influence, artifact source).
+ */
+export interface ResolveFreeRecruitTargetEffect {
+  readonly type: typeof EFFECT_RESOLVE_FREE_RECRUIT_TARGET;
+  readonly unitId: UnitId;
+  readonly unitName: string;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1012,7 +1037,9 @@ export type CardEffect =
   | ResolveManaRadianceColorEffect
   | AltemMagesColdFireEffect
   | PureMagicEffect
-  | ApplyRecruitmentBonusEffect;
+  | ApplyRecruitmentBonusEffect
+  | FreeRecruitEffect
+  | ResolveFreeRecruitTargetEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -221,3 +221,12 @@ export const EFFECT_PURE_MAGIC = "pure_magic" as const;
 // Adds a turn-scoped modifier that grants reputation and/or fame per unit recruited.
 // Used by Heroic Tale (basic: Rep+1 per recruit, powered: Rep+1 + Fame+1 per recruit).
 export const EFFECT_APPLY_RECRUITMENT_BONUS = "apply_recruitment_bonus" as const;
+
+// === Free Recruit Effect ===
+// Recruit any unit from the units offer for free (no influence cost).
+// No location restrictions (can be anywhere, even in combat).
+// If at command limit, must disband a unit first.
+// Used by Banner of Command powered effect and Call to Glory spell.
+export const EFFECT_FREE_RECRUIT = "free_recruit" as const;
+// Internal: resolve after unit selection for free recruitment
+export const EFFECT_RESOLVE_FREE_RECRUIT_TARGET = "resolve_free_recruit_target" as const;


### PR DESCRIPTION
## Summary
- Implements Banner of Command artifact card (#216)
- **Basic effect**: Influence 4 (with banner assignment via existing banner system)
- **Powered effect**: Fame +2, then recruit any unit from the offer for free (destroys artifact)
- Creates reusable `EFFECT_FREE_RECRUIT` / `EFFECT_RESOLVE_FREE_RECRUIT_TARGET` effect system

## Changes
- `bannerOfCommand.ts` — Card definition with basic Influence 4 and powered Fame+2 + FreeRecruit
- `freeRecruitEffects.ts` — New effect module: entry point → unit choice → apply free recruitment
- `effectTypes.ts` / `cards.ts` — New effect type constants and interfaces
- `effectRegistrations.ts` / `resolvability.ts` / `describeEffect.ts` / `index.ts` — Registry wiring
- `bannerOfCommand.test.ts` — 19 tests covering card definition, effects, resolvability, edge cases

## Notes
- The free recruit effect system is reusable for Call to Glory spell (future)
- Banner assignment mechanics leverage the existing banner system from #211
- Advanced mechanics (command token replacement, end-of-round keep/reclaim choice) are tracked separately

## Test plan
- [x] 19 unit tests pass for card definition, basic/powered effects, resolvability, auto-resolve, multi-choice, edge cases
- [x] Full test suite passes (2696 core + 48 server)
- [x] Build passes with 0 lint errors

Closes #216