### PR TITLE
feat: implement Decompose throw-away mechanic with crystal generation (#162)

### DIFF
--- a/packages/core/src/data/advancedActions/red/decompose.ts
+++ b/packages/core/src/data/advancedActions/red/decompose.ts
@@ -1,7 +1,17 @@
-import type { DeedCard } from "../../../types/cards.js";
+import type { DeedCard, DecomposeEffect } from "../../../types/cards.js";
 import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_RED, CARD_DECOMPOSE } from "@mage-knight/shared";
-import { gainCrystal } from "../helpers.js";
+import { EFFECT_DECOMPOSE } from "../../../types/effectTypes.js";
+
+const basicEffect: DecomposeEffect = {
+  type: EFFECT_DECOMPOSE,
+  mode: "basic",
+};
+
+const poweredEffect: DecomposeEffect = {
+  type: EFFECT_DECOMPOSE,
+  mode: "powered",
+};
 
 export const DECOMPOSE: DeedCard = {
   id: CARD_DECOMPOSE,
@@ -9,10 +19,9 @@ export const DECOMPOSE: DeedCard = {
   cardType: DEED_CARD_TYPE_ADVANCED_ACTION,
   poweredBy: [MANA_RED],
   categories: [CATEGORY_SPECIAL],
-  // Basic: When you play this card, throw away an Action card from hand. Gain two crystals to your Inventory that are the same color as the thrown away card.
-  // Powered: When you play this card, throw away an Action card from hand. Gain a crystal to your Inventory of each basic color that does not match the color of the thrown away card.
-  // TODO: Implement throw-away mechanic and crystal generation based on discarded card
-  basicEffect: gainCrystal(MANA_RED),
-  poweredEffect: gainCrystal(MANA_RED),
+  // Basic: Throw away an Action card from hand → gain 2 crystals of matching color
+  // Powered: Throw away an Action card from hand → gain 1 crystal of each non-matching basic color
+  basicEffect,
+  poweredEffect,
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/decompose.test.ts
+++ b/packages/core/src/engine/__tests__/decompose.test.ts
@@ -1,0 +1,780 @@
+/**
+ * Tests for Decompose (red advanced action card)
+ *
+ * Decompose allows throwing away (permanently removing) an action card from hand
+ * to gain crystals:
+ * - Basic: Throw away action card → gain 2 crystals of that card's color
+ * - Powered (Red): Throw away action card → gain 1 crystal of each basic color
+ *   that does NOT match the thrown card's color (3 crystals total)
+ *
+ * Key rules:
+ * - Only action cards (basic/advanced) can be thrown away (not wounds, artifacts, spells)
+ * - The Decompose card itself cannot be thrown away
+ * - Thrown away cards go to removedCards (permanent, not recycled)
+ * - Crystals capped at 3 per color
+ * - Card destroyed event is emitted (permanent removal)
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { isEffectResolvable } from "../effects/index.js";
+import { handleDecomposeEffect, getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
+import { createResolveDecomposeCommand } from "../commands/resolveDecomposeCommand.js";
+import { describeEffect } from "../effects/describeEffect.js";
+import {
+  validateHasPendingDecompose,
+  validateDecomposeSelection,
+} from "../validators/decomposeValidators.js";
+import { EFFECT_DECOMPOSE } from "../../types/effectTypes.js";
+import type { DecomposeEffect } from "../../types/cards.js";
+import type { PendingDecompose } from "../../types/player.js";
+import {
+  CARD_DECOMPOSE,
+  CARD_MARCH,
+  CARD_RAGE,
+  CARD_WOUND,
+  CARD_BANNER_OF_GLORY,
+  CARD_FIREBALL,
+  CARD_SWIFTNESS,
+  CARD_DETERMINATION,
+  CARD_DESTROYED,
+  RESOLVE_DECOMPOSE_ACTION,
+} from "@mage-knight/shared";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function makePending(overrides: Partial<PendingDecompose> = {}): PendingDecompose {
+  return {
+    sourceCardId: CARD_DECOMPOSE,
+    mode: "basic",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// ELIGIBILITY
+// ============================================================================
+
+describe("Decompose", () => {
+  describe("getCardsEligibleForDecompose", () => {
+    it("should return action cards excluding wounds and the source card", () => {
+      const hand = [CARD_MARCH, CARD_RAGE, CARD_WOUND, CARD_DECOMPOSE];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+
+    it("should exclude wounds", () => {
+      const hand = [CARD_WOUND, CARD_MARCH];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude the source card (Decompose itself)", () => {
+      const hand = [CARD_DECOMPOSE, CARD_MARCH];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude artifacts (not action cards)", () => {
+      const hand = [CARD_BANNER_OF_GLORY, CARD_MARCH];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude spells (not action cards)", () => {
+      const hand = [CARD_FIREBALL, CARD_MARCH];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should return empty when only wounds and Decompose in hand", () => {
+      const hand = [CARD_WOUND, CARD_DECOMPOSE];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([]);
+    });
+
+    it("should return empty for empty hand", () => {
+      const eligible = getCardsEligibleForDecompose([], CARD_DECOMPOSE);
+      expect(eligible).toEqual([]);
+    });
+
+    it("should include both basic and advanced action cards", () => {
+      // CARD_MARCH is a basic green action, CARD_DECOMPOSE is advanced red
+      // But we're using CARD_DECOMPOSE as sourceCardId, so it's excluded
+      const hand = [CARD_MARCH, CARD_RAGE];
+      const eligible = getCardsEligibleForDecompose(hand, CARD_DECOMPOSE);
+      expect(eligible).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+  });
+
+  // ============================================================================
+  // RESOLVABILITY
+  // ============================================================================
+
+  describe("isEffectResolvable", () => {
+    const basicEffect: DecomposeEffect = {
+      type: EFFECT_DECOMPOSE,
+      mode: "basic",
+    };
+
+    it("should be resolvable when player has action cards", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should NOT be resolvable when player only has wounds", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when hand is empty", () => {
+      const player = createTestPlayer({ hand: [] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should be resolvable with mix of wounds and action cards", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND, CARD_MARCH, CARD_WOUND] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should NOT be resolvable when only artifacts in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_BANNER_OF_GLORY] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when only spells in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_FIREBALL] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // EFFECT HANDLER
+  // ============================================================================
+
+  describe("handleDecomposeEffect", () => {
+    it("should create pending state (basic mode)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH, CARD_RAGE] });
+      const state = createTestGameState({ players: [player] });
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "basic",
+      };
+
+      const result = handleDecomposeEffect(
+        state, 0, player, effect, CARD_DECOMPOSE
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingDecompose).not.toBeNull();
+      expect(result.state.players[0].pendingDecompose?.mode).toBe("basic");
+      expect(result.state.players[0].pendingDecompose?.sourceCardId).toBe(CARD_DECOMPOSE);
+    });
+
+    it("should create pending state (powered mode)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "powered",
+      };
+
+      const result = handleDecomposeEffect(
+        state, 0, player, effect, CARD_DECOMPOSE
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingDecompose?.mode).toBe("powered");
+    });
+
+    it("should throw when no eligible action cards", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND, CARD_DECOMPOSE] });
+      const state = createTestGameState({ players: [player] });
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "basic",
+      };
+
+      expect(() =>
+        handleDecomposeEffect(state, 0, player, effect, CARD_DECOMPOSE)
+      ).toThrow("No action cards available to throw away for Decompose");
+    });
+
+    it("should throw when sourceCardId is null", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "basic",
+      };
+
+      expect(() =>
+        handleDecomposeEffect(state, 0, player, effect, null)
+      ).toThrow("DecomposeEffect requires sourceCardId");
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE DECOMPOSE COMMAND - BASIC MODE
+  // ============================================================================
+
+  describe("resolveDecomposeCommand (basic mode)", () => {
+    describe("green card → 2 green crystals", () => {
+      it("should throw away a green card and gain 2 green crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH, CARD_RAGE],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_MARCH, // green basic action
+        });
+        const result = command.execute(state);
+
+        // Card removed from hand
+        expect(result.state.players[0].hand).not.toContain(CARD_MARCH);
+        // Card added to removedCards (permanent removal)
+        expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+        // Card NOT in discard pile (thrown away, not discarded)
+        expect(result.state.players[0].discard).not.toContain(CARD_MARCH);
+        // 2 green crystals gained
+        expect(result.state.players[0].crystals.green).toBe(2);
+        // Other crystals unchanged
+        expect(result.state.players[0].crystals.red).toBe(0);
+        expect(result.state.players[0].crystals.blue).toBe(0);
+        expect(result.state.players[0].crystals.white).toBe(0);
+        // Pending state cleared
+        expect(result.state.players[0].pendingDecompose).toBeNull();
+        // Card destroyed event emitted
+        expect(result.events).toContainEqual(
+          expect.objectContaining({
+            type: CARD_DESTROYED,
+            cardId: CARD_MARCH,
+          })
+        );
+      });
+    });
+
+    describe("red card → 2 red crystals", () => {
+      it("should throw away a red card and gain 2 red crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_RAGE],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_RAGE, // red basic action
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.red).toBe(2);
+        expect(result.state.players[0].removedCards).toContain(CARD_RAGE);
+      });
+    });
+
+    describe("blue card → 2 blue crystals", () => {
+      it("should throw away a blue card and gain 2 blue crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_DETERMINATION],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_DETERMINATION, // blue basic action
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.blue).toBe(2);
+        expect(result.state.players[0].removedCards).toContain(CARD_DETERMINATION);
+      });
+    });
+
+    describe("white card → 2 white crystals", () => {
+      it("should throw away a white card and gain 2 white crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_SWIFTNESS],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_SWIFTNESS, // white basic action
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.white).toBe(2);
+        expect(result.state.players[0].removedCards).toContain(CARD_SWIFTNESS);
+      });
+    });
+
+    describe("crystal cap at 3", () => {
+      it("should cap at 3 when starting with 2 crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          crystals: { red: 0, blue: 0, green: 2, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_MARCH, // green → +2 green, capped at 3
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.green).toBe(3);
+      });
+
+      it("should not exceed 3 when starting with 3 crystals", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          crystals: { red: 0, blue: 0, green: 3, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "basic" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_MARCH, // green → +2 green, stays at 3
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.green).toBe(3);
+        // Card still removed
+        expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      });
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE DECOMPOSE COMMAND - POWERED MODE
+  // ============================================================================
+
+  describe("resolveDecomposeCommand (powered mode)", () => {
+    describe("green card → 1 red, 1 blue, 1 white crystals", () => {
+      it("should throw away green card and gain 1 of each non-green crystal", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "powered" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_MARCH, // green → gain 1 red, 1 blue, 1 white
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.red).toBe(1);
+        expect(result.state.players[0].crystals.blue).toBe(1);
+        expect(result.state.players[0].crystals.green).toBe(0); // No green!
+        expect(result.state.players[0].crystals.white).toBe(1);
+        expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      });
+    });
+
+    describe("red card → 1 blue, 1 green, 1 white crystals", () => {
+      it("should throw away red card and gain 1 of each non-red crystal", () => {
+        const player = createTestPlayer({
+          hand: [CARD_RAGE],
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "powered" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_RAGE, // red → gain 1 blue, 1 green, 1 white
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.red).toBe(0); // No red!
+        expect(result.state.players[0].crystals.blue).toBe(1);
+        expect(result.state.players[0].crystals.green).toBe(1);
+        expect(result.state.players[0].crystals.white).toBe(1);
+      });
+    });
+
+    describe("crystal cap per color in powered mode", () => {
+      it("should cap individual colors at 3", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          crystals: { red: 3, blue: 2, green: 0, white: 3 },
+          removedCards: [],
+          pendingDecompose: makePending({ mode: "powered" }),
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createResolveDecomposeCommand({
+          playerId: "player1",
+          cardId: CARD_MARCH, // green → gain 1 red (capped), 1 blue, 1 white (capped)
+        });
+        const result = command.execute(state);
+
+        expect(result.state.players[0].crystals.red).toBe(3); // Already at cap
+        expect(result.state.players[0].crystals.blue).toBe(3);
+        expect(result.state.players[0].crystals.green).toBe(0); // Matching color, not gained
+        expect(result.state.players[0].crystals.white).toBe(3); // Already at cap
+      });
+    });
+  });
+
+  // ============================================================================
+  // ERROR HANDLING
+  // ============================================================================
+
+  describe("resolveDecomposeCommand error handling", () => {
+    it("should throw when no pending state exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingDecompose: null,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+
+      expect(() => command.execute(state)).toThrow("No pending decompose to resolve");
+    });
+
+    it("should throw when card is not eligible (wound)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_WOUND,
+      });
+
+      expect(() => command.execute(state)).toThrow("not eligible for Decompose");
+    });
+
+    it("should throw when card is not eligible (artifact)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_BANNER_OF_GLORY],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_BANNER_OF_GLORY,
+      });
+
+      expect(() => command.execute(state)).toThrow("not eligible for Decompose");
+    });
+
+    it("should throw when player not found", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "nonexistent",
+        cardId: CARD_MARCH,
+      });
+
+      expect(() => command.execute(state)).toThrow("Player not found");
+    });
+  });
+
+  // ============================================================================
+  // UNDO
+  // ============================================================================
+
+  describe("resolveDecomposeCommand undo", () => {
+    it("should restore hand, removedCards, crystals, and pending state (basic)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        discard: [],
+        removedCards: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+        pendingDecompose: makePending({ mode: "basic" }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+
+      const executed = command.execute(state);
+      // Verify execute changed state
+      expect(executed.state.players[0].crystals.green).toBe(2);
+      expect(executed.state.players[0].hand).not.toContain(CARD_MARCH);
+      expect(executed.state.players[0].removedCards).toContain(CARD_MARCH);
+
+      const undone = command.undo(executed.state);
+
+      // Hand restored
+      expect(undone.state.players[0].hand).toContain(CARD_MARCH);
+      expect(undone.state.players[0].hand).toContain(CARD_RAGE);
+      // removedCards restored
+      expect(undone.state.players[0].removedCards).toEqual([]);
+      // Crystals restored
+      expect(undone.state.players[0].crystals.green).toBe(0);
+      // Pending state restored
+      expect(undone.state.players[0].pendingDecompose).not.toBeNull();
+      expect(undone.state.players[0].pendingDecompose?.mode).toBe("basic");
+    });
+
+    it("should restore state after powered mode", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        discard: [],
+        removedCards: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+        pendingDecompose: makePending({ mode: "powered" }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+
+      const executed = command.execute(state);
+      expect(executed.state.players[0].crystals.red).toBe(1);
+      expect(executed.state.players[0].crystals.blue).toBe(1);
+      expect(executed.state.players[0].crystals.white).toBe(1);
+
+      const undone = command.undo(executed.state);
+
+      // All crystals restored
+      expect(undone.state.players[0].crystals).toEqual({ red: 0, blue: 0, green: 0, white: 0 });
+      // removedCards restored
+      expect(undone.state.players[0].removedCards).toEqual([]);
+      // Pending state restored
+      expect(undone.state.players[0].pendingDecompose?.mode).toBe("powered");
+    });
+  });
+
+  // ============================================================================
+  // DESCRIBE EFFECT
+  // ============================================================================
+
+  describe("describeEffect", () => {
+    it("should describe basic decompose", () => {
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "basic",
+      };
+      expect(describeEffect(effect)).toBe(
+        "Throw away an action card to gain 2 crystals of matching color"
+      );
+    });
+
+    it("should describe powered decompose", () => {
+      const effect: DecomposeEffect = {
+        type: EFFECT_DECOMPOSE,
+        mode: "powered",
+      };
+      expect(describeEffect(effect)).toBe(
+        "Throw away an action card to gain 1 crystal of each non-matching color"
+      );
+    });
+  });
+
+  // ============================================================================
+  // VALIDATORS
+  // ============================================================================
+
+  describe("validators", () => {
+    describe("validateHasPendingDecompose", () => {
+      it("should pass when pending state exists", () => {
+        const player = createTestPlayer({
+          pendingDecompose: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateHasPendingDecompose(state, "player1", action);
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail when no pending state", () => {
+        const player = createTestPlayer({
+          pendingDecompose: null,
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateHasPendingDecompose(state, "player1", action);
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe("validateDecomposeSelection", () => {
+      it("should pass for eligible action card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          pendingDecompose: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateDecomposeSelection(state, "player1", action);
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail for wound card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_WOUND],
+          pendingDecompose: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_WOUND,
+        } as const;
+
+        const result = validateDecomposeSelection(state, "player1", action);
+        expect(result.valid).toBe(false);
+      });
+
+      it("should fail for artifact card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_BANNER_OF_GLORY],
+          pendingDecompose: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_BANNER_OF_GLORY,
+        } as const;
+
+        const result = validateDecomposeSelection(state, "player1", action);
+        expect(result.valid).toBe(false);
+      });
+
+      it("should fail for the Decompose card itself", () => {
+        const player = createTestPlayer({
+          hand: [CARD_DECOMPOSE, CARD_MARCH],
+          pendingDecompose: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_DECOMPOSE_ACTION,
+          cardId: CARD_DECOMPOSE,
+        } as const;
+
+        const result = validateDecomposeSelection(state, "player1", action);
+        expect(result.valid).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================================
+  // PERMANENT REMOVAL VERIFICATION
+  // ============================================================================
+
+  describe("permanent removal (throw away)", () => {
+    it("should add card to removedCards, not discard pile", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        discard: [],
+        removedCards: [],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      // Card is in removedCards (permanent)
+      expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      // Card is NOT in discard (would be recycled)
+      expect(result.state.players[0].discard).not.toContain(CARD_MARCH);
+      // Card is NOT in hand
+      expect(result.state.players[0].hand).not.toContain(CARD_MARCH);
+      // Other cards remain in hand
+      expect(result.state.players[0].hand).toContain(CARD_RAGE);
+    });
+
+    it("should emit CARD_DESTROYED event", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        removedCards: [],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toEqual({
+        type: CARD_DESTROYED,
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+    });
+
+    it("should preserve existing removedCards", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        removedCards: [CARD_RAGE],
+        pendingDecompose: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveDecomposeCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      expect(result.state.players[0].removedCards).toEqual([CARD_RAGE, CARD_MARCH]);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -159,6 +159,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingUnitMaintenance: null,
     pendingDiscardForAttack: null,
     pendingDiscardForCrystal: null,
+    pendingDecompose: null,
     pendingTerrainCostReduction: null,
     pendingAttackDefeatFame: [],
     enemiesDefeatedThisTurn: 0,

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -64,6 +64,9 @@ export const RESOLVE_DISCARD_COMMAND = "RESOLVE_DISCARD" as const;
 export const RESOLVE_DISCARD_FOR_CRYSTAL_COMMAND = "RESOLVE_DISCARD_FOR_CRYSTAL" as const;
 export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_COMMAND = "RESOLVE_ARTIFACT_CRYSTAL_COLOR" as const;
 
+// Decompose command (throw away action card for crystals)
+export const RESOLVE_DECOMPOSE_COMMAND = "RESOLVE_DECOMPOSE" as const;
+
 // Burn monastery command
 export const BURN_MONASTERY_COMMAND = "BURN_MONASTERY" as const;
 

--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -23,6 +23,7 @@ import {
   RESOLVE_DISCARD_ACTION,
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
+  RESOLVE_DECOMPOSE_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   MANA_BLACK,
 } from "@mage-knight/shared";
@@ -36,6 +37,7 @@ import { createResolveDiscardCommand } from "../resolveDiscardCommand.js";
 import { createResolveDiscardForAttackCommand } from "../resolveDiscardForAttackCommand.js";
 import { createResolveDiscardForCrystalCommand } from "../resolveDiscardForCrystalCommand.js";
 import { createResolveArtifactCrystalColorCommand } from "../resolveArtifactCrystalColorCommand.js";
+import { createResolveDecomposeCommand } from "../resolveDecomposeCommand.js";
 import { getCard } from "../../validActions/cards/index.js";
 import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
 import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
@@ -331,5 +333,25 @@ export const createResolveArtifactCrystalColorCommandFromAction: CommandFactory 
   return createResolveArtifactCrystalColorCommand({
     playerId,
     color: action.color,
+  });
+};
+
+/**
+ * Resolve decompose command factory.
+ * Creates a command to resolve a pending decompose (throw away action card for crystals).
+ */
+export const createResolveDecomposeCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_DECOMPOSE_ACTION) return null;
+
+  const player = getPlayerById(state, playerId);
+  if (!player?.pendingDecompose) return null;
+
+  return createResolveDecomposeCommand({
+    playerId,
+    cardId: action.cardId,
   });
 };

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -28,6 +28,7 @@ import {
   RESOLVE_DISCARD_ACTION,
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
+  RESOLVE_DECOMPOSE_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   REST_ACTION,
   DECLARE_REST_ACTION,
@@ -98,6 +99,7 @@ export {
   createResolveDiscardCommandFromAction,
   createResolveDiscardForAttackCommandFromAction,
   createResolveDiscardForCrystalCommandFromAction,
+  createResolveDecomposeCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -209,6 +211,7 @@ import {
   createResolveDiscardCommandFromAction,
   createResolveDiscardForAttackCommandFromAction,
   createResolveDiscardForCrystalCommandFromAction,
+  createResolveDecomposeCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -314,6 +317,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [RESOLVE_DISCARD_ACTION]: createResolveDiscardCommandFromAction,
   [RESOLVE_DISCARD_FOR_ATTACK_ACTION]: createResolveDiscardForAttackCommandFromAction,
   [RESOLVE_DISCARD_FOR_CRYSTAL_ACTION]: createResolveDiscardForCrystalCommandFromAction,
+  [RESOLVE_DECOMPOSE_ACTION]: createResolveDecomposeCommandFromAction,
   [RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION]: createResolveArtifactCrystalColorCommandFromAction,
   [REST_ACTION]: createRestCommandFromAction,
   [DECLARE_REST_ACTION]: createDeclareRestCommandFromAction,

--- a/packages/core/src/engine/commands/resolveDecomposeCommand.ts
+++ b/packages/core/src/engine/commands/resolveDecomposeCommand.ts
@@ -1,0 +1,232 @@
+/**
+ * Resolve Decompose Command
+ *
+ * Handles player resolution of a pending decompose (Decompose advanced action).
+ * When the player selects an action card to throw away:
+ * - Card is permanently removed from the game (added to removedCards)
+ * - Basic mode: gain 2 crystals matching the card's color
+ * - Powered mode: gain 1 crystal of each basic color NOT matching the card's color
+ *
+ * Flow:
+ * 1. Card played creates pendingDecompose via EFFECT_DECOMPOSE
+ * 2. Player sends RESOLVE_DECOMPOSE action with selected cardId
+ * 3. Card is removed from hand → added to removedCards (permanent)
+ * 4. Crystals are granted based on mode and card color
+ *
+ * This command is reversible since it's part of normal card play flow.
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, CardId, BasicManaColor } from "@mage-knight/shared";
+import { CARD_DESTROYED, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
+import type { Player, PendingDecompose, Crystals } from "../../types/player.js";
+import { RESOLVE_DECOMPOSE_COMMAND } from "./commandTypes.js";
+import { getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+
+export { RESOLVE_DECOMPOSE_COMMAND };
+
+export interface ResolveDecomposeCommandParams {
+  readonly playerId: string;
+  /** Card ID of the action card to throw away */
+  readonly cardId: CardId;
+}
+
+export function createResolveDecomposeCommand(
+  params: ResolveDecomposeCommandParams
+): Command {
+  // Store previous state for undo
+  let previousPendingDecompose: PendingDecompose | null = null;
+  let previousHand: readonly CardId[] = [];
+  let previousRemovedCards: readonly CardId[] = [];
+  let previousCrystals: Crystals | null = null;
+
+  return {
+    type: RESOLVE_DECOMPOSE_COMMAND,
+    playerId: params.playerId,
+    isReversible: true, // Part of normal card play flow
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      if (!player.pendingDecompose) {
+        throw new Error("No pending decompose to resolve");
+      }
+
+      const pending = player.pendingDecompose;
+
+      // Store for undo
+      previousPendingDecompose = pending;
+      previousHand = player.hand;
+      previousRemovedCards = player.removedCards;
+      previousCrystals = player.crystals;
+
+      const events: GameEvent[] = [];
+
+      // Validate card is eligible
+      const eligibleCards = getCardsEligibleForDecompose(player.hand, pending.sourceCardId);
+      if (!eligibleCards.includes(params.cardId)) {
+        throw new Error(
+          `Card ${params.cardId} is not eligible for Decompose (must be an action card in hand, not the Decompose card itself)`
+        );
+      }
+
+      // Remove card from hand
+      const updatedHand = [...player.hand];
+      const cardIndex = updatedHand.indexOf(params.cardId);
+      if (cardIndex === -1) {
+        throw new Error(`Card ${params.cardId} not found in hand`);
+      }
+      updatedHand.splice(cardIndex, 1);
+
+      // Add to removedCards (permanent removal - throw away)
+      const updatedRemovedCards = [...player.removedCards, params.cardId];
+
+      // Emit card destroyed event (permanent removal)
+      events.push({
+        type: CARD_DESTROYED,
+        playerId: params.playerId,
+        cardId: params.cardId,
+      });
+
+      // Get the action card color
+      const cardColor = getActionCardColor(params.cardId);
+      if (!cardColor) {
+        // Should not happen since we filter for action cards in eligibility check
+        throw new Error(`Card ${params.cardId} has no color (not an action card)`);
+      }
+
+      // Convert card color to mana color
+      const manaColor = cardColorToManaColor(cardColor);
+
+      // Grant crystals based on mode
+      let updatedCrystals: Crystals;
+      if (pending.mode === "basic") {
+        // Basic: gain 2 crystals of matching color
+        updatedCrystals = addCrystals(player.crystals, manaColor, 2);
+      } else {
+        // Powered: gain 1 crystal of each basic color NOT matching
+        const nonMatchingColors = ALL_BASIC_COLORS.filter((c) => c !== manaColor);
+        updatedCrystals = player.crystals;
+        for (const color of nonMatchingColors) {
+          updatedCrystals = addCrystals(updatedCrystals, color, 1);
+        }
+      }
+
+      // Clear pending state
+      const updatedPlayer: Player = {
+        ...player,
+        hand: updatedHand,
+        removedCards: updatedRemovedCards,
+        crystals: updatedCrystals,
+        pendingDecompose: null,
+      };
+
+      const newState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? updatedPlayer : p
+        ),
+      };
+
+      return {
+        state: newState,
+        events,
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      // Restore previous state
+      const restoredPlayer: Player = {
+        ...player,
+        hand: previousHand,
+        removedCards: previousRemovedCards,
+        crystals: previousCrystals ?? player.crystals,
+        pendingDecompose: previousPendingDecompose,
+      };
+
+      const newState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? restoredPlayer : p
+        ),
+      };
+
+      return {
+        state: newState,
+        events: [],
+      };
+    },
+  };
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+const ALL_BASIC_COLORS: readonly BasicManaColor[] = [
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+];
+
+/**
+ * Convert card color to mana color.
+ * Card colors and mana colors use the same string values ("red", "blue", etc.)
+ * but this function provides a type-safe conversion.
+ */
+function cardColorToManaColor(
+  cardColor: string
+): BasicManaColor {
+  switch (cardColor) {
+    case "red":
+      return MANA_RED;
+    case "blue":
+      return MANA_BLUE;
+    case "green":
+      return MANA_GREEN;
+    case "white":
+      return MANA_WHITE;
+    default:
+      throw new Error(`Unknown card color: ${cardColor}`);
+  }
+}
+
+/**
+ * Add crystals of the specified color (capped at 3 per color)
+ */
+function addCrystals(crystals: Crystals, color: BasicManaColor, count: number): Crystals {
+  const current = crystals[color];
+  const newValue = Math.min(current + count, 3);
+  if (newValue === current) {
+    return crystals;
+  }
+  return {
+    ...crystals,
+    [color]: newValue,
+  };
+}

