### PR TITLE
feat: implement Glittering Fortune skill for Goldyx (#335)

### DIFF
--- a/packages/core/src/data/skills/goldyx/glitteringFortune.ts
+++ b/packages/core/src/data/skills/goldyx/glitteringFortune.ts
@@ -5,15 +5,18 @@
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_INFLUENCE } from "../../../types/cards.js";
+import { SCALING_PER_CRYSTAL_COLOR } from "../../../types/scaling.js";
+import { scalingInfluence } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_GOLDYX_GLITTERING_FORTUNE = "goldyx_glittering_fortune" as SkillId;
 
 export const glitteringFortune: SkillDefinition = {
   id: SKILL_GOLDYX_GLITTERING_FORTUNE,
-    name: "Glittering Fortune",
-    heroId: "goldyx",
-    description: "During interaction: Influence 1 per different color crystal",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_INFLUENCE],
+  name: "Glittering Fortune",
+  heroId: "goldyx",
+  description: "During interaction: Influence 1 per different color crystal",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  effect: scalingInfluence(0, { type: SCALING_PER_CRYSTAL_COLOR }, 1),
+  categories: [CATEGORY_INFLUENCE],
 };

--- a/packages/core/src/engine/__tests__/skillGlitteringFortune.test.ts
+++ b/packages/core/src/engine/__tests__/skillGlitteringFortune.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for Glittering Fortune skill (Goldyx)
+ *
+ * Skill effect: Once a turn, during interaction: Get Influence 1
+ * for each different color crystal in your inventory.
+ *
+ * Key rules:
+ * - Once per turn (flip to activate)
+ * - Only usable during interaction (at inhabited site)
+ * - Counts distinct crystal colors, not quantities
+ * - Returns 0 influence with no crystals
+ * - Maximum of 4 influence (all four colors present)
+ * - Crystals counted at activation; can be spent afterward
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import {
+  createTestPlayer,
+  createTestGameState,
+  createTestHex,
+  createVillageSite,
+} from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  UNDO_ACTION,
+  CARD_MARCH,
+  hexKey,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_GOLDYX_GLITTERING_FORTUNE } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import { TERRAIN_PLAINS } from "@mage-knight/shared";
+
+describe("Glittering Fortune skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  /**
+   * Helper to create a game state where the player is at a village (interaction site).
+   */
+  function createInteractionState(overrides: {
+    crystals?: { red: number; blue: number; green: number; white: number };
+    skillCooldowns?: {
+      usedThisRound: readonly string[];
+      usedThisTurn: readonly string[];
+      usedThisCombat: readonly string[];
+      activeUntilNextTurn: readonly string[];
+    };
+    skills?: readonly string[];
+  } = {}) {
+    const player = createTestPlayer({
+      hero: Hero.Goldyx,
+      skills: overrides.skills ?? [SKILL_GOLDYX_GLITTERING_FORTUNE],
+      skillCooldowns: overrides.skillCooldowns ?? {
+        usedThisRound: [],
+        usedThisTurn: [],
+        usedThisCombat: [],
+        activeUntilNextTurn: [],
+      },
+      hand: [CARD_MARCH],
+      crystals: overrides.crystals ?? { red: 0, blue: 0, green: 0, white: 0 },
+      influencePoints: 0,
+      position: { q: 0, r: 0 },
+    });
+
+    const hexWithVillage = createTestHex(0, 0, TERRAIN_PLAINS, createVillageSite());
+
+    return createTestGameState({
+      players: [player],
+      map: {
+        hexes: {
+          [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+        },
+        tiles: [],
+        tileDeck: { countryside: [], core: [] },
+      },
+    });
+  }
+
+  describe("activation and influence calculation", () => {
+    it("should grant 0 influence with no crystals", () => {
+      const state = createInteractionState({
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+        })
+      );
+
+      expect(result.state.players[0].influencePoints).toBe(0);
+    });
+
+    it("should grant 1 influence with one crystal color", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(1);
+    });
+
+    it("should grant 2 influence with two distinct crystal colors", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 0, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(2);
+    });
+
+    it("should grant 3 influence with three distinct crystal colors", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 1, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(3);
+    });
+
+    it("should grant 4 influence with all four crystal colors", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(4);
+    });
+
+    it("should count distinct colors, not total crystal quantity", () => {
+      // 3 blue crystals = only 1 distinct color = 1 influence
+      const state = createInteractionState({
+        crystals: { red: 0, blue: 3, green: 0, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(1);
+    });
+
+    it("should count distinct colors regardless of quantity per color", () => {
+      // 3 red + 2 blue + 1 green = 3 distinct colors = 3 influence
+      const state = createInteractionState({
+        crystals: { red: 3, blue: 2, green: 1, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.state.players[0].influencePoints).toBe(3);
+    });
+  });
+
+  describe("cooldown tracking", () => {
+    it("should add skill to usedThisTurn cooldown", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(
+        result.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_GOLDYX_GLITTERING_FORTUNE);
+    });
+
+    it("should reject if skill already used this turn", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_GOLDYX_GLITTERING_FORTUNE],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if skill not learned", () => {
+      const state = createInteractionState({
+        skills: [],
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("interaction restriction", () => {
+    it("should reject when player is not at an inhabited site", () => {
+      // Player at a plain hex with no site
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_GLITTERING_FORTUNE],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+        position: { q: 0, r: 0 },
+      });
+
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill in valid actions when at interaction site", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+        })
+      );
+    });
+
+    it("should not show skill when not at interaction site", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_GLITTERING_FORTUNE],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+          })
+        );
+      }
+    });
+
+    it("should not show skill when on cooldown", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_GOLDYX_GLITTERING_FORTUNE],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+          })
+        );
+      }
+    });
+  });
+
+  describe("undo", () => {
+    it("should be undoable after activation", () => {
+      const state = createInteractionState({
+        crystals: { red: 1, blue: 1, green: 1, white: 1 },
+      });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_GLITTERING_FORTUNE,
+      });
+
+      // Verify activation happened
+      expect(
+        afterSkill.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_GOLDYX_GLITTERING_FORTUNE);
+      expect(afterSkill.state.players[0].influencePoints).toBe(4);
+
+      // Undo
+      const afterUndo = engine.processAction(afterSkill.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Skill should be removed from cooldown
+      expect(
+        afterUndo.state.players[0].skillCooldowns.usedThisTurn
+      ).not.toContain(SKILL_GOLDYX_GLITTERING_FORTUNE);
+
+      // Influence should be reverted
+      expect(afterUndo.state.players[0].influencePoints).toBe(0);
+    });
+  });
+});

