### PR TITLE
feat: implement Mind Read / Mind Steal spell (#204)

### DIFF
--- a/packages/core/src/data/spells/white/index.ts
+++ b/packages/core/src/data/spells/white/index.ts
@@ -6,17 +6,19 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_WHIRLWIND, CARD_EXPOSE, CARD_CURE, CARD_CALL_TO_ARMS } from "@mage-knight/shared";
+import { CARD_WHIRLWIND, CARD_EXPOSE, CARD_CURE, CARD_CALL_TO_ARMS, CARD_MIND_READ } from "@mage-knight/shared";
 import { WHIRLWIND } from "./whirlwind.js";
 import { EXPOSE } from "./expose.js";
 import { CURE } from "./cure.js";
 import { CALL_TO_ARMS } from "./callToArms.js";
+import { MIND_READ } from "./mindRead.js";
 
 export const WHITE_SPELLS: Record<CardId, DeedCard> = {
   [CARD_WHIRLWIND]: WHIRLWIND,
   [CARD_EXPOSE]: EXPOSE,
   [CARD_CURE]: CURE,
   [CARD_CALL_TO_ARMS]: CALL_TO_ARMS,
+  [CARD_MIND_READ]: MIND_READ,
 };
 
-export { WHIRLWIND, EXPOSE, CURE, CALL_TO_ARMS };
+export { WHIRLWIND, EXPOSE, CURE, CALL_TO_ARMS, MIND_READ };

