### PR TITLE
feat: implement Offering / Sacrifice spell

### DIFF
--- a/packages/core/src/data/spells/red/index.ts
+++ b/packages/core/src/data/spells/red/index.ts
@@ -13,6 +13,7 @@ import {
   CARD_MANA_MELTDOWN,
   CARD_DEMOLISH,
   CARD_BURNING_SHIELD,
+  CARD_OFFERING,
 } from "@mage-knight/shared";
 import { FIREBALL } from "./fireball.js";
 import { FLAME_WALL } from "./flameWall.js";
@@ -20,6 +21,7 @@ import { TREMOR } from "./tremor.js";
 import { MANA_MELTDOWN } from "./manaMeltdown.js";
 import { DEMOLISH } from "./demolish.js";
 import { BURNING_SHIELD } from "./burningShield.js";
+import { OFFERING } from "./offering.js";
 
 export const RED_SPELLS: Record<CardId, DeedCard> = {
   [CARD_FIREBALL]: FIREBALL,
@@ -28,6 +30,7 @@ export const RED_SPELLS: Record<CardId, DeedCard> = {
   [CARD_MANA_MELTDOWN]: MANA_MELTDOWN,
   [CARD_DEMOLISH]: DEMOLISH,
   [CARD_BURNING_SHIELD]: BURNING_SHIELD,
+  [CARD_OFFERING]: OFFERING,
 };
 
-export { FIREBALL, FLAME_WALL, TREMOR, MANA_MELTDOWN, DEMOLISH, BURNING_SHIELD };
+export { FIREBALL, FLAME_WALL, TREMOR, MANA_MELTDOWN, DEMOLISH, BURNING_SHIELD, OFFERING };

--- a/packages/core/src/data/spells/red/offering.ts
+++ b/packages/core/src/data/spells/red/offering.ts
@@ -1,0 +1,54 @@
+/**
+ * Offering / Sacrifice (Red Spell #46)
+ *
+ * Basic (Offering): Gain a red crystal. You may discard up to 3 non-Wound cards
+ * from your hand. For each discarded card, gain a crystal of matching color.
+ * For artifacts, you choose any basic color.
+ *
+ * Powered (Sacrifice): Choose green OR white, then choose red OR blue.
+ * Count crystal pairs of chosen colors:
+ * - green+red → Siege Fire Attack 4 per pair
+ * - green+blue → Siege Ice Attack 4 per pair
+ * - white+red → Ranged Fire Attack 6 per pair
+ * - white+blue → Ranged Ice Attack 6 per pair
+ * Then convert ALL complete crystal pairs to mana tokens (immediately usable).
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_DISCARD_FOR_CRYSTAL,
+  EFFECT_SACRIFICE,
+} from "../../../types/effectTypes.js";
+import { MANA_RED, MANA_BLACK, CARD_OFFERING } from "@mage-knight/shared";
+
+export const OFFERING: DeedCard = {
+  id: CARD_OFFERING,
+  name: "Offering",
+  poweredName: "Sacrifice",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_SPECIAL],
+  poweredEffectCategories: [CATEGORY_COMBAT],
+  poweredBy: [MANA_BLACK, MANA_RED],
+  basicEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // Gain a red crystal
+      { type: EFFECT_GAIN_CRYSTAL, color: MANA_RED },
+      // Optionally discard up to 3 non-wound cards for crystals (sequential)
+      { type: EFFECT_DISCARD_FOR_CRYSTAL, optional: true },
+      { type: EFFECT_DISCARD_FOR_CRYSTAL, optional: true },
+      { type: EFFECT_DISCARD_FOR_CRYSTAL, optional: true },
+    ],
+  },
+  poweredEffect: {
+    type: EFFECT_SACRIFICE,
+  },
+  sidewaysValue: 1,
+};

--- a/packages/core/src/engine/__tests__/offeringSpell.test.ts
+++ b/packages/core/src/engine/__tests__/offeringSpell.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Tests for the Offering / Sacrifice spell (Red Spell #46)
+ *
+ * Basic (Offering): Gain a red crystal. You may discard up to 3 non-Wound cards
+ * from your hand. For each discarded card, gain a crystal of matching color.
+ * For artifacts, you choose any basic color.
+ *
+ * Powered (Sacrifice): Choose green OR white, then choose red OR blue.
+ * Count crystal pairs of chosen colors:
+ * - green+red → Siege Fire Attack 4 per pair
+ * - green+blue → Siege Ice Attack 4 per pair
+ * - white+red → Ranged Fire Attack 6 per pair
+ * - white+blue → Ranged Ice Attack 6 per pair
+ * Then convert ALL complete crystal pairs to mana tokens (immediately usable).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type {
+  SacrificeEffect,
+  ResolveSacrificeEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_DISCARD_FOR_CRYSTAL,
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
+} from "../../types/effectTypes.js";
+import {
+  CARD_OFFERING,
+  MANA_BLACK,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import { OFFERING } from "../../data/spells/red/offering.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createSacrificeState(
+  crystals = { red: 0, blue: 0, green: 0, white: 0 }
+): GameState {
+  const player = createTestPlayer({
+    id: "player1",
+    crystals,
+  });
+
+  return createTestGameState({
+    players: [player],
+  });
+}
+
+function getPlayer(state: GameState) {
+  return state.players[0]!;
+}
+
+// ============================================================================
+// SPELL CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Offering spell card definition", () => {
+  it("should be registered in spell cards", () => {
+    const card = getSpellCard(CARD_OFFERING);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Offering");
+  });
+
+  it("should have correct metadata", () => {
+    expect(OFFERING.id).toBe(CARD_OFFERING);
+    expect(OFFERING.name).toBe("Offering");
+    expect(OFFERING.poweredName).toBe("Sacrifice");
+    expect(OFFERING.cardType).toBe(DEED_CARD_TYPE_SPELL);
+    expect(OFFERING.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by black + red mana", () => {
+    expect(OFFERING.poweredBy).toEqual([MANA_BLACK, MANA_RED]);
+  });
+
+  it("should have special category for basic effect", () => {
+    expect(OFFERING.categories).toEqual([CATEGORY_SPECIAL]);
+  });
+
+  it("should have combat category for powered effect", () => {
+    expect(OFFERING.poweredEffectCategories).toEqual([CATEGORY_COMBAT]);
+  });
+
+  it("should have compound basic effect with red crystal and 3 optional discards", () => {
+    expect(OFFERING.basicEffect.type).toBe(EFFECT_COMPOUND);
+    const compound = OFFERING.basicEffect as { effects: readonly { type: string; color?: string; optional?: boolean }[] };
+    expect(compound.effects).toHaveLength(4);
+
+    // First: gain red crystal
+    expect(compound.effects[0]!.type).toBe(EFFECT_GAIN_CRYSTAL);
+    expect(compound.effects[0]!.color).toBe(MANA_RED);
+
+    // Next 3: optional discard for crystal
+    for (let i = 1; i <= 3; i++) {
+      expect(compound.effects[i]!.type).toBe(EFFECT_DISCARD_FOR_CRYSTAL);
+      expect(compound.effects[i]!.optional).toBe(true);
+    }
+  });
+
+  it("should have sacrifice powered effect", () => {
+    expect(OFFERING.poweredEffect.type).toBe(EFFECT_SACRIFICE);
+  });
+});
+
+// ============================================================================
+// SACRIFICE ENTRY POINT TESTS
+// ============================================================================
+
+describe("EFFECT_SACRIFICE", () => {
+  const sacrificeEffect: SacrificeEffect = {
+    type: EFFECT_SACRIFICE,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should be resolvable when player has at least one pair", () => {
+      const state = createSacrificeState({ red: 1, blue: 0, green: 1, white: 0 });
+      expect(isEffectResolvable(state, "player1", sacrificeEffect)).toBe(true);
+    });
+
+    it("should be resolvable with white + blue pair", () => {
+      const state = createSacrificeState({ red: 0, blue: 1, green: 0, white: 1 });
+      expect(isEffectResolvable(state, "player1", sacrificeEffect)).toBe(true);
+    });
+
+    it("should not be resolvable with only attack colors (green/white)", () => {
+      const state = createSacrificeState({ red: 0, blue: 0, green: 2, white: 2 });
+      expect(isEffectResolvable(state, "player1", sacrificeEffect)).toBe(false);
+    });
+
+    it("should not be resolvable with only element colors (red/blue)", () => {
+      const state = createSacrificeState({ red: 2, blue: 2, green: 0, white: 0 });
+      expect(isEffectResolvable(state, "player1", sacrificeEffect)).toBe(false);
+    });
+
+    it("should not be resolvable with no crystals", () => {
+      const state = createSacrificeState();
+      expect(isEffectResolvable(state, "player1", sacrificeEffect)).toBe(false);
+    });
+  });
+
+  describe("color choice presentation", () => {
+    it("should present 4 combination options", () => {
+      const state = createSacrificeState({ red: 1, blue: 1, green: 1, white: 1 });
+
+      const result = resolveEffect(state, "player1", sacrificeEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+    });
+
+    it("should present all 4 crystal pair combinations", () => {
+      const state = createSacrificeState({ red: 1, blue: 1, green: 1, white: 1 });
+
+      const result = resolveEffect(state, "player1", sacrificeEffect);
+
+      const options = result.dynamicChoiceOptions as ResolveSacrificeEffect[];
+
+      // green+red → Siege Fire
+      expect(options).toContainEqual({
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      });
+
+      // green+blue → Siege Ice
+      expect(options).toContainEqual({
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_BLUE,
+      });
+
+      // white+red → Ranged Fire
+      expect(options).toContainEqual({
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_RED,
+      });
+
+      // white+blue → Ranged Ice
+      expect(options).toContainEqual({
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_BLUE,
+      });
+    });
+
+    it("should not modify state when presenting choices", () => {
+      const state = createSacrificeState({ red: 1, blue: 1, green: 1, white: 1 });
+
+      const result = resolveEffect(state, "player1", sacrificeEffect);
+
+      expect(result.state).toBe(state);
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE SACRIFICE TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_SACRIFICE", () => {
+  describe("green+red pair (Siege Fire Attack 4)", () => {
+    it("should grant Siege Fire Attack 4 for 1 pair", () => {
+      const state = createSacrificeState({ red: 1, blue: 0, green: 1, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      expect(player.combatAccumulator.attack.siegeElements.fire).toBe(4);
+    });
+
+    it("should scale attack with multiple pairs", () => {
+      const state = createSacrificeState({ red: 3, blue: 0, green: 2, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // 2 pairs (min of 3 red, 2 green) → Siege Fire 8
+      expect(player.combatAccumulator.attack.siegeElements.fire).toBe(8);
+    });
+  });
+
+  describe("green+blue pair (Siege Ice Attack 4)", () => {
+    it("should grant Siege Ice Attack 4 for 1 pair", () => {
+      const state = createSacrificeState({ red: 0, blue: 1, green: 1, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_BLUE,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      expect(player.combatAccumulator.attack.siegeElements.ice).toBe(4);
+    });
+  });
+
+  describe("white+red pair (Ranged Fire Attack 6)", () => {
+    it("should grant Ranged Fire Attack 6 for 1 pair", () => {
+      const state = createSacrificeState({ red: 1, blue: 0, green: 0, white: 1 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      expect(player.combatAccumulator.attack.rangedElements.fire).toBe(6);
+    });
+
+    it("should scale attack with multiple pairs", () => {
+      const state = createSacrificeState({ red: 2, blue: 0, green: 0, white: 3 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // 2 pairs (min of 2 red, 3 white) → Ranged Fire 12
+      expect(player.combatAccumulator.attack.rangedElements.fire).toBe(12);
+    });
+  });
+
+  describe("white+blue pair (Ranged Ice Attack 6)", () => {
+    it("should grant Ranged Ice Attack 6 for 1 pair", () => {
+      const state = createSacrificeState({ red: 0, blue: 1, green: 0, white: 1 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_BLUE,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      expect(player.combatAccumulator.attack.rangedElements.ice).toBe(6);
+    });
+  });
+
+  describe("crystal conversion to mana tokens", () => {
+    it("should remove crystals for complete pairs", () => {
+      const state = createSacrificeState({ red: 2, blue: 0, green: 3, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // 2 pairs consumed: 2 green, 2 red removed
+      expect(player.crystals.green).toBe(1); // 3 - 2
+      expect(player.crystals.red).toBe(0); // 2 - 2
+    });
+
+    it("should create mana tokens from converted crystals", () => {
+      const state = createSacrificeState({ red: 1, blue: 0, green: 1, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // 1 pair → 2 mana tokens (1 green + 1 red)
+      expect(player.pureMana).toHaveLength(2);
+      expect(player.pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(player.pureMana).toContainEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should create 2 tokens per pair", () => {
+      const state = createSacrificeState({ red: 0, blue: 2, green: 0, white: 3 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_WHITE,
+        elementColor: MANA_BLUE,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // 2 pairs → 4 mana tokens (2 white + 2 blue)
+      expect(player.pureMana).toHaveLength(4);
+
+      const whiteTokens = player.pureMana.filter((t) => t.color === MANA_WHITE);
+      const blueTokens = player.pureMana.filter((t) => t.color === MANA_BLUE);
+      expect(whiteTokens).toHaveLength(2);
+      expect(blueTokens).toHaveLength(2);
+    });
+
+    it("should not affect other crystal colors", () => {
+      const state = createSacrificeState({ red: 1, blue: 2, green: 1, white: 3 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // Only green and red affected
+      expect(player.crystals.blue).toBe(2);
+      expect(player.crystals.white).toBe(3);
+    });
+  });
+
+  describe("zero pairs edge case", () => {
+    it("should do nothing when no pairs available", () => {
+      const state = createSacrificeState({ red: 0, blue: 0, green: 1, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // No pairs → no attack, no conversion
+      expect(player.combatAccumulator.attack.siege).toBe(0);
+      expect(player.crystals.green).toBe(1); // unchanged
+      expect(player.pureMana).toHaveLength(0);
+    });
+  });
+
+  describe("pair count is min of two crystal counts", () => {
+    it("should use minimum when attack color is limiting", () => {
+      const state = createSacrificeState({ red: 3, blue: 0, green: 1, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // min(1 green, 3 red) = 1 pair
+      expect(player.combatAccumulator.attack.siegeElements.fire).toBe(4);
+      expect(player.crystals.green).toBe(0);
+      expect(player.crystals.red).toBe(2);
+    });
+
+    it("should use minimum when element color is limiting", () => {
+      const state = createSacrificeState({ red: 1, blue: 0, green: 3, white: 0 });
+
+      const effect: ResolveSacrificeEffect = {
+        type: EFFECT_RESOLVE_SACRIFICE,
+        attackColor: MANA_GREEN,
+        elementColor: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = getPlayer(result.state);
+      // min(3 green, 1 red) = 1 pair
+      expect(player.combatAccumulator.attack.siegeElements.fire).toBe(4);
+      expect(player.crystals.green).toBe(2);
+      expect(player.crystals.red).toBe(0);
+    });
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Sacrifice effects", () => {
+  it("should describe EFFECT_SACRIFICE", () => {
+    const effect: SacrificeEffect = { type: EFFECT_SACRIFICE };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Sacrifice");
+  });
+
+  it("should describe green+red resolve sacrifice", () => {
+    const effect: ResolveSacrificeEffect = {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_GREEN,
+      elementColor: MANA_RED,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Siege");
+    expect(desc).toContain("Fire");
+    expect(desc).toContain("4");
+  });
+
+  it("should describe white+blue resolve sacrifice", () => {
+    const effect: ResolveSacrificeEffect = {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_WHITE,
+      elementColor: MANA_BLUE,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Ranged");
+    expect(desc).toContain("Ice");
+    expect(desc).toContain("6");
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -55,6 +55,8 @@ import {
   EFFECT_APPLY_INTERACTION_BONUS,
   EFFECT_FREE_RECRUIT,
   EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -72,6 +74,7 @@ import type {
   ResolveManaRadianceColorEffect,
   ApplyRecruitmentBonusEffect,
   ApplyInteractionBonusEffect,
+  ResolveSacrificeEffect,
 } from "../../types/cards.js";
 import type {
   GainMoveEffect,
@@ -397,6 +400,16 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_RESOLVE_FREE_RECRUIT_TARGET]: (effect) => {
     const e = effect as import("../../types/cards.js").ResolveFreeRecruitTargetEffect;
     return `Recruit ${e.unitName} for free`;
+  },
+
+  [EFFECT_SACRIFICE]: () => "Choose crystal colors for Sacrifice attack",
+
+  [EFFECT_RESOLVE_SACRIFICE]: (effect) => {
+    const e = effect as ResolveSacrificeEffect;
+    const attackType = e.attackColor === "white" ? "Ranged" : "Siege";
+    const element = e.elementColor === "red" ? "Fire" : "Ice";
+    const perPair = e.attackColor === "white" ? 6 : 4;
+    return `${attackType} ${element} Attack ${perPair} per ${e.attackColor}/${e.elementColor} crystal pair`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -44,6 +44,7 @@ import { registerPureMagicEffects } from "./pureMagicEffects.js";
 import { registerHeroicTaleEffects } from "./heroicTaleEffects.js";
 import { registerNobleMannersBonusEffects } from "./nobleMannersBonusEffects.js";
 import { registerFreeRecruitEffects } from "./freeRecruitEffects.js";
+import { registerSacrificeEffects } from "./sacrificeEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -158,4 +159,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Free recruit effects (Banner of Command, Call to Glory)
   registerFreeRecruitEffects();
+
+  // Sacrifice effects (Offering powered spell)
+  registerSacrificeEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -281,6 +281,13 @@ export {
   resetFreeRecruitInstanceCounter,
 } from "./freeRecruitEffects.js";
 
+// Sacrifice effects (Offering powered spell)
+export {
+  handleSacrifice,
+  resolveSacrifice,
+  registerSacrificeEffects,
+} from "./sacrificeEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -90,6 +90,8 @@ import {
   EFFECT_RESOLVE_MANA_RADIANCE_COLOR,
   EFFECT_FREE_RECRUIT,
   EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -458,6 +460,18 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Free recruit target resolution is always resolvable (unit validated at resolution time)
   [EFFECT_RESOLVE_FREE_RECRUIT_TARGET]: () => true,
+
+  // Sacrifice is resolvable if player has at least one crystal pair of any combination
+  [EFFECT_SACRIFICE]: (state, player) => {
+    const { red, blue, green, white } = player.crystals;
+    // Need at least one complete pair: (green OR white) AND (red OR blue)
+    const hasAttackColor = green > 0 || white > 0;
+    const hasElementColor = red > 0 || blue > 0;
+    return hasAttackColor && hasElementColor;
+  },
+
+  // Resolve sacrifice is always resolvable (validated at resolution time)
+  [EFFECT_RESOLVE_SACRIFICE]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -57,6 +57,8 @@ import {
   EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION,
   EFFECT_WOUND_ACTIVATING_UNIT,
   EFFECT_APPLY_INTERACTION_BONUS,
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -319,6 +321,13 @@ const reverseHandlers: Partial<Record<EffectType, ReverseHandler>> = {
   // Interaction bonus adds a modifier — modifier cleanup handled by snapshot restore.
   // No player-level state to reverse.
   [EFFECT_APPLY_INTERACTION_BONUS]: (player) => player,
+
+  // Sacrifice just presents choices — no player state change
+  [EFFECT_SACRIFICE]: (player) => player,
+
+  // Resolve Sacrifice modifies crystals, pureMana, and combat accumulator.
+  // Too complex to reverse reliably — should be non-reversible.
+  [EFFECT_RESOLVE_SACRIFICE]: (player) => player,
 
   [EFFECT_TRACK_ATTACK_DEFEAT_FAME]: (player, effect) => {
     const e = effect as TrackAttackDefeatFameEffect;

--- a/packages/core/src/engine/effects/sacrificeEffects.ts
+++ b/packages/core/src/engine/effects/sacrificeEffects.ts
@@ -1,0 +1,203 @@
+/**
+ * Sacrifice Effect Handlers (Offering powered effect)
+ *
+ * Implements the Sacrifice powered spell:
+ * 1. Player chooses a combination of crystal colors
+ * 2. Count complete crystal pairs of chosen colors
+ * 3. Grant combined attack based on pairs:
+ *    - green+red pair → Siege Fire Attack 4 per pair
+ *    - green+blue pair → Siege Ice Attack 4 per pair
+ *    - white+red pair → Ranged Fire Attack 6 per pair
+ *    - white+blue pair → Ranged Ice Attack 6 per pair
+ * 4. Convert ALL complete crystal pairs to mana tokens (immediately usable)
+ *
+ * @module effects/sacrificeEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { ManaToken, Crystals } from "../../types/player.js";
+import type {
+  SacrificeEffect,
+  ResolveSacrificeEffect,
+  GainAttackEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import {
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+import { applyGainAttack } from "./atomicCombatEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_SIEGE,
+  COMBAT_TYPE_RANGED,
+} from "../../types/effectTypes.js";
+import { ELEMENT_FIRE, ELEMENT_ICE } from "../../types/modifierConstants.js";
+
+// ============================================================================
+// SACRIFICE ENTRY POINT
+// ============================================================================
+
+/**
+ * Handle EFFECT_SACRIFICE — present all 4 color combination options.
+ *
+ * The player picks one of 4 combinations (green/white × red/blue),
+ * then EFFECT_RESOLVE_SACRIFICE handles the calculation and conversion.
+ */
+export function handleSacrifice(
+  state: GameState,
+  _playerId: string,
+  _effect: SacrificeEffect
+): EffectResolutionResult {
+  const options: ResolveSacrificeEffect[] = [
+    {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_GREEN,
+      elementColor: MANA_RED,
+    },
+    {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_GREEN,
+      elementColor: MANA_BLUE,
+    },
+    {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_WHITE,
+      elementColor: MANA_RED,
+    },
+    {
+      type: EFFECT_RESOLVE_SACRIFICE,
+      attackColor: MANA_WHITE,
+      elementColor: MANA_BLUE,
+    },
+  ];
+
+  return {
+    state,
+    description: "Choose crystal colors for Sacrifice",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+// ============================================================================
+// RESOLVE SACRIFICE
+// ============================================================================
+
+/**
+ * Resolve after color choice — calculate attack from crystal pairs,
+ * convert pairs to mana tokens.
+ *
+ * Attack values per pair:
+ * - green+red → Siege Fire 4
+ * - green+blue → Siege Ice 4
+ * - white+red → Ranged Fire 6
+ * - white+blue → Ranged Ice 6
+ *
+ * All complete pairs are converted: crystals become mana tokens.
+ */
+export function resolveSacrifice(
+  state: GameState,
+  playerId: string,
+  effect: ResolveSacrificeEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+  const { attackColor, elementColor } = effect;
+
+  // Count complete pairs (minimum of the two crystal counts)
+  const attackCrystalCount = player.crystals[attackColor];
+  const elementCrystalCount = player.crystals[elementColor];
+  const pairCount = Math.min(attackCrystalCount, elementCrystalCount);
+
+  if (pairCount === 0) {
+    return {
+      state,
+      description: `Sacrifice: No ${attackColor}/${elementColor} crystal pairs to convert`,
+    };
+  }
+
+  // Determine attack parameters
+  const isRanged = attackColor === MANA_WHITE;
+  const combatType = isRanged ? COMBAT_TYPE_RANGED : COMBAT_TYPE_SIEGE;
+  const attackPerPair = isRanged ? 6 : 4;
+  const totalAttack = pairCount * attackPerPair;
+  const element = elementColor === MANA_RED ? ELEMENT_FIRE : ELEMENT_ICE;
+
+  // Remove crystals (convert pairs)
+  const updatedCrystals: Crystals = {
+    ...player.crystals,
+    [attackColor]: player.crystals[attackColor] - pairCount,
+    [elementColor]: player.crystals[elementColor] - pairCount,
+  };
+
+  // Create mana tokens from converted crystals
+  const newTokens: ManaToken[] = [];
+  for (let i = 0; i < pairCount; i++) {
+    newTokens.push({ color: attackColor, source: MANA_TOKEN_SOURCE_CARD });
+    newTokens.push({ color: elementColor, source: MANA_TOKEN_SOURCE_CARD });
+  }
+
+  // Apply crystal reduction and mana gain
+  const updatedPlayer = {
+    ...player,
+    crystals: updatedCrystals,
+    pureMana: [...player.pureMana, ...newTokens],
+  };
+
+  const stateAfterConversion = updatePlayer(state, playerIndex, updatedPlayer);
+
+  // Apply attack using the standard applyGainAttack (handles Altem Mages modifiers etc.)
+  const attackEffect: GainAttackEffect = {
+    type: EFFECT_GAIN_ATTACK,
+    amount: totalAttack,
+    combatType,
+    element,
+  };
+
+  const playerAfterConversion = stateAfterConversion.players[playerIndex]!;
+  const attackResult = applyGainAttack(
+    stateAfterConversion,
+    playerIndex,
+    playerAfterConversion,
+    attackEffect
+  );
+
+  const attackTypeName = isRanged ? "Ranged" : "Siege";
+  const elementName = elementColor === MANA_RED ? "Fire" : "Ice";
+
+  return {
+    state: attackResult.state,
+    description: `Sacrifice: ${pairCount} ${attackColor}/${elementColor} pair(s) → ${attackTypeName} ${elementName} Attack ${totalAttack}. Converted ${pairCount * 2} crystals to mana tokens`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Sacrifice effect handlers with the effect registry.
+ */
+export function registerSacrificeEffects(): void {
+  registerEffect(
+    EFFECT_SACRIFICE,
+    (state, playerId, effect) => {
+      return handleSacrifice(state, playerId, effect as SacrificeEffect);
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_SACRIFICE,
+    (state, playerId, effect) => {
+      return resolveSacrifice(state, playerId, effect as ResolveSacrificeEffect);
+    }
+  );
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -13,6 +13,12 @@ import type {
   RevealTileType,
   ResistanceType,
 } from "@mage-knight/shared";
+import {
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
 import type { ModifierEffect, ModifierDuration, ModifierScope } from "./modifiers.js";
 import type { CombatPhase } from "./combat.js";
 import type { SourceDieId } from "./mana.js";
@@ -84,6 +90,8 @@ import {
   EFFECT_APPLY_INTERACTION_BONUS,
   EFFECT_FREE_RECRUIT,
   EFFECT_RESOLVE_FREE_RECRUIT_TARGET,
+  EFFECT_SACRIFICE,
+  EFFECT_RESOLVE_SACRIFICE,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -988,6 +996,37 @@ export interface ResolveFreeRecruitTargetEffect {
   readonly unitName: string;
 }
 
+/**
+ * Sacrifice effect entry point (Offering powered effect).
+ *
+ * Two-stage color choice:
+ * 1. Choose green or white (determines attack type: siege vs ranged)
+ * 2. Choose red or blue (determines element: fire vs ice)
+ *
+ * Crystal pairs of the chosen colors determine attack value:
+ * - green+red pair → Siege Fire Attack 4 per pair
+ * - green+blue pair → Siege Ice Attack 4 per pair
+ * - white+red pair → Ranged Fire Attack 6 per pair
+ * - white+blue pair → Ranged Ice Attack 6 per pair
+ *
+ * All complete pairs are converted to mana tokens (immediately usable).
+ */
+export interface SacrificeEffect {
+  readonly type: typeof EFFECT_SACRIFICE;
+}
+
+/**
+ * Internal: Resolve after both color choices for Sacrifice.
+ * Calculates attack from crystal pairs and converts pairs to mana tokens.
+ */
+export interface ResolveSacrificeEffect {
+  readonly type: typeof EFFECT_RESOLVE_SACRIFICE;
+  /** First choice: green or white */
+  readonly attackColor: typeof MANA_GREEN | typeof MANA_WHITE;
+  /** Second choice: red or blue */
+  readonly elementColor: typeof MANA_RED | typeof MANA_BLUE;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1056,7 +1095,9 @@ export type CardEffect =
   | ApplyRecruitmentBonusEffect
   | ApplyInteractionBonusEffect
   | FreeRecruitEffect
-  | ResolveFreeRecruitTargetEffect;
+  | ResolveFreeRecruitTargetEffect
+  | SacrificeEffect
+  | ResolveSacrificeEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -227,6 +227,14 @@ export const EFFECT_APPLY_RECRUITMENT_BONUS = "apply_recruitment_bonus" as const
 // Used by Noble Manners (basic: Fame+1 on interact, powered: Fame+1 + Rep+1 on interact).
 export const EFFECT_APPLY_INTERACTION_BONUS = "apply_interaction_bonus" as const;
 
+// === Sacrifice (Offering powered) Effect ===
+// Two-stage color choice: first green/white (attack type), then red/blue (element).
+// Count crystal pairs of chosen colors. Each pair generates attack.
+// Convert all complete pairs to mana tokens.
+export const EFFECT_SACRIFICE = "sacrifice" as const;
+// Internal: Resolve after second color choice — calculate attack, convert crystals.
+export const EFFECT_RESOLVE_SACRIFICE = "resolve_sacrifice" as const;
+
 // === Free Recruit Effect ===
 // Recruit any unit from the units offer for free (no influence cost).
 // No location restrictions (can be anywhere, even in combat).

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -105,6 +105,7 @@ export const CARD_TREMOR = cardId("tremor"); // #11 - Target/All Armor reduction
 export const CARD_MANA_MELTDOWN = cardId("mana_meltdown"); // #109 - Random crystal loss / Color wound + gain crystals
 export const CARD_DEMOLISH = cardId("demolish"); // #12 - Ignore fortification + Armor -1 / Destroy enemy + Armor -1
 export const CARD_BURNING_SHIELD = cardId("burning_shield"); // #08 - Fire Block 4 + conditional Fire Attack 4 / Fire Block 4 + destroy blocked enemy
+export const CARD_OFFERING = cardId("offering"); // #46 - Gain red crystal + discard for crystals / Sacrifice crystal pairs for attacks
 
 // Blue spells
 export const CARD_SNOWSTORM = cardId("snowstorm"); // #15 - Ice Ranged Attack 5 / Siege Ice Attack 8
@@ -168,6 +169,7 @@ export type SpellCardId =
   | typeof CARD_MANA_MELTDOWN
   | typeof CARD_DEMOLISH
   | typeof CARD_BURNING_SHIELD
+  | typeof CARD_OFFERING
   // Blue spells
   | typeof CARD_SNOWSTORM
   | typeof CARD_CHILL


### PR DESCRIPTION
## Summary

Closes #197

- **Offering (basic)**: Gain a red crystal, then optionally discard up to 3 non-Wound cards from hand for crystals of matching color (reuses existing discard-for-crystal system)
- **Sacrifice (powered)**: Choose crystal pair colors (green/white × red/blue), count complete pairs, grant elemental attack per pair (green→Siege 4, white→Ranged 6, red→Fire, blue→Ice), then convert all pairs to immediately usable mana tokens

## Changes

- Added `CARD_OFFERING` to shared card ID constants
- Created spell data definition with compound basic effect and sacrifice powered effect  
- Implemented `sacrificeEffects.ts` with dynamic choice options for all 4 color combinations
- Registered effects in `effectRegistrations.ts` and `index.ts`
- Added entries in `describeEffect.ts`, `resolvability.ts`, and `reverse.ts`
- 31 new tests covering card definition, choice presentation, attack calculation, crystal conversion, mana token generation, edge cases, and effect descriptions

## Test plan

- [x] All 31 new tests pass (`offeringSpell.test.ts`)
- [x] Full test suite passes (2842 + 48 tests, 0 failures)
- [x] Build succeeds
- [x] Lint clean (0 warnings, 0 errors)