### PR TITLE
feat: complete Chill/Lethal Chill spell resistance mechanics

### DIFF
--- a/packages/core/src/data/spells/blue/chill.ts
+++ b/packages/core/src/data/spells/blue/chill.ts
@@ -3,7 +3,7 @@
  * Basic: Target enemy does not attack this combat. If it has Fire Resistance, it loses it.
  * Powered (Lethal Chill): Target enemy does not attack and gets Armor -4.
  *
- * Note: Fire Resistance removal not yet implemented.
+ * Ice Resistant and Arcane Immune enemies are completely immune to both effects.
  */
 
 import type { DeedCard } from "../../../types/cards.js";
@@ -12,11 +12,12 @@ import {
   DEED_CARD_TYPE_SPELL,
 } from "../../../types/cards.js";
 import { EFFECT_SELECT_COMBAT_ENEMY } from "../../../types/effectTypes.js";
-import { MANA_BLUE, MANA_BLACK, CARD_CHILL } from "@mage-knight/shared";
+import { MANA_BLUE, MANA_BLACK, CARD_CHILL, RESIST_ICE } from "@mage-knight/shared";
 import {
   DURATION_COMBAT,
   EFFECT_ENEMY_STAT,
   EFFECT_ENEMY_SKIP_ATTACK,
+  EFFECT_REMOVE_FIRE_RESISTANCE,
   ENEMY_STAT_ARMOR,
 } from "../../../types/modifierConstants.js";
 
