### PR TITLE
feat: implement Banner of Glory artifact card (#212)

### DIFF
--- a/packages/core/src/data/artifacts/bannerOfGlory.ts
+++ b/packages/core/src/data/artifacts/bannerOfGlory.ts
@@ -14,19 +14,65 @@ import {
   CATEGORY_BANNER,
   DEED_CARD_TYPE_ARTIFACT,
 } from "../../types/cards.js";
-import { EFFECT_NOOP } from "../../types/effectTypes.js";
+import { EFFECT_APPLY_MODIFIER, EFFECT_COMPOUND, EFFECT_NOOP } from "../../types/effectTypes.js";
+import {
+  DURATION_TURN,
+  EFFECT_UNIT_ATTACK_BONUS,
+  EFFECT_UNIT_ARMOR_BONUS,
+  EFFECT_UNIT_BLOCK_BONUS,
+  EFFECT_BANNER_GLORY_FAME_TRACKING,
+  SCOPE_ALL_UNITS,
+  SCOPE_SELF,
+} from "../../types/modifierConstants.js";
 import { CARD_BANNER_OF_GLORY, MANA_RED } from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
 
-// TODO: Implement full banner effects (basic/powered) in individual banner tickets
 const BANNER_OF_GLORY: DeedCard = {
   id: CARD_BANNER_OF_GLORY,
   name: "Banner of Glory",
   cardType: DEED_CARD_TYPE_ARTIFACT,
   categories: [CATEGORY_BANNER],
   poweredBy: [MANA_RED],
+  // Basic: assign to unit (handled by banner system, not card effect)
   basicEffect: { type: EFFECT_NOOP },
-  poweredEffect: { type: EFFECT_NOOP },
+  // Powered: all units get Armor +1, +1 attack/block tack-on, Fame +1 per unit that attacks/blocks
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // +1 armor to all units this turn
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: { type: EFFECT_UNIT_ARMOR_BONUS, amount: 1 },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_ALL_UNITS },
+        description: "All units get Armor +1",
+      },
+      // +1 attack to all units this turn (tack-on, requires base attack)
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: { type: EFFECT_UNIT_ATTACK_BONUS, amount: 1 },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_ALL_UNITS },
+        description: "All units get +1 to attacks",
+      },
+      // +1 block to all units this turn (tack-on, requires base block)
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: { type: EFFECT_UNIT_BLOCK_BONUS, amount: 1 },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_ALL_UNITS },
+        description: "All units get +1 to blocks",
+      },
+      // Fame +1 per unit that attacks or blocks this turn (tracked by modifier)
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        description: "Fame +1 per unit that attacks or blocks",
+      },
+    ],
+  },
   sidewaysValue: 0,
   destroyOnPowered: true,
 };