--- a/packages/core/src/engine/rules/siteInteraction.ts
+++ b/packages/core/src/engine/rules/siteInteraction.ts
@@ -85,6 +85,18 @@ export function canBuyAdvancedActionsAtMonastery(site: Site): boolean {
 }
 
 /**
+ * Check if a player is at an inhabited site where they can interact.
+ * Combines inhabited check with accessibility check.
+ * Used by skill activation rules and condition evaluators.
+ */
+export function isPlayerAtInteractionSite(
+  site: Site,
+  playerId: string
+): boolean {
+  return canInteractWithSite(site) && isSiteAccessibleForInteraction(site, playerId);
+}
+
+/**
  * Validate site is accessible based on site type and state.
  *
  * Returns true if accessible, false otherwise. The caller determines the error message.

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -51,6 +51,7 @@ import {
   SKILL_TOVAK_RESISTANCE_BREAK,
   SKILL_TOVAK_MOTIVATION,
   SKILL_TOVAK_MANA_OVERLOAD,
+  SKILL_GOLDYX_GLITTERING_FORTUNE,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -62,6 +63,8 @@ import { CARD_WOUND } from "@mage-knight/shared";
 import { canActivatePolarization } from "../commands/skills/polarizationEffect.js";
 import { canActivateInvocation } from "../commands/skills/invocationEffect.js";
 import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
+import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
+import { hexKey } from "@mage-knight/shared";
 
 /**
  * Skills that have effect implementations and can be activated.
@@ -101,6 +104,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
   SKILL_TOVAK_MOTIVATION,
   SKILL_TOVAK_MANA_OVERLOAD,
+  SKILL_GOLDYX_GLITTERING_FORTUNE,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER]);
@@ -140,6 +144,14 @@ function canActivateSkill(
     case SKILL_ARYTHEA_INVOCATION:
       // Must have at least one card in hand to discard
       return canActivateInvocation(player);
+
+    case SKILL_GOLDYX_GLITTERING_FORTUNE: {
+      // Only usable during interaction at an inhabited site
+      if (!player.position) return false;
+      const hex = state.map.hexes[hexKey(player.position)];
+      if (!hex?.site) return false;
+      return isPlayerAtInteractionSite(hex.site, player.id);
+    }
 
     default:
       // No special requirements

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -21,6 +21,7 @@ import {
   WRONG_COMBAT_PHASE,
   SKILL_REQUIRES_NOT_IN_COMBAT,
   SKILL_REQUIRES_WOUND_IN_HAND,
+  SKILL_REQUIRES_INTERACTION,
 } from "./validationCodes.js";
 import {
   SKILLS,
@@ -38,6 +39,7 @@ import {
   SKILL_NOROWAS_INSPIRATION,
   SKILL_NOROWAS_PRAYER_OF_WEATHER,
   SKILL_GOLDYX_POTION_MAKING,
+  SKILL_GOLDYX_GLITTERING_FORTUNE,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -45,9 +47,10 @@ import {
   COMBAT_PHASE_BLOCK,
   COMBAT_PHASE_RANGED_SIEGE,
 } from "../../types/combat.js";
-import { CARD_WOUND } from "@mage-knight/shared";
+import { CARD_WOUND, hexKey } from "@mage-knight/shared";
 import { getPlayerById } from "../helpers/playerHelpers.js";
 import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
+import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER]);
 
@@ -279,6 +282,22 @@ export const validateSkillRequirements: Validator = (
       return invalid(
         SKILL_REQUIRES_NOT_IN_COMBAT,
         "Potion Making cannot be used during combat"
+      );
+    }
+  }
+
+  if (useSkillAction.skillId === SKILL_GOLDYX_GLITTERING_FORTUNE) {
+    if (!player.position) {
+      return invalid(
+        SKILL_REQUIRES_INTERACTION,
+        "Glittering Fortune can only be used during interaction"
+      );
+    }
+    const hex = state.map.hexes[hexKey(player.position)];
+    if (!hex?.site || !isPlayerAtInteractionSite(hex.site, playerId)) {
+      return invalid(
+        SKILL_REQUIRES_INTERACTION,
+        "Glittering Fortune can only be used during interaction"
       );
     }
   }

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -318,6 +318,7 @@ export const SKILL_NOT_FOUND = "SKILL_NOT_FOUND" as const;
 export const SKILL_ON_COOLDOWN = "SKILL_ON_COOLDOWN" as const;
 export const SKILL_REQUIRES_NOT_IN_COMBAT = "SKILL_REQUIRES_NOT_IN_COMBAT" as const;
 export const SKILL_REQUIRES_WOUND_IN_HAND = "SKILL_REQUIRES_WOUND_IN_HAND" as const;
+export const SKILL_REQUIRES_INTERACTION = "SKILL_REQUIRES_INTERACTION" as const;
 export const SKILL_NOT_IN_CENTER = "SKILL_NOT_IN_CENTER" as const;
 export const CANNOT_RETURN_OWN_SKILL = "CANNOT_RETURN_OWN_SKILL" as const;
 
@@ -571,6 +572,7 @@ export type ValidationErrorCode =
   | typeof SKILL_ON_COOLDOWN
   | typeof SKILL_REQUIRES_NOT_IN_COMBAT
   | typeof SKILL_REQUIRES_WOUND_IN_HAND
+  | typeof SKILL_REQUIRES_INTERACTION
   // Time Bending chain prevention
   | typeof TIME_BENDING_CHAIN_PREVENTED
   | typeof SKILL_NOT_IN_CENTER


### PR DESCRIPTION
Implement the Glittering Fortune hero skill that grants influence
based on distinct crystal colors during interaction. The skill counts
unique crystal colors (red, blue, green, white) in the player's
inventory and grants 1 influence per color (0-4 max).

Key implementation details:
- Uses ScalingEffect with SCALING_PER_CRYSTAL_COLOR factor
- Restricted to interaction sites via validator and validActions
- Added isPlayerAtInteractionSite shared rule for alignment
- Fixed scaling effect undo by capturing resolved amount at execution
- Comprehensive test suite covering all edge cases

Closes #335

https://claude.ai/code/session_013Y41SU2HyNXDdhUBhfqmLp