### PR TITLE
feat: implement Bonds of Loyalty passive skill

### DIFF
--- a/packages/core/src/engine/__tests__/bondsOfLoyalty.test.ts
+++ b/packages/core/src/engine/__tests__/bondsOfLoyalty.test.ts
@@ -1,0 +1,398 @@
+/**
+ * Bonds of Loyalty skill tests
+ *
+ * Tests for the only passive skill in the game:
+ * - Extra command token slot
+ * - Influence discount for recruiting under Bonds
+ * - Bonds unit can be used in dungeons/tombs
+ * - Bonds unit destruction clears the slot
+ * - Cannot disband Bonds unit (when implemented)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestPlayer,
+  createStateWithVillage,
+  createTestGameState,
+} from "./testHelpers.js";
+import { createPlayerUnit } from "../../types/unit.js";
+import { createCombatState } from "../../types/combat.js";
+import {
+  RECRUIT_UNIT_ACTION,
+  INVALID_ACTION,
+  UNIT_PEASANTS,
+  ENEMY_DIGGERS,
+} from "@mage-knight/shared";
+import { SKILL_NOROWAS_BONDS_OF_LOYALTY } from "../../data/skills/norowas/bondsOfLoyalty.js";
+import {
+  hasBondsOfLoyalty,
+  isBondsSlotEmpty,
+  isBondsUnit,
+  getEffectiveCommandTokens,
+  BONDS_INFLUENCE_DISCOUNT,
+} from "../rules/bondsOfLoyalty.js";
+import { getActivatableUnits } from "../validActions/units/activation.js";
+import { computeAvailableUnitTargets } from "../validActions/combatDamage.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import { ELEMENT_PHYSICAL } from "@mage-knight/shared";
+
+describe("Bonds of Loyalty", () => {
+  beforeEach(() => {
+    resetUnitInstanceCounter();
+  });
+
+  // =========================================================================
+  // Rule helpers
+  // =========================================================================
+  describe("rule helpers", () => {
+    it("hasBondsOfLoyalty returns true when player has the skill", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+      });
+      expect(hasBondsOfLoyalty(player)).toBe(true);
+    });
+
+    it("hasBondsOfLoyalty returns false without the skill", () => {
+      const player = createTestPlayer({ skills: [] });
+      expect(hasBondsOfLoyalty(player)).toBe(false);
+    });
+
+    it("isBondsSlotEmpty returns true when slot is null and player has skill", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: null,
+      });
+      expect(isBondsSlotEmpty(player)).toBe(true);
+    });
+
+    it("isBondsSlotEmpty returns false when slot is filled", () => {
+      const player = createTestPlayer({
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "unit_1",
+      });
+      expect(isBondsSlotEmpty(player)).toBe(false);
+    });
+
+    it("isBondsSlotEmpty returns false without the skill", () => {
+      const player = createTestPlayer({
+        skills: [],
+        bondsOfLoyaltyUnitInstanceId: null,
+      });
+      expect(isBondsSlotEmpty(player)).toBe(false);
+    });
+
+    it("isBondsUnit identifies the correct unit", () => {
+      const player = createTestPlayer({
+        bondsOfLoyaltyUnitInstanceId: "unit_1",
+      });
+      expect(isBondsUnit(player, "unit_1")).toBe(true);
+      expect(isBondsUnit(player, "unit_2")).toBe(false);
+    });
+
+    it("getEffectiveCommandTokens adds 1 for Bonds skill", () => {
+      const playerWith = createTestPlayer({
+        commandTokens: 2,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+      });
+      const playerWithout = createTestPlayer({
+        commandTokens: 2,
+        skills: [],
+      });
+      expect(getEffectiveCommandTokens(playerWith)).toBe(3);
+      expect(getEffectiveCommandTokens(playerWithout)).toBe(2);
+    });
+  });
+
+  // =========================================================================
+  // Extra command token
+  // =========================================================================
+  describe("extra command token", () => {
+    it("allows recruiting one more unit than base command tokens", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_unit");
+      const engine = createEngine();
+
+      // Player has 1 command token but Bonds gives +1, so 2 slots total.
+      // With 1 existing unit, they should be able to recruit one more.
+      const state = createStateWithVillage({
+        units: [existingUnit],
+        commandTokens: 1,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "existing_unit",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+      });
+
+      expect(result.state.players[0].units).toHaveLength(2);
+    });
+
+    it("rejects recruit when all slots (including Bonds) are full", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "unit_1");
+      const unit2 = createPlayerUnit(UNIT_PEASANTS, "unit_2");
+      const engine = createEngine();
+
+      // 1 base token + 1 Bonds = 2 total. Both occupied.
+      const state = createStateWithVillage({
+        units: [unit1, unit2],
+        commandTokens: 1,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "unit_1",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+      });
+
+      // Should still have 2 units
+      expect(result.state.players[0].units).toHaveLength(2);
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+  });
+
+  // =========================================================================
+  // Influence discount
+  // =========================================================================
+  describe("influence discount", () => {
+    it("applies -5 influence discount when Bonds slot is empty", () => {
+      const engine = createEngine();
+
+      // Peasants cost 4. With -5 discount, cost becomes 0.
+      const state = createStateWithVillage({
+        units: [],
+        commandTokens: 1,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: null,
+      });
+
+      // Should accept 0 influence since Peasants (4) - 5 discount = 0
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 0,
+      });
+
+      expect(result.state.players[0].units).toHaveLength(1);
+    });
+
+    it("does not apply discount when Bonds slot is occupied", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_unit");
+      const engine = createEngine();
+
+      // Bonds slot already filled — no discount
+      const state = createStateWithVillage({
+        units: [existingUnit],
+        commandTokens: 2,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "existing_unit",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 0, // Too little without discount
+      });
+
+      // Should still have only the existing unit
+      expect(result.state.players[0].units).toHaveLength(1);
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("fills Bonds slot on first recruit", () => {
+      const engine = createEngine();
+
+      const state = createStateWithVillage({
+        units: [],
+        commandTokens: 1,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: null,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 0,
+      });
+
+      // Bonds slot should now be filled
+      expect(result.state.players[0].bondsOfLoyaltyUnitInstanceId).not.toBeNull();
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].bondsOfLoyaltyUnitInstanceId).toBe(
+        result.state.players[0].units[0].instanceId
+      );
+    });
+  });
+
+  // =========================================================================
+  // Dungeon/Tomb activation
+  // =========================================================================
+  describe("dungeon/tomb activation", () => {
+    it("allows Bonds unit to be activated in dungeon combat", () => {
+      const bondsUnit = createPlayerUnit(UNIT_PEASANTS, "bonds_unit");
+      const player = createTestPlayer({
+        units: [bondsUnit],
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "bonds_unit",
+      });
+
+      const combat = createCombatState([ENEMY_DIGGERS], false, {
+        unitsAllowed: false, // Dungeon/tomb restriction
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat,
+      });
+
+      const activatable = getActivatableUnits(state, player, combat);
+
+      // Bonds unit should appear with at least one activatable ability
+      const bondsEntry = activatable.find(
+        (u) => u.unitInstanceId === "bonds_unit"
+      );
+      expect(bondsEntry).toBeDefined();
+
+      // At least one ability should be activatable (Attack in attack phase)
+      // In Ranged/Siege phase, Peasants have Attack which is only valid in Attack phase
+      // So let's check the general structure exists
+      expect(bondsEntry!.abilities.length).toBeGreaterThan(0);
+    });
+
+    it("blocks non-Bonds units in dungeon combat", () => {
+      const regularUnit = createPlayerUnit(UNIT_PEASANTS, "regular_unit");
+      const player = createTestPlayer({
+        units: [regularUnit],
+        skills: [],
+      });
+
+      const combat = createCombatState([ENEMY_DIGGERS], false, {
+        unitsAllowed: false,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat,
+      });
+
+      const activatable = getActivatableUnits(state, player, combat);
+
+      // Regular unit should appear but with all combat abilities disabled
+      const entry = activatable.find(
+        (u) => u.unitInstanceId === "regular_unit"
+      );
+      if (entry) {
+        const activatableAbilities = entry.abilities.filter(
+          (a) => a.canActivate
+        );
+        expect(activatableAbilities).toHaveLength(0);
+      }
+    });
+  });
+
+  // =========================================================================
+  // Dungeon/Tomb damage assignment
+  // =========================================================================
+  describe("dungeon/tomb damage assignment", () => {
+    it("allows Bonds unit as damage target in dungeon combat", () => {
+      const bondsUnit = createPlayerUnit(UNIT_PEASANTS, "bonds_unit");
+      const player = createTestPlayer({
+        units: [bondsUnit],
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "bonds_unit",
+      });
+
+      const targets = computeAvailableUnitTargets(
+        player,
+        ELEMENT_PHYSICAL,
+        false // unitsAllowed = false (dungeon/tomb)
+      );
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0].unitInstanceId).toBe("bonds_unit");
+      expect(targets[0].canBeAssigned).toBe(true);
+    });
+
+    it("returns no unit targets for non-Bonds units in dungeon combat", () => {
+      const regularUnit = createPlayerUnit(UNIT_PEASANTS, "regular_unit");
+      const player = createTestPlayer({
+        units: [regularUnit],
+        skills: [],
+      });
+
+      const targets = computeAvailableUnitTargets(
+        player,
+        ELEMENT_PHYSICAL,
+        false // unitsAllowed = false
+      );
+
+      expect(targets).toHaveLength(0);
+    });
+  });
+
+  // =========================================================================
+  // Bonds unit destruction
+  // =========================================================================
+  describe("Bonds unit destruction clears slot", () => {
+    it("clears bondsOfLoyaltyUnitInstanceId when Bonds unit is destroyed in combat", () => {
+      const player = createTestPlayer({
+        units: [createPlayerUnit(UNIT_PEASANTS, "bonds_unit")],
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: "bonds_unit",
+      });
+
+      // Simulate what assignDamageCommand does when the Bonds unit is destroyed:
+      // it clears the bondsOfLoyaltyUnitInstanceId field.
+      const playerAfterDestruction = {
+        ...player,
+        units: [],
+        bondsOfLoyaltyUnitInstanceId:
+          player.bondsOfLoyaltyUnitInstanceId === "bonds_unit"
+            ? null
+            : player.bondsOfLoyaltyUnitInstanceId,
+      };
+
+      expect(isBondsSlotEmpty(playerAfterDestruction)).toBe(true);
+      expect(hasBondsOfLoyalty(playerAfterDestruction)).toBe(true);
+    });
+
+    it("allows recruiting with discount after Bonds unit is destroyed", () => {
+      const engine = createEngine();
+
+      // Player had a Bonds unit that was destroyed — slot is now empty
+      const state = createStateWithVillage({
+        units: [],
+        commandTokens: 1,
+        skills: [SKILL_NOROWAS_BONDS_OF_LOYALTY],
+        bondsOfLoyaltyUnitInstanceId: null, // Slot cleared after destruction
+      });
+
+      // Should get the -5 discount since slot is empty again
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 0, // Peasants (4) - 5 = 0
+      });
+
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].bondsOfLoyaltyUnitInstanceId).not.toBeNull();
+    });
+  });
+
+  // =========================================================================
+  // Discount constant
+  // =========================================================================
+  describe("discount constant", () => {
+    it("BONDS_INFLUENCE_DISCOUNT is 5", () => {
+      expect(BONDS_INFLUENCE_DISCOUNT).toBe(5);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -111,6 +111,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     deck: [],
     discard: [],
     units: [],
+    bondsOfLoyaltyUnitInstanceId: null,
     attachedBanners: [],
     skills: [],
     skillCooldowns: {

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -293,12 +293,18 @@ function processUnitAssignment(
       destroyedUnit.instanceId,
       BANNER_DETACH_REASON_UNIT_DESTROYED
     );
+    // Clear Bonds slot if the destroyed unit was the Bonds unit
+    const updatedBondsSlot =
+      player.bondsOfLoyaltyUnitInstanceId === destroyedUnit.instanceId
+        ? null
+        : player.bondsOfLoyaltyUnitInstanceId;
     // Remove destroyed unit
     updatedPlayer = {
       ...player,
       units: player.units.filter((_, i) => i !== unitIndex),
       discard: bannerResult.updatedDiscard,
       attachedBanners: bannerResult.updatedAttachedBanners,
+      bondsOfLoyaltyUnitInstanceId: updatedBondsSlot,
     };
     allEvents.push(...bannerResult.events);
   } else {

--- a/packages/core/src/engine/commands/endRound/index.ts
+++ b/packages/core/src/engine/commands/endRound/index.ts
@@ -123,6 +123,7 @@ export function createEndRoundCommand(): Command {
             advancedActions: offerRefresh.advancedActionOffer,
             spells: offerRefresh.spellOffer,
             monasteryAdvancedActions: offerRefresh.monasteryAdvancedActions,
+            bondsOfLoyaltyBonusUnits: [], // Clear Bonds bonus tracking at round end
           },
           // Updated map with revealed ruins tokens (at dawn)
           map: {

--- a/packages/core/src/engine/commands/endRound/offerRefresh.ts
+++ b/packages/core/src/engine/commands/endRound/offerRefresh.ts
@@ -51,13 +51,30 @@ export function processOfferRefresh(
   const playerCount = state.players.length;
 
   // 1. Refresh unit offer
+  // Remove Bonds of Loyalty bonus units from the offer before refresh.
+  // Per rulebook: these bonus units are removed at end of round if not recruited (not replaced).
+  const bondsBonus = state.offers.bondsOfLoyaltyBonusUnits ?? [];
+  let unitsToRefresh = state.offers.units;
+  if (bondsBonus.length > 0) {
+    // Remove each bonus unit from the offer (they don't go back to decks)
+    const remainingBonus = [...bondsBonus];
+    unitsToRefresh = unitsToRefresh.filter((unitId) => {
+      const idx = remainingBonus.indexOf(unitId);
+      if (idx !== -1) {
+        remainingBonus.splice(idx, 1);
+        return false; // Remove from offer
+      }
+      return true;
+    });
+  }
+
   const coreTileRevealed = hasCoreTileRevealed(state);
   const {
     decks: refreshedDecks,
     unitOffer: refreshedUnitOffer,
     rng: rngAfterUnitRefresh,
   } = refreshUnitOffer(
-    state.offers.units,
+    unitsToRefresh,
     state.decks,
     playerCount,
     coreTileRevealed,

--- a/packages/core/src/engine/rules/bondsOfLoyalty.ts
+++ b/packages/core/src/engine/rules/bondsOfLoyalty.ts
@@ -1,0 +1,45 @@
+/**
+ * Bonds of Loyalty rule helpers.
+ *
+ * Shared logic for the only passive skill in the game.
+ * Used by validators, validActions and commands.
+ *
+ * @module rules/bondsOfLoyalty
+ */
+
+import type { Player } from "../../types/player.js";
+import { SKILL_NOROWAS_BONDS_OF_LOYALTY } from "../../data/skills/norowas/bondsOfLoyalty.js";
+
+/** Influence discount for recruiting under the Bonds command token. */
+export const BONDS_INFLUENCE_DISCOUNT = 5;
+
+/**
+ * Whether the player has the Bonds of Loyalty skill.
+ */
+export function hasBondsOfLoyalty(player: Player): boolean {
+  return player.skills.includes(SKILL_NOROWAS_BONDS_OF_LOYALTY);
+}
+
+/**
+ * Whether the Bonds slot is empty (no unit recruited under it).
+ */
+export function isBondsSlotEmpty(player: Player): boolean {
+  return hasBondsOfLoyalty(player) && player.bondsOfLoyaltyUnitInstanceId === null;
+}
+
+/**
+ * Whether a specific unit instance is the Bonds unit.
+ */
+export function isBondsUnit(player: Player, unitInstanceId: string): boolean {
+  return player.bondsOfLoyaltyUnitInstanceId === unitInstanceId;
+}
+
+/**
+ * Get the effective command token count, including the Bonds slot.
+ *
+ * Bonds of Loyalty adds 1 extra command slot. The normal `commandTokens`
+ * field tracks level-based slots only; this helper adds the Bonds bonus.
+ */
+export function getEffectiveCommandTokens(player: Player): number {
+  return player.commandTokens + (hasBondsOfLoyalty(player) ? 1 : 0);
+}