--- a/packages/core/src/engine/effects/decomposeEffects.ts
+++ b/packages/core/src/engine/effects/decomposeEffects.ts
@@ -1,0 +1,117 @@
+/**
+ * Decompose Effect Handlers
+ *
+ * Handles the Decompose advanced action card effect:
+ * - Throw away an action card from hand (permanent removal)
+ * - Basic: gain 2 crystals matching the thrown card's color
+ * - Powered: gain 1 crystal of each basic color NOT matching the thrown card's color
+ *
+ * Only action cards (basic or advanced) can be thrown away.
+ * Wounds, artifacts, spells, and the Decompose card itself are excluded.
+ *
+ * @module effects/decomposeEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, PendingDecompose } from "../../types/player.js";
+import type { DecomposeEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { CardId } from "@mage-knight/shared";
+import { CARD_WOUND } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_DECOMPOSE } from "../../types/effectTypes.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+
+// ============================================================================
+// ELIGIBILITY HELPERS
+// ============================================================================
+
+/**
+ * Get cards eligible for Decompose (action cards in hand, excluding
+ * wounds and the source Decompose card itself).
+ */
+export function getCardsEligibleForDecompose(
+  hand: readonly CardId[],
+  sourceCardId: CardId
+): CardId[] {
+  return hand.filter((cardId) => {
+    if (cardId === CARD_WOUND) return false;
+    if (cardId === sourceCardId) return false;
+    // Only action cards (those with a color) can be thrown away
+    return getActionCardColor(cardId) !== null;
+  });
+}
+
+// ============================================================================
+// EFFECT HANDLER
+// ============================================================================
+
+/**
+ * Handle the EFFECT_DECOMPOSE effect.
+ *
+ * Creates a pendingDecompose state on the player, blocking other actions
+ * until the player resolves it via RESOLVE_DECOMPOSE action.
+ */
+export function handleDecomposeEffect(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: DecomposeEffect,
+  sourceCardId: CardId | null
+): EffectResolutionResult {
+  if (!sourceCardId) {
+    throw new Error("DecomposeEffect requires sourceCardId");
+  }
+
+  const eligibleCards = getCardsEligibleForDecompose(player.hand, sourceCardId);
+
+  // If no action cards available, the effect cannot resolve
+  if (eligibleCards.length === 0) {
+    throw new Error("No action cards available to throw away for Decompose");
+  }
+
+  // Create pending state for card selection
+  const pending: PendingDecompose = {
+    sourceCardId,
+    mode: effect.mode,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingDecompose: pending,
+  };
+
+  const updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+
+  return {
+    state: updatedState,
+    description: `Decompose (${effect.mode}) requires throwing away an action card`,
+    requiresChoice: true, // Blocks further resolution until player selects
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register decompose effect handler with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerDecomposeEffects(): void {
+  registerEffect(
+    EFFECT_DECOMPOSE,
+    (state, playerId, effect, sourceCardId) => {
+      const { playerIndex, player } = getPlayerContext(state, playerId);
+      return handleDecomposeEffect(
+        state,
+        playerIndex,
+        player,
+        effect as DecomposeEffect,
+        (sourceCardId as CardId | undefined) ?? null
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -36,6 +36,7 @@ import {
   EFFECT_TRACK_ATTACK_DEFEAT_FAME,
   EFFECT_PLACE_SKILL_IN_CENTER,
   EFFECT_DISCARD_FOR_CRYSTAL,
+  EFFECT_DECOMPOSE,
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
@@ -77,6 +78,7 @@ import {
 } from "../../types/effectTypes.js";
 import type {
   DiscardForCrystalEffect,
+  DecomposeEffect,
   RecruitDiscountEffect,
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
@@ -322,6 +324,13 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     return e.optional
       ? "Optionally discard a card to gain a crystal"
       : "Discard a card to gain a crystal";
+  },
+
+  [EFFECT_DECOMPOSE]: (effect) => {
+    const e = effect as DecomposeEffect;
+    return e.mode === "basic"
+      ? "Throw away an action card to gain 2 crystals of matching color"
+      : "Throw away an action card to gain 1 crystal of each non-matching color";
   },
 
   [EFFECT_APPLY_RECRUIT_DISCOUNT]: (effect) => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -51,6 +51,7 @@ import { registerManaBoltEffects } from "./manaBoltEffects.js";
 import { registerMindReadEffects } from "./mindReadEffects.js";
 import { registerBannerProtectionEffects } from "./bannerProtectionEffects.js";
 import { registerWingsOfNightEffects } from "./wingsOfNightEffects.js";
+import { registerDecomposeEffects } from "./decomposeEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -186,4 +187,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Wings of Night effects (multi-target skip-attack with move cost)
   registerWingsOfNightEffects();
+
+  // Decompose effects (throw away action card for crystals)
+  registerDecomposeEffects();
 }

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -103,6 +103,7 @@ import {
   EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   EFFECT_WINGS_OF_NIGHT,
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
+  EFFECT_DECOMPOSE,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -132,6 +133,7 @@ import {
 } from "../../types/modifierConstants.js";
 import { isRuleActive } from "../modifiers/index.js";
 import { getSpentUnitsAtOrBelowLevel } from "./unitEffects.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
 
 // ============================================================================
 // TYPES
@@ -230,6 +232,16 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
     // Discard for crystal is resolvable if optional (can always skip) or if player has non-wound cards
     const hasNonWoundCards = player.hand.some((c) => c !== CARD_WOUND);
     return hasNonWoundCards;
+  },
+
+  [EFFECT_DECOMPOSE]: (state, player, _effect) => {
+    // Decompose is resolvable if player has at least one action card in hand
+    // (excluding wounds and the decompose card itself - but we approximate here
+    // since sourceCardId may not be in hand yet when checking resolvability)
+    const hasActionCards = player.hand.some(
+      (c) => c !== CARD_WOUND && getActionCardColor(c) !== null
+    );
+    return hasActionCards;
   },
 
   [EFFECT_DISCARD_WOUNDS]: (state, player, effect) => {

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -41,6 +41,7 @@ import {
   getDiscardCostOptions,
   getDiscardForAttackOptions,
   getDiscardForCrystalOptions,
+  getDecomposeOptions,
   getArtifactCrystalColorOptions,
   getCrystalJoyReclaimOptions,
   getSteadyTempoOptions,
@@ -165,6 +166,13 @@ export function getValidActions(
       mode: "pending_discard_for_crystal",
       turn: { canUndo: getTurnOptions(state, player).canUndo },
       discardForCrystal: getDiscardForCrystalOptions(state, player),
+    };
+  }
+  if (player.pendingDecompose) {
+    return {
+      mode: "pending_decompose",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      decompose: getDecomposeOptions(state, player),
     };
   }
   if (player.pendingLevelUpRewards.length > 0) {

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -18,6 +18,7 @@ import type {
   DiscardCostOptions,
   DiscardForAttackOptions,
   DiscardForCrystalOptions,
+  DecomposeOptions,
   ArtifactCrystalColorOptions,
   CrystalJoyReclaimOptions,
   SteadyTempoOptions,
@@ -31,6 +32,7 @@ import { SiteType } from "../../types/map.js";
 import { getCardsEligibleForDiscardCost } from "../effects/discardEffects.js";
 import { getCardsEligibleForDiscardForAttack } from "../effects/swordOfJusticeEffects.js";
 import { getCardsEligibleForDiscardForCrystal } from "../effects/discardForCrystalEffects.js";
+import { getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
 import { getCard } from "../helpers/cardLookup.js";
 import { isCardEligibleForReclaim } from "../rules/crystalJoyReclaim.js";
 
@@ -188,6 +190,28 @@ export function getArtifactCrystalColorOptions(
 
   return {
     availableColors: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  };
+}
+
+/**
+ * Get decompose options for the player.
+ * Returns options if player has a pending decompose state (Decompose card).
+ */
+export function getDecomposeOptions(
+  _state: GameState,
+  player: Player
+): DecomposeOptions | undefined {
+  if (!player.pendingDecompose) {
+    return undefined;
+  }
+
+  const { sourceCardId, mode } = player.pendingDecompose;
+  const availableCardIds = getCardsEligibleForDecompose(player.hand, sourceCardId);
+
+  return {
+    sourceCardId,
+    availableCardIds,
+    mode,
   };
 }
 

--- a/packages/core/src/engine/validators/decomposeValidators.ts
+++ b/packages/core/src/engine/validators/decomposeValidators.ts
@@ -1,0 +1,77 @@
+/**
+ * Decompose validators
+ *
+ * Validates RESOLVE_DECOMPOSE actions for the Decompose advanced action card,
+ * which requires throwing away an action card from hand to gain crystals.
+ */
+
+import type { Validator, ValidationResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import { RESOLVE_DECOMPOSE_ACTION } from "@mage-knight/shared";
+import { valid, invalid } from "./types.js";
+import {
+  DECOMPOSE_REQUIRED,
+  DECOMPOSE_CARD_NOT_ELIGIBLE,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+import { getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
+
+/**
+ * Validate that the player has a pending decompose state
+ */
+export const validateHasPendingDecompose: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingDecompose) {
+    return invalid(
+      DECOMPOSE_REQUIRED,
+      "No pending decompose to resolve"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate the decompose card selection
+ */
+export const validateDecomposeSelection: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_DECOMPOSE_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingDecompose) {
+    return valid(); // Let the other validator handle this
+  }
+
+  const cardId = action.cardId;
+
+  // Check card is eligible (action card, in hand, not the Decompose card itself)
+  const eligibleCards = getCardsEligibleForDecompose(player.hand, player.pendingDecompose.sourceCardId);
+  if (!eligibleCards.includes(cardId)) {
+    return invalid(
+      DECOMPOSE_CARD_NOT_ELIGIBLE,
+      `Card ${cardId} is not eligible for Decompose (must be an action card in hand, not the Decompose card itself)`
+    );
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -14,6 +14,7 @@ import {
   RESOLVE_DISCARD_ACTION,
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
+  RESOLVE_DECOMPOSE_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   RESOLVE_HEX_COST_REDUCTION_ACTION,
   RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
@@ -72,6 +73,12 @@ import {
   validateHasPendingArtifactColorChoice,
   validateArtifactCrystalColorSelection,
 } from "../discardForCrystalValidators.js";
+
+// Decompose validators
+import {
+  validateHasPendingDecompose,
+  validateDecomposeSelection,
+} from "../decomposeValidators.js";
 
 // Crystal Joy validators
 import {
@@ -142,6 +149,11 @@ export const choiceRegistry: Record<string, Validator[]> = {
     validateIsPlayersTurn,
     validateHasPendingDiscardForCrystal,
     validateDiscardForCrystalSelection,
+  ],
+  [RESOLVE_DECOMPOSE_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingDecompose,
+    validateDecomposeSelection,
   ],
   [RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION]: [
     validateIsPlayersTurn,

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -248,6 +248,10 @@ export const DISCARD_FOR_CRYSTAL_CANNOT_SKIP = "DISCARD_FOR_CRYSTAL_CANNOT_SKIP"
 export const ARTIFACT_CRYSTAL_COLOR_REQUIRED = "ARTIFACT_CRYSTAL_COLOR_REQUIRED" as const;
 export const ARTIFACT_CRYSTAL_INVALID_COLOR = "ARTIFACT_CRYSTAL_INVALID_COLOR" as const;
 
+// Decompose validation codes
+export const DECOMPOSE_REQUIRED = "DECOMPOSE_REQUIRED" as const;
+export const DECOMPOSE_CARD_NOT_ELIGIBLE = "DECOMPOSE_CARD_NOT_ELIGIBLE" as const;
+
 // Spell purchase validation codes
 export const SPELL_NOT_IN_OFFER = "SPELL_NOT_IN_OFFER" as const;
 export const NOT_AT_SPELL_SITE = "NOT_AT_SPELL_SITE" as const;
@@ -513,6 +517,9 @@ export type ValidationErrorCode =
   | typeof DISCARD_FOR_CRYSTAL_CANNOT_SKIP
   | typeof ARTIFACT_CRYSTAL_COLOR_REQUIRED
   | typeof ARTIFACT_CRYSTAL_INVALID_COLOR
+  // Decompose validation
+  | typeof DECOMPOSE_REQUIRED
+  | typeof DECOMPOSE_CARD_NOT_ELIGIBLE
   // Spell purchase validation
   | typeof SPELL_NOT_IN_OFFER
   | typeof NOT_AT_SPELL_SITE

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -106,6 +106,7 @@ import {
   EFFECT_RESOLVE_MIND_STEAL_COLOR,
   EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   EFFECT_ACTIVATE_BANNER_PROTECTION,
+  EFFECT_DECOMPOSE,
   EFFECT_WINGS_OF_NIGHT,
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
   MANA_ANY,
@@ -719,6 +720,24 @@ export interface DiscardForCrystalEffect {
 }
 
 /**
+ * Decompose effect - throw away an action card from hand and gain crystals.
+ * Used by the Decompose advanced action card.
+ *
+ * Resolution:
+ * - Player selects an action card from hand (excluding Decompose itself and wounds)
+ * - Card is permanently removed from the game (added to removedCards)
+ * - Basic mode: gain 2 crystals matching the thrown card's color
+ * - Powered mode: gain 1 crystal of each basic color NOT matching the thrown card's color
+ *
+ * Creates pendingDecompose state. Player selects card via RESOLVE_DECOMPOSE action.
+ */
+export interface DecomposeEffect {
+  readonly type: typeof EFFECT_DECOMPOSE;
+  /** "basic" = 2 crystals of matching color, "powered" = 1 of each non-matching color */
+  readonly mode: "basic" | "powered";
+}
+
+/**
  * Recruit discount effect - grants a turn-scoped modifier that discounts
  * the cost of recruiting one unit. If the discounted unit is recruited,
  * reputation changes.
@@ -1275,6 +1294,7 @@ export type CardEffect =
   | TrackAttackDefeatFameEffect
   | PolarizeManaEffect
   | DiscardForCrystalEffect
+  | DecomposeEffect
   | RecruitDiscountEffect
   | ReadyUnitsForInfluenceEffect
   | ResolveReadyUnitForInfluenceEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -287,6 +287,12 @@ export const EFFECT_RESOLVE_MIND_STEAL_COLOR = "resolve_mind_steal_color" as con
 // Internal: Resolve after caster selects which Action card to steal (or skip)
 export const EFFECT_RESOLVE_MIND_STEAL_SELECTION = "resolve_mind_steal_selection" as const;
 
+// === Decompose Effect ===
+// Throw away an action card from hand and gain crystals based on mode.
+// Basic: gain 2 crystals matching the thrown card's color.
+// Powered: gain 1 crystal of each basic color NOT matching the thrown card's color.
+export const EFFECT_DECOMPOSE = "decompose" as const;
+
 // === Banner of Protection Activation Effect ===
 // Marks that Banner of Protection powered effect is active this turn.
 // At end of turn, player may throw away wounds received this turn.

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -232,6 +232,19 @@ export interface PendingDiscardForCrystal {
 }
 
 /**
+ * Pending decompose resolution (Decompose advanced action card).
+ * Player must select an action card from hand to throw away.
+ * - Basic mode: gain 2 crystals matching the thrown card's color
+ * - Powered mode: gain 1 crystal of each basic color NOT matching the thrown card's color
+ */
+export interface PendingDecompose {
+  /** Source card that triggered the decompose (Decompose card) */
+  readonly sourceCardId: CardId;
+  /** Whether this is "basic" or "powered" mode */
+  readonly mode: "basic" | "powered";
+}
+
+/**
  * Pending terrain cost reduction choice (Druidic Paths and similar effects).
  * Player must choose a hex coordinate or terrain type to apply cost reduction.
  */
@@ -437,6 +450,9 @@ export interface Player {
 
   // Discard for crystal pending (Savage Harvesting)
   readonly pendingDiscardForCrystal: PendingDiscardForCrystal | null;
+
+  // Decompose pending (throw away action card for crystals)
+  readonly pendingDecompose: PendingDecompose | null;
 
   // Attack-based fame tracking (e.g., Axe Throw powered effect)
   readonly pendingAttackDefeatFame: readonly AttackDefeatFameTracker[];

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -569,6 +569,7 @@ export class GameServer {
       pendingDiscard: null,
       pendingDiscardForAttack: null,
       pendingDiscardForCrystal: null,
+      pendingDecompose: null,
       pendingAttackDefeatFame: [],
       enemiesDefeatedThisTurn: 0,
       healingPoints: 0,

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -494,6 +494,14 @@ export interface ResolveDiscardForCrystalAction {
   readonly cardId: CardId | null;
 }
 
+// Decompose action (throw away action card for crystals)
+export const RESOLVE_DECOMPOSE_ACTION = "RESOLVE_DECOMPOSE" as const;
+export interface ResolveDecomposeAction {
+  readonly type: typeof RESOLVE_DECOMPOSE_ACTION;
+  /** Card ID of the action card to throw away */
+  readonly cardId: CardId;
+}
+
 // Artifact crystal color choice action (Savage Harvesting - second step for artifacts)
 export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION = "RESOLVE_ARTIFACT_CRYSTAL_COLOR" as const;
 export interface ResolveArtifactCrystalColorAction {
@@ -773,6 +781,8 @@ export type PlayerAction =
   | ResolveDiscardForAttackAction
   // Discard for crystal (Savage Harvesting)
   | ResolveDiscardForCrystalAction
+  // Decompose (throw away action card for crystals)
+  | ResolveDecomposeAction
   // Artifact crystal color choice (Savage Harvesting - for artifacts)
   | ResolveArtifactCrystalColorAction
   // Combat

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -257,6 +257,8 @@ export type {
   // Discard for crystal options (Savage Harvesting)
   DiscardForCrystalOptions,
   ArtifactCrystalColorOptions,
+  // Decompose options (throw away action card for crystals)
+  DecomposeOptions,
   // Crystal Joy reclaim options
   CrystalJoyReclaimOptions,
   // Steady Tempo deck placement options

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -840,6 +840,24 @@ export interface ArtifactCrystalColorOptions {
 }
 
 // ============================================================================
+// Decompose (throw away action card for crystals)
+// ============================================================================
+
+/**
+ * Options for Decompose card resolution.
+ * Only present when player has a pending decompose state.
+ * Player must select an action card from hand to throw away.
+ */
+export interface DecomposeOptions {
+  /** Source card that triggered the decompose (Decompose card) */
+  readonly sourceCardId: CardId;
+  /** Action cards available to throw away (excludes Decompose itself and wounds) */
+  readonly availableCardIds: readonly CardId[];
+  /** Whether the effect is basic or powered */
+  readonly mode: "basic" | "powered";
+}
+
+// ============================================================================
 // Unit Maintenance (Magic Familiars round-start)
 // ============================================================================
 
@@ -1111,6 +1129,12 @@ export interface PendingArtifactCrystalColorState {
   readonly artifactCrystalColor: ArtifactCrystalColorOptions;
 }
 
+export interface PendingDecomposeState {
+  readonly mode: "pending_decompose";
+  readonly turn: BlockingTurnOptions;
+  readonly decompose: DecomposeOptions;
+}
+
 export interface PendingCrystalJoyState {
   readonly mode: "pending_crystal_joy_reclaim";
   readonly turn: BlockingTurnOptions;
@@ -1198,6 +1222,7 @@ export type ValidActions =
   | PendingDiscardCostState
   | PendingDiscardForAttackState
   | PendingDiscardForCrystalState
+  | PendingDecomposeState
   | PendingArtifactCrystalColorState
   | PendingCrystalJoyState
   | PendingSteadyTempoState


### PR DESCRIPTION
Implement the Decompose advanced action card's throw-away mechanic:
- Basic: throw away an action card, gain 2 crystals of matching color
- Powered (red): throw away an action card, gain 1 crystal of each
  non-matching basic color (3 crystals total)

Cards are permanently removed (added to removedCards, not discard pile).
Only action cards can be thrown away (not wounds, artifacts, or spells).
The Decompose card itself is excluded from selection.

https://claude.ai/code/session_013A82jtbyFZD1LvAS61Edpo Closes #162