### PR TITLE
feat: implement Mana Bolt / Mana Thunderbolt spell

### DIFF
--- a/packages/core/src/data/spells/blue/index.ts
+++ b/packages/core/src/data/spells/blue/index.ts
@@ -6,12 +6,13 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_SNOWSTORM, CARD_CHILL, CARD_MIST_FORM, CARD_MANA_CLAIM, CARD_SPACE_BENDING } from "@mage-knight/shared";
+import { CARD_SNOWSTORM, CARD_CHILL, CARD_MIST_FORM, CARD_MANA_CLAIM, CARD_SPACE_BENDING, CARD_MANA_BOLT } from "@mage-knight/shared";
 import { SNOWSTORM } from "./snowstorm.js";
 import { CHILL } from "./chill.js";
 import { MIST_FORM } from "./mistForm.js";
 import { MANA_CLAIM } from "./manaClaim.js";
 import { SPACE_BENDING } from "./spaceBending.js";
+import { MANA_BOLT } from "./manaBolt.js";
 
 export const BLUE_SPELLS: Record<CardId, DeedCard> = {
   [CARD_SNOWSTORM]: SNOWSTORM,
@@ -19,6 +20,7 @@ export const BLUE_SPELLS: Record<CardId, DeedCard> = {
   [CARD_MIST_FORM]: MIST_FORM,
   [CARD_MANA_CLAIM]: MANA_CLAIM,
   [CARD_SPACE_BENDING]: SPACE_BENDING,
+  [CARD_MANA_BOLT]: MANA_BOLT,
 };
 
-export { SNOWSTORM, CHILL, MIST_FORM, MANA_CLAIM, SPACE_BENDING };
+export { SNOWSTORM, CHILL, MIST_FORM, MANA_CLAIM, SPACE_BENDING, MANA_BOLT };

--- a/packages/core/src/data/spells/blue/manaBolt.ts
+++ b/packages/core/src/data/spells/blue/manaBolt.ts
@@ -1,0 +1,35 @@
+/**
+ * Mana Bolt / Mana Thunderbolt (Blue Spell)
+ *
+ * Basic (Mana Bolt): Pay a mana token. Attack determined by color:
+ * - Blue → Ice Attack 8
+ * - Red → Cold Fire Attack 7
+ * - White → Ranged Ice Attack 6
+ * - Green → Siege Ice Attack 5
+ *
+ * Powered (Mana Thunderbolt): Pay a mana token. Attack determined by color:
+ * - Blue → Ice Attack 11
+ * - Red → Cold Fire Attack 10
+ * - White → Ranged Ice Attack 9
+ * - Green → Siege Ice Attack 8
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import { EFFECT_MANA_BOLT } from "../../../types/effectTypes.js";
+import { MANA_BLACK, MANA_BLUE, CARD_MANA_BOLT } from "@mage-knight/shared";
+
+export const MANA_BOLT: DeedCard = {
+  id: CARD_MANA_BOLT,
+  name: "Mana Bolt",
+  poweredName: "Mana Thunderbolt",
+  cardType: DEED_CARD_TYPE_SPELL,
+  poweredBy: [MANA_BLACK, MANA_BLUE],
+  categories: [CATEGORY_COMBAT],
+  basicEffect: { type: EFFECT_MANA_BOLT, baseValue: 8 },
+  poweredEffect: { type: EFFECT_MANA_BOLT, baseValue: 11 },
+  sidewaysValue: 1,
+};

--- a/packages/core/src/engine/__tests__/manaBoltSpell.test.ts
+++ b/packages/core/src/engine/__tests__/manaBoltSpell.test.ts
@@ -42,7 +42,8 @@ import {
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
-import { resolveEffect, isEffectResolvable } from "../effects/index.js";
+import { resolveEffect, isEffectResolvable, describeEffect } from "../effects/index.js";
+import { effectHasAttack, effectHasRangedOrSiege } from "../rules/effectDetection/combatEffects.js";
 import {
   createTestGameState,
   createTestPlayer,
@@ -398,6 +399,44 @@ describe("Mana Bolt / Mana Thunderbolt Spell", () => {
       // which is checked by validators. The effect handler also handles gracefully
       // by detecting combat state, but the primary restriction is category-based.
       expect(MANA_BOLT.categories).toContain(CATEGORY_COMBAT);
+    });
+  });
+
+  // ============================================================================
+  // EFFECT DETECTION TESTS
+  // ============================================================================
+
+  describe("Effect Detection", () => {
+    it("should be detected as having attack", () => {
+      expect(effectHasAttack(MANA_BOLT.basicEffect)).toBe(true);
+      expect(effectHasAttack(MANA_BOLT.poweredEffect)).toBe(true);
+    });
+
+    it("should be detected as having ranged or siege", () => {
+      expect(effectHasRangedOrSiege(MANA_BOLT.basicEffect)).toBe(true);
+      expect(effectHasRangedOrSiege(MANA_BOLT.poweredEffect)).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // EFFECT DESCRIPTION TESTS
+  // ============================================================================
+
+  describe("Effect Description", () => {
+    it("should describe basic effect with correct values", () => {
+      const desc = describeEffect(MANA_BOLT.basicEffect);
+      expect(desc).toContain("Ice Attack 8");
+      expect(desc).toContain("ColdFire Attack 7");
+      expect(desc).toContain("Ranged Ice Attack 6");
+      expect(desc).toContain("Siege Ice Attack 5");
+    });
+
+    it("should describe powered effect with correct values", () => {
+      const desc = describeEffect(MANA_BOLT.poweredEffect);
+      expect(desc).toContain("Ice Attack 11");
+      expect(desc).toContain("ColdFire Attack 10");
+      expect(desc).toContain("Ranged Ice Attack 9");
+      expect(desc).toContain("Siege Ice Attack 8");
     });
   });
 });

--- a/packages/core/src/engine/__tests__/manaBoltSpell.test.ts
+++ b/packages/core/src/engine/__tests__/manaBoltSpell.test.ts
@@ -1,0 +1,403 @@
+/**
+ * Mana Bolt / Mana Thunderbolt Spell Tests
+ *
+ * Tests for:
+ * - Card definition and registration
+ * - Basic (Mana Bolt): Pay mana for attack based on color
+ *   Blue → Ice Attack 8, Red → Cold Fire Attack 7, White → Ranged Ice Attack 6, Green → Siege Ice Attack 5
+ * - Powered (Mana Thunderbolt): Higher attack values
+ *   Blue → Ice Attack 11, Red → Cold Fire Attack 10, White → Ranged Ice Attack 9, Green → Siege Ice Attack 8
+ * - Cold Fire element on red mana payment
+ * - Gold mana substitution
+ * - Mandatory mana cost (no options without mana)
+ * - Combat-only playability
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  CARD_MANA_BOLT,
+  MANA_BLACK,
+  MANA_BLUE,
+  MANA_RED,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_GOLD,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  MANA_TOKEN_SOURCE_CARD,
+} from "@mage-knight/shared";
+import { MANA_BOLT } from "../../data/spells/blue/manaBolt.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import type { CompoundEffect, GainAttackEffect, PayManaCostEffect } from "../../types/cards.js";
+import {
+  EFFECT_MANA_BOLT,
+  EFFECT_COMPOUND,
+  EFFECT_PAY_MANA,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_MELEE,
+  COMBAT_TYPE_RANGED,
+  COMBAT_TYPE_SIEGE,
+} from "../../types/effectTypes.js";
+import { resolveEffect, isEffectResolvable } from "../effects/index.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import {
+  COMBAT_PHASE_ATTACK,
+} from "../../types/combat.js";
+import type { ManaToken } from "../../types/mana.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function manaToken(color: string): ManaToken {
+  return { color, source: MANA_TOKEN_SOURCE_CARD } as ManaToken;
+}
+
+function createCombatState(): CombatState {
+  return createUnitCombatState(COMBAT_PHASE_ATTACK);
+}
+
+function createStateInCombat(pureMana: ManaToken[] = []) {
+  return createTestGameState({
+    players: [
+      createTestPlayer({
+        pureMana,
+      }),
+    ],
+    combat: createCombatState(),
+  });
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Mana Bolt / Mana Thunderbolt Spell", () => {
+  describe("Card Definition", () => {
+    it("should be properly defined", () => {
+      expect(MANA_BOLT.id).toBe(CARD_MANA_BOLT);
+      expect(MANA_BOLT.name).toBe("Mana Bolt");
+      expect(MANA_BOLT.poweredName).toBe("Mana Thunderbolt");
+      expect(MANA_BOLT.cardType).toBe(DEED_CARD_TYPE_SPELL);
+      expect(MANA_BOLT.categories).toContain(CATEGORY_COMBAT);
+      expect(MANA_BOLT.poweredBy).toContain(MANA_BLACK);
+      expect(MANA_BOLT.poweredBy).toContain(MANA_BLUE);
+    });
+
+    it("should be registered in spell registry", () => {
+      const card = getSpellCard(CARD_MANA_BOLT);
+      expect(card).toBeDefined();
+      expect(card?.id).toBe(CARD_MANA_BOLT);
+    });
+
+    it("should have correct basic effect", () => {
+      expect(MANA_BOLT.basicEffect).toEqual({
+        type: EFFECT_MANA_BOLT,
+        baseValue: 8,
+      });
+    });
+
+    it("should have correct powered effect", () => {
+      expect(MANA_BOLT.poweredEffect).toEqual({
+        type: EFFECT_MANA_BOLT,
+        baseValue: 11,
+      });
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT TESTS (Mana Bolt)
+  // ============================================================================
+
+  describe("Basic Effect (Mana Bolt)", () => {
+    it("should generate Ice Attack 8 option when player has blue mana", () => {
+      const state = createStateInCombat([manaToken(MANA_BLUE)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const option = result.dynamicChoiceOptions![0] as CompoundEffect;
+      expect(option.type).toBe(EFFECT_COMPOUND);
+
+      const [payEffect, gainEffect] = option.effects;
+      expect((payEffect as PayManaCostEffect).type).toBe(EFFECT_PAY_MANA);
+      expect((payEffect as PayManaCostEffect).colors).toEqual([MANA_BLUE]);
+
+      const attack = gainEffect as GainAttackEffect;
+      expect(attack.type).toBe(EFFECT_GAIN_ATTACK);
+      expect(attack.amount).toBe(8);
+      expect(attack.combatType).toBe(COMBAT_TYPE_MELEE);
+      expect(attack.element).toBe(ELEMENT_ICE);
+    });
+
+    it("should generate Cold Fire Attack 7 option when player has red mana", () => {
+      const state = createStateInCombat([manaToken(MANA_RED)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const option = result.dynamicChoiceOptions![0] as CompoundEffect;
+      const attack = option.effects[1] as GainAttackEffect;
+      expect(attack.amount).toBe(7);
+      expect(attack.combatType).toBe(COMBAT_TYPE_MELEE);
+      expect(attack.element).toBe(ELEMENT_COLD_FIRE);
+    });
+
+    it("should generate Ranged Ice Attack 6 option when player has white mana", () => {
+      const state = createStateInCombat([manaToken(MANA_WHITE)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const option = result.dynamicChoiceOptions![0] as CompoundEffect;
+      const attack = option.effects[1] as GainAttackEffect;
+      expect(attack.amount).toBe(6);
+      expect(attack.combatType).toBe(COMBAT_TYPE_RANGED);
+      expect(attack.element).toBe(ELEMENT_ICE);
+    });
+
+    it("should generate Siege Ice Attack 5 option when player has green mana", () => {
+      const state = createStateInCombat([manaToken(MANA_GREEN)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(1);
+
+      const option = result.dynamicChoiceOptions![0] as CompoundEffect;
+      const attack = option.effects[1] as GainAttackEffect;
+      expect(attack.amount).toBe(5);
+      expect(attack.combatType).toBe(COMBAT_TYPE_SIEGE);
+      expect(attack.element).toBe(ELEMENT_ICE);
+    });
+
+    it("should generate all 4 options when player has all basic mana colors", () => {
+      const state = createStateInCombat([
+        manaToken(MANA_BLUE),
+        manaToken(MANA_RED),
+        manaToken(MANA_WHITE),
+        manaToken(MANA_GREEN),
+      ]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      // Blue → Ice Attack 8
+      const blueOption = result.dynamicChoiceOptions![0] as CompoundEffect;
+      const blueAttack = blueOption.effects[1] as GainAttackEffect;
+      expect(blueAttack.amount).toBe(8);
+      expect(blueAttack.element).toBe(ELEMENT_ICE);
+      expect(blueAttack.combatType).toBe(COMBAT_TYPE_MELEE);
+
+      // Red → Cold Fire Attack 7
+      const redOption = result.dynamicChoiceOptions![1] as CompoundEffect;
+      const redAttack = redOption.effects[1] as GainAttackEffect;
+      expect(redAttack.amount).toBe(7);
+      expect(redAttack.element).toBe(ELEMENT_COLD_FIRE);
+      expect(redAttack.combatType).toBe(COMBAT_TYPE_MELEE);
+
+      // White → Ranged Ice Attack 6
+      const whiteOption = result.dynamicChoiceOptions![2] as CompoundEffect;
+      const whiteAttack = whiteOption.effects[1] as GainAttackEffect;
+      expect(whiteAttack.amount).toBe(6);
+      expect(whiteAttack.combatType).toBe(COMBAT_TYPE_RANGED);
+
+      // Green → Siege Ice Attack 5
+      const greenOption = result.dynamicChoiceOptions![3] as CompoundEffect;
+      const greenAttack = greenOption.effects[1] as GainAttackEffect;
+      expect(greenAttack.amount).toBe(5);
+      expect(greenAttack.combatType).toBe(COMBAT_TYPE_SIEGE);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT TESTS (Mana Thunderbolt)
+  // ============================================================================
+
+  describe("Powered Effect (Mana Thunderbolt)", () => {
+    it("should generate higher attack values than basic", () => {
+      const state = createStateInCombat([
+        manaToken(MANA_BLUE),
+        manaToken(MANA_RED),
+        manaToken(MANA_WHITE),
+        manaToken(MANA_GREEN),
+      ]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.poweredEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      // Blue → Ice Attack 11
+      const blueAttack = (result.dynamicChoiceOptions![0] as CompoundEffect)
+        .effects[1] as GainAttackEffect;
+      expect(blueAttack.amount).toBe(11);
+      expect(blueAttack.element).toBe(ELEMENT_ICE);
+      expect(blueAttack.combatType).toBe(COMBAT_TYPE_MELEE);
+
+      // Red → Cold Fire Attack 10
+      const redAttack = (result.dynamicChoiceOptions![1] as CompoundEffect)
+        .effects[1] as GainAttackEffect;
+      expect(redAttack.amount).toBe(10);
+      expect(redAttack.element).toBe(ELEMENT_COLD_FIRE);
+
+      // White → Ranged Ice Attack 9
+      const whiteAttack = (result.dynamicChoiceOptions![2] as CompoundEffect)
+        .effects[1] as GainAttackEffect;
+      expect(whiteAttack.amount).toBe(9);
+      expect(whiteAttack.combatType).toBe(COMBAT_TYPE_RANGED);
+
+      // Green → Siege Ice Attack 8
+      const greenAttack = (result.dynamicChoiceOptions![3] as CompoundEffect)
+        .effects[1] as GainAttackEffect;
+      expect(greenAttack.amount).toBe(8);
+      expect(greenAttack.combatType).toBe(COMBAT_TYPE_SIEGE);
+    });
+  });
+
+  // ============================================================================
+  // GOLD MANA TESTS
+  // ============================================================================
+
+  describe("Gold Mana Substitution", () => {
+    it("should allow gold mana to substitute for missing basic colors", () => {
+      const state = createStateInCombat([manaToken(MANA_GOLD)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      // Gold should generate 4 options (one for each basic color)
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      // All options should pay gold mana
+      for (const opt of result.dynamicChoiceOptions!) {
+        const compound = opt as CompoundEffect;
+        const pay = compound.effects[0] as PayManaCostEffect;
+        expect(pay.colors).toEqual([MANA_GOLD]);
+      }
+    });
+
+    it("should not duplicate options when player has both basic and gold", () => {
+      const state = createStateInCombat([
+        manaToken(MANA_BLUE),
+        manaToken(MANA_GOLD),
+      ]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      // Blue → pay blue (direct), Red/White/Green → pay gold (substitution)
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      // First option pays blue (direct)
+      const blueOption = result.dynamicChoiceOptions![0] as CompoundEffect;
+      const bluePay = blueOption.effects[0] as PayManaCostEffect;
+      expect(bluePay.colors).toEqual([MANA_BLUE]);
+
+      // Remaining 3 options pay gold (substitution for red, white, green)
+      for (let i = 1; i < 4; i++) {
+        const option = result.dynamicChoiceOptions![i] as CompoundEffect;
+        const pay = option.effects[0] as PayManaCostEffect;
+        expect(pay.colors).toEqual([MANA_GOLD]);
+      }
+    });
+  });
+
+  // ============================================================================
+  // MANDATORY MANA / NO MANA TESTS
+  // ============================================================================
+
+  describe("Mandatory Mana Cost", () => {
+    it("should return no options when player has no mana", () => {
+      const state = createStateInCombat([]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBeUndefined();
+      expect(result.dynamicChoiceOptions).toBeUndefined();
+      expect(result.description).toContain("No mana available");
+    });
+
+    it("should not be resolvable without mana tokens", () => {
+      const state = createStateInCombat([]);
+
+      const resolvable = isEffectResolvable(state, "player1", MANA_BOLT.basicEffect);
+      expect(resolvable).toBe(false);
+    });
+
+    it("should be resolvable with mana tokens", () => {
+      const state = createStateInCombat([manaToken(MANA_BLUE)]);
+
+      const resolvable = isEffectResolvable(state, "player1", MANA_BOLT.basicEffect);
+      expect(resolvable).toBe(true);
+    });
+
+    it("should not count black mana as a valid payment", () => {
+      const state = createStateInCombat([manaToken(MANA_BLACK)]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+
+      expect(result.requiresChoice).toBeUndefined();
+      expect(result.description).toContain("No mana available");
+    });
+  });
+
+  // ============================================================================
+  // COLD FIRE ELEMENT TESTS
+  // ============================================================================
+
+  describe("Cold Fire Element", () => {
+    it("should use Cold Fire element only for red mana payment", () => {
+      const state = createStateInCombat([
+        manaToken(MANA_BLUE),
+        manaToken(MANA_RED),
+        manaToken(MANA_WHITE),
+        manaToken(MANA_GREEN),
+      ]);
+
+      const result = resolveEffect(state, "player1", MANA_BOLT.basicEffect);
+      const options = result.dynamicChoiceOptions!;
+
+      // Blue → Ice (not Cold Fire)
+      expect((((options[0] as CompoundEffect).effects[1]) as GainAttackEffect).element).toBe(ELEMENT_ICE);
+
+      // Red → Cold Fire
+      expect((((options[1] as CompoundEffect).effects[1]) as GainAttackEffect).element).toBe(ELEMENT_COLD_FIRE);
+
+      // White → Ice (not Cold Fire)
+      expect((((options[2] as CompoundEffect).effects[1]) as GainAttackEffect).element).toBe(ELEMENT_ICE);
+
+      // Green → Ice (not Cold Fire)
+      expect((((options[3] as CompoundEffect).effects[1]) as GainAttackEffect).element).toBe(ELEMENT_ICE);
+    });
+  });
+
+  // ============================================================================
+  // COMBAT-ONLY VALIDATION TESTS
+  // ============================================================================
+
+  describe("Combat-Only Restriction", () => {
+    it("should not be resolvable outside combat based on effect detection", () => {
+      // The combat-only restriction is enforced by the card's CATEGORY_COMBAT
+      // which is checked by validators. The effect handler also handles gracefully
+      // by detecting combat state, but the primary restriction is category-based.
+      expect(MANA_BOLT.categories).toContain(CATEGORY_COMBAT);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -64,6 +64,7 @@ import {
   EFFECT_RESOLVE_MANA_CLAIM_DIE,
   EFFECT_RESOLVE_MANA_CLAIM_MODE,
   EFFECT_MANA_CURSE,
+  EFFECT_MANA_BOLT,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -378,6 +379,12 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_PURE_MAGIC]: (effect) => {
     const e = effect as import("../../types/cards.js").PureMagicEffect;
     return `Pay mana: Green=Move ${e.value}, White=Influence ${e.value}, Blue=Block ${e.value}, Red=Attack ${e.value}`;
+  },
+
+  [EFFECT_MANA_BOLT]: (effect) => {
+    const e = effect as import("../../types/cards.js").ManaBoltEffect;
+    const b = e.baseValue;
+    return `Pay mana: Blue=Ice Attack ${b}, Red=ColdFire Attack ${b - 1}, White=Ranged Ice Attack ${b - 2}, Green=Siege Ice Attack ${b - 3}`;
   },
 
   [EFFECT_APPLY_RECRUITMENT_BONUS]: (effect) => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -47,6 +47,7 @@ import { registerFreeRecruitEffects } from "./freeRecruitEffects.js";
 import { registerSacrificeEffects } from "./sacrificeEffects.js";
 import { registerCallToArmsEffects } from "./callToArmsEffects.js";
 import { registerManaClaimEffects } from "./manaClaimEffects.js";
+import { registerManaBoltEffects } from "./manaBoltEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -170,4 +171,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Mana Claim / Mana Curse effects (interactive blue spell)
   registerManaClaimEffects();
+
+  // Mana Bolt effects (blue spell, mana-color-driven attack)
+  registerManaBoltEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -293,6 +293,11 @@ export {
   registerCallToArmsEffects,
 } from "./callToArmsEffects.js";
 
+// Mana Bolt effects (blue spell, mana-color-driven attack)
+export {
+  registerManaBoltEffects,
+} from "./manaBoltEffects.js";
+
 // Mana Claim / Mana Curse effects (interactive blue spell)
 export {
   handleManaClaim,

--- a/packages/core/src/engine/effects/manaBoltEffects.ts
+++ b/packages/core/src/engine/effects/manaBoltEffects.ts
@@ -1,0 +1,193 @@
+/**
+ * Mana Bolt / Mana Thunderbolt Effect Handler
+ *
+ * Generates dynamic choice options where the player pays a basic mana token
+ * and the color determines the attack:
+ * - Blue → Melee Ice Attack
+ * - Red → Melee Cold Fire Attack
+ * - White → Ranged Ice Attack
+ * - Green → Siege Ice Attack
+ *
+ * The handler checks the player's available mana tokens at resolution time
+ * and generates compound effects (pay mana + gain attack) for each viable color.
+ *
+ * @module effects/manaBoltEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { ManaBoltEffect, CardEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_MANA_BOLT,
+  EFFECT_COMPOUND,
+  EFFECT_PAY_MANA,
+  EFFECT_GAIN_ATTACK,
+  COMBAT_TYPE_MELEE,
+  COMBAT_TYPE_RANGED,
+  COMBAT_TYPE_SIEGE,
+} from "../../types/effectTypes.js";
+import {
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_BLUE,
+  MANA_RED,
+  MANA_GOLD,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+} from "@mage-knight/shared";
+import type { ManaColor } from "@mage-knight/shared";
+import { countManaTokens } from "./manaPaymentEffects.js";
+import { canUseGoldAsWild } from "../rules/mana.js";
+
+/**
+ * Handle the EFFECT_MANA_BOLT entry point.
+ *
+ * Generates dynamic choices based on available mana tokens:
+ * - Blue mana → Melee Ice Attack {value}
+ * - Red mana → Melee Cold Fire Attack {value}
+ * - White mana → Ranged Ice Attack {value}
+ * - Green mana → Siege Ice Attack {value}
+ *
+ * Gold mana tokens are wild and can substitute for any basic color.
+ * Only available during combat.
+ */
+function handleManaBolt(
+  state: GameState,
+  playerId: string,
+  effect: ManaBoltEffect
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+  const base = effect.baseValue;
+  const goldIsWild = canUseGoldAsWild(state);
+
+  // Per-color attack values: Blue = base, Red = base-1, White = base-2, Green = base-3
+  const blueValue = base;
+  const redValue = base - 1;
+  const whiteValue = base - 2;
+  const greenValue = base - 3;
+
+  // Check which basic colors the player has tokens for
+  const hasGreen = countManaTokens(player, MANA_GREEN) >= 1;
+  const hasWhite = countManaTokens(player, MANA_WHITE) >= 1;
+  const hasBlue = countManaTokens(player, MANA_BLUE) >= 1;
+  const hasRed = countManaTokens(player, MANA_RED) >= 1;
+  const hasGold = goldIsWild && countManaTokens(player, MANA_GOLD) >= 1;
+
+  const options: CardEffect[] = [];
+
+  // Helper to create a compound option: pay mana + gain attack
+  function addOption(payColor: ManaColor, gainEffect: CardEffect) {
+    options.push({
+      type: EFFECT_COMPOUND,
+      effects: [
+        { type: EFFECT_PAY_MANA, colors: [payColor], amount: 1 },
+        gainEffect,
+      ],
+    });
+  }
+
+  // Blue → Melee Ice Attack (highest value)
+  if (hasBlue) {
+    addOption(MANA_BLUE, {
+      type: EFFECT_GAIN_ATTACK,
+      amount: blueValue,
+      combatType: COMBAT_TYPE_MELEE,
+      element: ELEMENT_ICE,
+    });
+  }
+
+  // Red → Melee Cold Fire Attack
+  if (hasRed) {
+    addOption(MANA_RED, {
+      type: EFFECT_GAIN_ATTACK,
+      amount: redValue,
+      combatType: COMBAT_TYPE_MELEE,
+      element: ELEMENT_COLD_FIRE,
+    });
+  }
+
+  // White → Ranged Ice Attack
+  if (hasWhite) {
+    addOption(MANA_WHITE, {
+      type: EFFECT_GAIN_ATTACK,
+      amount: whiteValue,
+      combatType: COMBAT_TYPE_RANGED,
+      element: ELEMENT_ICE,
+    });
+  }
+
+  // Green → Siege Ice Attack (lowest value)
+  if (hasGreen) {
+    addOption(MANA_GREEN, {
+      type: EFFECT_GAIN_ATTACK,
+      amount: greenValue,
+      combatType: COMBAT_TYPE_SIEGE,
+      element: ELEMENT_ICE,
+    });
+  }
+
+  // Gold is wild — can substitute for any basic color
+  if (hasGold) {
+    if (!hasBlue) {
+      addOption(MANA_GOLD, {
+        type: EFFECT_GAIN_ATTACK,
+        amount: blueValue,
+        combatType: COMBAT_TYPE_MELEE,
+        element: ELEMENT_ICE,
+      });
+    }
+    if (!hasRed) {
+      addOption(MANA_GOLD, {
+        type: EFFECT_GAIN_ATTACK,
+        amount: redValue,
+        combatType: COMBAT_TYPE_MELEE,
+        element: ELEMENT_COLD_FIRE,
+      });
+    }
+    if (!hasWhite) {
+      addOption(MANA_GOLD, {
+        type: EFFECT_GAIN_ATTACK,
+        amount: whiteValue,
+        combatType: COMBAT_TYPE_RANGED,
+        element: ELEMENT_ICE,
+      });
+    }
+    if (!hasGreen) {
+      addOption(MANA_GOLD, {
+        type: EFFECT_GAIN_ATTACK,
+        amount: greenValue,
+        combatType: COMBAT_TYPE_SIEGE,
+        element: ELEMENT_ICE,
+      });
+    }
+  }
+
+  if (options.length === 0) {
+    return {
+      state,
+      description: "No mana available to pay for Mana Bolt",
+    };
+  }
+
+  return {
+    state,
+    description: "Choose mana color to pay for Mana Bolt",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Mana Bolt effect handlers with the effect registry.
+ */
+export function registerManaBoltEffects(): void {
+  registerEffect(EFFECT_MANA_BOLT, (state, playerId, effect) => {
+    return handleManaBolt(state, playerId, effect as ManaBoltEffect);
+  });
+}

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -95,6 +95,7 @@ import {
   EFFECT_CALL_TO_ARMS,
   EFFECT_RESOLVE_CALL_TO_ARMS_UNIT,
   EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY,
+  EFFECT_MANA_BOLT,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -484,6 +485,14 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   // Call to Arms unit/ability resolution steps are always resolvable
   [EFFECT_RESOLVE_CALL_TO_ARMS_UNIT]: () => true,
   [EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY]: () => true,
+
+  // Mana Bolt is resolvable if the player has any basic or gold mana tokens
+  [EFFECT_MANA_BOLT]: (state, player) => {
+    const basicColors = [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE];
+    return player.pureMana.some(
+      (token) => basicColors.includes(token.color as typeof MANA_RED) || token.color === "gold"
+    );
+  },
 };
 
 // ============================================================================

--- a/packages/core/src/engine/rules/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/combatEffects.ts
@@ -15,6 +15,7 @@ import {
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
   EFFECT_PURE_MAGIC,
+  EFFECT_MANA_BOLT,
 } from "../../../types/effectTypes.js";
 import {
   COMBAT_TYPE_RANGED,
@@ -30,6 +31,9 @@ export function effectHasRangedOrSiege(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
       return effect.combatType === COMBAT_TYPE_RANGED || effect.combatType === COMBAT_TYPE_SIEGE;
+
+    case EFFECT_MANA_BOLT: // Mana Bolt can provide Ranged (white) or Siege (green)
+      return true;
 
     case EFFECT_CHOICE:
       return effect.options.some(opt => effectHasRangedOrSiege(opt));
@@ -173,6 +177,7 @@ export function effectHasAttack(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
     case EFFECT_PURE_MAGIC: // Pure Magic can provide Attack (via red mana)
+    case EFFECT_MANA_BOLT: // Mana Bolt always provides Attack (all colors → attack)
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -99,6 +99,7 @@ import {
   EFFECT_RESOLVE_MANA_CLAIM_DIE,
   EFFECT_RESOLVE_MANA_CLAIM_MODE,
   EFFECT_MANA_CURSE,
+  EFFECT_MANA_BOLT,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1048,6 +1049,18 @@ export interface PureMagicEffect {
 }
 
 /**
+ * Mana Bolt mana-payment-driven combat effect.
+ * Player pays 1 basic mana token and the color determines the attack:
+ * Blue → Melee Ice Attack (baseValue), Red → Melee Cold Fire Attack (baseValue - 1),
+ * White → Ranged Ice Attack (baseValue - 2), Green → Siege Ice Attack (baseValue - 3).
+ * Combat only. baseValue differs between basic (8) and powered (11) modes.
+ */
+export interface ManaBoltEffect {
+  readonly type: typeof EFFECT_MANA_BOLT;
+  readonly baseValue: number;
+}
+
+/**
  * Free recruit effect entry point.
  * Presents the units offer for the player to pick a unit for free.
  * No location restrictions (works anywhere, even in combat).
@@ -1197,6 +1210,7 @@ export type CardEffect =
   | ResolveManaRadianceColorEffect
   | AltemMagesColdFireEffect
   | PureMagicEffect
+  | ManaBoltEffect
   | ApplyRecruitmentBonusEffect
   | ApplyInteractionBonusEffect
   | FreeRecruitEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -228,6 +228,13 @@ export const EFFECT_ALTEM_MAGES_COLD_FIRE = "altem_mages_cold_fire" as const;
 // Values differ between basic (4) and powered (7) modes.
 export const EFFECT_PURE_MAGIC = "pure_magic" as const;
 
+// === Mana Bolt Effect ===
+// Pay a basic mana token → attack determined by color paid:
+// Blue → Melee Ice Attack, Red → Melee Cold Fire Attack,
+// White → Ranged Ice Attack, Green → Siege Ice Attack.
+// Combat only. Values differ between basic and powered modes.
+export const EFFECT_MANA_BOLT = "mana_bolt" as const;
+
 // === Recruitment Bonus Effect ===
 // Adds a turn-scoped modifier that grants reputation and/or fame per unit recruited.
 // Used by Heroic Tale (basic: Rep+1 per recruit, powered: Rep+1 + Fame+1 per recruit).

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -113,6 +113,7 @@ export const CARD_CHILL = cardId("chill"); // #13 - Target doesn't attack / defe
 export const CARD_MIST_FORM = cardId("mist_form"); // #14 - Move with all terrains cost 2 / Unit resistances + wound immunity
 export const CARD_MANA_CLAIM = cardId("mana_claim"); // #110 - Claim die from Source / Curse mana color
 export const CARD_SPACE_BENDING = cardId("space_bending"); // #16 - Distance-2 movement / Extra turn
+export const CARD_MANA_BOLT = cardId("mana_bolt"); // #203 - Pay mana: Blue→Ice, Red→ColdFire, White→Ranged Ice, Green→Siege Ice
 
 // Green spells
 export const CARD_RESTORATION = cardId("restoration"); // #05 - Heal 3 (5 in forest)
@@ -179,6 +180,7 @@ export type SpellCardId =
   | typeof CARD_MIST_FORM
   | typeof CARD_MANA_CLAIM
   | typeof CARD_SPACE_BENDING
+  | typeof CARD_MANA_BOLT
   // Green spells
   | typeof CARD_RESTORATION
   | typeof CARD_WHIRLWIND
@@ -269,6 +271,7 @@ export const ALL_SPELL_IDS = [
   CARD_MIST_FORM,
   CARD_MANA_CLAIM,
   CARD_SPACE_BENDING,
+  CARD_MANA_BOLT,
   CARD_RESTORATION,
   CARD_WHIRLWIND,
   CARD_ENERGY_FLOW,


### PR DESCRIPTION
## Summary
- Implement the Mana Bolt / Mana Thunderbolt blue spell (#203)
- Player pays a basic mana token; color determines attack type and value
- Uses the Pure Magic dynamic choice pattern for mana-color-driven effects

## Changes
- Add `CARD_MANA_BOLT` to shared constants and spell ID arrays
- Add `EFFECT_MANA_BOLT` effect type with `ManaBoltEffect` interface
- Create spell card definition (Blue spell, powered by Black + Blue)
- Implement effect handler with per-color attack generation:
  - Blue → Melee Ice Attack (8/11)
  - Red → Melee Cold Fire Attack (7/10)
  - White → Ranged Ice Attack (6/9)
  - Green → Siege Ice Attack (5/8)
- Register effect in effect registry and spell registry
- Add effect detection for combat phase validation (attack, ranged/siege)
- Add resolvability check (needs basic or gold mana tokens)
- Add effect description for UI display
- Gold mana wildcard support (substitutes for missing basic colors)
- 18 tests covering all acceptance criteria

## Acceptance Criteria
- [x] Add `CARD_MANA_BOLT` to shared constants
- [x] Effect requires mana payment choice (blue/red/white/green)
- [x] Basic: Attack values per color (8/7/6/5)
- [x] Powered: Higher attack values per color (11/10/9/8)
- [x] Cold Fire element handling (red mana → Cold Fire)
- [x] Combat-only playability validation (CATEGORY_COMBAT)
- [x] Mandatory mana cost (cannot skip — no options without mana)

Closes #203