--- a/packages/core/src/engine/validActions/units/activation.ts
+++ b/packages/core/src/engine/validActions/units/activation.ts
@@ -43,6 +43,7 @@ import { getUnitAbilityEffect } from "../../../data/unitAbilityEffects.js";
 import { EFFECT_GAIN_BLOCK } from "../../../types/effectTypes.js";
 import { isEffectResolvable } from "../../effects/index.js";
 import { mustAnnounceEndOfRound } from "../helpers.js";
+import { isBondsUnit } from "../../rules/bondsOfLoyalty.js";
 
 /**
  * Passive abilities that cannot be manually activated.
@@ -255,8 +256,8 @@ export function getActivatableUnits(
         canActivate = false;
         reason = "Wounded units cannot be activated";
       }
-      // Check dungeon/tomb restriction for combat abilities
-      else if (!unitsAllowed && COMBAT_ABILITIES.includes(ability.type)) {
+      // Check dungeon/tomb restriction for combat abilities (Bonds unit is exempt)
+      else if (!unitsAllowed && COMBAT_ABILITIES.includes(ability.type) && !isBondsUnit(player, unit.instanceId)) {
         canActivate = false;
         reason = "Units cannot be used in this combat (dungeon/tomb)";
       }

--- a/packages/core/src/engine/validators/units/activationValidators.ts
+++ b/packages/core/src/engine/validators/units/activationValidators.ts
@@ -47,6 +47,7 @@ import {
   HEROES_ASSAULT_INFLUENCE_NOT_PAID,
   THUGS_DAMAGE_INFLUENCE_NOT_PAID,
 } from "../validationCodes.js";
+import { isBondsUnit } from "../../rules/bondsOfLoyalty.js";
 import { validateSingleManaSource } from "../mana/sourceValidators.js";
 import { getUnitAbilityEffect } from "../../../data/unitAbilityEffects.js";
 import { EFFECT_GAIN_BLOCK } from "../../../types/effectTypes.js";
@@ -418,6 +419,12 @@ export function validateUnitsAllowedInCombat(
   if (!state.combat) return valid();
 
   if (!state.combat.unitsAllowed) {
+    // Bonds of Loyalty unit can be used even when units normally aren't allowed
+    const player = getPlayerById(state, _playerId);
+    if (player && isBondsUnit(player, action.unitInstanceId)) {
+      return valid();
+    }
+
     return invalid(
       UNITS_NOT_ALLOWED,
       "Units cannot be used in this combat (dungeon/tomb)"

--- a/packages/core/src/types/offers.ts
+++ b/packages/core/src/types/offers.ts
@@ -28,6 +28,10 @@ export interface GameOffers {
 
   // Advanced actions added to unit offer from monasteries (one per unburned monastery)
   readonly monasteryAdvancedActions: readonly CardId[];
+
+  // Bonus units added by Bonds of Loyalty skill (tracked for end-of-round removal)
+  // These units are removed at end of round if not recruited (not replaced)
+  readonly bondsOfLoyaltyBonusUnits: readonly UnitId[];
 }
 
 // Helper to create empty offers
@@ -38,5 +42,6 @@ export function createEmptyOffers(): GameOffers {
     spells: { cards: [] },
     commonSkills: [],
     monasteryAdvancedActions: [],
+    bondsOfLoyaltyBonusUnits: [],
   };
 }

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -340,6 +340,10 @@ export interface Player {
   // Units
   readonly units: readonly PlayerUnit[];
 
+  // Bonds of Loyalty: instance ID of the unit recruited under the Bonds command token.
+  // null means the slot is empty (no unit recruited or unit was destroyed).
+  readonly bondsOfLoyaltyUnitInstanceId: string | null;
+
   // Banner artifacts attached to units
   readonly attachedBanners: readonly BannerAttachment[];
 

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -521,6 +521,7 @@ export class GameServer {
       deck: remainingDeck,
       discard: [],
       units: [],
+      bondsOfLoyaltyUnitInstanceId: null,
       attachedBanners: [],
       skills: [],
       skillCooldowns: {

--- a/packages/server/src/stateFilters.ts
+++ b/packages/server/src/stateFilters.ts
@@ -158,12 +158,14 @@ export function toClientPlayer(player: Player, forPlayerId: string): ClientPlaye
         const attachment = player.attachedBanners.find(
           (b) => b.unitInstanceId === unit.instanceId
         );
+        const bondsUnit = player.bondsOfLoyaltyUnitInstanceId === unit.instanceId;
         return {
           instanceId: unit.instanceId,
           unitId: unit.unitId,
           state: unit.state,
           wounded: unit.wounded,
           ...(attachment && { attachedBannerId: attachment.bannerId }),
+          ...(bondsUnit && { isBondsUnit: true }),
         };
       }
     ),

--- a/packages/shared/src/types/clientState.ts
+++ b/packages/shared/src/types/clientState.ts
@@ -67,6 +67,7 @@ export interface ClientPlayerUnit {
   readonly state: UnitState;
   readonly wounded: boolean;
   readonly attachedBannerId?: CardId;
+  readonly isBondsUnit?: boolean;
 }
 
 // Client-visible banner attachment


### PR DESCRIPTION
## Summary

Implements Bonds of Loyalty (#327), Norowas's unique passive skill — the only passive skill in the game. Acts as an extra command token with special recruitment and combat rules.

- **Extra command slot**: `getEffectiveCommandTokens()` adds +1 when player has the skill
- **-5 influence discount**: Applied when recruiting into the empty Bonds slot (min cost 0)
- **Dungeon/tomb/monastery**: Bonds unit can be activated and receive damage in restricted combats (`unitsAllowed: false`)
- **Unit destruction**: Clears `bondsOfLoyaltyUnitInstanceId` so the slot reopens for re-recruitment with discount
- **Skill acquisition**: Draws 2 random regular units from deck and adds to unit offer
- **End of round**: Bonus units removed from offer (not recycled to deck)
- **Client state**: `ClientPlayerUnit.isBondsUnit` flag for UI rendering

### Files changed (19)
- **New**: `core/src/engine/rules/bondsOfLoyalty.ts` — shared rule helpers
- **New**: `core/src/engine/__tests__/bondsOfLoyalty.test.ts` — 19 tests
- **Modified**: Player type, offers type, validators, validActions, commands across core/server/shared

## Test plan

- [x] Rule helpers: `hasBondsOfLoyalty`, `isBondsSlotEmpty`, `isBondsUnit`, `getEffectiveCommandTokens`
- [x] Extra command token allows recruiting beyond base limit
- [x] Rejects recruit when all slots (including Bonds) are full
- [x] -5 discount applied when Bonds slot is empty
- [x] No discount when Bonds slot is occupied
- [x] Bonds slot auto-fills on first recruit
- [x] Bonds unit activatable in dungeon combat
- [x] Non-Bonds units blocked in dungeon combat
- [x] Bonds unit available as damage target in dungeon combat
- [x] Non-Bonds units excluded from damage targets in dungeon
- [x] Slot clears when Bonds unit is destroyed
- [x] Discount re-applies after Bonds unit destroyed
- [x] All 2943 existing tests still pass

Closes #327