--- a/packages/core/src/data/spells/white/mindRead.ts
+++ b/packages/core/src/data/spells/white/mindRead.ts
@@ -1,0 +1,42 @@
+/**
+ * Mind Read / Mind Steal (White Spell #111)
+ *
+ * Basic (Mind Read): Choose a color. Gain a crystal of the chosen color.
+ * Each other player must discard a Spell or Action card of that color from
+ * their hand, or reveal their hand to show they have none.
+ *
+ * Powered (Mind Steal): Same as basic. In addition, you may permanently
+ * steal one of the Action cards (NOT Spells) discarded this way and put
+ * it into your hand.
+ *
+ * Interactive spell — removed in friendly game mode since it directly
+ * affects other players' hands.
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_SPELL,
+} from "../../../types/cards.js";
+import { MANA_WHITE, MANA_BLACK, CARD_MIND_READ } from "@mage-knight/shared";
+import {
+  EFFECT_MIND_READ,
+  EFFECT_MIND_STEAL,
+} from "../../../types/effectTypes.js";
+
+export const MIND_READ: DeedCard = {
+  id: CARD_MIND_READ,
+  name: "Mind Read",
+  poweredName: "Mind Steal",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [CATEGORY_SPECIAL],
+  poweredBy: [MANA_BLACK, MANA_WHITE],
+  basicEffect: {
+    type: EFFECT_MIND_READ,
+  },
+  poweredEffect: {
+    type: EFFECT_MIND_STEAL,
+  },
+  sidewaysValue: 1,
+  interactive: true,
+};

--- a/packages/core/src/engine/__tests__/mindReadSpell.test.ts
+++ b/packages/core/src/engine/__tests__/mindReadSpell.test.ts
@@ -1,0 +1,703 @@
+/**
+ * Tests for the Mind Read / Mind Steal spell (White Spell #111)
+ *
+ * Basic (Mind Read): Choose a color. Gain a crystal of the chosen color.
+ * Each other player must discard a Spell or Action card of that color from
+ * their hand, or reveal their hand to show they have none.
+ *
+ * Powered (Mind Steal): Same as basic. In addition, you may permanently
+ * steal one of the Action cards (NOT Spells) discarded this way.
+ *
+ * Key rules:
+ * - Special category (both effects)
+ * - Interactive: removed in friendly game mode
+ * - End-of-round: opponents not affected
+ * - Steal: Only Action cards (not Spells)
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type {
+  MindReadEffect,
+  ResolveMindReadColorEffect,
+  MindStealEffect,
+  ResolveMindStealColorEffect,
+  ResolveMindStealSelectionEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_SPELL,
+} from "../../types/cards.js";
+import {
+  EFFECT_MIND_READ,
+  EFFECT_RESOLVE_MIND_READ_COLOR,
+  EFFECT_MIND_STEAL,
+  EFFECT_RESOLVE_MIND_STEAL_COLOR,
+  EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+} from "../../types/effectTypes.js";
+import {
+  CARD_MIND_READ,
+  CARD_WOUND,
+  CARD_RAGE,
+  CARD_MARCH,
+  CARD_FIREBALL,
+  CARD_SNOWSTORM,
+  CARD_TRANQUILITY,
+  CARD_PROMISE,
+  MANA_BLACK,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import { MIND_READ } from "../../data/spells/white/mindRead.js";
+import { getSpellCard } from "../../data/spells/index.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createMultiplayerState(
+  casterCrystals = { red: 0, blue: 0, green: 0, white: 0 },
+  opponentHand: CardId[] = [],
+  opponentCrystals = { red: 0, blue: 0, green: 0, white: 0 }
+): GameState {
+  const caster = createTestPlayer({
+    id: "caster",
+    crystals: casterCrystals,
+  });
+  const opponent = createTestPlayer({
+    id: "opponent",
+    hand: opponentHand,
+    crystals: opponentCrystals,
+    position: { q: 1, r: 0 },
+  });
+
+  return createTestGameState({
+    players: [caster, opponent],
+    turnOrder: ["caster", "opponent"],
+  });
+}
+
+function createThreePlayerState(
+  opponent1Hand: CardId[] = [],
+  opponent2Hand: CardId[] = []
+): GameState {
+  const caster = createTestPlayer({
+    id: "caster",
+  });
+  const opponent1 = createTestPlayer({
+    id: "opponent1",
+    hand: opponent1Hand,
+    position: { q: 1, r: 0 },
+  });
+  const opponent2 = createTestPlayer({
+    id: "opponent2",
+    hand: opponent2Hand,
+    position: { q: 2, r: 0 },
+  });
+
+  return createTestGameState({
+    players: [caster, opponent1, opponent2],
+    turnOrder: ["caster", "opponent1", "opponent2"],
+  });
+}
+
+function getCaster(state: GameState) {
+  return state.players.find((p) => p.id === "caster")!;
+}
+
+function getOpponent(state: GameState, id = "opponent") {
+  return state.players.find((p) => p.id === id)!;
+}
+
+// ============================================================================
+// SPELL CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Mind Read spell card definition", () => {
+  it("should be registered in spell cards", () => {
+    const card = getSpellCard(CARD_MIND_READ);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Mind Read");
+  });
+
+  it("should have correct metadata", () => {
+    expect(MIND_READ.id).toBe(CARD_MIND_READ);
+    expect(MIND_READ.name).toBe("Mind Read");
+    expect(MIND_READ.poweredName).toBe("Mind Steal");
+    expect(MIND_READ.cardType).toBe(DEED_CARD_TYPE_SPELL);
+    expect(MIND_READ.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by black + white mana", () => {
+    expect(MIND_READ.poweredBy).toEqual([MANA_BLACK, MANA_WHITE]);
+  });
+
+  it("should have special category", () => {
+    expect(MIND_READ.categories).toEqual([CATEGORY_SPECIAL]);
+  });
+
+  it("should be marked as interactive", () => {
+    expect(MIND_READ.interactive).toBe(true);
+  });
+
+  it("should have basic effect of type EFFECT_MIND_READ", () => {
+    const effect = MIND_READ.basicEffect as MindReadEffect;
+    expect(effect.type).toBe(EFFECT_MIND_READ);
+  });
+
+  it("should have powered effect of type EFFECT_MIND_STEAL", () => {
+    const effect = MIND_READ.poweredEffect as MindStealEffect;
+    expect(effect.type).toBe(EFFECT_MIND_STEAL);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT (MIND READ) TESTS
+// ============================================================================
+
+describe("EFFECT_MIND_READ (basic)", () => {
+  const basicEffect: MindReadEffect = {
+    type: EFFECT_MIND_READ,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should always be resolvable", () => {
+      const state = createMultiplayerState();
+      expect(isEffectResolvable(state, "caster", basicEffect)).toBe(true);
+    });
+  });
+
+  describe("color choice", () => {
+    it("should present 4 basic color choices", () => {
+      const state = createMultiplayerState();
+
+      const result = resolveEffect(state, "caster", basicEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      const colors = (
+        result.dynamicChoiceOptions as ResolveMindReadColorEffect[]
+      ).map((opt) => opt.color);
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLUE);
+      expect(colors).toContain(MANA_GREEN);
+      expect(colors).toContain(MANA_WHITE);
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE MIND READ COLOR TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MIND_READ_COLOR", () => {
+  describe("crystal gain", () => {
+    it("should grant caster a crystal of chosen color", () => {
+      const state = createMultiplayerState();
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const caster = getCaster(result.state);
+      expect(caster.crystals.red).toBe(1);
+    });
+
+    it("should add to existing crystal count", () => {
+      const state = createMultiplayerState({ red: 1, blue: 0, green: 0, white: 0 });
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const caster = getCaster(result.state);
+      expect(caster.crystals.red).toBe(2);
+    });
+  });
+
+  describe("forced discard from opponents", () => {
+    it("should force opponent to discard a matching Action card", () => {
+      // CARD_RAGE is a red basic action
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE, CARD_MARCH]
+      );
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const opponent = getOpponent(result.state);
+      // Rage is red, March is green — only Rage should be discarded
+      expect(opponent.hand).not.toContain(CARD_RAGE);
+      expect(opponent.hand).toContain(CARD_MARCH);
+      expect(opponent.discard).toContain(CARD_RAGE);
+    });
+
+    it("should force opponent to discard a matching Spell card", () => {
+      // CARD_FIREBALL is a red spell
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_FIREBALL, CARD_SNOWSTORM]
+      );
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).not.toContain(CARD_FIREBALL);
+      expect(opponent.hand).toContain(CARD_SNOWSTORM);
+      expect(opponent.discard).toContain(CARD_FIREBALL);
+    });
+
+    it("should reveal hand when no matching cards", () => {
+      // Only green cards in hand, choosing red
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_MARCH, CARD_TRANQUILITY]
+      );
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const opponent = getOpponent(result.state);
+      // Hand should be unchanged (no matching cards)
+      expect(opponent.hand).toHaveLength(2);
+      expect(opponent.discard).toHaveLength(0);
+      expect(result.description).toContain("revealed hand");
+    });
+
+    it("should handle wound cards in hand (not matching any color)", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_WOUND, CARD_WOUND]
+      );
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).toHaveLength(2); // Wounds still in hand
+      expect(result.description).toContain("revealed hand");
+    });
+  });
+
+  describe("single-player mode", () => {
+    it("should still gain crystal with no opponents", () => {
+      const state = createTestGameState();
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_BLUE,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const player = result.state.players[0]!;
+      expect(player.crystals.blue).toBe(1);
+    });
+  });
+
+  describe("multiple opponents", () => {
+    it("should affect all opponents", () => {
+      const state = createThreePlayerState(
+        [CARD_RAGE], // opponent1 has red
+        [CARD_MARCH] // opponent2 has green
+      );
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      // Opponent1 should discard Rage (red)
+      const op1 = getOpponent(result.state, "opponent1");
+      expect(op1.hand).not.toContain(CARD_RAGE);
+      expect(op1.discard).toContain(CARD_RAGE);
+
+      // Opponent2 has no red cards — revealed hand
+      const op2 = getOpponent(result.state, "opponent2");
+      expect(op2.hand).toContain(CARD_MARCH);
+      expect(op2.discard).toHaveLength(0);
+    });
+  });
+
+  describe("end-of-round restriction", () => {
+    it("should not affect opponents when end of round announced", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE]
+      );
+
+      const endOfRoundState: GameState = {
+        ...state,
+        endOfRoundAnnouncedBy: "opponent",
+      };
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(endOfRoundState, "caster", effect);
+
+      // Caster should still gain crystal
+      const caster = getCaster(result.state);
+      expect(caster.crystals.red).toBe(1);
+
+      // Opponent should NOT be forced to discard
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).toContain(CARD_RAGE);
+    });
+
+    it("should not affect opponents when scenario end triggered", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE]
+      );
+
+      const scenarioEndState: GameState = {
+        ...state,
+        scenarioEndTriggered: true,
+      };
+
+      const effect: ResolveMindReadColorEffect = {
+        type: EFFECT_RESOLVE_MIND_READ_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(scenarioEndState, "caster", effect);
+
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).toContain(CARD_RAGE);
+    });
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT (MIND STEAL) TESTS
+// ============================================================================
+
+describe("EFFECT_MIND_STEAL (powered)", () => {
+  const poweredEffect: MindStealEffect = {
+    type: EFFECT_MIND_STEAL,
+  };
+
+  describe("isEffectResolvable", () => {
+    it("should always be resolvable", () => {
+      const state = createMultiplayerState();
+      expect(isEffectResolvable(state, "caster", poweredEffect)).toBe(true);
+    });
+  });
+
+  describe("color choice", () => {
+    it("should present 4 basic color choices", () => {
+      const state = createMultiplayerState();
+
+      const result = resolveEffect(state, "caster", poweredEffect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+      const colors = (
+        result.dynamicChoiceOptions as ResolveMindStealColorEffect[]
+      ).map((opt) => opt.color);
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLUE);
+      expect(colors).toContain(MANA_GREEN);
+      expect(colors).toContain(MANA_WHITE);
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE MIND STEAL COLOR TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MIND_STEAL_COLOR", () => {
+  describe("crystal gain + discard", () => {
+    it("should gain crystal and force discard like Mind Read", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE]
+      );
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      // Caster gains crystal
+      const caster = getCaster(result.state);
+      expect(caster.crystals.red).toBe(1);
+
+      // Opponent discards matching card
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).not.toContain(CARD_RAGE);
+    });
+  });
+
+  describe("steal option", () => {
+    it("should offer steal choice when Action card is discarded", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE]
+      );
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      // Should offer steal choice since Rage is an Action card
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toBeDefined();
+      expect(result.dynamicChoiceOptions!.length).toBeGreaterThanOrEqual(1);
+
+      const option = result
+        .dynamicChoiceOptions![0] as ResolveMindStealSelectionEffect;
+      expect(option.type).toBe(EFFECT_RESOLVE_MIND_STEAL_SELECTION);
+      expect(option.cardId).toBe(CARD_RAGE);
+    });
+
+    it("should NOT offer steal when only Spells are discarded", () => {
+      // Fireball is a spell, not an Action card — cannot be stolen
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_FIREBALL]
+      );
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      // No steal choice since Fireball is a Spell, not Action
+      expect(result.requiresChoice).toBeFalsy();
+    });
+
+    it("should NOT offer steal when opponent reveals hand (no matching cards)", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_MARCH] // green, not red
+      );
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      expect(result.requiresChoice).toBeFalsy();
+    });
+  });
+
+  describe("end-of-round restriction", () => {
+    it("should not offer steal when end of round announced", () => {
+      const state = createMultiplayerState(
+        { red: 0, blue: 0, green: 0, white: 0 },
+        [CARD_RAGE]
+      );
+
+      const endOfRoundState: GameState = {
+        ...state,
+        endOfRoundAnnouncedBy: "opponent",
+      };
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(endOfRoundState, "caster", effect);
+
+      // Caster still gains crystal
+      const caster = getCaster(result.state);
+      expect(caster.crystals.red).toBe(1);
+
+      // No discard, no steal
+      const opponent = getOpponent(result.state);
+      expect(opponent.hand).toContain(CARD_RAGE);
+      expect(result.requiresChoice).toBeFalsy();
+    });
+  });
+
+  describe("multiple opponents with steal", () => {
+    it("should offer steal from multiple discarded Action cards", () => {
+      const state = createThreePlayerState(
+        [CARD_RAGE], // opponent1 has red action
+        [CARD_RAGE] // opponent2 also has red action
+      );
+
+      const effect: ResolveMindStealColorEffect = {
+        type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+        color: MANA_RED,
+      };
+
+      const result = resolveEffect(state, "caster", effect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions!.length).toBe(2);
+    });
+  });
+});
+
+// ============================================================================
+// RESOLVE MIND STEAL SELECTION TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_MIND_STEAL_SELECTION", () => {
+  it("should move the card from opponent's discard to caster's hand", () => {
+    // Set up: opponent has Rage in discard (already discarded by Mind Steal)
+    const caster = createTestPlayer({ id: "caster" });
+    const opponent = createTestPlayer({
+      id: "opponent",
+      discard: [CARD_RAGE],
+      position: { q: 1, r: 0 },
+    });
+
+    const state = createTestGameState({
+      players: [caster, opponent],
+      turnOrder: ["caster", "opponent"],
+    });
+
+    const effect: ResolveMindStealSelectionEffect = {
+      type: EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+      cardId: CARD_RAGE,
+      cardName: "Rage",
+      fromPlayerId: "opponent",
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    // Caster should have the card in hand
+    const updatedCaster = getCaster(result.state);
+    expect(updatedCaster.hand).toContain(CARD_RAGE);
+
+    // Opponent should no longer have the card in discard
+    const updatedOpponent = getOpponent(result.state);
+    expect(updatedOpponent.discard).not.toContain(CARD_RAGE);
+  });
+
+  it("should add stolen card to existing hand", () => {
+    const caster = createTestPlayer({
+      id: "caster",
+      hand: [CARD_MARCH, CARD_PROMISE],
+    });
+    const opponent = createTestPlayer({
+      id: "opponent",
+      discard: [CARD_RAGE],
+      position: { q: 1, r: 0 },
+    });
+
+    const state = createTestGameState({
+      players: [caster, opponent],
+      turnOrder: ["caster", "opponent"],
+    });
+
+    const effect: ResolveMindStealSelectionEffect = {
+      type: EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+      cardId: CARD_RAGE,
+      cardName: "Rage",
+      fromPlayerId: "opponent",
+    };
+
+    const result = resolveEffect(state, "caster", effect);
+
+    const updatedCaster = getCaster(result.state);
+    expect(updatedCaster.hand).toHaveLength(3);
+    expect(updatedCaster.hand).toContain(CARD_RAGE);
+    expect(updatedCaster.hand).toContain(CARD_MARCH);
+    expect(updatedCaster.hand).toContain(CARD_PROMISE);
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Mind Read effects", () => {
+  it("should describe EFFECT_MIND_READ", () => {
+    const effect: MindReadEffect = { type: EFFECT_MIND_READ };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("crystal");
+    expect(desc).toContain("discard");
+  });
+
+  it("should describe EFFECT_RESOLVE_MIND_READ_COLOR", () => {
+    const effect: ResolveMindReadColorEffect = {
+      type: EFFECT_RESOLVE_MIND_READ_COLOR,
+      color: MANA_RED,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("red");
+    expect(desc).toContain("crystal");
+  });
+
+  it("should describe EFFECT_MIND_STEAL", () => {
+    const effect: MindStealEffect = { type: EFFECT_MIND_STEAL };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("steal");
+  });
+
+  it("should describe EFFECT_RESOLVE_MIND_STEAL_COLOR", () => {
+    const effect: ResolveMindStealColorEffect = {
+      type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+      color: MANA_BLUE,
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("blue");
+  });
+
+  it("should describe EFFECT_RESOLVE_MIND_STEAL_SELECTION", () => {
+    const effect: ResolveMindStealSelectionEffect = {
+      type: EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+      cardId: CARD_RAGE,
+      cardName: "Rage",
+      fromPlayerId: "opponent",
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Rage");
+    expect(desc).toContain("opponent");
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -65,6 +65,11 @@ import {
   EFFECT_RESOLVE_MANA_CLAIM_MODE,
   EFFECT_MANA_CURSE,
   EFFECT_MANA_BOLT,
+  EFFECT_MIND_READ,
+  EFFECT_RESOLVE_MIND_READ_COLOR,
+  EFFECT_MIND_STEAL,
+  EFFECT_RESOLVE_MIND_STEAL_COLOR,
+  EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
 } from "../../types/effectTypes.js";
@@ -456,6 +461,27 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   },
 
   [EFFECT_MANA_CURSE]: () => "Claim a die and curse its color",
+
+  [EFFECT_MIND_READ]: () =>
+    "Choose a color: gain crystal, opponents discard matching card",
+
+  [EFFECT_RESOLVE_MIND_READ_COLOR]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveMindReadColorEffect;
+    return `Gain ${e.color} crystal, opponents discard ${e.color} card`;
+  },
+
+  [EFFECT_MIND_STEAL]: () =>
+    "Choose a color: gain crystal, opponents discard, steal an Action card",
+
+  [EFFECT_RESOLVE_MIND_STEAL_COLOR]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveMindStealColorEffect;
+    return `Gain ${e.color} crystal, opponents discard ${e.color} card, steal option`;
+  },
+
+  [EFFECT_RESOLVE_MIND_STEAL_SELECTION]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveMindStealSelectionEffect;
+    return `Steal ${e.cardName} from ${e.fromPlayerId}`;
+  },
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -48,6 +48,7 @@ import { registerSacrificeEffects } from "./sacrificeEffects.js";
 import { registerCallToArmsEffects } from "./callToArmsEffects.js";
 import { registerManaClaimEffects } from "./manaClaimEffects.js";
 import { registerManaBoltEffects } from "./manaBoltEffects.js";
+import { registerMindReadEffects } from "./mindReadEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -174,4 +175,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Mana Bolt effects (blue spell, mana-color-driven attack)
   registerManaBoltEffects();
+
+  // Mind Read / Mind Steal effects (interactive white spell)
+  registerMindReadEffects();
 }

--- a/packages/core/src/engine/effects/mindReadEffects.ts
+++ b/packages/core/src/engine/effects/mindReadEffects.ts
@@ -1,0 +1,507 @@
+/**
+ * Mind Read / Mind Steal effect handlers
+ *
+ * Handles the Mind Read spell (White Spell #111) which:
+ *
+ * Basic (Mind Read):
+ * - Caster picks a basic mana color
+ * - Caster gains a crystal of the chosen color
+ * - Each opponent must discard a Spell or Action card of that color from hand
+ * - Opponents with no matching cards reveal their hand (no discard)
+ * - After end-of-round announced: does nothing to opponents
+ *
+ * Powered (Mind Steal):
+ * - Same as basic (crystal + forced discard)
+ * - Caster may steal one of the discarded Action cards (NOT Spells)
+ * - Stolen card goes to caster's hand permanently
+ * - Optional: caster can skip stealing
+ *
+ * @module effects/mindReadEffects
+ *
+ * @remarks Resolution Flow
+ * ```
+ * EFFECT_MIND_READ
+ *   └─► Present 4 basic color choices
+ *       └─► EFFECT_RESOLVE_MIND_READ_COLOR
+ *           ├─ Gain crystal of chosen color
+ *           └─ Force opponent discards (or reveal)
+ *
+ * EFFECT_MIND_STEAL
+ *   └─► Present 4 basic color choices
+ *       └─► EFFECT_RESOLVE_MIND_STEAL_COLOR
+ *           ├─ Gain crystal of chosen color
+ *           ├─ Force opponent discards (or reveal)
+ *           └─ If Action cards discarded: present steal choices + skip
+ *               └─► EFFECT_RESOLVE_MIND_STEAL_SELECTION
+ *                   └─ Move card to caster's hand
+ * ```
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  MindReadEffect,
+  ResolveMindReadColorEffect,
+  MindStealEffect,
+  ResolveMindStealColorEffect,
+  ResolveMindStealSelectionEffect,
+  CardEffect,
+} from "../../types/cards.js";
+import {
+  DEED_CARD_TYPE_BASIC_ACTION,
+  DEED_CARD_TYPE_ADVANCED_ACTION,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { BasicManaColor, CardId } from "@mage-knight/shared";
+import { BASIC_MANA_COLORS, CARD_WOUND } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import {
+  EFFECT_MIND_READ,
+  EFFECT_RESOLVE_MIND_READ_COLOR,
+  EFFECT_MIND_STEAL,
+  EFFECT_RESOLVE_MIND_STEAL_COLOR,
+  EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+} from "../../types/effectTypes.js";
+import { isCardOfColor } from "../helpers/cardColor.js";
+import type { BasicCardColor } from "../../types/effectTypes.js";
+import { getCard } from "../helpers/cardLookup.js";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Check if end-of-round has been announced (or scenario end triggered).
+ */
+function isEndOfRoundAnnounced(state: GameState): boolean {
+  return state.endOfRoundAnnouncedBy !== null || state.scenarioEndTriggered;
+}
+
+/**
+ * Convert BasicManaColor to BasicCardColor for color matching.
+ */
+function manaColorToCardColor(color: BasicManaColor): BasicCardColor {
+  return color as BasicCardColor;
+}
+
+/**
+ * Find cards in a player's hand that match a given color (Spell or Action cards).
+ * Excludes wound cards and artifacts.
+ */
+function getMatchingCardsInHand(
+  hand: readonly CardId[],
+  color: BasicCardColor
+): CardId[] {
+  return hand.filter(
+    (cardId) => cardId !== CARD_WOUND && isCardOfColor(cardId, color)
+  );
+}
+
+/**
+ * Check if a card is an Action card (Basic or Advanced Action).
+ */
+function isActionCard(cardId: CardId): boolean {
+  const card = getCard(cardId);
+  if (!card) return false;
+  return (
+    card.cardType === DEED_CARD_TYPE_BASIC_ACTION ||
+    card.cardType === DEED_CARD_TYPE_ADVANCED_ACTION
+  );
+}
+
+/**
+ * Process forced discard from opponents.
+ * Each opponent must discard one matching Spell or Action card, or reveal hand.
+ *
+ * Returns updated players array, descriptions, and list of discarded Action cards
+ * (for potential stealing in Mind Steal).
+ */
+function processOpponentDiscards(
+  state: GameState,
+  playerId: string,
+  cardColor: BasicCardColor
+): {
+  updatedPlayers: Player[];
+  descriptions: string[];
+  discardedActionCards: Array<{ cardId: CardId; cardName: string; fromPlayerId: string }>;
+} {
+  const updatedPlayers = [...state.players];
+  const descriptions: string[] = [];
+  const discardedActionCards: Array<{
+    cardId: CardId;
+    cardName: string;
+    fromPlayerId: string;
+  }> = [];
+
+  const opponents = state.players.filter((p) => p.id !== playerId);
+
+  for (const opponent of opponents) {
+    const opponentIndex = updatedPlayers.findIndex(
+      (p) => p.id === opponent.id
+    );
+    if (opponentIndex === -1) continue;
+
+    const currentOpponent = updatedPlayers[opponentIndex]!;
+    const matchingCards = getMatchingCardsInHand(
+      currentOpponent.hand,
+      cardColor
+    );
+
+    if (matchingCards.length === 0) {
+      // No matching cards — opponent reveals hand
+      descriptions.push(`${currentOpponent.id} revealed hand (no matching cards)`);
+    } else {
+      // Discard the first matching card found
+      // (In the board game, the opponent chooses which to discard. Since this is
+      // an automated resolution, we discard the first match. For full multiplayer,
+      // this would need an opponent choice step.)
+      const discardedCardId = matchingCards[0]!;
+      const card = getCard(discardedCardId);
+      const cardName = card?.name ?? String(discardedCardId);
+
+      const updatedHand = [...currentOpponent.hand];
+      const handIndex = updatedHand.indexOf(discardedCardId);
+      if (handIndex !== -1) {
+        updatedHand.splice(handIndex, 1);
+      }
+
+      updatedPlayers[opponentIndex] = {
+        ...currentOpponent,
+        hand: updatedHand,
+        discard: [...currentOpponent.discard, discardedCardId],
+      };
+
+      descriptions.push(`${currentOpponent.id} discarded ${cardName}`);
+
+      // Track if this was an Action card (for potential stealing)
+      if (isActionCard(discardedCardId)) {
+        discardedActionCards.push({
+          cardId: discardedCardId,
+          cardName,
+          fromPlayerId: currentOpponent.id,
+        });
+      }
+    }
+  }
+
+  return { updatedPlayers, descriptions, discardedActionCards };
+}
+
+// ============================================================================
+// MIND READ (BASIC)
+// ============================================================================
+
+/**
+ * Handle EFFECT_MIND_READ entry point.
+ * Presents the caster with a choice of basic mana color.
+ */
+export function handleMindRead(
+  state: GameState,
+  _playerId: string,
+  _effect: MindReadEffect
+): EffectResolutionResult {
+  const colorOptions: ResolveMindReadColorEffect[] = BASIC_MANA_COLORS.map(
+    (color) => ({
+      type: EFFECT_RESOLVE_MIND_READ_COLOR,
+      color,
+    })
+  );
+
+  return {
+    state,
+    description: "Choose a basic mana color for Mind Read",
+    requiresChoice: true,
+    dynamicChoiceOptions: colorOptions,
+  };
+}
+
+/**
+ * Resolve after caster picks a basic mana color for Mind Read.
+ * - Gain crystal of chosen color
+ * - Force each opponent to discard a matching card (or reveal hand)
+ */
+export function resolveMindReadColor(
+  state: GameState,
+  playerId: string,
+  effect: ResolveMindReadColorEffect
+): EffectResolutionResult {
+  const { playerIndex: casterIndex, player: caster } = getPlayerContext(
+    state,
+    playerId
+  );
+  const chosenColor = effect.color;
+  const cardColor = manaColorToCardColor(chosenColor);
+  const descriptions: string[] = [];
+
+  // Gain crystal of chosen color
+  const updatedCaster: Player = {
+    ...caster,
+    crystals: {
+      ...caster.crystals,
+      [chosenColor]: caster.crystals[chosenColor] + 1,
+    },
+  };
+  descriptions.push(`Gained ${chosenColor} crystal`);
+
+  let currentState = updatePlayer(state, casterIndex, updatedCaster);
+
+  // After end-of-round: opponents are not affected
+  if (isEndOfRoundAnnounced(state)) {
+    descriptions.push("No effect on opponents (end of round)");
+    return {
+      state: currentState,
+      description: descriptions.join(". "),
+    };
+  }
+
+  // Process opponent discards
+  const opponents = currentState.players.filter((p) => p.id !== playerId);
+  if (opponents.length === 0) {
+    descriptions.push("No opponents to affect");
+    return {
+      state: currentState,
+      description: descriptions.join(". "),
+    };
+  }
+
+  const { updatedPlayers, descriptions: discardDescriptions } =
+    processOpponentDiscards(currentState, playerId, cardColor);
+
+  currentState = {
+    ...currentState,
+    players: updatedPlayers,
+  };
+
+  descriptions.push(...discardDescriptions);
+
+  return {
+    state: currentState,
+    description: descriptions.join(". "),
+  };
+}
+
+// ============================================================================
+// MIND STEAL (POWERED)
+// ============================================================================
+
+/**
+ * Handle EFFECT_MIND_STEAL entry point.
+ * Presents the caster with a choice of basic mana color.
+ */
+export function handleMindSteal(
+  state: GameState,
+  _playerId: string,
+  _effect: MindStealEffect
+): EffectResolutionResult {
+  const colorOptions: ResolveMindStealColorEffect[] = BASIC_MANA_COLORS.map(
+    (color) => ({
+      type: EFFECT_RESOLVE_MIND_STEAL_COLOR,
+      color,
+    })
+  );
+
+  return {
+    state,
+    description: "Choose a basic mana color for Mind Steal",
+    requiresChoice: true,
+    dynamicChoiceOptions: colorOptions,
+  };
+}
+
+/**
+ * Resolve after caster picks a basic mana color for Mind Steal.
+ * - Same as Mind Read (crystal + forced discard)
+ * - If any Action cards were discarded, present steal options
+ */
+export function resolveMindStealColor(
+  state: GameState,
+  playerId: string,
+  effect: ResolveMindStealColorEffect
+): EffectResolutionResult {
+  const { playerIndex: casterIndex, player: caster } = getPlayerContext(
+    state,
+    playerId
+  );
+  const chosenColor = effect.color;
+  const cardColor = manaColorToCardColor(chosenColor);
+  const descriptions: string[] = [];
+
+  // Gain crystal of chosen color
+  const updatedCaster: Player = {
+    ...caster,
+    crystals: {
+      ...caster.crystals,
+      [chosenColor]: caster.crystals[chosenColor] + 1,
+    },
+  };
+  descriptions.push(`Gained ${chosenColor} crystal`);
+
+  let currentState = updatePlayer(state, casterIndex, updatedCaster);
+
+  // After end-of-round: opponents are not affected
+  if (isEndOfRoundAnnounced(state)) {
+    descriptions.push("No effect on opponents (end of round)");
+    return {
+      state: currentState,
+      description: descriptions.join(". "),
+    };
+  }
+
+  // Process opponent discards
+  const opponents = currentState.players.filter((p) => p.id !== playerId);
+  if (opponents.length === 0) {
+    descriptions.push("No opponents to affect");
+    return {
+      state: currentState,
+      description: descriptions.join(". "),
+    };
+  }
+
+  const {
+    updatedPlayers,
+    descriptions: discardDescriptions,
+    discardedActionCards,
+  } = processOpponentDiscards(currentState, playerId, cardColor);
+
+  currentState = {
+    ...currentState,
+    players: updatedPlayers,
+  };
+
+  descriptions.push(...discardDescriptions);
+
+  // If Action cards were discarded, offer steal options
+  if (discardedActionCards.length > 0) {
+    const stealOptions: CardEffect[] = discardedActionCards.map((card) => ({
+      type: EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+      cardId: card.cardId,
+      cardName: card.cardName,
+      fromPlayerId: card.fromPlayerId,
+    }));
+
+    return {
+      state: currentState,
+      description: descriptions.join(". ") + ". Choose an Action card to steal",
+      requiresChoice: true,
+      dynamicChoiceOptions: stealOptions,
+    };
+  }
+
+  // No Action cards to steal
+  return {
+    state: currentState,
+    description: descriptions.join(". "),
+  };
+}
+
+// ============================================================================
+// RESOLVE MIND STEAL SELECTION
+// ============================================================================
+
+/**
+ * Resolve after caster selects an Action card to steal.
+ * Moves the card from the opponent's discard pile to the caster's hand.
+ */
+export function resolveMindStealSelection(
+  state: GameState,
+  playerId: string,
+  effect: ResolveMindStealSelectionEffect
+): EffectResolutionResult {
+  const { playerIndex: casterIndex, player: caster } = getPlayerContext(
+    state,
+    playerId
+  );
+
+  // Find the opponent who had the card
+  const fromPlayerIndex = state.players.findIndex(
+    (p) => p.id === effect.fromPlayerId
+  );
+  if (fromPlayerIndex === -1) {
+    return {
+      state,
+      description: `Could not find player ${effect.fromPlayerId}`,
+    };
+  }
+
+  const fromPlayer = state.players[fromPlayerIndex]!;
+
+  // Remove from opponent's discard pile
+  const updatedDiscard = [...fromPlayer.discard];
+  const discardIndex = updatedDiscard.indexOf(effect.cardId);
+  if (discardIndex === -1) {
+    return {
+      state,
+      description: `Card ${effect.cardName} not found in ${effect.fromPlayerId}'s discard`,
+    };
+  }
+  updatedDiscard.splice(discardIndex, 1);
+
+  const updatedFromPlayer: Player = {
+    ...fromPlayer,
+    discard: updatedDiscard,
+  };
+
+  // Add to caster's hand
+  const updatedCaster: Player = {
+    ...caster,
+    hand: [...caster.hand, effect.cardId],
+  };
+
+  const updatedPlayers = [...state.players];
+  updatedPlayers[fromPlayerIndex] = updatedFromPlayer;
+  updatedPlayers[casterIndex] = updatedCaster;
+
+  return {
+    state: { ...state, players: updatedPlayers },
+    description: `Stole ${effect.cardName} from ${effect.fromPlayerId}`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Mind Read / Mind Steal effect handlers with the effect registry.
+ */
+export function registerMindReadEffects(): void {
+  registerEffect(EFFECT_MIND_READ, (state, playerId, effect) => {
+    return handleMindRead(state, playerId, effect as MindReadEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_MIND_READ_COLOR, (state, playerId, effect) => {
+    return resolveMindReadColor(
+      state,
+      playerId,
+      effect as ResolveMindReadColorEffect
+    );
+  });
+
+  registerEffect(EFFECT_MIND_STEAL, (state, playerId, effect) => {
+    return handleMindSteal(state, playerId, effect as MindStealEffect);
+  });
+
+  registerEffect(
+    EFFECT_RESOLVE_MIND_STEAL_COLOR,
+    (state, playerId, effect) => {
+      return resolveMindStealColor(
+        state,
+        playerId,
+        effect as ResolveMindStealColorEffect
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_MIND_STEAL_SELECTION,
+    (state, playerId, effect) => {
+      return resolveMindStealSelection(
+        state,
+        playerId,
+        effect as ResolveMindStealSelectionEffect
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -96,6 +96,11 @@ import {
   EFFECT_RESOLVE_CALL_TO_ARMS_UNIT,
   EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY,
   EFFECT_MANA_BOLT,
+  EFFECT_MIND_READ,
+  EFFECT_RESOLVE_MIND_READ_COLOR,
+  EFFECT_MIND_STEAL,
+  EFFECT_RESOLVE_MIND_STEAL_COLOR,
+  EFFECT_RESOLVE_MIND_STEAL_SELECTION,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -485,6 +490,13 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   // Call to Arms unit/ability resolution steps are always resolvable
   [EFFECT_RESOLVE_CALL_TO_ARMS_UNIT]: () => true,
   [EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY]: () => true,
+
+  // Mind Read / Mind Steal are always resolvable (crystal gain always works)
+  [EFFECT_MIND_READ]: () => true,
+  [EFFECT_RESOLVE_MIND_READ_COLOR]: () => true,
+  [EFFECT_MIND_STEAL]: () => true,
+  [EFFECT_RESOLVE_MIND_STEAL_COLOR]: () => true,
+  [EFFECT_RESOLVE_MIND_STEAL_SELECTION]: () => true,
 
   // Mana Bolt is resolvable if the player has any basic or gold mana tokens
   [EFFECT_MANA_BOLT]: (state, player) => {

--- a/packages/core/src/engine/helpers/cardColor.ts
+++ b/packages/core/src/engine/helpers/cardColor.ts
@@ -25,6 +25,10 @@ import {
   GREEN_ADVANCED_ACTIONS,
   WHITE_ADVANCED_ACTIONS,
 } from "../../data/advancedActions/index.js";
+import { RED_SPELLS } from "../../data/spells/red/index.js";
+import { BLUE_SPELLS } from "../../data/spells/blue/index.js";
+import { GREEN_SPELLS } from "../../data/spells/green/index.js";
+import { WHITE_SPELLS } from "../../data/spells/white/index.js";
 
 const RED_ACTION_CARD_IDS = new Set<string>([
   ...Object.keys(RED_BASIC_ACTIONS),
@@ -43,6 +47,11 @@ const WHITE_ACTION_CARD_IDS = new Set<string>([
   ...Object.keys(WHITE_ADVANCED_ACTIONS),
 ]);
 
+const RED_SPELL_IDS = new Set<string>(Object.keys(RED_SPELLS));
+const BLUE_SPELL_IDS = new Set<string>(Object.keys(BLUE_SPELLS));
+const GREEN_SPELL_IDS = new Set<string>(Object.keys(GREEN_SPELLS));
+const WHITE_SPELL_IDS = new Set<string>(Object.keys(WHITE_SPELLS));
+
 /**
  * Get the frame color of an Action card by ID.
  * Returns null for non-action cards or unsupported colors.
@@ -53,4 +62,23 @@ export function getActionCardColor(cardId: CardId): BasicCardColor | null {
   if (GREEN_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_GREEN;
   if (WHITE_ACTION_CARD_IDS.has(cardId)) return CARD_COLOR_WHITE;
   return null;
+}
+
+/**
+ * Check if a card (Action or Spell) matches a given basic card color.
+ * Action cards use their frame color. Spells use their non-black mana color.
+ * Returns false for wounds, artifacts, and other uncolored cards.
+ */
+export function isCardOfColor(cardId: CardId, color: BasicCardColor): boolean {
+  // Check action cards first (most common case)
+  const actionColor = getActionCardColor(cardId);
+  if (actionColor !== null) return actionColor === color;
+
+  // Check spell cards by their registry membership
+  if (RED_SPELL_IDS.has(cardId)) return color === CARD_COLOR_RED;
+  if (BLUE_SPELL_IDS.has(cardId)) return color === CARD_COLOR_BLUE;
+  if (GREEN_SPELL_IDS.has(cardId)) return color === CARD_COLOR_GREEN;
+  if (WHITE_SPELL_IDS.has(cardId)) return color === CARD_COLOR_WHITE;
+
+  return false;
 }

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -100,6 +100,11 @@ import {
   EFFECT_RESOLVE_MANA_CLAIM_MODE,
   EFFECT_MANA_CURSE,
   EFFECT_MANA_BOLT,
+  EFFECT_MIND_READ,
+  EFFECT_RESOLVE_MIND_READ_COLOR,
+  EFFECT_MIND_STEAL,
+  EFFECT_RESOLVE_MIND_STEAL_COLOR,
+  EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1145,6 +1150,52 @@ export interface ResolveCallToArmsAbilityEffect {
   readonly abilityDescription: string;
 }
 
+/**
+ * Mind Read effect entry point (White Spell basic effect).
+ * Choose a basic mana color. Gain crystal. Each opponent must discard
+ * a Spell or Action card of that color, or reveal hand to show they have none.
+ */
+export interface MindReadEffect {
+  readonly type: typeof EFFECT_MIND_READ;
+}
+
+/**
+ * Internal: Resolve after caster selects a color for Mind Read.
+ * Applies crystal gain and forced discard.
+ */
+export interface ResolveMindReadColorEffect {
+  readonly type: typeof EFFECT_RESOLVE_MIND_READ_COLOR;
+  readonly color: BasicManaColor;
+}
+
+/**
+ * Mind Steal effect entry point (White Spell powered effect).
+ * Same as Mind Read, plus caster may steal one discarded Action card.
+ */
+export interface MindStealEffect {
+  readonly type: typeof EFFECT_MIND_STEAL;
+}
+
+/**
+ * Internal: Resolve after caster selects a color for Mind Steal.
+ * Applies crystal gain, forced discard, then presents steal options.
+ */
+export interface ResolveMindStealColorEffect {
+  readonly type: typeof EFFECT_RESOLVE_MIND_STEAL_COLOR;
+  readonly color: BasicManaColor;
+}
+
+/**
+ * Internal: Resolve after caster selects an Action card to steal (or skip).
+ * Moves the selected card to the caster's hand permanently.
+ */
+export interface ResolveMindStealSelectionEffect {
+  readonly type: typeof EFFECT_RESOLVE_MIND_STEAL_SELECTION;
+  readonly cardId: CardId;
+  readonly cardName: string;
+  readonly fromPlayerId: string;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1223,7 +1274,12 @@ export type CardEffect =
   | ManaClaimEffect
   | ResolveManaClaimDieEffect
   | ResolveManaClaimModeEffect
-  | ManaCurseEffect;
+  | ManaCurseEffect
+  | MindReadEffect
+  | ResolveMindReadColorEffect
+  | MindStealEffect
+  | ResolveMindStealColorEffect
+  | ResolveMindStealSelectionEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -273,3 +273,16 @@ export const EFFECT_CALL_TO_ARMS = "call_to_arms" as const;
 export const EFFECT_RESOLVE_CALL_TO_ARMS_UNIT = "resolve_call_to_arms_unit" as const;
 // Internal: resolve after selecting which ability to use from the borrowed unit
 export const EFFECT_RESOLVE_CALL_TO_ARMS_ABILITY = "resolve_call_to_arms_ability" as const;
+
+// === Mind Read / Mind Steal Effects ===
+// Basic (Mind Read): Choose color, gain crystal, force opponents to discard matching card.
+// Opponents with no matching cards reveal their hand.
+export const EFFECT_MIND_READ = "mind_read" as const;
+// Internal: Resolve after color selection for Mind Read
+export const EFFECT_RESOLVE_MIND_READ_COLOR = "resolve_mind_read_color" as const;
+// Powered (Mind Steal): Same as basic + optionally steal one discarded Action card.
+export const EFFECT_MIND_STEAL = "mind_steal" as const;
+// Internal: Resolve after color selection for Mind Steal
+export const EFFECT_RESOLVE_MIND_STEAL_COLOR = "resolve_mind_steal_color" as const;
+// Internal: Resolve after caster selects which Action card to steal (or skip)
+export const EFFECT_RESOLVE_MIND_STEAL_SELECTION = "resolve_mind_steal_selection" as const;

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -125,6 +125,7 @@ export const CARD_UNDERGROUND_TRAVEL = cardId("underground_travel"); // #04 - Mo
 export const CARD_EXPOSE = cardId("expose"); // #19 - Lose fortification/resistances
 export const CARD_CURE = cardId("cure"); // #17 - Heal 2 + draw/ready / Armor reduction to 1
 export const CARD_CALL_TO_ARMS = cardId("call_to_arms"); // #XX - Borrow unit ability / Free recruit
+export const CARD_MIND_READ = cardId("mind_read"); // #111 - Crystal gain + forced discard / Steal action card
 
 // === Card ID Type Unions ===
 
@@ -189,7 +190,8 @@ export type SpellCardId =
   // White spells
   | typeof CARD_EXPOSE
   | typeof CARD_CURE
-  | typeof CARD_CALL_TO_ARMS;
+  | typeof CARD_CALL_TO_ARMS
+  | typeof CARD_MIND_READ;
 
 export type ArtifactCardId =
   // Banners
@@ -279,6 +281,7 @@ export const ALL_SPELL_IDS = [
   CARD_EXPOSE,
   CARD_CURE,
   CARD_CALL_TO_ARMS,
+  CARD_MIND_READ,
 ] as const;
 
 export const ALL_ARTIFACT_IDS = [


### PR DESCRIPTION
## Summary
- Implement White Spell #111 (Mind Read / Mind Steal) with `interactive: true`
- Basic (Mind Read): Choose color → gain crystal → force opponents to discard matching Spell or Action card (or reveal hand)
- Powered (Mind Steal): Same as basic + optionally steal one discarded Action card permanently
- End-of-round restriction: opponents not affected after announcement
- Added `isCardOfColor()` helper to support color-matching for both Action and Spell cards

## Changes
- `packages/shared/src/cardIds.ts` — Added `CARD_MIND_READ` constant and type union entry
- `packages/core/src/types/effectTypes.ts` — Added 5 new effect type constants
- `packages/core/src/types/cards.ts` — Added 5 new effect interfaces and CardEffect union entries
- `packages/core/src/data/spells/white/mindRead.ts` — **New** spell card definition
- `packages/core/src/data/spells/white/index.ts` — Registered Mind Read in white spells
- `packages/core/src/engine/effects/mindReadEffects.ts` — **New** effect handlers with registration
- `packages/core/src/engine/effects/effectRegistrations.ts` — Registered Mind Read effects
- `packages/core/src/engine/effects/describeEffect.ts` — Added descriptions for all 5 effect types
- `packages/core/src/engine/effects/resolvability.ts` — Added resolvability entries for all 5 effect types
- `packages/core/src/engine/helpers/cardColor.ts` — Added `isCardOfColor()` helper and spell color sets
- `packages/core/src/engine/__tests__/mindReadSpell.test.ts` — **New** 34 tests covering all mechanics

Closes #204