--- a/packages/core/src/engine/__tests__/bannerOfGlory.test.ts
+++ b/packages/core/src/engine/__tests__/bannerOfGlory.test.ts
@@ -1,0 +1,883 @@
+/**
+ * Banner of Glory artifact tests
+ *
+ * Basic Effect (attached to unit):
+ * - Armor +1 to the attached unit
+ * - +1 tack-on to attacks and blocks (requires base ability)
+ * - Fame +1 when attached unit attacks or blocks
+ *
+ * Powered Effect (destroy artifact):
+ * - All units get Armor +1 this turn
+ * - All units get +1 to attacks and blocks (tack-on)
+ * - Fame +1 for each unit that attacks or blocks this turn
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import {
+  createTestPlayer,
+  createTestGameState,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import {
+  CARD_BANNER_OF_GLORY,
+  UNIT_PEASANTS,
+  UNIT_FORESTERS,
+  ACTIVATE_UNIT_ACTION,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import {
+  getEffectiveUnitArmor,
+  getBannerAttackTackOn,
+  getBannerBlockTackOn,
+  shouldBannerGrantFame,
+  unitHasBaseAttack,
+  unitHasBaseBlock,
+} from "../rules/banners.js";
+import { computeAvailableUnitTargets } from "../validActions/combatDamage.js";
+import {
+  COMBAT_PHASE_ATTACK,
+  COMBAT_PHASE_BLOCK,
+} from "../../types/combat.js";
+import { ELEMENT_PHYSICAL } from "@mage-knight/shared";
+import {
+  DURATION_TURN,
+  EFFECT_UNIT_ARMOR_BONUS,
+  EFFECT_UNIT_ATTACK_BONUS,
+  EFFECT_UNIT_BLOCK_BONUS,
+  EFFECT_BANNER_GLORY_FAME_TRACKING,
+  SCOPE_ALL_UNITS,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { getUnitArmorBonus, getUnitBlockBonus, getUnitAttackBonus } from "../modifiers/index.js";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+const TEST_UNIT_1 = "unit_1";
+const TEST_UNIT_2 = "unit_2";
+
+function createPeasantUnit(instanceId: string) {
+  return createPlayerUnit(UNIT_PEASANTS, instanceId);
+}
+
+function createForestersUnit(instanceId: string) {
+  return createPlayerUnit(UNIT_FORESTERS, instanceId);
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Banner of Glory", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // --------------------------------------------------------------------------
+  // Basic Effect: Armor +1
+  // --------------------------------------------------------------------------
+  describe("Basic Effect: Armor +1 (attached)", () => {
+    it("should grant +1 armor to the attached unit", () => {
+      // Peasants base armor = 3
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getEffectiveUnitArmor(player, unit)).toBe(4); // 3 base + 1 banner
+    });
+
+    it("should not affect units without the banner attached", () => {
+      const unit1 = createPeasantUnit(TEST_UNIT_1);
+      const unit2 = createPeasantUnit(TEST_UNIT_2);
+      const player = createTestPlayer({
+        units: [unit1, unit2],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getEffectiveUnitArmor(player, unit1)).toBe(4); // Banner attached
+      expect(getEffectiveUnitArmor(player, unit2)).toBe(3); // No banner
+    });
+
+    it("should show correct armor in damage assignment valid actions", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const targets = computeAvailableUnitTargets(
+        player,
+        ELEMENT_PHYSICAL,
+        true, // unitsAllowed
+      );
+
+      expect(targets).toHaveLength(1);
+      expect(targets[0]!.armor).toBe(4); // 3 base + 1 banner
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Basic Effect: Attack/Block Tack-On
+  // --------------------------------------------------------------------------
+  describe("Basic Effect: Attack/Block Tack-On (attached)", () => {
+    it("should detect base attack ability on Peasants", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      expect(unitHasBaseAttack(unit)).toBe(true);
+    });
+
+    it("should detect base block ability on Peasants", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      expect(unitHasBaseBlock(unit)).toBe(true);
+    });
+
+    it("should detect base block but no base attack on Foresters", () => {
+      const unit = createForestersUnit(TEST_UNIT_1);
+      expect(unitHasBaseAttack(unit)).toBe(false);
+      expect(unitHasBaseBlock(unit)).toBe(true);
+    });
+
+    it("should give +1 attack tack-on when banner is attached to unit with base attack", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getBannerAttackTackOn(player, unit)).toBe(1);
+    });
+
+    it("should give +1 block tack-on when banner is attached to unit with base block", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getBannerBlockTackOn(player, unit)).toBe(1);
+    });
+
+    it("should not give attack tack-on when unit has no base attack (Foresters)", () => {
+      const unit = createForestersUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getBannerAttackTackOn(player, unit)).toBe(0);
+    });
+
+    it("should give block tack-on to Foresters (has base block)", () => {
+      const unit = createForestersUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(getBannerBlockTackOn(player, unit)).toBe(1);
+    });
+
+    it("should return 0 for tack-on when no banner attached", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({ units: [unit] });
+
+      expect(getBannerAttackTackOn(player, unit)).toBe(0);
+      expect(getBannerBlockTackOn(player, unit)).toBe(0);
+    });
+
+    it("should apply +1 attack tack-on when activating unit ability in combat", () => {
+      // Peasants: Attack 2 (ability index 0)
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      // Peasants Attack 2 + 1 banner tack-on = 3
+      expect(result.state.players[0]!.combatAccumulator.attack.normal).toBe(3);
+    });
+
+    it("should apply +1 block tack-on when activating unit block ability in combat", () => {
+      // Peasants: Block 2 (ability index 1)
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 1, // Block 2
+      });
+
+      // Peasants Block 2 + 1 banner tack-on = 3
+      expect(result.state.players[0]!.combatAccumulator.block).toBe(3);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Basic Effect: Fame +1 on Attack/Block
+  // --------------------------------------------------------------------------
+  describe("Basic Effect: Fame +1 on Attack/Block (attached)", () => {
+    it("should detect when banner should grant fame", () => {
+      const player = createTestPlayer({
+        units: [createPeasantUnit(TEST_UNIT_1)],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      expect(shouldBannerGrantFame(player, TEST_UNIT_1)).toBe(true);
+      expect(shouldBannerGrantFame(player, TEST_UNIT_2)).toBe(false);
+    });
+
+    it("should grant +1 fame when attached unit attacks", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+
+    it("should grant +1 fame when attached unit blocks", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 1, // Block 2
+      });
+
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+
+    it("should not grant fame when activating unit without banner", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      expect(result.state.players[0]!.fame).toBe(0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Powered Effect: Armor +1 to All Units (via modifier)
+  // --------------------------------------------------------------------------
+  describe("Powered Effect: Armor +1 to All Units", () => {
+    it("should return armor bonus from active modifier", () => {
+      const state = createTestGameState({
+        activeModifiers: [
+          {
+            id: "mod_test_armor",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_ARMOR_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      expect(getUnitArmorBonus(state, "player1")).toBe(1);
+    });
+
+    it("should show combined armor (banner attached + powered modifier) in valid actions", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+      const state = createTestGameState({
+        players: [player],
+        activeModifiers: [
+          {
+            id: "mod_test_armor",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_ARMOR_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const targets = computeAvailableUnitTargets(
+        player,
+        ELEMENT_PHYSICAL,
+        true,
+        undefined,
+        state,
+        "player1"
+      );
+
+      // Peasants 3 base + 1 banner attached + 1 powered modifier = 5
+      expect(targets[0]!.armor).toBe(5);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Powered Effect: Attack/Block Bonus to All Units (via modifier)
+  // --------------------------------------------------------------------------
+  describe("Powered Effect: Attack/Block Bonus to All Units", () => {
+    it("should return attack bonus from active modifier", () => {
+      const state = createTestGameState({
+        activeModifiers: [
+          {
+            id: "mod_test_attack",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_ATTACK_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      expect(getUnitAttackBonus(state, "player1")).toBe(1);
+    });
+
+    it("should return block bonus from active modifier", () => {
+      const state = createTestGameState({
+        activeModifiers: [
+          {
+            id: "mod_test_block",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_BLOCK_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      expect(getUnitBlockBonus(state, "player1")).toBe(1);
+    });
+
+    it("should apply powered attack bonus when activating unit attack", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_test_attack",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_ATTACK_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      // Peasants Attack 2 + 1 powered bonus = 3
+      expect(result.state.players[0]!.combatAccumulator.attack.normal).toBe(3);
+    });
+
+    it("should apply powered block bonus when activating unit block", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+        activeModifiers: [
+          {
+            id: "mod_test_block",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_BLOCK_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 1, // Block 2
+      });
+
+      // Peasants Block 2 + 1 powered bonus = 3
+      expect(result.state.players[0]!.combatAccumulator.block).toBe(3);
+    });
+
+    it("should stack attached banner and powered bonus", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_test_attack",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_ALL_UNITS },
+            effect: { type: EFFECT_UNIT_ATTACK_BONUS, amount: 1 },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      // Peasants Attack 2 + 1 banner tack-on + 1 powered bonus = 4
+      expect(result.state.players[0]!.combatAccumulator.attack.normal).toBe(4);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Powered Effect: Fame Tracking
+  // --------------------------------------------------------------------------
+  describe("Powered Effect: Fame Tracking (modifier)", () => {
+    it("should grant +1 fame when unit attacks with fame tracking active", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+
+    it("should grant +1 fame when unit blocks with fame tracking active", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 1, // Block 2
+      });
+
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+
+    it("should not grant fame twice for the same unit", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+      });
+
+      // Unit already tracked as awarded
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: {
+              type: EFFECT_BANNER_GLORY_FAME_TRACKING,
+              unitInstanceIdsAwarded: [TEST_UNIT_1],
+            },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0, // Attack 2
+      });
+
+      // No fame because unit was already tracked
+      expect(result.state.players[0]!.fame).toBe(0);
+    });
+
+    it("should track unit instance IDs in the modifier after granting fame", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0,
+      });
+
+      // Find the fame tracking modifier
+      const fameModifier = result.state.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_BANNER_GLORY_FAME_TRACKING
+      );
+      expect(fameModifier).toBeDefined();
+      expect(
+        (fameModifier!.effect as { unitInstanceIdsAwarded: string[] }).unitInstanceIdsAwarded
+      ).toContain(TEST_UNIT_1);
+    });
+
+    it("should stack banner attached fame and powered fame tracking", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 0,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0,
+      });
+
+      // +1 from attached banner + 1 from powered tracking = 2
+      expect(result.state.players[0]!.fame).toBe(2);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Undo
+  // --------------------------------------------------------------------------
+  describe("Undo", () => {
+    it("should undo fame gained from banner attached on unit activation", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 5,
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_GLORY,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+      });
+
+      const afterActivate = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0,
+      });
+
+      expect(afterActivate.state.players[0]!.fame).toBe(6); // +1 fame
+
+      const afterUndo = engine.processAction(afterActivate.state, "player1", {
+        type: "UNDO" as const,
+      });
+
+      expect(afterUndo.state.players[0]!.fame).toBe(5); // Restored
+    });
+
+    it("should undo fame and modifier changes from powered tracking", () => {
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        units: [unit],
+        commandTokens: 1,
+        fame: 5,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_ATTACK),
+        activeModifiers: [
+          {
+            id: "mod_fame_track",
+            source: { type: SOURCE_CARD, cardId: CARD_BANNER_OF_GLORY, playerId: "player1" },
+            duration: DURATION_TURN,
+            scope: { type: SCOPE_SELF },
+            effect: { type: EFFECT_BANNER_GLORY_FAME_TRACKING, unitInstanceIdsAwarded: [] },
+            createdAtRound: 1,
+            createdByPlayerId: "player1",
+          },
+        ],
+      });
+
+      const afterActivate = engine.processAction(state, "player1", {
+        type: ACTIVATE_UNIT_ACTION,
+        unitInstanceId: TEST_UNIT_1,
+        abilityIndex: 0,
+      });
+
+      expect(afterActivate.state.players[0]!.fame).toBe(6);
+
+      const afterUndo = engine.processAction(afterActivate.state, "player1", {
+        type: "UNDO" as const,
+      });
+
+      expect(afterUndo.state.players[0]!.fame).toBe(5);
+      // Modifier should be restored to original (empty tracking)
+      const fameModifier = afterUndo.state.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_BANNER_GLORY_FAME_TRACKING
+      );
+      expect(fameModifier).toBeDefined();
+      expect(
+        (fameModifier!.effect as { unitInstanceIdsAwarded: string[] }).unitInstanceIdsAwarded
+      ).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -280,7 +280,8 @@ function processUnitAssignment(
     attackElement,
     playerId,
     isPoisoned,
-    isParalyzed
+    isParalyzed,
+    player
   );
 
   let updatedPlayer: Player;

--- a/packages/core/src/engine/modifiers/index.ts
+++ b/packages/core/src/engine/modifiers/index.ts
@@ -38,7 +38,14 @@ export {
 } from "./terrain.js";
 
 // Unit effective values
-export { getEffectiveUnitResistances, getUnitAttackBonus, getLeadershipBonusModifier } from "./units.js";
+export {
+  getEffectiveUnitResistances,
+  getUnitAttackBonus,
+  getUnitArmorBonus,
+  getUnitBlockBonus,
+  getBannerGloryFameTracker,
+  getLeadershipBonusModifier,
+} from "./units.js";
 
 // Card values
 export { getEffectiveSidewaysValue, isRuleActive, consumeMovementCardBonus } from "./cardValues.js";

--- a/packages/core/src/engine/rules/banners.ts
+++ b/packages/core/src/engine/rules/banners.ts
@@ -7,7 +7,16 @@
 
 import type { DeedCard } from "../../types/cards.js";
 import type { Player, BannerAttachment } from "../../types/player.js";
+import type { PlayerUnit } from "../../types/unit.js";
 import type { CardId } from "@mage-knight/shared";
+import {
+  CARD_BANNER_OF_GLORY,
+  getUnit,
+  UNIT_ABILITY_ATTACK,
+  UNIT_ABILITY_RANGED_ATTACK,
+  UNIT_ABILITY_SIEGE_ATTACK,
+  UNIT_ABILITY_BLOCK,
+} from "@mage-knight/shared";
 import { DEED_CARD_TYPE_ARTIFACT, CATEGORY_BANNER } from "../../types/cards.js";
 
 /**
@@ -55,4 +64,101 @@ export function markBannerUsed(
   return attachedBanners.map((b) =>
     b.bannerId === bannerId ? { ...b, isUsedThisRound: true } : b
   );
+}
+
+// ============================================================================
+// Banner of Glory: Armor Bonus
+// ============================================================================
+
+/**
+ * Get the effective armor for a unit, including Banner of Glory bonus.
+ * Banner of Glory grants +1 armor while attached to a unit.
+ */
+export function getEffectiveUnitArmor(
+  player: Player,
+  unit: PlayerUnit
+): number {
+  const unitDef = getUnit(unit.unitId);
+  let armor = unitDef.armor;
+
+  const banner = getBannerForUnit(player, unit.instanceId);
+  if (banner && banner.bannerId === CARD_BANNER_OF_GLORY) {
+    armor += 1;
+  }
+
+  return armor;
+}
+
+// ============================================================================
+// Banner of Glory: Attack/Block Tack-On Bonus
+// ============================================================================
+
+/**
+ * Check if a unit has a base attack ability (melee, ranged, or siege).
+ * Used by Banner of Glory tack-on bonus: +1 only applies if unit has base attack.
+ */
+export function unitHasBaseAttack(unit: PlayerUnit): boolean {
+  const unitDef = getUnit(unit.unitId);
+  return unitDef.abilities.some(
+    (a) =>
+      (a.type === UNIT_ABILITY_ATTACK ||
+        a.type === UNIT_ABILITY_RANGED_ATTACK ||
+        a.type === UNIT_ABILITY_SIEGE_ATTACK) &&
+      (a.value ?? 0) > 0
+  );
+}
+
+/**
+ * Check if a unit has a base block ability.
+ * Used by Banner of Glory tack-on bonus: +1 only applies if unit has base block.
+ */
+export function unitHasBaseBlock(unit: PlayerUnit): boolean {
+  const unitDef = getUnit(unit.unitId);
+  return unitDef.abilities.some(
+    (a) => a.type === UNIT_ABILITY_BLOCK && (a.value ?? 0) > 0
+  );
+}
+
+/**
+ * Get the Banner of Glory tack-on bonus for an attack ability.
+ * Returns +1 if the unit has Banner of Glory attached AND has a base attack ability.
+ * Returns 0 otherwise (tack-on bonus requires base value).
+ */
+export function getBannerAttackTackOn(
+  player: Player,
+  unit: PlayerUnit
+): number {
+  const banner = getBannerForUnit(player, unit.instanceId);
+  if (!banner || banner.bannerId !== CARD_BANNER_OF_GLORY) return 0;
+  return unitHasBaseAttack(unit) ? 1 : 0;
+}
+
+/**
+ * Get the Banner of Glory tack-on bonus for a block ability.
+ * Returns +1 if the unit has Banner of Glory attached AND has a base block ability.
+ * Returns 0 otherwise (tack-on bonus requires base value).
+ */
+export function getBannerBlockTackOn(
+  player: Player,
+  unit: PlayerUnit
+): number {
+  const banner = getBannerForUnit(player, unit.instanceId);
+  if (!banner || banner.bannerId !== CARD_BANNER_OF_GLORY) return 0;
+  return unitHasBaseBlock(unit) ? 1 : 0;
+}
+
+// ============================================================================
+// Banner of Glory: Fame on Combat Action
+// ============================================================================
+
+/**
+ * Check if a unit should grant fame when it attacks or blocks,
+ * due to Banner of Glory being attached.
+ */
+export function shouldBannerGrantFame(
+  player: Player,
+  unitInstanceId: string
+): boolean {
+  const banner = getBannerForUnit(player, unitInstanceId);
+  return banner !== undefined && banner.bannerId === CARD_BANNER_OF_GLORY;
 }