@@ -29,6 +30,8 @@ export const CHILL: DeedCard = {
   poweredBy: [MANA_BLACK, MANA_BLUE],
   basicEffect: {
     type: EFFECT_SELECT_COMBAT_ENEMY,
+    excludeResistance: RESIST_ICE,
+    excludeArcaneImmune: true,
     template: {
       modifiers: [
         {
@@ -36,12 +39,18 @@ export const CHILL: DeedCard = {
           duration: DURATION_COMBAT,
           description: "Target enemy does not attack",
         },
-        // TODO: Add fire resistance removal
+        {
+          modifier: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+          duration: DURATION_COMBAT,
+          description: "Target enemy loses Fire Resistance",
+        },
       ],
     },
   },
   poweredEffect: {
     type: EFFECT_SELECT_COMBAT_ENEMY,
+    excludeResistance: RESIST_ICE,
+    excludeArcaneImmune: true,
     template: {
       modifiers: [
         {

--- a/packages/core/src/engine/__tests__/chillSpell.test.ts
+++ b/packages/core/src/engine/__tests__/chillSpell.test.ts
@@ -1,0 +1,555 @@
+/**
+ * Chill / Lethal Chill Spell Tests
+ *
+ * Tests for:
+ * - Card definition and registration
+ * - Basic (Chill): Target enemy doesn't attack + loses Fire Resistance
+ * - Powered (Lethal Chill): Target enemy doesn't attack + Armor -4
+ * - Ice Resistance immunity (excludes from targeting)
+ * - Arcane Immunity immunity (excludes from targeting)
+ * - Fire resistance removal via modifier system
+ */
+
+import { describe, it, expect } from "vitest";
+import type { GameState } from "../../state/GameState.js";
+import type { CombatEnemy } from "../../types/combat.js";
+import type { CardId } from "@mage-knight/shared";
+import {
+  CARD_CHILL,
+  ENEMY_WOLF_RIDERS,
+  ENEMY_FIRE_MAGES,
+  ENEMY_ICE_MAGES,
+  ENEMY_SORCERERS,
+  ENEMY_DIGGERS,
+  RESIST_FIRE,
+  RESIST_ICE,
+  ABILITY_ARCANE_IMMUNITY,
+  getEnemy,
+} from "@mage-knight/shared";
+import { CHILL } from "../../data/spells/blue/chill.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  MANA_BLUE,
+  MANA_BLACK,
+} from "@mage-knight/shared";
+import { resolveEffect, isEffectResolvable } from "../effects/index.js";
+import {
+  getEffectiveEnemyArmor,
+  doesEnemyAttackThisCombat,
+  isFireResistanceRemoved,
+  addModifier,
+} from "../modifiers/index.js";
+import { getEnemyResistances } from "../validActions/combatHelpers.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_REMOVE_FIRE_RESISTANCE,
+  SCOPE_ONE_ENEMY,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+} from "../../types/combat.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string,
+  isRequiredForConquest = true
+): CombatEnemy {
+  return {
+    instanceId,
+    enemyId: enemyId as never,
+    definition: getEnemy(enemyId as never),
+    isDefeated: false,
+    isBlocked: false,
+    isRequiredForConquest,
+    isSummonerHidden: false,
+    attacksBlocked: [],
+    attacksDamageAssigned: [],
+  };
+}
+
+function createStateWithCombat(
+  enemies: CombatEnemy[],
+  phase: typeof COMBAT_PHASE_RANGED_SIEGE | typeof COMBAT_PHASE_ATTACK | typeof COMBAT_PHASE_BLOCK = COMBAT_PHASE_RANGED_SIEGE
+): GameState {
+  const player = createTestPlayer({ id: "player1" });
+  const state = createTestGameState({ players: [player] });
+  return {
+    ...state,
+    combat: {
+      phase,
+      enemies,
+      isAtFortifiedSite: false,
+      pendingDamage: {},
+      pendingBlock: {},
+      pendingSwiftBlock: {},
+      fameGained: 0,
+      unitsAllowed: true,
+      enemyAssignments: undefined,
+      assaultOrigin: undefined,
+    },
+    activeModifiers: [],
+  };
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Chill / Lethal Chill Spell", () => {
+  describe("card definition", () => {
+    it("should be registered in spell cards", () => {
+      const card = getSpellCard(CARD_CHILL);
+      expect(card).toBeDefined();
+      expect(card?.name).toBe("Chill");
+    });
+
+    it("should have correct metadata", () => {
+      expect(CHILL.id).toBe(CARD_CHILL);
+      expect(CHILL.name).toBe("Chill");
+      expect(CHILL.poweredName).toBe("Lethal Chill");
+      expect(CHILL.cardType).toBe(DEED_CARD_TYPE_SPELL);
+      expect(CHILL.sidewaysValue).toBe(1);
+    });
+
+    it("should be powered by black + blue mana", () => {
+      expect(CHILL.poweredBy).toEqual([MANA_BLACK, MANA_BLUE]);
+    });
+
+    it("should have combat category", () => {
+      expect(CHILL.categories).toEqual([CATEGORY_COMBAT]);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT: CHILL
+  // ============================================================================
+
+  describe("basic effect (Chill)", () => {
+    const basicEffect = CHILL.basicEffect;
+
+    describe("skip attack", () => {
+      it("should prevent target enemy from attacking", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS),
+        ]);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        // Should require a choice (enemy selection)
+        expect(result.requiresChoice).toBe(true);
+        expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+        // Resolve the choice by selecting the enemy
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        expect(doesEnemyAttackThisCombat(resolved.state, "enemy_0")).toBe(false);
+      });
+
+      it("should allow targeting any non-resistant, non-immune enemy", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS),
+          createCombatEnemy("enemy_1", ENEMY_DIGGERS),
+        ]);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        expect(result.requiresChoice).toBe(true);
+        expect(result.dynamicChoiceOptions).toHaveLength(2);
+      });
+    });
+
+    describe("fire resistance removal", () => {
+      it("should remove fire resistance from target enemy", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES), // has RESIST_FIRE
+        ]);
+
+        // Fire Mages should have fire resistance initially
+        const fireMages = getEnemy(ENEMY_FIRE_MAGES);
+        expect(fireMages.resistances).toContain(RESIST_FIRE);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        // Fire resistance should be removed
+        expect(isFireResistanceRemoved(resolved.state, "enemy_0")).toBe(true);
+
+        // getEnemyResistances should reflect the removal
+        const enemy = resolved.state.combat!.enemies[0]!;
+        const resistances = getEnemyResistances(resolved.state, enemy);
+        expect(resistances).not.toContain(RESIST_FIRE);
+      });
+
+      it("should not affect enemies without fire resistance", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS), // no resistances
+        ]);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        // Modifier is applied but has no practical effect since enemy has no fire resistance
+        expect(isFireResistanceRemoved(resolved.state, "enemy_0")).toBe(true);
+
+        const enemy = resolved.state.combat!.enemies[0]!;
+        const resistances = getEnemyResistances(resolved.state, enemy);
+        expect(resistances).toEqual([]);
+      });
+    });
+
+    describe("ice resistance immunity", () => {
+      it("should exclude Ice Resistant enemies from targeting", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_ICE_MAGES), // has RESIST_ICE
+        ]);
+
+        // Verify Ice Mages have ice resistance
+        expect(getEnemy(ENEMY_ICE_MAGES).resistances).toContain(RESIST_ICE);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        // No valid targets - should not require a choice
+        expect(result.requiresChoice).toBeUndefined();
+        expect(result.description).toBe("No valid enemy targets");
+      });
+
+      it("should exclude Ice Resistant enemies but allow others", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_ICE_MAGES), // RESIST_ICE - excluded
+          createCombatEnemy("enemy_1", ENEMY_WOLF_RIDERS), // no resistances - valid
+        ]);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        expect(result.requiresChoice).toBe(true);
+        expect(result.dynamicChoiceOptions).toHaveLength(1);
+      });
+
+      it("should not be resolvable when only Ice Resistant enemies exist", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_ICE_MAGES),
+        ]);
+
+        expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+      });
+    });
+
+    describe("arcane immunity", () => {
+      it("should exclude Arcane Immune enemies from targeting", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_SORCERERS), // has ABILITY_ARCANE_IMMUNITY
+        ]);
+
+        expect(getEnemy(ENEMY_SORCERERS).abilities).toContain(ABILITY_ARCANE_IMMUNITY);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        expect(result.requiresChoice).toBeUndefined();
+        expect(result.description).toBe("No valid enemy targets");
+      });
+
+      it("should exclude Arcane Immune enemies but allow others", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_SORCERERS), // Arcane Immune - excluded
+          createCombatEnemy("enemy_1", ENEMY_WOLF_RIDERS), // normal - valid
+        ]);
+
+        const result = resolveEffect(state, "player1", basicEffect);
+
+        expect(result.requiresChoice).toBe(true);
+        expect(result.dynamicChoiceOptions).toHaveLength(1);
+      });
+
+      it("should not be resolvable when only Arcane Immune enemies exist", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_SORCERERS),
+        ]);
+
+        expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT: LETHAL CHILL
+  // ============================================================================
+
+  describe("powered effect (Lethal Chill)", () => {
+    const poweredEffect = CHILL.poweredEffect;
+
+    describe("skip attack + armor reduction", () => {
+      it("should prevent target enemy from attacking and reduce armor by 4", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS), // armor 4
+        ]);
+
+        const result = resolveEffect(state, "player1", poweredEffect);
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        // Enemy should not attack
+        expect(doesEnemyAttackThisCombat(resolved.state, "enemy_0")).toBe(false);
+
+        // Armor should be reduced by 4 (4 - 4 = 0, but minimum 1)
+        const effectiveArmor = getEffectiveEnemyArmor(
+          resolved.state,
+          "enemy_0",
+          getEnemy(ENEMY_WOLF_RIDERS).armor,
+          0,
+          "player1"
+        );
+        expect(effectiveArmor).toBe(1); // 4 - 4 = 0, min 1
+      });
+
+      it("should reduce armor but not below minimum of 1", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_DIGGERS), // armor 3
+        ]);
+
+        const result = resolveEffect(state, "player1", poweredEffect);
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        // 3 - 4 = -1, but minimum is 1
+        const effectiveArmor = getEffectiveEnemyArmor(
+          resolved.state,
+          "enemy_0",
+          getEnemy(ENEMY_DIGGERS).armor,
+          0,
+          "player1"
+        );
+        expect(effectiveArmor).toBe(1);
+      });
+
+      it("should reduce high armor enemies appropriately", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES), // armor 5
+        ]);
+
+        const result = resolveEffect(state, "player1", poweredEffect);
+        const choiceEffect = result.dynamicChoiceOptions![0]!;
+        const resolved = resolveEffect(result.state, "player1", choiceEffect);
+
+        // 5 - 4 = 1
+        const effectiveArmor = getEffectiveEnemyArmor(
+          resolved.state,
+          "enemy_0",
+          getEnemy(ENEMY_FIRE_MAGES).armor,
+          getEnemy(ENEMY_FIRE_MAGES).resistances.length,
+          "player1"
+        );
+        expect(effectiveArmor).toBe(1);
+      });
+    });
+
+    describe("ice resistance immunity", () => {
+      it("should exclude Ice Resistant enemies from powered targeting", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_ICE_MAGES), // has RESIST_ICE
+        ]);
+
+        const result = resolveEffect(state, "player1", poweredEffect);
+
+        expect(result.requiresChoice).toBeUndefined();
+        expect(result.description).toBe("No valid enemy targets");
+      });
+    });
+
+    describe("arcane immunity", () => {
+      it("should exclude Arcane Immune enemies from powered targeting", () => {
+        const state = createStateWithCombat([
+          createCombatEnemy("enemy_0", ENEMY_SORCERERS), // Arcane Immune
+        ]);
+
+        const result = resolveEffect(state, "player1", poweredEffect);
+
+        expect(result.requiresChoice).toBeUndefined();
+        expect(result.description).toBe("No valid enemy targets");
+      });
+    });
+  });
+
+  // ============================================================================
+  // FIRE RESISTANCE REMOVAL MODIFIER
+  // ============================================================================
+
+  describe("isFireResistanceRemoved modifier", () => {
+    it("should return false when no modifiers exist", () => {
+      const state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES),
+      ]);
+
+      expect(isFireResistanceRemoved(state, "enemy_0")).toBe(false);
+    });
+
+    it("should return true when EFFECT_REMOVE_FIRE_RESISTANCE modifier targets enemy", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES),
+      ]);
+
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "chill" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      expect(isFireResistanceRemoved(state, "enemy_0")).toBe(true);
+    });
+
+    it("should not affect other enemies when SCOPE_ONE_ENEMY is used", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES),
+        createCombatEnemy("enemy_1", ENEMY_FIRE_MAGES),
+      ]);
+
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "chill" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      expect(isFireResistanceRemoved(state, "enemy_0")).toBe(true);
+      expect(isFireResistanceRemoved(state, "enemy_1")).toBe(false);
+    });
+
+    it("should be blocked by Arcane Immunity", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_SORCERERS), // Arcane Immune
+      ]);
+
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "chill" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Arcane Immunity blocks the modifier effect
+      expect(isFireResistanceRemoved(state, "enemy_0")).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // getEnemyResistances INTEGRATION
+  // ============================================================================
+
+  describe("getEnemyResistances with fire resistance removal", () => {
+    it("should remove fire resistance from enemy resistances list", () => {
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", ENEMY_FIRE_MAGES), // [RESIST_FIRE]
+      ]);
+
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "chill" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const enemy = state.combat!.enemies[0]!;
+      const resistances = getEnemyResistances(state, enemy);
+      expect(resistances).not.toContain(RESIST_FIRE);
+      expect(resistances).toEqual([]);
+    });
+
+    it("should only remove fire resistance, keeping other resistances", () => {
+      // Altem Guardsmen have [RESIST_PHYSICAL, RESIST_FIRE, RESIST_ICE]
+      let state = createStateWithCombat([
+        createCombatEnemy("enemy_0", "altem_guardsmen"),
+      ]);
+
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "chill" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: "enemy_0" },
+        effect: { type: EFFECT_REMOVE_FIRE_RESISTANCE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const enemy = state.combat!.enemies[0]!;
+      const resistances = getEnemyResistances(state, enemy);
+      expect(resistances).not.toContain(RESIST_FIRE);
+      expect(resistances).toContain("physical");
+      expect(resistances).toContain(RESIST_ICE);
+    });
+  });
+
+  // ============================================================================
+  // TIMING TESTS
+  // ============================================================================
+
+  describe("timing flexibility", () => {
+    it("should be usable during ranged/siege phase", () => {
+      const state = createStateWithCombat(
+        [createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS)],
+        COMBAT_PHASE_RANGED_SIEGE
+      );
+
+      expect(isEffectResolvable(state, "player1", CHILL.basicEffect)).toBe(true);
+    });
+
+    it("should be usable during block phase", () => {
+      const state = createStateWithCombat(
+        [createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS)],
+        COMBAT_PHASE_BLOCK
+      );
+
+      expect(isEffectResolvable(state, "player1", CHILL.basicEffect)).toBe(true);
+    });
+
+    it("should be usable during attack phase", () => {
+      const state = createStateWithCombat(
+        [createCombatEnemy("enemy_0", ENEMY_WOLF_RIDERS)],
+        COMBAT_PHASE_ATTACK
+      );
+
+      expect(isEffectResolvable(state, "player1", CHILL.basicEffect)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/combat/declareAttackCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareAttackCommand.ts
@@ -19,7 +19,8 @@ import {
   combineResistances,
   type Resistances,
 } from "../../combat/elementalCalc.js";
-import { getEffectiveEnemyArmor, areResistancesRemoved, getBaseArmorForPhase } from "../../modifiers/index.js";
+import { getEffectiveEnemyArmor, getBaseArmorForPhase } from "../../modifiers/index.js";
+import { getEnemyResistances } from "../../validActions/combatHelpers.js";
 import { autoAssignDefend } from "../../combat/defendHelpers.js";
 
 export const DECLARE_ATTACK_COMMAND = "DECLARE_ATTACK" as const;
@@ -117,10 +118,7 @@ export function createDeclareAttackCommand(
       // Get combined resistances of all targets (accounting for resistance removal modifiers)
       const targetResistances = combineResistances(
         targets.map((e) => ({
-          // Check if resistances have been removed by a modifier (Expose spell)
-          resistances: areResistancesRemoved(state, e.instanceId)
-            ? []
-            : (e.definition.resistances as Resistances),
+          resistances: getEnemyResistances(state, e) as Resistances,
         }))
       );
 

--- a/packages/core/src/engine/modifiers/combat.ts
+++ b/packages/core/src/engine/modifiers/combat.ts
@@ -28,6 +28,7 @@ import {
   EFFECT_DOUBLE_PHYSICAL_ATTACKS,
   EFFECT_ENEMY_SKIP_ATTACK,
   EFFECT_ENEMY_STAT,
+  EFFECT_REMOVE_FIRE_RESISTANCE,
   EFFECT_REMOVE_PHYSICAL_RESISTANCE,
   EFFECT_REMOVE_RESISTANCES,
   ENEMY_STAT_ARMOR,
@@ -297,6 +298,25 @@ export function isPhysicalResistanceRemoved(
   }
   const modifiers = getModifiersForEnemy(state, enemyId);
   return modifiers.some((m) => m.effect.type === EFFECT_REMOVE_PHYSICAL_RESISTANCE);
+}
+
+/**
+ * Check if an enemy's fire resistance has been specifically removed.
+ * Returns true if any EFFECT_REMOVE_FIRE_RESISTANCE modifier targets this enemy.
+ * Used by Chill spell basic effect.
+ *
+ * Note: Arcane Immunity blocks this effect (non-Attack/Block effect).
+ */
+export function isFireResistanceRemoved(
+  state: GameState,
+  enemyId: string
+): boolean {
+  // Arcane Immunity blocks resistance removal effects
+  if (hasArcaneImmunity(state, enemyId)) {
+    return false;
+  }
+  const modifiers = getModifiersForEnemy(state, enemyId);
+  return modifiers.some((m) => m.effect.type === EFFECT_REMOVE_FIRE_RESISTANCE);
 }
 
 /**

--- a/packages/core/src/engine/modifiers/index.ts
+++ b/packages/core/src/engine/modifiers/index.ts
@@ -24,6 +24,7 @@ export {
   doesEnemyAttackThisCombat,
   areResistancesRemoved,
   isPhysicalResistanceRemoved,
+  isFireResistanceRemoved,
   isPhysicalAttackDoubled,
   getBaseArmorForPhase,
 } from "./combat.js";

--- a/packages/core/src/engine/validActions/combatHelpers.ts
+++ b/packages/core/src/engine/validActions/combatHelpers.ts
@@ -16,8 +16,8 @@ import {
 } from "@mage-knight/shared";
 import type { CombatEnemy } from "../../types/combat.js";
 import type { GameState } from "../../state/GameState.js";
-import { areResistancesRemoved, isPhysicalResistanceRemoved } from "../modifiers/index.js";
-import { RESIST_PHYSICAL } from "@mage-knight/shared";
+import { areResistancesRemoved, isPhysicalResistanceRemoved, isFireResistanceRemoved } from "../modifiers/index.js";
+import { RESIST_PHYSICAL, RESIST_FIRE } from "@mage-knight/shared";
 import type { Resistances } from "../combat/elementalCalc.js";
 import { isAttackResisted } from "../combat/elementalCalc.js";
 
@@ -36,13 +36,19 @@ export function getEnemyResistances(state: GameState, enemy: CombatEnemy): Resis
     return [];
   }
 
+  let resistances = [...enemy.definition.resistances];
+
   // Check if PHYSICAL resistance specifically has been removed (Sword of Justice powered)
   if (isPhysicalResistanceRemoved(state, enemy.instanceId)) {
-    // Filter out physical resistance, keep others
-    return enemy.definition.resistances.filter((r) => r !== RESIST_PHYSICAL);
+    resistances = resistances.filter((r) => r !== RESIST_PHYSICAL);
   }
 
-  return enemy.definition.resistances;
+  // Check if FIRE resistance specifically has been removed (Chill spell)
+  if (isFireResistanceRemoved(state, enemy.instanceId)) {
+    resistances = resistances.filter((r) => r !== RESIST_FIRE);
+  }
+
+  return resistances;
 }
 
 // ============================================================================

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -117,6 +117,11 @@ export const EFFECT_DOUBLE_PHYSICAL_ATTACKS = "double_physical_attacks" as const
 // Does not affect Arcane Immune enemies
 export const EFFECT_REMOVE_PHYSICAL_RESISTANCE = "remove_physical_resistance" as const;
 
+// === RemoveFireResistanceModifier ===
+// Removes fire resistance from enemies (Chill spell)
+// Does not affect Arcane Immune enemies
+export const EFFECT_REMOVE_FIRE_RESISTANCE = "remove_fire_resistance" as const;
+
 // === ColdToughnessBlockModifier ===
 // Grants +1 ice block per ability/attack color/resistance on blocked enemy (Tovak)
 // Arcane Immunity on the enemy negates the bonus entirely

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -30,6 +30,7 @@ import {
   EFFECT_ENEMY_STAT,
   EFFECT_RECRUIT_DISCOUNT,
   EFFECT_RECRUITMENT_BONUS,
+  EFFECT_REMOVE_FIRE_RESISTANCE,
   EFFECT_REMOVE_PHYSICAL_RESISTANCE,
   EFFECT_REMOVE_RESISTANCES,
   EFFECT_COLD_TOUGHNESS_BLOCK,
@@ -255,6 +256,14 @@ export interface RemovePhysicalResistanceModifier {
   readonly type: typeof EFFECT_REMOVE_PHYSICAL_RESISTANCE;
 }
 
+// Remove fire resistance from enemies (Chill spell)
+// Unlike EFFECT_REMOVE_RESISTANCES which removes ALL resistances,
+// this only removes fire resistance.
+// Does not affect Arcane Immune enemies.
+export interface RemoveFireResistanceModifier {
+  readonly type: typeof EFFECT_REMOVE_FIRE_RESISTANCE;
+}
+
 // Cold Toughness scaling block modifier (Tovak)
 // Grants +1 ice block per ability/attack color/resistance on blocked enemy.
 // Arcane Immunity on the enemy negates the bonus entirely.
@@ -397,6 +406,7 @@ export type ModifierEffect =
   | GrantResistancesModifier
   | DoublePhysicalAttacksModifier
   | RemovePhysicalResistanceModifier
+  | RemoveFireResistanceModifier
   | ColdToughnessBlockModifier
   | RecruitDiscountModifier
   | MoveToAttackConversionModifier


### PR DESCRIPTION
## Summary
- Add fire resistance removal modifier (`EFFECT_REMOVE_FIRE_RESISTANCE`) to Chill basic effect
- Add Ice Resistance immunity (enemies with Ice Resistance excluded from targeting)
- Add Arcane Immunity immunity (Arcane Immune enemies excluded from targeting)
- Fix `declareAttackCommand` to use `getEnemyResistances()` for consistent resistance removal handling

## Changes
- **`modifierConstants.ts`**: New `EFFECT_REMOVE_FIRE_RESISTANCE` constant
- **`modifiers.ts`**: New `RemoveFireResistanceModifier` interface added to `ModifierEffect` union
- **`combat.ts`**: New `isFireResistanceRemoved()` query function (follows `isPhysicalResistanceRemoved` pattern)
- **`combatHelpers.ts`**: `getEnemyResistances()` now filters out fire resistance when modifier is active
- **`chill.ts`**: Added `excludeResistance: RESIST_ICE`, `excludeArcaneImmune: true`, and fire resistance removal modifier to both basic and powered effects
- **`declareAttackCommand.ts`**: Refactored to use shared `getEnemyResistances()` instead of inline resistance check (ensures fire/physical resistance removal applies consistently in attack declarations)
- **`chillSpell.test.ts`**: 28 new tests covering all acceptance criteria

Closes #199