### PR TITLE
feat: implement Mana Claim / Mana Curse spell (#198)

### DIFF
--- a/packages/core/src/data/spells/blue/index.ts
+++ b/packages/core/src/data/spells/blue/index.ts
@@ -6,15 +6,17 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_SNOWSTORM, CARD_CHILL, CARD_MIST_FORM } from "@mage-knight/shared";
+import { CARD_SNOWSTORM, CARD_CHILL, CARD_MIST_FORM, CARD_MANA_CLAIM } from "@mage-knight/shared";
 import { SNOWSTORM } from "./snowstorm.js";
 import { CHILL } from "./chill.js";
 import { MIST_FORM } from "./mistForm.js";
+import { MANA_CLAIM } from "./manaClaim.js";
 
 export const BLUE_SPELLS: Record<CardId, DeedCard> = {
   [CARD_SNOWSTORM]: SNOWSTORM,
   [CARD_CHILL]: CHILL,
   [CARD_MIST_FORM]: MIST_FORM,
+  [CARD_MANA_CLAIM]: MANA_CLAIM,
 };
 
-export { SNOWSTORM, CHILL, MIST_FORM };
+export { SNOWSTORM, CHILL, MIST_FORM, MANA_CLAIM };

--- a/packages/core/src/data/spells/blue/manaClaim.ts
+++ b/packages/core/src/data/spells/blue/manaClaim.ts
@@ -1,0 +1,44 @@
+/**
+ * Mana Claim / Mana Curse (Blue Spell #110)
+ *
+ * Basic (Mana Claim): Take a mana die of a basic color from the Source
+ * and keep it in your play area until end of round. Choose one:
+ * - Gain 3 mana tokens of that color THIS turn, OR
+ * - Gain 1 mana token of that color EACH turn for remainder of round
+ *
+ * Powered (Mana Curse): Same as basic effect. In addition, until end of
+ * round: each time another player uses one or more mana of that color on
+ * their turn (from any source), they take a Wound. Each player can get
+ * only one Wound per turn this way.
+ *
+ * Interactive spell — removed in friendly game mode since the curse
+ * directly affects other players.
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import { MANA_BLUE, MANA_BLACK, CARD_MANA_CLAIM } from "@mage-knight/shared";
+import {
+  EFFECT_MANA_CLAIM,
+  EFFECT_MANA_CURSE,
+} from "../../../types/effectTypes.js";
+
+export const MANA_CLAIM: DeedCard = {
+  id: CARD_MANA_CLAIM,
+  name: "Mana Claim",
+  poweredName: "Mana Curse",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_SPECIAL],
+  poweredBy: [MANA_BLACK, MANA_BLUE],
+  basicEffect: {
+    type: EFFECT_MANA_CLAIM,
+  },
+  poweredEffect: {
+    type: EFFECT_MANA_CURSE,
+  },
+  sidewaysValue: 1,
+  interactive: true,
+};

--- a/packages/core/src/engine/__tests__/manaClaimSpell.test.ts
+++ b/packages/core/src/engine/__tests__/manaClaimSpell.test.ts
@@ -1,0 +1,1150 @@
+/**
+ * Tests for the Mana Claim / Mana Curse spell (Blue Spell #110)
+ *
+ * Basic (Mana Claim): Take a basic color die from Source, keep until end of
+ * round. Choose: gain 3 mana tokens of that color THIS turn, OR gain 1 mana
+ * token each turn for remainder of round (starting next turn).
+ *
+ * Powered (Mana Curse): Same as basic effect. In addition, until end of round:
+ * each time another player uses one or more mana of that color on their turn
+ * (from any source), they take a Wound (max 1 per player per turn).
+ *
+ * Key rules:
+ * - Special category (both effects)
+ * - Interactive: removed in friendly game mode
+ * - End-of-round: basic does nothing, powered has no curse effect
+ * - Die stays claimed until end of round (excluded from turn-end safety net)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+  checkManaCurseWound,
+  grantManaClaimSustainedToken,
+  resetManaCurseWoundTracking,
+} from "../effects/index.js";
+import type {
+  ManaClaimEffect,
+  ResolveManaClaimDieEffect,
+  ResolveManaClaimModeEffect,
+  ManaCurseEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  EFFECT_MANA_CLAIM,
+  EFFECT_RESOLVE_MANA_CLAIM_DIE,
+  EFFECT_RESOLVE_MANA_CLAIM_MODE,
+  EFFECT_MANA_CURSE,
+} from "../../types/effectTypes.js";
+import {
+  EFFECT_MANA_CLAIM_SUSTAINED,
+  EFFECT_MANA_CURSE as MODIFIER_MANA_CURSE,
+} from "../../types/modifierConstants.js";
+import {
+  CARD_MANA_CLAIM,
+  CARD_WOUND,
+  CARD_MARCH,
+  MANA_BLACK,
+  MANA_BLUE,
+  MANA_RED,
+  MANA_GREEN,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import { MANA_CLAIM } from "../../data/spells/blue/manaClaim.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+import { sourceDieId } from "../../types/mana.js";
+import type { SourceDie } from "../../types/mana.js";
+import type { ManaClaimSustainedModifier, ManaCurseModifier } from "../../types/modifiers.js";
+import { setupNextPlayer } from "../commands/endTurn/turnAdvancement.js";
+import { processDiceReturn } from "../commands/endTurn/diceManagement.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createSourceDie(
+  id: string,
+  color: string,
+  takenByPlayerId: string | null = null
+): SourceDie {
+  return {
+    id: sourceDieId(id),
+    color: color as SourceDie["color"],
+    isDepleted: false,
+    takenByPlayerId,
+  };
+}
+
+function createStateWithDice(
+  dice: SourceDie[],
+  overrides: Partial<GameState> = {}
+): GameState {
+  const caster = createTestPlayer({ id: "caster" });
+  const opponent = createTestPlayer({
+    id: "opponent",
+    position: { q: 1, r: 0 },
+  });
+
+  return createTestGameState({
+    players: [caster, opponent],
+    turnOrder: ["caster", "opponent"],
+    source: { dice },
+    ...overrides,
+  });
+}
+
+function createStateWithBasicDice(
+  overrides: Partial<GameState> = {}
+): GameState {
+  const dice: SourceDie[] = [
+    createSourceDie("die_1", MANA_RED),
+    createSourceDie("die_2", MANA_BLUE),
+    createSourceDie("die_3", MANA_GREEN),
+  ];
+  return createStateWithDice(dice, overrides);
+}
+
+function getCaster(state: GameState) {
+  return state.players.find((p) => p.id === "caster")!;
+}
+
+function getOpponent(state: GameState, id = "opponent") {
+  return state.players.find((p) => p.id === id)!;
+}
+
+// ============================================================================
+// SPELL CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Mana Claim spell card definition", () => {
+  it("should be registered in spell cards", () => {
+    const card = getSpellCard(CARD_MANA_CLAIM);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Mana Claim");
+  });
+
+  it("should have correct metadata", () => {
+    expect(MANA_CLAIM.id).toBe(CARD_MANA_CLAIM);
+    expect(MANA_CLAIM.name).toBe("Mana Claim");
+    expect(MANA_CLAIM.poweredName).toBe("Mana Curse");
+    expect(MANA_CLAIM.cardType).toBe(DEED_CARD_TYPE_SPELL);
+    expect(MANA_CLAIM.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by black + blue mana", () => {
+    expect(MANA_CLAIM.poweredBy).toEqual([MANA_BLACK, MANA_BLUE]);
+  });
+
+  it("should have special category", () => {
+    expect(MANA_CLAIM.categories).toEqual([CATEGORY_SPECIAL]);
+  });
+
+  it("should be marked as interactive", () => {
+    expect(MANA_CLAIM.interactive).toBe(true);
+  });
+
+  it("should have basic effect of type EFFECT_MANA_CLAIM", () => {
+    const effect = MANA_CLAIM.basicEffect as ManaClaimEffect;
+    expect(effect.type).toBe(EFFECT_MANA_CLAIM);
+  });
+
+  it("should have powered effect of type EFFECT_MANA_CURSE", () => {
+    const effect = MANA_CLAIM.poweredEffect as ManaCurseEffect;
+    expect(effect.type).toBe(EFFECT_MANA_CURSE);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT (MANA CLAIM) TESTS
+// ============================================================================
+
+describe("EFFECT_MANA_CLAIM (basic)", () => {
+  const basicEffect: ManaClaimEffect = {
+    type: EFFECT_MANA_CLAIM,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should always be resolvable", () => {
+      const state = createStateWithBasicDice();
+      expect(isEffectResolvable(state, "caster", basicEffect)).toBe(true);
+    });
+  });
+
+  describe("die selection", () => {
+    it("should present basic color dice as options", () => {
+      const state = createStateWithBasicDice();
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toBeDefined();
+      expect(result.dynamicChoiceOptions!.length).toBe(3);
+
+      const options = result.dynamicChoiceOptions as ResolveManaClaimDieEffect[];
+      expect(options[0]!.type).toBe(EFFECT_RESOLVE_MANA_CLAIM_DIE);
+      expect(options[0]!.withCurse).toBe(false);
+    });
+
+    it("should only show available (untaken) dice", () => {
+      const dice: SourceDie[] = [
+        createSourceDie("die_1", MANA_RED, "opponent"), // taken
+        createSourceDie("die_2", MANA_BLUE),
+        createSourceDie("die_3", MANA_GREEN),
+      ];
+      const state = createStateWithDice(dice);
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.dynamicChoiceOptions!.length).toBe(2);
+      const dieIds = (result.dynamicChoiceOptions as ResolveManaClaimDieEffect[])
+        .map((o) => o.dieId);
+      expect(dieIds).not.toContain(sourceDieId("die_1"));
+    });
+
+    it("should exclude non-basic color dice (gold, black)", () => {
+      const dice: SourceDie[] = [
+        createSourceDie("die_1", MANA_RED),
+        createSourceDie("die_2", "gold"),
+        createSourceDie("die_3", "black"),
+      ];
+      const state = createStateWithDice(dice);
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.dynamicChoiceOptions!.length).toBe(1);
+      const option = (result.dynamicChoiceOptions as ResolveManaClaimDieEffect[])[0]!;
+      expect(option.dieColor).toBe(MANA_RED);
+    });
+
+    it("should return no-op when no basic color dice available", () => {
+      const dice: SourceDie[] = [
+        createSourceDie("die_1", "gold"),
+        createSourceDie("die_2", "black"),
+      ];
+      const state = createStateWithDice(dice);
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBeFalsy();
+      expect(result.description).toContain("No basic color dice");
+    });
+
+    it("should return no-op when all dice are taken", () => {
+      const dice: SourceDie[] = [
+        createSourceDie("die_1", MANA_RED, "opponent"),
+        createSourceDie("die_2", MANA_BLUE, "caster"),
+      ];
+      const state = createStateWithDice(dice);
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBeFalsy();
+    });
+  });
+
+  describe("end-of-round restriction", () => {
+    it("should do nothing when end of round announced", () => {
+      const state = createStateWithBasicDice({
+        endOfRoundAnnouncedBy: "opponent",
+      });
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBeFalsy();
+      expect(result.description).toContain("no effect");
+    });
+
+    it("should do nothing when scenario end triggered", () => {
+      const state = createStateWithBasicDice({
+        scenarioEndTriggered: true,
+      });
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBeFalsy();
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE MANA CLAIM DIE TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MANA_CLAIM_DIE", () => {
+  it("should present burst and sustained mode options", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimDieEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_DIE,
+      dieId: sourceDieId("die_1"),
+      dieColor: MANA_RED,
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+    const options = result.dynamicChoiceOptions as ResolveManaClaimModeEffect[];
+    expect(options[0]!.mode).toBe("burst");
+    expect(options[0]!.color).toBe(MANA_RED);
+    expect(options[0]!.withCurse).toBe(false);
+    expect(options[1]!.mode).toBe("sustained");
+  });
+
+  it("should propagate curse flag to mode options", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimDieEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_DIE,
+      dieId: sourceDieId("die_1"),
+      dieColor: MANA_RED,
+      withCurse: true,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const options = result.dynamicChoiceOptions as ResolveManaClaimModeEffect[];
+    expect(options[0]!.withCurse).toBe(true);
+    expect(options[1]!.withCurse).toBe(true);
+  });
+
+  it("should handle die no longer available", () => {
+    const dice: SourceDie[] = [
+      createSourceDie("die_1", MANA_RED, "opponent"), // now taken
+    ];
+    const state = createStateWithDice(dice);
+
+    const effect: ResolveManaClaimDieEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_DIE,
+      dieId: sourceDieId("die_1"),
+      dieColor: MANA_RED,
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    expect(result.requiresChoice).toBeFalsy();
+    expect(result.description).toContain("no longer available");
+  });
+});
+
+// ============================================================================
+// RESOLVE MANA CLAIM MODE - BURST TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MANA_CLAIM_MODE (burst)", () => {
+  it("should grant 3 mana tokens of the claimed color", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const caster = getCaster(result.state);
+    const redTokens = caster.pureMana.filter((t) => t.color === MANA_RED);
+    expect(redTokens).toHaveLength(3);
+    expect(redTokens[0]!.source).toBe(MANA_TOKEN_SOURCE_CARD);
+  });
+
+  it("should claim the die (set takenByPlayerId)", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const claimedDie = result.state.source.dice.find(
+      (d) => d.id === sourceDieId("die_1")
+    );
+    expect(claimedDie!.takenByPlayerId).toBe("caster");
+  });
+
+  it("should not add sustained modifier for burst mode", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const sustainedModifiers = result.state.activeModifiers.filter(
+      (m) => m.effect.type === EFFECT_MANA_CLAIM_SUSTAINED
+    );
+    expect(sustainedModifiers).toHaveLength(0);
+  });
+});
+
+// ============================================================================
+// RESOLVE MANA CLAIM MODE - SUSTAINED TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MANA_CLAIM_MODE (sustained)", () => {
+  it("should NOT grant tokens immediately (starts next turn)", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_2"),
+      color: MANA_BLUE,
+      mode: "sustained",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const caster = getCaster(result.state);
+    expect(caster.pureMana).toHaveLength(0);
+  });
+
+  it("should add a round-duration sustained modifier", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_2"),
+      color: MANA_BLUE,
+      mode: "sustained",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const sustainedModifiers = result.state.activeModifiers.filter(
+      (m) => m.effect.type === EFFECT_MANA_CLAIM_SUSTAINED
+    );
+    expect(sustainedModifiers).toHaveLength(1);
+
+    const mod = sustainedModifiers[0]!;
+    const modEffect = mod.effect as ManaClaimSustainedModifier;
+    expect(modEffect.color).toBe(MANA_BLUE);
+    expect(modEffect.claimedDieId).toEqual(sourceDieId("die_2"));
+    expect(mod.duration).toBe("round");
+    expect(mod.createdByPlayerId).toBe("caster");
+  });
+
+  it("should claim the die (set takenByPlayerId)", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_2"),
+      color: MANA_BLUE,
+      mode: "sustained",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const claimedDie = result.state.source.dice.find(
+      (d) => d.id === sourceDieId("die_2")
+    );
+    expect(claimedDie!.takenByPlayerId).toBe("caster");
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT (MANA CURSE) TESTS
+// ============================================================================
+
+describe("EFFECT_MANA_CURSE (powered)", () => {
+  const poweredEffect: ManaCurseEffect = {
+    type: EFFECT_MANA_CURSE,
+  };
+
+  describe("die selection", () => {
+    it("should present die options with curse flag", () => {
+      const state = createStateWithBasicDice();
+
+      const result = resolveEffect(state, "caster", poweredEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      const options = result.dynamicChoiceOptions as ResolveManaClaimDieEffect[];
+      expect(options[0]!.withCurse).toBe(true);
+    });
+  });
+
+  describe("end-of-round restriction", () => {
+    it("should disable curse after end of round announced", () => {
+      const state = createStateWithBasicDice({
+        endOfRoundAnnouncedBy: "opponent",
+      });
+
+      const result = resolveEffect(state, "caster", poweredEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      // Die options should have withCurse = false
+      const options = result.dynamicChoiceOptions as ResolveManaClaimDieEffect[];
+      expect(options[0]!.withCurse).toBe(false);
+      expect(result.description).toContain("no curse");
+    });
+  });
+
+  describe("curse modifier creation", () => {
+    it("should add curse modifier when burst mode with curse", () => {
+      const state = createStateWithBasicDice();
+
+      const effect: ResolveManaClaimModeEffect = {
+        type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+        dieId: sourceDieId("die_1"),
+        color: MANA_RED,
+        mode: "burst",
+        withCurse: true,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const curseModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === MODIFIER_MANA_CURSE
+      );
+      expect(curseModifiers).toHaveLength(1);
+
+      const mod = curseModifiers[0]!;
+      const modEffect = mod.effect as ManaCurseModifier;
+      expect(modEffect.color).toBe(MANA_RED);
+      expect(modEffect.claimedDieId).toEqual(sourceDieId("die_1"));
+      expect(modEffect.woundedPlayerIdsThisTurn).toEqual([]);
+      expect(mod.duration).toBe("round");
+      expect(mod.createdByPlayerId).toBe("caster");
+    });
+
+    it("should add both sustained and curse modifiers when sustained mode with curse", () => {
+      const state = createStateWithBasicDice();
+
+      const effect: ResolveManaClaimModeEffect = {
+        type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+        dieId: sourceDieId("die_3"),
+        color: MANA_GREEN,
+        mode: "sustained",
+        withCurse: true,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const sustainedModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_MANA_CLAIM_SUSTAINED
+      );
+      const curseModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === MODIFIER_MANA_CURSE
+      );
+
+      expect(sustainedModifiers).toHaveLength(1);
+      expect(curseModifiers).toHaveLength(1);
+    });
+
+    it("should not add curse modifier without curse flag", () => {
+      const state = createStateWithBasicDice();
+
+      const effect: ResolveManaClaimModeEffect = {
+        type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+        dieId: sourceDieId("die_1"),
+        color: MANA_RED,
+        mode: "burst",
+        withCurse: false,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const curseModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === MODIFIER_MANA_CURSE
+      );
+      expect(curseModifiers).toHaveLength(0);
+    });
+  });
+});
+
+// ============================================================================
+// MANA CURSE WOUND CHECK TESTS
+// ============================================================================
+
+describe("checkManaCurseWound", () => {
+  function createStateWithCurse(
+    curseColor: string,
+    casterId: string = "caster"
+  ): GameState {
+    const state = createStateWithBasicDice();
+    return {
+      ...state,
+      activeModifiers: [
+        {
+          id: "curse_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as import("@mage-knight/shared").CardId, playerId: casterId },
+          duration: "round" as const,
+          scope: { type: "other_players" as const },
+          effect: {
+            type: MODIFIER_MANA_CURSE,
+            color: curseColor as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_1"),
+            woundedPlayerIdsThisTurn: [] as readonly string[],
+          },
+          createdAtRound: 1,
+          createdByPlayerId: casterId,
+        },
+      ],
+    };
+  }
+
+  it("should wound opponent when they use cursed mana color", () => {
+    const state = createStateWithCurse(MANA_RED);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    const opponent = getOpponent(result);
+    const wounds = opponent.hand.filter((c) => c === CARD_WOUND);
+    expect(wounds).toHaveLength(1);
+  });
+
+  it("should not wound caster when they use their own cursed color", () => {
+    const state = createStateWithCurse(MANA_RED, "caster");
+
+    const result = checkManaCurseWound(state, "caster", MANA_RED);
+
+    const caster = getCaster(result);
+    const wounds = caster.hand.filter((c) => c === CARD_WOUND);
+    expect(wounds).toHaveLength(0);
+  });
+
+  it("should not wound when using a different color", () => {
+    const state = createStateWithCurse(MANA_RED);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_BLUE);
+
+    const opponent = getOpponent(result);
+    const wounds = opponent.hand.filter((c) => c === CARD_WOUND);
+    expect(wounds).toHaveLength(0);
+  });
+
+  it("should limit wound to 1 per player per turn", () => {
+    const state = createStateWithCurse(MANA_RED);
+
+    // First usage - should wound
+    const afterFirst = checkManaCurseWound(state, "opponent", MANA_RED);
+    const opponentAfterFirst = getOpponent(afterFirst);
+    const woundsAfterFirst = opponentAfterFirst.hand.filter((c) => c === CARD_WOUND);
+    expect(woundsAfterFirst).toHaveLength(1);
+
+    // Second usage same turn - should NOT wound again
+    const afterSecond = checkManaCurseWound(afterFirst, "opponent", MANA_RED);
+    const opponentAfterSecond = getOpponent(afterSecond);
+    const woundsAfterSecond = opponentAfterSecond.hand.filter((c) => c === CARD_WOUND);
+    expect(woundsAfterSecond).toHaveLength(1); // Still only 1
+  });
+
+  it("should track wounded player IDs on the modifier", () => {
+    const state = createStateWithCurse(MANA_RED);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    const curseMod = result.activeModifiers.find(
+      (m) => m.effect.type === MODIFIER_MANA_CURSE
+    );
+    const effect = curseMod!.effect as ManaCurseModifier;
+    expect(effect.woundedPlayerIdsThisTurn).toContain("opponent");
+  });
+
+  it("should do nothing when no curse modifiers are active", () => {
+    const state = createStateWithBasicDice();
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    // State should be unchanged
+    expect(result).toBe(state);
+  });
+});
+
+// ============================================================================
+// SUSTAINED TOKEN GRANT TESTS
+// ============================================================================
+
+describe("grantManaClaimSustainedToken", () => {
+  function createStateWithSustainedModifier(
+    color: string,
+    casterId: string = "caster"
+  ): GameState {
+    const state = createStateWithBasicDice();
+    return {
+      ...state,
+      activeModifiers: [
+        {
+          id: "sustained_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as import("@mage-knight/shared").CardId, playerId: casterId },
+          duration: "round" as const,
+          scope: { type: "self" as const },
+          effect: {
+            type: EFFECT_MANA_CLAIM_SUSTAINED,
+            color: color as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_1"),
+          },
+          createdAtRound: 1,
+          createdByPlayerId: casterId,
+        },
+      ],
+    };
+  }
+
+  it("should grant 1 token of the sustained color", () => {
+    const state = createStateWithSustainedModifier(MANA_BLUE);
+    const player = getCaster(state);
+
+    const result = grantManaClaimSustainedToken(state, player);
+
+    const blueTokens = result.pureMana.filter((t) => t.color === MANA_BLUE);
+    expect(blueTokens).toHaveLength(1);
+    expect(blueTokens[0]!.source).toBe(MANA_TOKEN_SOURCE_CARD);
+  });
+
+  it("should not grant tokens to a different player", () => {
+    const state = createStateWithSustainedModifier(MANA_BLUE, "caster");
+    const opponent = getOpponent(state);
+
+    const result = grantManaClaimSustainedToken(state, opponent);
+
+    expect(result.pureMana).toHaveLength(0);
+  });
+
+  it("should return player unchanged when no sustained modifier exists", () => {
+    const state = createStateWithBasicDice();
+    const player = getCaster(state);
+
+    const result = grantManaClaimSustainedToken(state, player);
+
+    expect(result).toBe(player);
+  });
+});
+
+// ============================================================================
+// RESET MANA CURSE WOUND TRACKING TESTS
+// ============================================================================
+
+describe("resetManaCurseWoundTracking", () => {
+  it("should clear wounded player IDs on curse modifiers", () => {
+    const state = createStateWithBasicDice();
+    const stateWithCurse: GameState = {
+      ...state,
+      activeModifiers: [
+        {
+          id: "curse_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as import("@mage-knight/shared").CardId, playerId: "caster" },
+          duration: "round" as const,
+          scope: { type: "other_players" as const },
+          effect: {
+            type: MODIFIER_MANA_CURSE,
+            color: MANA_RED as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_1"),
+            woundedPlayerIdsThisTurn: ["opponent"] as readonly string[],
+          },
+          createdAtRound: 1,
+          createdByPlayerId: "caster",
+        },
+      ],
+    };
+
+    const result = resetManaCurseWoundTracking(stateWithCurse);
+
+    const curseMod = result.activeModifiers.find(
+      (m) => m.effect.type === MODIFIER_MANA_CURSE
+    );
+    const effect = curseMod!.effect as ManaCurseModifier;
+    expect(effect.woundedPlayerIdsThisTurn).toEqual([]);
+  });
+
+  it("should return state unchanged when no curse modifiers exist", () => {
+    const state = createStateWithBasicDice();
+
+    const result = resetManaCurseWoundTracking(state);
+
+    expect(result).toBe(state);
+  });
+});
+
+// ============================================================================
+// DICE PERSISTENCE TESTS (die should NOT be released at end of turn)
+// ============================================================================
+
+describe("Mana Claim die persistence across turns", () => {
+  it("should exclude Mana Claim dice from turn-end safety net cleanup", () => {
+    // This test verifies the logic in diceManagement.ts
+    // When a player ends their turn, claimed dice should NOT be released
+    const state = createStateWithBasicDice();
+
+    // First, claim a die via burst mode
+    const claimEffect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", claimEffect);
+
+    // Verify die is claimed
+    const claimedDie = result.state.source.dice.find(
+      (d) => d.id === sourceDieId("die_1")
+    );
+    expect(claimedDie!.takenByPlayerId).toBe("caster");
+
+    // The sustained modifier tracks the claimed die ID
+    // In diceManagement.ts, this die would be excluded from the safety net
+    // because the active modifier references it via claimedDieId
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Mana Claim effects", () => {
+  it("should describe EFFECT_MANA_CLAIM", () => {
+    const effect: ManaClaimEffect = { type: EFFECT_MANA_CLAIM };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Claim");
+    expect(desc).toContain("die");
+  });
+
+  it("should describe EFFECT_RESOLVE_MANA_CLAIM_DIE", () => {
+    const effect: ResolveManaClaimDieEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_DIE,
+      dieId: sourceDieId("die_1"),
+      dieColor: MANA_RED,
+      withCurse: false,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("red");
+  });
+
+  it("should describe EFFECT_RESOLVE_MANA_CLAIM_MODE burst", () => {
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("3");
+    expect(desc).toContain("red");
+  });
+
+  it("should describe EFFECT_RESOLVE_MANA_CLAIM_MODE sustained", () => {
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("die_1"),
+      color: MANA_BLUE,
+      mode: "sustained",
+      withCurse: false,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("1");
+    expect(desc).toContain("blue");
+  });
+
+  it("should describe EFFECT_MANA_CURSE", () => {
+    const effect: ManaCurseEffect = { type: EFFECT_MANA_CURSE };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Claim");
+    expect(desc).toContain("curse");
+  });
+});
+
+// ============================================================================
+// COVERAGE: handleManaCurse no-dice path (lines 154-158)
+// ============================================================================
+
+describe("EFFECT_MANA_CURSE - no dice available", () => {
+  it("should return no-op when no basic color dice available", () => {
+    const dice: SourceDie[] = [
+      createSourceDie("die_1", "gold"),
+      createSourceDie("die_2", "black"),
+    ];
+    const state = createStateWithDice(dice);
+
+    const poweredEffect: ManaCurseEffect = { type: EFFECT_MANA_CURSE };
+    const result = resolveEffect(state, "caster", poweredEffect);
+
+    expect(result.requiresChoice).toBeFalsy();
+    expect(result.description).toContain("No basic color dice");
+  });
+});
+
+// ============================================================================
+// COVERAGE: resolveManaClaimMode die-not-found path (lines 244-248)
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MANA_CLAIM_MODE - die not found", () => {
+  it("should handle die not found in source", () => {
+    const state = createStateWithBasicDice();
+
+    const effect: ResolveManaClaimModeEffect = {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId: sourceDieId("nonexistent_die"),
+      color: MANA_RED,
+      mode: "burst",
+      withCurse: false,
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    expect(result.requiresChoice).toBeFalsy();
+    expect(result.description).toContain("Die not found");
+  });
+});
+
+// ============================================================================
+// COVERAGE: checkManaCurseWound woundPileCount handling (lines 379-382)
+// ============================================================================
+
+describe("checkManaCurseWound - wound pile count", () => {
+  function createStateWithCurseAndWoundPile(
+    woundPileCount: number | null
+  ): GameState {
+    const state = createStateWithBasicDice({ woundPileCount });
+    return {
+      ...state,
+      activeModifiers: [
+        {
+          id: "curse_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as CardId, playerId: "caster" },
+          duration: "round" as const,
+          scope: { type: "other_players" as const },
+          effect: {
+            type: MODIFIER_MANA_CURSE,
+            color: MANA_RED as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_1"),
+            woundedPlayerIdsThisTurn: [] as readonly string[],
+          },
+          createdAtRound: 1,
+          createdByPlayerId: "caster",
+        },
+      ],
+    };
+  }
+
+  it("should decrement woundPileCount when finite", () => {
+    const state = createStateWithCurseAndWoundPile(10);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    expect(result.woundPileCount).toBe(9);
+  });
+
+  it("should keep woundPileCount as null when null (unlimited wounds)", () => {
+    const state = createStateWithCurseAndWoundPile(null);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    expect(result.woundPileCount).toBeNull();
+  });
+
+  it("should not go below 0 for woundPileCount", () => {
+    const state = createStateWithCurseAndWoundPile(0);
+
+    const result = checkManaCurseWound(state, "opponent", MANA_RED);
+
+    expect(result.woundPileCount).toBe(0);
+  });
+});
+
+// ============================================================================
+// COVERAGE: setupNextPlayer calling grantManaClaimSustainedToken (lines 121, 155-156)
+// ============================================================================
+
+describe("setupNextPlayer - Mana Claim sustained token integration", () => {
+  function createStateWithSustainedModForPlayer(
+    playerId: string
+  ): GameState {
+    const caster = createTestPlayer({
+      id: "caster",
+      hand: [CARD_MARCH as CardId],
+    });
+    const opponent = createTestPlayer({
+      id: "opponent",
+      position: { q: 1, r: 0 },
+      hand: [CARD_MARCH as CardId],
+    });
+
+    const state = createTestGameState({
+      players: [caster, opponent],
+      turnOrder: ["caster", "opponent"],
+    });
+
+    return {
+      ...state,
+      activeModifiers: [
+        {
+          id: "sustained_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as CardId, playerId },
+          duration: "round" as const,
+          scope: { type: "self" as const },
+          effect: {
+            type: EFFECT_MANA_CLAIM_SUSTAINED,
+            color: MANA_BLUE as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_1"),
+          },
+          createdAtRound: 1,
+          createdByPlayerId: playerId,
+        },
+      ],
+    };
+  }
+
+  it("should grant sustained token when advancing to next player (normal turn)", () => {
+    const state = createStateWithSustainedModForPlayer("opponent");
+
+    const result = setupNextPlayer(state, "opponent", false, "caster");
+
+    const opponent = result.players.find((p) => p.id === "opponent")!;
+    const blueTokens = opponent.pureMana.filter((t) => t.color === MANA_BLUE);
+    expect(blueTokens).toHaveLength(1);
+    expect(blueTokens[0]!.source).toBe(MANA_TOKEN_SOURCE_CARD);
+  });
+
+  it("should grant sustained token on extra turn (same player)", () => {
+    const caster = createTestPlayer({
+      id: "caster",
+      hand: [CARD_MARCH as CardId],
+      tacticState: { extraTurnPending: true },
+    });
+    const opponent = createTestPlayer({
+      id: "opponent",
+      position: { q: 1, r: 0 },
+    });
+
+    const state = createTestGameState({
+      players: [caster, opponent],
+      turnOrder: ["caster", "opponent"],
+      activeModifiers: [
+        {
+          id: "sustained_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as CardId, playerId: "caster" },
+          duration: "round" as const,
+          scope: { type: "self" as const },
+          effect: {
+            type: EFFECT_MANA_CLAIM_SUSTAINED,
+            color: MANA_GREEN as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: sourceDieId("die_2"),
+          },
+          createdAtRound: 1,
+          createdByPlayerId: "caster",
+        },
+      ],
+    });
+
+    const result = setupNextPlayer(state, "caster", true, "caster");
+
+    const casterResult = result.players.find((p) => p.id === "caster")!;
+    const greenTokens = casterResult.pureMana.filter((t) => t.color === MANA_GREEN);
+    expect(greenTokens).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// COVERAGE: processDiceReturn excluding Mana Claim dice (lines 78-83)
+// ============================================================================
+
+describe("processDiceReturn - Mana Claim die exclusion", () => {
+  it("should not release dice referenced by EFFECT_MANA_CLAIM_SUSTAINED modifier", () => {
+    const claimedDieId = sourceDieId("claimed_die");
+    const normalDieId = sourceDieId("normal_die");
+
+    const dice: SourceDie[] = [
+      createSourceDie("claimed_die", MANA_BLUE, "caster"),
+      createSourceDie("normal_die", MANA_RED, "caster"),
+    ];
+
+    const caster = createTestPlayer({ id: "caster" });
+    const state = createTestGameState({
+      players: [caster],
+      turnOrder: ["caster"],
+      source: { dice },
+      activeModifiers: [
+        {
+          id: "sustained_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as CardId, playerId: "caster" },
+          duration: "round" as const,
+          scope: { type: "self" as const },
+          effect: {
+            type: EFFECT_MANA_CLAIM_SUSTAINED,
+            color: MANA_BLUE as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId,
+          },
+          createdAtRound: 1,
+          createdByPlayerId: "caster",
+        },
+      ],
+    });
+
+    const result = processDiceReturn(state, caster, [caster]);
+
+    // Claimed die should still be taken
+    const claimedDie = result.source.dice.find((d) => d.id === claimedDieId);
+    expect(claimedDie!.takenByPlayerId).toBe("caster");
+
+    // Normal die should be released
+    const normalDie = result.source.dice.find((d) => d.id === normalDieId);
+    expect(normalDie!.takenByPlayerId).toBeNull();
+  });
+
+  it("should not release dice referenced by EFFECT_MANA_CURSE modifier", () => {
+    const curseDieId = sourceDieId("curse_die");
+
+    const dice: SourceDie[] = [
+      createSourceDie("curse_die", MANA_RED, "caster"),
+    ];
+
+    const caster = createTestPlayer({ id: "caster" });
+    const state = createTestGameState({
+      players: [caster],
+      turnOrder: ["caster"],
+      source: { dice },
+      activeModifiers: [
+        {
+          id: "curse_mod_1",
+          source: { type: "card" as const, cardId: CARD_MANA_CLAIM as CardId, playerId: "caster" },
+          duration: "round" as const,
+          scope: { type: "other_players" as const },
+          effect: {
+            type: MODIFIER_MANA_CURSE,
+            color: MANA_RED as import("@mage-knight/shared").BasicManaColor,
+            claimedDieId: curseDieId,
+            woundedPlayerIdsThisTurn: [] as readonly string[],
+          },
+          createdAtRound: 1,
+          createdByPlayerId: "caster",
+        },
+      ],
+    });
+
+    const result = processDiceReturn(state, caster, [caster]);
+
+    // Curse die should still be taken
+    const curseDie = result.source.dice.find((d) => d.id === curseDieId);
+    expect(curseDie!.takenByPlayerId).toBe("caster");
+  });
+});

--- a/packages/core/src/engine/commands/endTurn/index.ts
+++ b/packages/core/src/engine/commands/endTurn/index.ts
@@ -29,6 +29,7 @@ import { processCardFlow, getPlayAreaCardCount } from "./cardFlow.js";
 import { createResetPlayer } from "./playerReset.js";
 import { processDiceReturn } from "./diceManagement.js";
 import { determineNextPlayer, setupNextPlayer } from "./turnAdvancement.js";
+import { resetManaCurseWoundTracking } from "../../effects/manaClaimEffects.js";
 import { processLevelUps } from "./levelUp.js";
 import { calculateRingFameBonus } from "./ringFameBonus.js";
 
@@ -203,6 +204,9 @@ export function createEndTurnCommand(params: EndTurnCommandParams): Command {
         );
         newState = { ...newState, players: setupResult.players };
         gladeManaEvent = setupResult.gladeManaEvent;
+
+        // Reset Mana Curse per-turn wound tracking for the new turn
+        newState = resetManaCurseWoundTracking(newState);
       }
 
       // Build events

--- a/packages/core/src/engine/commands/endTurn/turnAdvancement.ts
+++ b/packages/core/src/engine/commands/endTurn/turnAdvancement.ts
@@ -23,6 +23,7 @@ import {
 import { SiteType } from "../../../types/map.js";
 import type { NextPlayerResult, NextPlayerSetupResult } from "./types.js";
 import { getPlayerById } from "../../helpers/playerHelpers.js";
+import { grantManaClaimSustainedToken } from "../../effects/manaClaimEffects.js";
 
 /**
  * Determine what happens after the current player's turn ends.
@@ -103,7 +104,7 @@ export function setupNextPlayer(
         const gladeResult = checkMagicalGladeMana(state, player);
         gladeManaEvent = gladeResult.event;
 
-        players[playerIdx] = {
+        let updatedPlayer: Player = {
           ...player,
           movePoints: TURN_START_MOVE_POINTS,
           tacticState: {
@@ -115,6 +116,11 @@ export function setupNextPlayer(
             ? [...player.pureMana, gladeResult.manaToken]
             : player.pureMana,
         };
+
+        // Grant sustained Mana Claim token at turn start
+        updatedPlayer = grantManaClaimSustainedToken(state, updatedPlayer);
+
+        players[playerIdx] = updatedPlayer;
       }
     }
   } else {
@@ -130,7 +136,7 @@ export function setupNextPlayer(
         const gladeResult = checkMagicalGladeMana(state, nextPlayer);
         gladeManaEvent = gladeResult.event;
 
-        players[nextPlayerIdx] = {
+        let updatedNextPlayer: Player = {
           ...nextPlayer,
           movePoints: TURN_START_MOVE_POINTS,
           tacticState: {
@@ -145,6 +151,11 @@ export function setupNextPlayer(
             ? [...nextPlayer.pureMana, gladeResult.manaToken]
             : nextPlayer.pureMana,
         };
+
+        // Grant sustained Mana Claim token at turn start
+        updatedNextPlayer = grantManaClaimSustainedToken(state, updatedNextPlayer);
+
+        players[nextPlayerIdx] = updatedNextPlayer;
       }
     }
   }

--- a/packages/core/src/engine/commands/playCardCommand.ts
+++ b/packages/core/src/engine/commands/playCardCommand.ts
@@ -27,6 +27,7 @@ import type { CardEffect, DeedCard } from "../../types/cards.js";
 import type { ActiveModifier } from "../../types/modifiers.js";
 
 import { consumeMultipleMana, restoreMana } from "./helpers/manaConsumptionHelpers.js";
+import { checkManaCurseWound } from "../effects/manaClaimEffects.js";
 import {
   getChoiceOptions,
   handleChoiceEffect,
@@ -140,7 +141,14 @@ export function createPlayCardCommand(params: PlayCardCommandParams): Command {
 
       const players = [...state.players];
       players[playerIndex] = updatedPlayer;
-      const newState: GameState = { ...state, players, source: updatedSource };
+      let newState: GameState = { ...state, players, source: updatedSource };
+
+      // Check for Mana Curse wounds after mana consumption
+      if (manaSources.length > 0) {
+        for (const manaSource of manaSources) {
+          newState = checkManaCurseWound(newState, params.playerId, manaSource.color);
+        }
+      }
 
       // Snapshot modifiers BEFORE effect resolution for undo
       preEffectModifiersSnapshot = newState.activeModifiers;

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -60,6 +60,10 @@ import {
   EFFECT_CALL_TO_ARMS,
   EFFECT_RESOLVE_CALL_TO_ARMS_UNIT,
   EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY,
+  EFFECT_MANA_CLAIM,
+  EFFECT_RESOLVE_MANA_CLAIM_DIE,
+  EFFECT_RESOLVE_MANA_CLAIM_MODE,
+  EFFECT_MANA_CURSE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -78,6 +82,8 @@ import type {
   ApplyRecruitmentBonusEffect,
   ApplyInteractionBonusEffect,
   ResolveSacrificeEffect,
+  ResolveManaClaimDieEffect,
+  ResolveManaClaimModeEffect,
 } from "../../types/cards.js";
 import type {
   GainMoveEffect,
@@ -426,6 +432,23 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     const e = effect as import("../../types/cards.js").ResolveCallToArmsAbilityEffect;
     return e.abilityDescription;
   },
+
+  [EFFECT_MANA_CLAIM]: () => "Claim a basic color die from the Source",
+
+  [EFFECT_RESOLVE_MANA_CLAIM_DIE]: (effect) => {
+    const e = effect as ResolveManaClaimDieEffect;
+    return `Claim ${e.dieColor} die`;
+  },
+
+  [EFFECT_RESOLVE_MANA_CLAIM_MODE]: (effect) => {
+    const e = effect as ResolveManaClaimModeEffect;
+    if (e.mode === "burst") {
+      return `Gain 3 ${e.color} mana now`;
+    }
+    return `Gain 1 ${e.color} mana each turn`;
+  },
+
+  [EFFECT_MANA_CURSE]: () => "Claim a die and curse its color",
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -46,6 +46,7 @@ import { registerNobleMannersBonusEffects } from "./nobleMannersBonusEffects.js"
 import { registerFreeRecruitEffects } from "./freeRecruitEffects.js";
 import { registerSacrificeEffects } from "./sacrificeEffects.js";
 import { registerCallToArmsEffects } from "./callToArmsEffects.js";
+import { registerManaClaimEffects } from "./manaClaimEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -166,4 +167,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Call to Arms effects (borrow unit ability from offer)
   registerCallToArmsEffects(resolver);
+
+  // Mana Claim / Mana Curse effects (interactive blue spell)
+  registerManaClaimEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -293,6 +293,18 @@ export {
   registerCallToArmsEffects,
 } from "./callToArmsEffects.js";
 
+// Mana Claim / Mana Curse effects (interactive blue spell)
+export {
+  handleManaClaim,
+  resolveManaClaimDie,
+  resolveManaClaimMode,
+  handleManaCurse,
+  checkManaCurseWound,
+  grantManaClaimSustainedToken,
+  resetManaCurseWoundTracking,
+  registerManaClaimEffects,
+} from "./manaClaimEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/manaClaimEffects.ts
+++ b/packages/core/src/engine/effects/manaClaimEffects.ts
@@ -1,0 +1,511 @@
+/**
+ * Mana Claim / Mana Curse effect handlers
+ *
+ * Handles the Mana Claim spell (Blue #110) which:
+ *
+ * Basic (Mana Claim):
+ * - Take a basic color die from Source, keep until end of round
+ * - Choose: 3 tokens now (burst) OR 1 token per turn (sustained)
+ * - After end-of-round announced: does nothing
+ *
+ * Powered (Mana Curse):
+ * - Same die claim and token choice as basic
+ * - Additionally, until end of round other players take a wound
+ *   when using mana of that color (max 1 wound per player per turn)
+ * - After end-of-round announced: only applies to caster (no curse)
+ *
+ * @module effects/manaClaimEffects
+ *
+ * @remarks Resolution Flow
+ * ```
+ * EFFECT_MANA_CLAIM / EFFECT_MANA_CURSE
+ *   └─► Generate die selection options (basic color dice only)
+ *       └─► RESOLVE_MANA_CLAIM_DIE (player picks die)
+ *           └─► Generate mode options (burst vs sustained)
+ *               └─► RESOLVE_MANA_CLAIM_MODE (player picks mode)
+ *                   ├─► burst: Grant 3 tokens immediately
+ *                   └─► sustained: Add round-duration modifier for 1/turn
+ *                   └─► (if curse): Add round-duration curse modifier
+ * ```
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  ManaClaimEffect,
+  ResolveManaClaimDieEffect,
+  ResolveManaClaimModeEffect,
+  ManaCurseEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { BasicManaColor, CardId } from "@mage-knight/shared";
+import {
+  BASIC_MANA_COLORS,
+  MANA_TOKEN_SOURCE_CARD,
+  CARD_MANA_CLAIM,
+  CARD_WOUND,
+} from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_MANA_CLAIM,
+  EFFECT_RESOLVE_MANA_CLAIM_DIE,
+  EFFECT_RESOLVE_MANA_CLAIM_MODE,
+  EFFECT_MANA_CURSE,
+} from "../../types/effectTypes.js";
+import {
+  DURATION_ROUND,
+  SCOPE_SELF,
+  SCOPE_OTHER_PLAYERS,
+  SOURCE_CARD,
+  EFFECT_MANA_CLAIM_SUSTAINED,
+  EFFECT_MANA_CURSE as MODIFIER_MANA_CURSE,
+} from "../../types/modifierConstants.js";
+import { addModifier } from "../modifiers/lifecycle.js";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Check if end-of-round has been announced (or scenario end triggered).
+ */
+function isEndOfRoundAnnounced(state: GameState): boolean {
+  return state.endOfRoundAnnouncedBy !== null || state.scenarioEndTriggered;
+}
+
+/**
+ * Generate die selection options for the player.
+ * Only basic color dice (not taken) are eligible.
+ */
+function generateDieOptions(
+  state: GameState,
+  withCurse: boolean
+): ResolveManaClaimDieEffect[] {
+  const availableDice = state.source.dice.filter(
+    (d) => d.takenByPlayerId === null && BASIC_MANA_COLORS.includes(d.color as BasicManaColor)
+  );
+
+  return availableDice.map((die) => ({
+    type: EFFECT_RESOLVE_MANA_CLAIM_DIE,
+    dieId: die.id,
+    dieColor: die.color,
+    withCurse,
+  }));
+}
+
+// ============================================================================
+// MANA CLAIM (BASIC)
+// ============================================================================
+
+/**
+ * Handle EFFECT_MANA_CLAIM entry point.
+ * Presents player with choice of which basic color die to claim.
+ */
+export function handleManaClaim(
+  state: GameState,
+  _playerId: string,
+  _effect: ManaClaimEffect
+): EffectResolutionResult {
+  // After end-of-round: does nothing
+  if (isEndOfRoundAnnounced(state)) {
+    return {
+      state,
+      description: "Mana Claim has no effect after end of round",
+    };
+  }
+
+  const dieOptions = generateDieOptions(state, false);
+
+  if (dieOptions.length === 0) {
+    return {
+      state,
+      description: "No basic color dice available in the Source",
+    };
+  }
+
+  return {
+    state,
+    description: "Choose a basic color die from the Source to claim",
+    requiresChoice: true,
+    dynamicChoiceOptions: dieOptions,
+  };
+}
+
+// ============================================================================
+// MANA CURSE (POWERED)
+// ============================================================================
+
+/**
+ * Handle EFFECT_MANA_CURSE entry point.
+ * Same as Mana Claim but with curse flag set.
+ */
+export function handleManaCurse(
+  state: GameState,
+  _playerId: string,
+  _effect: ManaCurseEffect
+): EffectResolutionResult {
+  // After end-of-round: only basic effect for caster (no curse)
+  const endOfRound = isEndOfRoundAnnounced(state);
+
+  const dieOptions = generateDieOptions(state, !endOfRound);
+
+  if (dieOptions.length === 0) {
+    return {
+      state,
+      description: "No basic color dice available in the Source",
+    };
+  }
+
+  return {
+    state,
+    description: endOfRound
+      ? "Choose a basic color die from the Source to claim (no curse after end of round)"
+      : "Choose a basic color die from the Source to claim and curse",
+    requiresChoice: true,
+    dynamicChoiceOptions: dieOptions,
+  };
+}
+
+// ============================================================================
+// RESOLVE MANA CLAIM DIE
+// ============================================================================
+
+/**
+ * Player has selected which die to claim.
+ * Present mode choice: burst (3 now) or sustained (1 per turn).
+ */
+export function resolveManaClaimDie(
+  state: GameState,
+  _playerId: string,
+  effect: ResolveManaClaimDieEffect
+): EffectResolutionResult {
+  const { dieId, dieColor, withCurse } = effect;
+
+  // Verify die is still available
+  const die = state.source.dice.find((d) => d.id === dieId);
+  if (!die || die.takenByPlayerId !== null) {
+    return {
+      state,
+      description: "Selected die is no longer available",
+    };
+  }
+
+  // The die color is always a basic color (ensured by generateDieOptions)
+  const color = dieColor as BasicManaColor;
+
+  // Generate mode choice options
+  const modeOptions: ResolveManaClaimModeEffect[] = [
+    {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId,
+      color,
+      mode: "burst",
+      withCurse,
+    },
+    {
+      type: EFFECT_RESOLVE_MANA_CLAIM_MODE,
+      dieId,
+      color,
+      mode: "sustained",
+      withCurse,
+    },
+  ];
+
+  return {
+    state,
+    description: `Claimed ${color} die. Choose: 3 ${color} mana now OR 1 ${color} mana each turn`,
+    requiresChoice: true,
+    dynamicChoiceOptions: modeOptions,
+  };
+}
+
+// ============================================================================
+// RESOLVE MANA CLAIM MODE
+// ============================================================================
+
+/**
+ * Player has chosen burst or sustained mode.
+ * - burst: Grant 3 tokens immediately
+ * - sustained: Add round-duration modifier for 1 token per turn
+ * - If curse: Add round-duration curse modifier
+ */
+export function resolveManaClaimMode(
+  state: GameState,
+  playerId: string,
+  effect: ResolveManaClaimModeEffect
+): EffectResolutionResult {
+  const { dieId, color, mode, withCurse } = effect;
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  // Claim the die: set takenByPlayerId (keeps it out of Source)
+  const dieIndex = state.source.dice.findIndex((d) => d.id === dieId);
+  if (dieIndex === -1) {
+    return {
+      state,
+      description: `Die not found: ${dieId}`,
+    };
+  }
+
+  const originalDie = state.source.dice[dieIndex]!;
+  const updatedDice = [...state.source.dice];
+  updatedDice[dieIndex] = {
+    ...originalDie,
+    color,
+    isDepleted: false,
+    takenByPlayerId: playerId,
+  };
+
+  let currentState: GameState = {
+    ...state,
+    source: {
+      ...state.source,
+      dice: updatedDice,
+    },
+  };
+
+  const descriptions: string[] = [];
+
+  if (mode === "burst") {
+    // Grant 3 tokens immediately
+    const newTokens = Array.from({ length: 3 }, () => ({
+      color,
+      source: MANA_TOKEN_SOURCE_CARD,
+    }));
+
+    const updatedPlayer: Player = {
+      ...player,
+      pureMana: [...player.pureMana, ...newTokens],
+    };
+
+    currentState = updatePlayer(currentState, playerIndex, updatedPlayer);
+    descriptions.push(`Gained 3 ${color} mana tokens`);
+  } else {
+    // Sustained mode: add round-duration modifier for 1 token per turn
+    // Token is NOT granted this turn — starts from next turn
+    currentState = addModifier(currentState, {
+      source: { type: SOURCE_CARD, cardId: CARD_MANA_CLAIM as CardId, playerId },
+      duration: DURATION_ROUND,
+      scope: { type: SCOPE_SELF },
+      effect: {
+        type: EFFECT_MANA_CLAIM_SUSTAINED,
+        color,
+        claimedDieId: dieId,
+      },
+      createdAtRound: currentState.round,
+      createdByPlayerId: playerId,
+    });
+    descriptions.push(`Will gain 1 ${color} mana each turn for remainder of round`);
+  }
+
+  // If curse: add round-duration curse modifier targeting other players
+  if (withCurse) {
+    currentState = addModifier(currentState, {
+      source: { type: SOURCE_CARD, cardId: CARD_MANA_CLAIM as CardId, playerId },
+      duration: DURATION_ROUND,
+      scope: { type: SCOPE_OTHER_PLAYERS },
+      effect: {
+        type: MODIFIER_MANA_CURSE,
+        color,
+        claimedDieId: dieId,
+        woundedPlayerIdsThisTurn: [],
+      },
+      createdAtRound: currentState.round,
+      createdByPlayerId: playerId,
+    });
+    descriptions.push(`Other players take a wound when using ${color} mana`);
+  }
+
+  return {
+    state: currentState,
+    description: descriptions.join(". "),
+  };
+}
+
+// ============================================================================
+// MANA CURSE WOUND CHECK
+// ============================================================================
+
+/**
+ * Check if a player should take a wound from a Mana Curse after using mana.
+ * Called from manaConsumptionHelpers when mana is consumed.
+ *
+ * Returns updated state with wound applied and modifier updated (if triggered).
+ */
+export function checkManaCurseWound(
+  state: GameState,
+  playerId: string,
+  manaColor: string
+): GameState {
+  // Find active Mana Curse modifiers for this color targeting other players
+  const curseModifiers = state.activeModifiers.filter(
+    (m) =>
+      m.effect.type === MODIFIER_MANA_CURSE &&
+      m.effect.color === manaColor &&
+      m.createdByPlayerId !== playerId // Curse doesn't affect caster
+  );
+
+  if (curseModifiers.length === 0) {
+    return state;
+  }
+
+  let currentState = state;
+
+  for (const curseMod of curseModifiers) {
+    const curseEffect = curseMod.effect as import("../../types/modifiers.js").ManaCurseModifier;
+
+    // Check if this player has already been wounded by this curse this turn
+    if (curseEffect.woundedPlayerIdsThisTurn.includes(playerId)) {
+      continue;
+    }
+
+    // Apply wound to the player
+    const playerIndex = currentState.players.findIndex((p) => p.id === playerId);
+    if (playerIndex === -1) continue;
+
+    const player = currentState.players[playerIndex]!;
+    const woundCard: CardId = CARD_WOUND;
+
+    const updatedPlayer: Player = {
+      ...player,
+      hand: [...player.hand, woundCard],
+    };
+
+    const updatedPlayers = [...currentState.players];
+    updatedPlayers[playerIndex] = updatedPlayer;
+
+    // Update wound pile count
+    const newWoundPileCount =
+      currentState.woundPileCount === null
+        ? null
+        : Math.max(0, currentState.woundPileCount - 1);
+
+    // Update the modifier to track this player as wounded this turn
+    const updatedModifiers = currentState.activeModifiers.map((m) =>
+      m.id === curseMod.id
+        ? {
+            ...m,
+            effect: {
+              ...curseEffect,
+              woundedPlayerIdsThisTurn: [
+                ...curseEffect.woundedPlayerIdsThisTurn,
+                playerId,
+              ],
+            },
+          }
+        : m
+    );
+
+    currentState = {
+      ...currentState,
+      players: updatedPlayers,
+      woundPileCount: newWoundPileCount,
+      activeModifiers: updatedModifiers,
+    };
+  }
+
+  return currentState;
+}
+
+/**
+ * Grant sustained Mana Claim token at start of turn.
+ * Called from turn advancement when a player's turn begins.
+ *
+ * Returns updated player with the token added (or unchanged if no modifier).
+ */
+export function grantManaClaimSustainedToken(
+  state: GameState,
+  player: Player
+): Player {
+  // Find active sustained Mana Claim modifiers for this player
+  const sustainedModifiers = state.activeModifiers.filter(
+    (m) =>
+      m.effect.type === EFFECT_MANA_CLAIM_SUSTAINED &&
+      m.createdByPlayerId === player.id
+  );
+
+  if (sustainedModifiers.length === 0) {
+    return player;
+  }
+
+  let updatedPlayer = player;
+
+  for (const mod of sustainedModifiers) {
+    const effect = mod.effect as import("../../types/modifiers.js").ManaClaimSustainedModifier;
+    updatedPlayer = {
+      ...updatedPlayer,
+      pureMana: [
+        ...updatedPlayer.pureMana,
+        { color: effect.color, source: MANA_TOKEN_SOURCE_CARD },
+      ],
+    };
+  }
+
+  return updatedPlayer;
+}
+
+/**
+ * Reset Mana Curse per-turn wound tracking at turn start.
+ * Called when a new turn begins so all players can be wounded again.
+ */
+export function resetManaCurseWoundTracking(state: GameState): GameState {
+  const curseModifiers = state.activeModifiers.filter(
+    (m) => m.effect.type === MODIFIER_MANA_CURSE
+  );
+
+  if (curseModifiers.length === 0) {
+    return state;
+  }
+
+  const updatedModifiers = state.activeModifiers.map((m) => {
+    if (m.effect.type === MODIFIER_MANA_CURSE) {
+      return {
+        ...m,
+        effect: {
+          ...(m.effect as import("../../types/modifiers.js").ManaCurseModifier),
+          woundedPlayerIdsThisTurn: [] as readonly string[],
+        },
+      };
+    }
+    return m;
+  });
+
+  return {
+    ...state,
+    activeModifiers: updatedModifiers,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Mana Claim / Mana Curse effect handlers with the effect registry.
+ */
+export function registerManaClaimEffects(): void {
+  registerEffect(EFFECT_MANA_CLAIM, (state, playerId, effect) => {
+    return handleManaClaim(state, playerId, effect as ManaClaimEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_MANA_CLAIM_DIE, (state, playerId, effect) => {
+    return resolveManaClaimDie(
+      state,
+      playerId,
+      effect as ResolveManaClaimDieEffect
+    );
+  });
+
+  registerEffect(EFFECT_RESOLVE_MANA_CLAIM_MODE, (state, playerId, effect) => {
+    return resolveManaClaimMode(
+      state,
+      playerId,
+      effect as ResolveManaClaimModeEffect
+    );
+  });
+
+  registerEffect(EFFECT_MANA_CURSE, (state, playerId, effect) => {
+    return handleManaCurse(state, playerId, effect as ManaCurseEffect);
+  });
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -95,6 +95,10 @@ import {
   EFFECT_CALL_TO_ARMS,
   EFFECT_RESOLVE_CALL_TO_ARMS_UNIT,
   EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY,
+  EFFECT_MANA_CLAIM,
+  EFFECT_RESOLVE_MANA_CLAIM_DIE,
+  EFFECT_RESOLVE_MANA_CLAIM_MODE,
+  EFFECT_MANA_CURSE,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -804,6 +808,49 @@ export interface ResolveManaRadianceColorEffect {
 }
 
 /**
+ * Mana Claim basic effect (Blue Spell #110).
+ * Take a basic color die from Source, keep until end of round.
+ * Choose: 3 tokens now OR 1 token per turn for remainder of round.
+ */
+export interface ManaClaimEffect {
+  readonly type: typeof EFFECT_MANA_CLAIM;
+}
+
+/**
+ * Internal: Player has selected which die to claim from the Source.
+ * Generates mode choice options (burst vs sustained).
+ */
+export interface ResolveManaClaimDieEffect {
+  readonly type: typeof EFFECT_RESOLVE_MANA_CLAIM_DIE;
+  readonly dieId: SourceDieId;
+  readonly dieColor: ManaColor;
+  /** Whether curse effect should be applied (powered mode) */
+  readonly withCurse: boolean;
+}
+
+/**
+ * Internal: Player has chosen burst or sustained mode for the claimed die.
+ * - burst: Gain 3 tokens of the claimed color immediately
+ * - sustained: Gain 1 token per turn for remainder of round (starting next turn)
+ */
+export interface ResolveManaClaimModeEffect {
+  readonly type: typeof EFFECT_RESOLVE_MANA_CLAIM_MODE;
+  readonly dieId: SourceDieId;
+  readonly color: BasicManaColor;
+  readonly mode: "burst" | "sustained";
+  readonly withCurse: boolean;
+}
+
+/**
+ * Mana Curse powered effect (Blue Spell #110).
+ * Same as Mana Claim basic, plus curse: until end of round, other players
+ * take a wound when using mana of the claimed color (max 1 per player per turn).
+ */
+export interface ManaCurseEffect {
+  readonly type: typeof EFFECT_MANA_CURSE;
+}
+
+/**
  * Scout peek effect (Scouts unit ability).
  * Reveals face-down enemy tokens within a distance from the player.
  * Also creates a ScoutFameBonus modifier tracking which enemies were newly revealed,
@@ -1135,7 +1182,11 @@ export type CardEffect =
   | ResolveSacrificeEffect
   | CallToArmsEffect
   | ResolveCallToArmsUnitEffect
-  | ResolveCallToArmsAbilityEffect;
+  | ResolveCallToArmsAbilityEffect
+  | ManaClaimEffect
+  | ResolveManaClaimDieEffect
+  | ResolveManaClaimModeEffect
+  | ManaCurseEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -198,6 +198,17 @@ export const EFFECT_MANA_RADIANCE = "mana_radiance" as const;
 // Internal: Resolve after color selection
 export const EFFECT_RESOLVE_MANA_RADIANCE_COLOR = "resolve_mana_radiance_color" as const;
 
+// === Mana Claim / Mana Curse Effects ===
+// Basic (Mana Claim): Take a basic color die from Source, keep until end of round.
+// Choose: 3 tokens now OR 1 token per turn for remainder of round.
+export const EFFECT_MANA_CLAIM = "mana_claim" as const;
+// Internal: Player has selected which die to claim
+export const EFFECT_RESOLVE_MANA_CLAIM_DIE = "resolve_mana_claim_die" as const;
+// Internal: Player has chosen burst (3 now) or sustained (1 per turn) mode
+export const EFFECT_RESOLVE_MANA_CLAIM_MODE = "resolve_mana_claim_mode" as const;
+// Powered (Mana Curse): Same as basic + curse effect on other players' mana usage.
+export const EFFECT_MANA_CURSE = "mana_curse" as const;
+
 // === Scout Peek Effect ===
 // Reveals face-down enemy tokens within a distance from the player.
 // Also creates a modifier tracking which enemies were revealed, granting +1 fame on defeat.

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -199,3 +199,14 @@ export const EFFECT_INTERACTION_BONUS = "interaction_bonus" as const;
 // The modifier fires ONCE on the first successful block, then is consumed.
 export const EFFECT_BURNING_SHIELD_ACTIVE = "burning_shield_active" as const;
 
+// === ManaClaimSustainedModifier ===
+// Grants 1 mana token of the claimed color at the start of each turn.
+// Duration: round (expires at end of round when die is returned).
+// Applied by Mana Claim sustained mode.
+export const EFFECT_MANA_CLAIM_SUSTAINED = "mana_claim_sustained" as const;
+
+// === ManaCurseModifier ===
+// When another player uses mana of the cursed color, they take a wound.
+// Max 1 wound per player per turn. Duration: round.
+export const EFFECT_MANA_CURSE = "mana_curse" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -5,9 +5,10 @@
  * This system tracks active modifiers and allows calculations to query effective values.
  */
 
-import type { SkillId, CardId, Terrain, ManaColor, ResistanceType, HexCoord } from "@mage-knight/shared";
+import type { SkillId, CardId, Terrain, ManaColor, BasicManaColor, ResistanceType, HexCoord } from "@mage-knight/shared";
 import type { EnemyAbility } from "./enemy.js";
 import type { DeedCardType } from "./cards.js";
+import type { SourceDieId } from "./mana.js";
 import {
   ABILITY_ANY,
   COMBAT_VALUE_ATTACK,
@@ -46,6 +47,8 @@ import {
   EFFECT_ADD_SIEGE_TO_ATTACKS,
   EFFECT_BURNING_SHIELD_ACTIVE,
   EFFECT_INTERACTION_BONUS,
+  EFFECT_MANA_CLAIM_SUSTAINED,
+  EFFECT_MANA_CURSE,
   ELEMENT_COLD_FIRE,
   ELEMENT_FIRE,
   ELEMENT_ICE,
@@ -357,6 +360,26 @@ export interface InteractionBonusModifier {
   readonly reputation: number;
 }
 
+// Mana Claim sustained token modifier (Mana Claim sustained mode)
+// Grants 1 mana token of the claimed color at the start of each subsequent turn.
+// Duration: round. The claimed die ID is tracked so it can be returned at round end.
+export interface ManaClaimSustainedModifier {
+  readonly type: typeof EFFECT_MANA_CLAIM_SUSTAINED;
+  readonly color: BasicManaColor;
+  readonly claimedDieId: SourceDieId;
+}
+
+// Mana Curse modifier (Mana Curse powered effect)
+// When another player uses mana of the cursed color, they take a wound.
+// Max 1 wound per player per turn from this curse.
+// Tracks which players have already been wounded this turn.
+export interface ManaCurseModifier {
+  readonly type: typeof EFFECT_MANA_CURSE;
+  readonly color: BasicManaColor;
+  readonly claimedDieId: SourceDieId;
+  readonly woundedPlayerIdsThisTurn: readonly string[];
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -385,7 +408,9 @@ export type ModifierEffect =
   | AddSiegeToAttacksModifier
   | BurningShieldActiveModifier
   | UnitRecruitmentBonusModifier
-  | InteractionBonusModifier;
+  | InteractionBonusModifier
+  | ManaClaimSustainedModifier
+  | ManaCurseModifier;
 
 // === Active Modifier (live in game state) ===
 

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -111,6 +111,7 @@ export const CARD_OFFERING = cardId("offering"); // #46 - Gain red crystal + dis
 export const CARD_SNOWSTORM = cardId("snowstorm"); // #15 - Ice Ranged Attack 5 / Siege Ice Attack 8
 export const CARD_CHILL = cardId("chill"); // #13 - Target doesn't attack / defeat
 export const CARD_MIST_FORM = cardId("mist_form"); // #14 - Move with all terrains cost 2 / Unit resistances + wound immunity
+export const CARD_MANA_CLAIM = cardId("mana_claim"); // #110 - Claim die from Source / Curse mana color
 
 // Green spells
 export const CARD_RESTORATION = cardId("restoration"); // #05 - Heal 3 (5 in forest)
@@ -175,6 +176,7 @@ export type SpellCardId =
   | typeof CARD_SNOWSTORM
   | typeof CARD_CHILL
   | typeof CARD_MIST_FORM
+  | typeof CARD_MANA_CLAIM
   // Green spells
   | typeof CARD_RESTORATION
   | typeof CARD_WHIRLWIND
@@ -263,6 +265,7 @@ export const ALL_SPELL_IDS = [
   CARD_SNOWSTORM,
   CARD_CHILL,
   CARD_MIST_FORM,
+  CARD_MANA_CLAIM,
   CARD_RESTORATION,
   CARD_WHIRLWIND,
   CARD_ENERGY_FLOW,


### PR DESCRIPTION
## Summary
- Implement Mana Claim (basic) and Mana Curse (powered) blue spell #110
- Interactive spell with multi-step resolution: die selection → mode choice (burst/sustained)
- Powered effect adds a round-duration curse that wounds opponents using the claimed mana color

## Changes
- Add `CARD_MANA_CLAIM` to shared constants and spell registry
- Add 4 effect types: `EFFECT_MANA_CLAIM`, `EFFECT_RESOLVE_MANA_CLAIM_DIE`, `EFFECT_RESOLVE_MANA_CLAIM_MODE`, `EFFECT_MANA_CURSE`
- Add 2 modifier types: `ManaClaimSustainedModifier` (1 token/turn) and `ManaCurseModifier` (wound on mana use)
- Create `manaClaimEffects.ts` handler module with full resolution flow
- Hook curse wound check into `playCardCommand` and `activateUnitCommand` after mana consumption
- Grant sustained tokens at turn start via `turnAdvancement.ts`
- Reset per-turn curse wound tracking at turn start via `endTurn/index.ts`
- Exclude claimed dice from turn-end safety net cleanup in `diceManagement.ts`
- Round-duration modifiers auto-expire; `processManaReset` naturally rebuilds source

## Test Plan
- 46 tests covering card definition, die selection, burst/sustained modes, curse modifier creation, curse wound application, wound-per-turn limit, sustained token grant, wound tracking reset, effect descriptions, and end-of-round restrictions

Closes #198