--- a/packages/core/src/engine/validActions/combatDamage.ts
+++ b/packages/core/src/engine/validActions/combatDamage.ts
@@ -17,6 +17,8 @@ import type { CombatEnemy } from "../../types/combat.js";
 import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
 import { isBondsUnit } from "../rules/bondsOfLoyalty.js";
+import { getEffectiveUnitArmor } from "../rules/banners.js";
+import { getUnitArmorBonus } from "../modifiers/index.js";
 import {
   getEffectiveEnemyAttack,
   doesEnemyAttackThisCombat,
@@ -55,8 +57,11 @@ export function computeAvailableUnitTargets(
   player: Player,
   attackElement: Element,
   unitsAllowed: boolean,
-  paidThugsDamageInfluence?: Readonly<Record<string, boolean>>
+  paidThugsDamageInfluence?: Readonly<Record<string, boolean>>,
+  state?: GameState,
+  playerId?: string
 ): readonly UnitDamageTarget[] {
+  const modifierArmorBonus = (state && playerId) ? getUnitArmorBonus(state, playerId) : 0;
   // If units are not allowed in this combat (dungeon/tomb), only Bonds unit can be targeted
   if (!unitsAllowed) {
     const bondsUnits = player.units.filter((u) => isBondsUnit(player, u.instanceId));
@@ -74,7 +79,7 @@ export function computeAvailableUnitTargets(
         unitInstanceId: unit.instanceId,
         unitId: unit.unitId,
         unitName: unitDef.name,
-        armor: unitDef.armor,
+        armor: getEffectiveUnitArmor(player, unit) + modifierArmorBonus,
         isResistantToAttack,
         alreadyAssignedThisCombat: unit.usedResistanceThisCombat,
         isWounded: unit.wounded,
@@ -108,7 +113,7 @@ export function computeAvailableUnitTargets(
       unitInstanceId: unit.instanceId,
       unitId: unit.unitId,
       unitName: unitDef.name,
-      armor: unitDef.armor,
+      armor: getEffectiveUnitArmor(player, unit) + modifierArmorBonus,
       isResistantToAttack,
       alreadyAssignedThisCombat: unit.usedResistanceThisCombat,
       isWounded: unit.wounded,
@@ -212,11 +217,11 @@ export function getDamageAssignmentOptions(
         availableUnits = [];
       } else if (redirectUnitId && currentPlayer) {
         // Only the redirect unit is a valid target
-        const allUnits = computeAvailableUnitTargets(currentPlayer, attackElement, combat.unitsAllowed, combat.paidThugsDamageInfluence);
+        const allUnits = computeAvailableUnitTargets(currentPlayer, attackElement, combat.unitsAllowed, combat.paidThugsDamageInfluence, state, currentPlayerId);
         availableUnits = allUnits.filter(u => u.unitInstanceId === redirectUnitId);
       } else {
         availableUnits = currentPlayer
-          ? computeAvailableUnitTargets(currentPlayer, attackElement, combat.unitsAllowed, combat.paidThugsDamageInfluence)
+          ? computeAvailableUnitTargets(currentPlayer, attackElement, combat.unitsAllowed, combat.paidThugsDamageInfluence, state, currentPlayerId)
           : [];
       }
 

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -227,3 +227,18 @@ export const LEADERSHIP_BONUS_BLOCK = "block" as const;
 export const LEADERSHIP_BONUS_ATTACK = "attack" as const;
 export const LEADERSHIP_BONUS_RANGED_ATTACK = "ranged_attack" as const;
 
+// === UnitArmorBonusModifier ===
+// Grants +N armor to all units for the duration.
+// Used by Banner of Glory powered effect.
+export const EFFECT_UNIT_ARMOR_BONUS = "unit_armor_bonus" as const;
+
+// === UnitBlockBonusModifier ===
+// Grants +N to all block values for units (tack-on, requires base block).
+// Used by Banner of Glory powered effect.
+export const EFFECT_UNIT_BLOCK_BONUS = "unit_block_bonus" as const;
+
+// === BannerOfGloryFameTracking ===
+// Tracks fame +1 per unit that attacks or blocks this turn.
+// Used by Banner of Glory powered effect.
+export const EFFECT_BANNER_GLORY_FAME_TRACKING = "banner_glory_fame_tracking" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -42,6 +42,9 @@ import {
   EFFECT_TERRAIN_COST,
   EFFECT_TERRAIN_SAFE,
   EFFECT_UNIT_ATTACK_BONUS,
+  EFFECT_UNIT_ARMOR_BONUS,
+  EFFECT_UNIT_BLOCK_BONUS,
+  EFFECT_BANNER_GLORY_FAME_TRACKING,
   EFFECT_DISEASE_ARMOR,
   EFFECT_CURE_ACTIVE,
   EFFECT_TRANSFORM_ATTACKS_COLD_FIRE,
@@ -409,6 +412,27 @@ export interface LeadershipBonusModifier {
   readonly amount: number;
 }
 
+// Unit armor bonus modifier (Banner of Glory powered)
+// Grants +N armor to all units for the duration.
+export interface UnitArmorBonusModifier {
+  readonly type: typeof EFFECT_UNIT_ARMOR_BONUS;
+  readonly amount: number;
+}
+
+// Unit block bonus modifier (Banner of Glory powered)
+// Grants +N to all block values for units (tack-on, requires base block).
+export interface UnitBlockBonusModifier {
+  readonly type: typeof EFFECT_UNIT_BLOCK_BONUS;
+  readonly amount: number;
+}
+
+// Banner of Glory fame tracking modifier (Banner of Glory powered)
+// Tracks which units have attacked/blocked and awards fame +1 per unit.
+export interface BannerGloryFameTrackingModifier {
+  readonly type: typeof EFFECT_BANNER_GLORY_FAME_TRACKING;
+  readonly unitInstanceIdsAwarded: readonly string[];
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -441,7 +465,10 @@ export type ModifierEffect =
   | InteractionBonusModifier
   | ManaClaimSustainedModifier
   | ManaCurseModifier
-  | LeadershipBonusModifier;
+  | LeadershipBonusModifier
+  | UnitArmorBonusModifier
+  | UnitBlockBonusModifier
+  | BannerGloryFameTrackingModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- Implement Banner of Glory artifact card with both basic (attached) and powered (destroy) modes
- Basic: Armor +1, +1 attack/block tack-on, Fame +1 on attack/block for the attached unit
- Powered: All units get Armor +1, +1 attack/block tack-on this turn, Fame +1 per unit that attacks/blocks

## Changes
- **`bannerOfGlory.ts`** - Card definition with powered compound effect (4 apply_modifier sub-effects)
- **`banners.ts`** - Banner rules: `getEffectiveUnitArmor`, `unitHasBaseAttack/Block`, `getBannerAttackTackOn/BlockTackOn`, `shouldBannerGrantFame`
- **`activateUnitCommand.ts`** - Apply banner tack-on bonuses and fame tracking (both attached and powered modifier)
- **`unitDamageProcessing.ts`** / **`assignDamageCommand.ts`** - Use effective armor with banner bonus
- **`combatDamage.ts`** - Show effective armor in valid actions display
- **`modifierConstants.ts`** / **`modifiers.ts`** - New modifier types: `EFFECT_UNIT_ARMOR_BONUS`, `EFFECT_UNIT_BLOCK_BONUS`, `EFFECT_BANNER_GLORY_FAME_TRACKING`
- **`modifiers/units.ts`** / **`modifiers/index.ts`** - Query functions for new modifier types

## Test Plan
- 31 tests in `bannerOfGlory.test.ts` covering:
  - Basic attached: armor +1, attack/block tack-on, fame on attack/block
  - Tack-on requires base ability (no bonus without base attack/block)
  - Powered: modifier-based armor/attack/block bonuses for all units
  - Powered fame tracking (per-unit, no double-counting)
  - Stacking of attached + powered bonuses
  - Undo restores fame and modifiers

Closes #212