### PR TITLE
feat: implement In Need wound-count scaling

### DIFF
--- a/packages/core/src/data/advancedActions/green/in-need.ts
+++ b/packages/core/src/data/advancedActions/green/in-need.ts
@@ -1,7 +1,7 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_INFLUENCE, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_GREEN, CARD_IN_NEED } from "@mage-knight/shared";
-import { influence } from "../helpers.js";
+import { influencePerWoundTotal } from "../../effectHelpers.js";
 
 export const IN_NEED: DeedCard = {
   id: CARD_IN_NEED,
@@ -11,8 +11,7 @@ export const IN_NEED: DeedCard = {
   categories: [CATEGORY_INFLUENCE],
   // Basic: Influence 3. Get an additional Influence 1 for each Wound card in your hand and on Units you control.
   // Powered: Influence 5. Get an additional Influence 2 for each Wound card in your hand and on Units you control.
-  // TODO: Implement wound-count scaling
-  basicEffect: influence(3),
-  poweredEffect: influence(5),
+  basicEffect: influencePerWoundTotal(3, 1),
+  poweredEffect: influencePerWoundTotal(5, 2),
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/effectHelpers.ts
+++ b/packages/core/src/data/effectHelpers.ts
@@ -27,6 +27,7 @@ import {
   SCALING_PER_ENEMY,
   SCALING_PER_WOUND_IN_HAND,
   SCALING_PER_UNIT,
+  SCALING_PER_WOUND_TOTAL,
 } from "../types/scaling.js";
 import type { CombatPhase } from "../types/combat.js";
 import type { Terrain, ManaColor, Element } from "@mage-knight/shared";
@@ -539,6 +540,16 @@ export function fireBlockPerEnemy(baseAmount: number, perEnemy: number): Scaling
  */
 export function iceBlockPerEnemy(baseAmount: number, perEnemy: number): ScalingEffect {
   return blockPerEnemy(baseAmount, perEnemy, ELEMENT_ICE);
+}
+
+/**
+ * Influence that scales per total wounds (hand + units)
+ */
+export function influencePerWoundTotal(
+  baseAmount: number,
+  perWound: number
+): ScalingEffect {
+  return scalingInfluence(baseAmount, { type: SCALING_PER_WOUND_TOTAL }, perWound);
 }
 
 // === Interaction Bonus Helper ===

--- a/packages/core/src/engine/__tests__/inNeed.test.ts
+++ b/packages/core/src/engine/__tests__/inNeed.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for In Need card - wound-count scaling for influence
+ *
+ * Basic: Influence 3. +1 per wound in hand and on units.
+ * Powered: Influence 5. +2 per wound in hand and on units.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { evaluateScalingFactor } from "../effects/scalingEvaluator.js";
+import { resolveEffect } from "../effects/index.js";
+import { SCALING_PER_WOUND_TOTAL } from "../../types/scaling.js";
+import { createPlayerUnit } from "../../types/unit.js";
+import { IN_NEED } from "../../data/advancedActions/green/in-need.js";
+import {
+  CARD_WOUND,
+  CARD_MARCH,
+  UNIT_PEASANTS,
+  UNIT_FORESTERS,
+  CARD_IN_NEED,
+} from "@mage-knight/shared";
+import { EFFECT_SCALING } from "../../types/effectTypes.js";
+import type { ScalingEffect } from "../../types/cards.js";
+
+describe("In Need", () => {
+  describe("card definition", () => {
+    it("should have scaling basic effect", () => {
+      expect(IN_NEED.basicEffect.type).toBe(EFFECT_SCALING);
+      const effect = IN_NEED.basicEffect as ScalingEffect;
+      expect(effect.baseEffect.amount).toBe(3);
+      expect(effect.scalingFactor.type).toBe(SCALING_PER_WOUND_TOTAL);
+      expect(effect.amountPerUnit).toBe(1);
+    });
+
+    it("should have scaling powered effect", () => {
+      expect(IN_NEED.poweredEffect.type).toBe(EFFECT_SCALING);
+      const effect = IN_NEED.poweredEffect as ScalingEffect;
+      expect(effect.baseEffect.amount).toBe(5);
+      expect(effect.scalingFactor.type).toBe(SCALING_PER_WOUND_TOTAL);
+      expect(effect.amountPerUnit).toBe(2);
+    });
+  });
+
+  describe("SCALING_PER_WOUND_TOTAL evaluator", () => {
+    it("should return 0 when no wounds anywhere", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_MARCH],
+        units: [createPlayerUnit(UNIT_PEASANTS)],
+      });
+      const state = createTestGameState({ players: [player] });
+      const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_TOTAL });
+      expect(count).toBe(0);
+    });
+
+    it("should count wounds in hand only", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH, CARD_WOUND],
+        units: [createPlayerUnit(UNIT_PEASANTS)],
+      });
+      const state = createTestGameState({ players: [player] });
+      const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_TOTAL });
+      expect(count).toBe(2);
+    });
+
+    it("should count wounded units only", () => {
+      const woundedUnit = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [createPlayerUnit(UNIT_FORESTERS), woundedUnit],
+      });
+      const state = createTestGameState({ players: [player] });
+      const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_TOTAL });
+      expect(count).toBe(1);
+    });
+
+    it("should count wounds in hand and on units combined", () => {
+      const woundedUnit1 = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const woundedUnit2 = { ...createPlayerUnit(UNIT_FORESTERS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [
+          createPlayerUnit(UNIT_PEASANTS),
+          woundedUnit1,
+          woundedUnit2,
+        ],
+      });
+      const state = createTestGameState({ players: [player] });
+      const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_TOTAL });
+      expect(count).toBe(5); // 3 in hand + 2 wounded units
+    });
+
+    it("should return 0 with no units and no wounds in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+      const count = evaluateScalingFactor(state, "player1", { type: SCALING_PER_WOUND_TOTAL });
+      expect(count).toBe(0);
+    });
+  });
+
+  describe("basic effect resolution", () => {
+    it("should give base influence 3 with no wounds", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.basicEffect, CARD_IN_NEED);
+
+      // 3 base + (1 × 0 wounds) = 3
+      expect(result.state.players[0]?.influencePoints).toBe(3);
+    });
+
+    it("should scale by wounds in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.basicEffect, CARD_IN_NEED);
+
+      // 3 base + (1 × 2 wounds) = 5
+      expect(result.state.players[0]?.influencePoints).toBe(5);
+    });
+
+    it("should scale by wounded units", () => {
+      const woundedUnit = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [woundedUnit, createPlayerUnit(UNIT_FORESTERS)],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.basicEffect, CARD_IN_NEED);
+
+      // 3 base + (1 × 1 wounded unit) = 4
+      expect(result.state.players[0]?.influencePoints).toBe(4);
+    });
+
+    it("should scale by combined wounds in hand and on units", () => {
+      const woundedUnit = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [woundedUnit, createPlayerUnit(UNIT_FORESTERS)],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.basicEffect, CARD_IN_NEED);
+
+      // 3 base + (1 × 3 total wounds) = 6
+      expect(result.state.players[0]?.influencePoints).toBe(6);
+    });
+  });
+
+  describe("powered effect resolution", () => {
+    it("should give base influence 5 with no wounds", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.poweredEffect, CARD_IN_NEED);
+
+      // 5 base + (2 × 0 wounds) = 5
+      expect(result.state.players[0]?.influencePoints).toBe(5);
+    });
+
+    it("should scale by +2 per wound in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.poweredEffect, CARD_IN_NEED);
+
+      // 5 base + (2 × 2 wounds) = 9
+      expect(result.state.players[0]?.influencePoints).toBe(9);
+    });
+
+    it("should scale by +2 per wounded unit", () => {
+      const woundedUnit1 = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const woundedUnit2 = { ...createPlayerUnit(UNIT_FORESTERS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        units: [woundedUnit1, woundedUnit2],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.poweredEffect, CARD_IN_NEED);
+
+      // 5 base + (2 × 2 wounded units) = 9
+      expect(result.state.players[0]?.influencePoints).toBe(9);
+    });
+
+    it("should scale by combined wounds at +2 each", () => {
+      const woundedUnit = { ...createPlayerUnit(UNIT_PEASANTS), wounded: true };
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [woundedUnit, createPlayerUnit(UNIT_FORESTERS)],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.poweredEffect, CARD_IN_NEED);
+
+      // 5 base + (2 × 4 total wounds) = 13
+      expect(result.state.players[0]?.influencePoints).toBe(13);
+    });
+  });
+
+  describe("timing", () => {
+    it("should count wounds at effect resolution time", () => {
+      // Wounds are counted when the effect resolves, not when the card is played.
+      // This test verifies that the scaling evaluator reads the current state,
+      // meaning any wounds added before resolution (e.g., from Mana Exploit) count.
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", IN_NEED.basicEffect, CARD_IN_NEED);
+
+      // 3 wounds at resolution time: 3 base + (1 × 3) = 6
+      expect(result.state.players[0]?.influencePoints).toBe(6);
+      expect(result.containsScaling).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/scalingEvaluator.ts
+++ b/packages/core/src/engine/effects/scalingEvaluator.ts
@@ -11,6 +11,7 @@ import {
   SCALING_PER_UNIT,
   SCALING_PER_CRYSTAL_COLOR,
   SCALING_PER_EMPTY_COMMAND_TOKEN,
+  SCALING_PER_WOUND_TOTAL,
 } from "../../types/scaling.js";
 import type { UnitFilter } from "../../types/scaling.js";
 import type { PlayerUnit } from "../../types/unit.js";
@@ -76,6 +77,13 @@ export function evaluateScalingFactor(
       // Empty = commandTokens - current unit count
       const usedSlots = player.units.length;
       return Math.max(0, player.commandTokens - usedSlots);
+    }
+
+    case SCALING_PER_WOUND_TOTAL: {
+      // Count wounds in hand + wounded units
+      const woundsInHand = player.hand.filter((c) => c === CARD_WOUND).length;
+      const woundedUnits = player.units.filter((u) => u.wounded).length;
+      return woundsInHand + woundedUnits;
     }
 
     default: {

--- a/packages/core/src/types/scaling.ts
+++ b/packages/core/src/types/scaling.ts
@@ -11,6 +11,7 @@ export const SCALING_PER_WOUND_THIS_COMBAT = "per_wound_this_combat" as const;
 export const SCALING_PER_UNIT = "per_unit" as const;
 export const SCALING_PER_CRYSTAL_COLOR = "per_crystal_color" as const;
 export const SCALING_PER_EMPTY_COMMAND_TOKEN = "per_empty_command_token" as const;
+export const SCALING_PER_WOUND_TOTAL = "per_wound_total" as const;
 
 // Note: SCALING_PER_WOUND_PLAYED was removed because wounds cannot be "played"
 // as cards in Mage Knight - they are dead cards.
@@ -52,6 +53,14 @@ export interface ScalingPerEmptyCommandTokenFactor {
 }
 
 /**
+ * Scales by total wound count: wounds in hand + wounded units.
+ * For cards like "In Need" that scale by all wound sources.
+ */
+export interface ScalingPerWoundTotalFactor {
+  readonly type: typeof SCALING_PER_WOUND_TOTAL;
+}
+
+/**
  * Filter criteria for unit-based scaling.
  */
 export interface UnitFilter {
@@ -71,4 +80,5 @@ export type ScalingFactor =
   | ScalingPerWoundThisCombatFactor
   | ScalingPerUnitFactor
   | ScalingPerCrystalColorFactor
-  | ScalingPerEmptyCommandTokenFactor;
+  | ScalingPerEmptyCommandTokenFactor
+  | ScalingPerWoundTotalFactor;


### PR DESCRIPTION
## Summary
- Added `SCALING_PER_WOUND_TOTAL` scaling factor that counts wounds in hand + wounded units
- Updated In Need card to use scaling influence instead of flat values
- Basic: Influence 3 + 1 per wound (hand + units)
- Powered: Influence 5 + 2 per wound (hand + units)

## Changes
- `packages/core/src/types/scaling.ts` — New `SCALING_PER_WOUND_TOTAL` scaling factor type
- `packages/core/src/engine/effects/scalingEvaluator.ts` — Evaluation logic for the new factor
- `packages/core/src/data/effectHelpers.ts` — `influencePerWoundTotal()` convenience helper
- `packages/core/src/data/advancedActions/green/in-need.ts` — Card now uses scaling effects
- `packages/core/src/engine/__tests__/inNeed.test.ts` — 16 tests covering evaluator, basic/powered effects, and timing

Closes #161