### PR TITLE
fix: allow Expose spell to be played against fortified enemies

### DIFF
--- a/packages/core/src/engine/rules/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/combatEffects.ts
@@ -20,6 +20,8 @@ import {
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "@mage-knight/shared";
+import { effectHasEnemyTargeting } from "./specialEffects.js";
+import { effectHasModifier } from "./resourceEffects.js";
 
 /**
  * Check if an effect provides ranged or siege attack.
@@ -104,6 +106,10 @@ export function effectIsRangedOnlyAttack(effect: CardEffect): boolean {
       return effect.options.every(opt => effectIsRangedOnlyAttack(opt));
 
     case EFFECT_COMPOUND:
+      // Compounds with enemy targeting or modifiers (e.g., Expose removes
+      // fortification) aren't purely ranged attacks — the non-attack sub-effects
+      // provide independent value even against fortified enemies
+      if (effectHasEnemyTargeting(effect) || effectHasModifier(effect)) return false;
       // Has ranged attack AND no siege/melee attack anywhere
       return effect.effects.some(eff => effectIsRangedOnlyAttack(eff)) &&
         !effect.effects.some(eff => effectHasSiegeAttack(eff));


### PR DESCRIPTION
## Summary
- `effectIsRangedOnlyAttack()` incorrectly classified Expose as a ranged-only attack, filtering it out when all enemies were fortified
- Added checks for enemy targeting and modifier sub-effects in the `EFFECT_COMPOUND` case so cards with utility value (like fortification removal) aren't treated as purely ranged attacks
- Fireball (a pure ranged attack) is still correctly excluded against all-fortified enemies

## Test plan
- [x] Expose basic playable against enemies with `ABILITY_FORTIFIED`
- [x] Mass Expose (powered) playable against fortified enemies
- [x] Expose basic playable at fortified sites
- [x] Fireball still excluded when all enemies fortified (existing tests pass)
- [x] Full test suite passes (2811 core + 48 server tests)
- [x] Manual testing confirmed fix