### PR TITLE
feat: implement Banner of Fortitude artifact card

### DIFF
--- a/packages/core/src/data/artifacts/bannerOfFortitude.ts
+++ b/packages/core/src/data/artifacts/bannerOfFortitude.ts
@@ -3,12 +3,49 @@
  * Card #18 (305/377)
  *
  * Basic: Assign to a Unit. Once per Round, when Unit would be wounded,
- *        flip to ignore wound. Unit can still only be assigned damage once.
- * Powered: Heal all Units completely (anytime except combat).
+ *        flip to ignore wound and any additional effects. Unit can still
+ *        only be assigned damage once.
+ * Powered (Any): Heal all Units completely (anytime except combat).
+ *                Artifact is destroyed after use.
+ *
+ * FAQ:
+ * - "Flip" = mark isUsedThisRound = true
+ * - "Additional effects" includes Paralyze, Poison, Vampiric
+ * - Does NOT prevent Brutal (doubles damage BEFORE assignment)
+ * - Using Banner to ignore wound counts as unit's damage assignment
+ * - THUGS require 2 influence to use Banner of Fortitude
  */
 
 import type { DeedCard } from "../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
+import {
+  CATEGORY_BANNER,
+  CATEGORY_HEALING,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import { EFFECT_NOOP, EFFECT_HEAL_ALL_UNITS } from "../../types/effectTypes.js";
+import {
+  CARD_BANNER_OF_FORTITUDE,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
 
-// TODO: Implement Banner of Fortitude
-export const BANNER_OF_FORTITUDE_CARDS: Record<CardId, DeedCard> = {};
+const BANNER_OF_FORTITUDE: DeedCard = {
+  id: CARD_BANNER_OF_FORTITUDE,
+  name: "Banner of Fortitude",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_BANNER, CATEGORY_HEALING],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  // Basic: assign to unit (wound prevention handled in damage assignment)
+  basicEffect: { type: EFFECT_NOOP },
+  // Powered: heal all units completely
+  poweredEffect: { type: EFFECT_HEAL_ALL_UNITS },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const BANNER_OF_FORTITUDE_CARDS: Record<CardId, DeedCard> = {
+  [CARD_BANNER_OF_FORTITUDE]: BANNER_OF_FORTITUDE,
+};

--- a/packages/core/src/engine/__tests__/bannerOfFortitude.test.ts
+++ b/packages/core/src/engine/__tests__/bannerOfFortitude.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Banner of Fortitude artifact tests
+ *
+ * Basic Effect (attached to unit):
+ * - Once per round, when unit would be wounded, flip to prevent wound
+ * - Ignores wound AND additional effects (poison, paralyze, vampiric)
+ * - Does NOT prevent Brutal (doubles damage BEFORE assignment)
+ * - Counts as unit's damage assignment for combat
+ * - Resets at start of round
+ *
+ * Powered Effect (destroy artifact):
+ * - Heal all units completely (anytime except combat)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestPlayer,
+  createTestGameState,
+} from "./testHelpers.js";
+import {
+  CARD_BANNER_OF_FORTITUDE,
+  UNIT_PEASANTS,
+  UNIT_FORESTERS,
+  ELEMENT_PHYSICAL,
+  DAMAGE_TARGET_UNIT,
+  BANNER_FORTITUDE_PREVENTED_WOUND,
+  UNIT_WOUNDED,
+  UNIT_DESTROYED,
+  UNIT_HEALED,
+  ABILITY_POISON,
+  ABILITY_PARALYZE,
+  ABILITY_VAMPIRIC,
+  ABILITY_BRUTAL,
+  COMBAT_PHASE_ASSIGN_DAMAGE,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { createAssignDamageCommand } from "../commands/combat/assignDamageCommand.js";
+import { resolveEffect } from "../effects/index.js";
+import { EFFECT_HEAL_ALL_UNITS } from "../../types/effectTypes.js";
+import type { HealAllUnitsEffect } from "../../types/cards.js";
+import type { CombatEnemy } from "../../types/combat.js";
+import { COMBAT_CONTEXT_STANDARD } from "../../types/combat.js";
+import { markBannerUsed } from "../rules/banners.js";
+import { getCard } from "../helpers/cardLookup.js";
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+const TEST_UNIT_1 = "unit_1";
+const TEST_UNIT_2 = "unit_2";
+const PLAYER_ID = "player1";
+const ENEMY_INSTANCE_ID = "enemy_1";
+
+function createPeasantUnit(instanceId: string) {
+  return createPlayerUnit(UNIT_PEASANTS, instanceId);
+}
+
+function createForesterUnit(instanceId: string) {
+  return createPlayerUnit(UNIT_FORESTERS, instanceId);
+}
+
+/**
+ * Create a combat enemy with specific abilities for testing.
+ */
+function createTestEnemy(
+  abilities: readonly string[] = [],
+  attack = 5,
+  attackElement = ELEMENT_PHYSICAL
+): CombatEnemy {
+  return {
+    instanceId: ENEMY_INSTANCE_ID,
+    enemyId: "test_enemy" as import("@mage-knight/shared").EnemyId,
+    definition: {
+      id: "test_enemy" as import("@mage-knight/shared").EnemyId,
+      name: "Test Enemy",
+      color: "green" as const,
+      attack,
+      attackElement,
+      armor: 3,
+      fame: 2,
+      resistances: [],
+      abilities: abilities as import("@mage-knight/shared").EnemyAbilityType[],
+    },
+    isBlocked: false,
+    isDefeated: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+  };
+}
+
+/**
+ * Create a game state in combat's assign damage phase with given enemy and player.
+ */
+function createDamageAssignmentState(
+  enemy: CombatEnemy,
+  playerOverrides: Partial<import("../../types/player.js").Player> = {}
+) {
+  const player = createTestPlayer({
+    id: PLAYER_ID,
+    ...playerOverrides,
+  });
+
+  return createTestGameState({
+    players: [player],
+    combat: {
+      enemies: [enemy],
+      phase: COMBAT_PHASE_ASSIGN_DAMAGE,
+      woundsThisCombat: 0,
+      attacksThisPhase: 0,
+      fameGained: 0,
+      isAtFortifiedSite: false,
+      unitsAllowed: true,
+      nightManaRules: false,
+      assaultOrigin: null,
+      combatHexCoord: null,
+      allDamageBlockedThisPhase: false,
+      discardEnemiesOnFailure: false,
+      pendingDamage: {},
+      pendingBlock: {},
+      pendingSwiftBlock: {},
+      combatContext: COMBAT_CONTEXT_STANDARD,
+      cumbersomeReductions: {},
+      usedDefend: {},
+      defendBonuses: {},
+      paidHeroesAssaultInfluence: false,
+      vampiricArmorBonus: {},
+      paidThugsDamageInfluence: {},
+      damageRedirects: {},
+    },
+  });
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe("Banner of Fortitude", () => {
+  beforeEach(() => {
+    createEngine();
+  });
+
+  // --------------------------------------------------------------------------
+  // Basic Effect: Wound Prevention
+  // --------------------------------------------------------------------------
+  describe("Basic Effect: Wound Prevention", () => {
+    it("should prevent wound when unit has banner attached and banner is unused", () => {
+      const enemy = createTestEnemy([], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner should have prevented the wound
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+      if (preventedEvent?.type === BANNER_FORTITUDE_PREVENTED_WOUND) {
+        expect(preventedEvent.unitInstanceId).toBe(TEST_UNIT_1);
+        expect(preventedEvent.damageNegated).toBe(5);
+      }
+
+      // Unit should NOT be wounded
+      const woundEvent = result.events.find((e) => e.type === UNIT_WOUNDED);
+      expect(woundEvent).toBeUndefined();
+
+      // Unit should NOT be destroyed
+      const destroyEvent = result.events.find((e) => e.type === UNIT_DESTROYED);
+      expect(destroyEvent).toBeUndefined();
+
+      // Banner should be marked as used
+      const updatedPlayer = result.state.players.find((p) => p.id === PLAYER_ID)!;
+      const bannerAttachment = updatedPlayer.attachedBanners.find(
+        (b) => b.bannerId === CARD_BANNER_OF_FORTITUDE
+      );
+      expect(bannerAttachment?.isUsedThisRound).toBe(true);
+    });
+
+    it("should not prevent wound when banner already used this round", () => {
+      const enemy = createTestEnemy([], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: true, // Already used
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner should NOT have prevented — unit should be wounded normally
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeUndefined();
+
+      // Unit SHOULD be wounded
+      const woundEvent = result.events.find((e) => e.type === UNIT_WOUNDED);
+      expect(woundEvent).toBeDefined();
+    });
+
+    it("should not prevent wound on a different unit without the banner", () => {
+      const enemy = createTestEnemy([], 5);
+      const unit1 = createPeasantUnit(TEST_UNIT_1);
+      const unit2 = createPeasantUnit(TEST_UNIT_2);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit1, unit2],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1, // Banner on unit 1
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      // Assign damage to unit 2 (no banner)
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_2, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // No banner prevention
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeUndefined();
+
+      // Unit 2 should be wounded
+      const woundEvent = result.events.find((e) => e.type === UNIT_WOUNDED);
+      expect(woundEvent).toBeDefined();
+    });
+
+    it("should prevent massive damage (damage >> armor)", () => {
+      const enemy = createTestEnemy([], 20);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 20 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner prevents regardless of damage amount
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+
+      // No wound or destruction
+      const woundEvent = result.events.find((e) => e.type === UNIT_WOUNDED);
+      expect(woundEvent).toBeUndefined();
+      const destroyEvent = result.events.find((e) => e.type === UNIT_DESTROYED);
+      expect(destroyEvent).toBeUndefined();
+
+      // No hero wounds from overflow
+      expect(result.state.combat!.woundsThisCombat).toBe(0);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Additional Effect Prevention
+  // --------------------------------------------------------------------------
+  describe("Additional Effect Prevention", () => {
+    it("should prevent Poison effect (no extra wounds)", () => {
+      const enemy = createTestEnemy([ABILITY_POISON], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner prevents wound AND poison
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+
+      // Unit should NOT be destroyed (poison would normally destroy)
+      const destroyEvent = result.events.find((e) => e.type === UNIT_DESTROYED);
+      expect(destroyEvent).toBeUndefined();
+    });
+
+    it("should prevent Paralyze effect (unit not destroyed)", () => {
+      const enemy = createTestEnemy([ABILITY_PARALYZE], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner prevents wound AND paralyze
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+
+      // Unit should NOT be destroyed (paralyze would normally destroy)
+      const destroyEvent = result.events.find((e) => e.type === UNIT_DESTROYED);
+      expect(destroyEvent).toBeUndefined();
+    });
+
+    it("should prevent Vampiric effect (attacker no +1 armor)", () => {
+      const enemy = createTestEnemy([ABILITY_VAMPIRIC], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner prevents wound
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+
+      // Vampiric armor bonus should NOT have been applied (no wounds dealt)
+      expect(result.state.combat!.vampiricArmorBonus[ENEMY_INSTANCE_ID]).toBeUndefined();
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Brutal: NOT Prevented
+  // --------------------------------------------------------------------------
+  describe("Brutal: NOT Prevented (damage already doubled)", () => {
+    it("should still prevent wound even with Brutal (Brutal doubles before assignment)", () => {
+      // Brutal doubles damage before it reaches the unit.
+      // The banner still prevents the wound entirely — but the damage was already doubled.
+      // The key distinction: Brutal is NOT an "additional effect from the wound" —
+      // it affects damage amount BEFORE the wound, so it's not prevented.
+      // But the banner still prevents the wound regardless of how much damage.
+      const enemy = createTestEnemy([ABILITY_BRUTAL], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      // Brutal doubles damage from 5 to 10, but banner prevents the wound
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          // getEffectiveDamage calculates 10 (5 * 2) — assignments use total damage
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 10 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      // Banner prevents the wound
+      const preventedEvent = result.events.find(
+        (e) => e.type === BANNER_FORTITUDE_PREVENTED_WOUND
+      );
+      expect(preventedEvent).toBeDefined();
+      if (preventedEvent?.type === BANNER_FORTITUDE_PREVENTED_WOUND) {
+        expect(preventedEvent.damageNegated).toBe(10);
+      }
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Banner Usage Tracking
+  // --------------------------------------------------------------------------
+  describe("Banner Usage Tracking", () => {
+    it("should mark banner as used after prevention (once per round)", () => {
+      const enemy = createTestEnemy([], 5);
+      const unit = createPeasantUnit(TEST_UNIT_1);
+      const state = createDamageAssignmentState(enemy, {
+        units: [unit],
+        attachedBanners: [
+          {
+            bannerId: CARD_BANNER_OF_FORTITUDE,
+            unitInstanceId: TEST_UNIT_1,
+            isUsedThisRound: false,
+          },
+        ],
+      });
+
+      const command = createAssignDamageCommand({
+        playerId: PLAYER_ID,
+        enemyInstanceId: ENEMY_INSTANCE_ID,
+        assignments: [
+          { target: DAMAGE_TARGET_UNIT, unitInstanceId: TEST_UNIT_1, amount: 5 },
+        ],
+      });
+
+      const result = command.execute(state);
+
+      const updatedPlayer = result.state.players.find((p) => p.id === PLAYER_ID)!;
+      const banner = updatedPlayer.attachedBanners.find(
+        (b) => b.bannerId === CARD_BANNER_OF_FORTITUDE
+      );
+      expect(banner?.isUsedThisRound).toBe(true);
+    });
+
+    it("should reset usage via markBannerUsed helper", () => {
+      const banners = [
+        {
+          bannerId: CARD_BANNER_OF_FORTITUDE as CardId,
+          unitInstanceId: TEST_UNIT_1,
+          isUsedThisRound: false,
+        },
+      ] as const;
+
+      const updated = markBannerUsed(banners, CARD_BANNER_OF_FORTITUDE);
+      expect(updated[0]?.isUsedThisRound).toBe(true);
+    });
+
+    it("should reset at end of round (banners array cleared)", () => {
+      // The round reset sets isUsedThisRound = false for all banners.
+      // This is handled by playerRoundReset.ts and tested in banners.test.ts.
+      // Just verify the data model supports it.
+      const banners = [
+        {
+          bannerId: CARD_BANNER_OF_FORTITUDE as CardId,
+          unitInstanceId: TEST_UNIT_1,
+          isUsedThisRound: true,
+        },
+      ];
+
+      const resetBanners = banners.map((b) => ({
+        ...b,
+        isUsedThisRound: false,
+      }));
+
+      expect(resetBanners[0]?.isUsedThisRound).toBe(false);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Powered Effect: Heal All Units
+  // --------------------------------------------------------------------------
+  describe("Powered Effect: Heal All Units", () => {
+    it("should heal all wounded units", () => {
+      const unit1 = { ...createPeasantUnit(TEST_UNIT_1), wounded: true };
+      const unit2 = { ...createForesterUnit(TEST_UNIT_2), wounded: true };
+      const player = createTestPlayer({
+        id: PLAYER_ID,
+        units: [unit1, unit2],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const effect: HealAllUnitsEffect = { type: EFFECT_HEAL_ALL_UNITS };
+      const result = resolveEffect(state, PLAYER_ID, effect);
+
+      // Both units should be healed
+      const updatedPlayer = result.state.players.find((p) => p.id === PLAYER_ID)!;
+      expect(updatedPlayer.units[0]?.wounded).toBe(false);
+      expect(updatedPlayer.units[1]?.wounded).toBe(false);
+
+      // UNIT_HEALED events for both
+      const healEvents = result.events?.filter((e) => e.type === UNIT_HEALED) ?? [];
+      expect(healEvents).toHaveLength(2);
+    });
+
+    it("should not affect unwounded units", () => {
+      const unit1 = createPeasantUnit(TEST_UNIT_1); // not wounded
+      const unit2 = { ...createForesterUnit(TEST_UNIT_2), wounded: true };
+      const player = createTestPlayer({
+        id: PLAYER_ID,
+        units: [unit1, unit2],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const effect: HealAllUnitsEffect = { type: EFFECT_HEAL_ALL_UNITS };
+      const result = resolveEffect(state, PLAYER_ID, effect);
+
+      const updatedPlayer = result.state.players.find((p) => p.id === PLAYER_ID)!;
+      // Unit 1 was already unwounded
+      expect(updatedPlayer.units[0]?.wounded).toBe(false);
+      // Unit 2 was healed
+      expect(updatedPlayer.units[1]?.wounded).toBe(false);
+
+      // Only 1 heal event (for unit 2)
+      const healEvents = result.events?.filter((e) => e.type === UNIT_HEALED) ?? [];
+      expect(healEvents).toHaveLength(1);
+    });
+
+    it("should do nothing when no units are wounded", () => {
+      const unit1 = createPeasantUnit(TEST_UNIT_1);
+      const player = createTestPlayer({
+        id: PLAYER_ID,
+        units: [unit1],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const effect: HealAllUnitsEffect = { type: EFFECT_HEAL_ALL_UNITS };
+      const result = resolveEffect(state, PLAYER_ID, effect);
+
+      expect(result.description).toBe("No wounded units to heal");
+    });
+
+    it("should do nothing when player has no units", () => {
+      const player = createTestPlayer({
+        id: PLAYER_ID,
+        units: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const effect: HealAllUnitsEffect = { type: EFFECT_HEAL_ALL_UNITS };
+      const result = resolveEffect(state, PLAYER_ID, effect);
+
+      expect(result.description).toBe("No wounded units to heal");
+    });
+
+    it("should track healed units in unitsHealedThisTurn", () => {
+      const unit1 = { ...createPeasantUnit(TEST_UNIT_1), wounded: true };
+      const unit2 = { ...createForesterUnit(TEST_UNIT_2), wounded: true };
+      const player = createTestPlayer({
+        id: PLAYER_ID,
+        units: [unit1, unit2],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const effect: HealAllUnitsEffect = { type: EFFECT_HEAL_ALL_UNITS };
+      const result = resolveEffect(state, PLAYER_ID, effect);
+
+      const updatedPlayer = result.state.players.find((p) => p.id === PLAYER_ID)!;
+      expect(updatedPlayer.unitsHealedThisTurn).toContain(TEST_UNIT_1);
+      expect(updatedPlayer.unitsHealedThisTurn).toContain(TEST_UNIT_2);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Card Definition
+  // --------------------------------------------------------------------------
+  describe("Card Definition", () => {
+    it("should be registered in artifact cards", () => {
+      const card = getCard(CARD_BANNER_OF_FORTITUDE);
+      expect(card).toBeDefined();
+      expect(card?.name).toBe("Banner of Fortitude");
+      expect(card?.cardType).toBe("artifact");
+      expect(card?.categories).toContain("banner");
+      expect(card?.categories).toContain("healing");
+      expect(card?.destroyOnPowered).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -45,6 +45,7 @@ import {
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_HEAL_ALL_UNITS,
   EFFECT_READY_UNITS_BUDGET,
   EFFECT_RESOLVE_READY_UNIT_BUDGET,
   EFFECT_CURE,
@@ -370,6 +371,8 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   },
 
   [EFFECT_READY_ALL_UNITS]: () => "Ready all Units",
+
+  [EFFECT_HEAL_ALL_UNITS]: () => "Heal all Units completely",
 
   [EFFECT_READY_UNITS_BUDGET]: (effect) => {
     const e = effect as ReadyUnitsBudgetEffect;

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -50,6 +50,7 @@ import { registerManaClaimEffects } from "./manaClaimEffects.js";
 import { registerManaBoltEffects } from "./manaBoltEffects.js";
 import { registerMindReadEffects } from "./mindReadEffects.js";
 import { registerBannerProtectionEffects } from "./bannerProtectionEffects.js";
+import { registerHealAllUnitsEffects } from "./healAllUnitsEffects.js";
 import { registerWingsOfNightEffects } from "./wingsOfNightEffects.js";
 import { registerDecomposeEffects } from "./decomposeEffects.js";
 import { registerCrystalMasteryEffects } from "./crystalMasteryEffects.js";
@@ -185,6 +186,9 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Banner of Protection effects (activate powered flag)
   registerBannerProtectionEffects();
+
+  // Heal all units effects (Banner of Fortitude powered)
+  registerHealAllUnitsEffects();
 
   // Wings of Night effects (multi-target skip-attack with move cost)
   registerWingsOfNightEffects();

--- a/packages/core/src/engine/effects/healAllUnitsEffects.ts
+++ b/packages/core/src/engine/effects/healAllUnitsEffects.ts
@@ -1,0 +1,103 @@
+/**
+ * Heal All Units effect handler
+ *
+ * Handles the EFFECT_HEAL_ALL_UNITS effect which heals all wounded units
+ * controlled by the player. No unit selection needed.
+ *
+ * Used by Banner of Fortitude powered effect.
+ *
+ * @module effects/healAllUnitsEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { EffectResolutionResult } from "./types.js";
+import { UNITS, UNIT_HEALED } from "@mage-knight/shared";
+import type { GameEvent } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicEffects.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_HEAL_ALL_UNITS } from "../../types/effectTypes.js";
+import { isCureActive } from "./cureHelpers.js";
+import { UNIT_STATE_READY } from "@mage-knight/shared";
+
+/**
+ * Handle EFFECT_HEAL_ALL_UNITS.
+ * Heals all wounded units controlled by the player.
+ * No selection needed — all wounded units are healed automatically.
+ */
+export function handleHealAllUnits(
+  state: GameState,
+  playerIndex: number,
+  player: Player
+): EffectResolutionResult {
+  const woundedUnits = player.units.filter((u) => u.wounded);
+
+  if (woundedUnits.length === 0) {
+    return {
+      state,
+      description: "No wounded units to heal",
+    };
+  }
+
+  const events: GameEvent[] = [];
+  const shouldReady = isCureActive(state, player.id);
+
+  const updatedUnits = player.units.map((unit) => {
+    if (unit.wounded) {
+      const unitDef = UNITS[unit.unitId];
+      const unitName = unitDef?.name ?? unit.unitId;
+      events.push({
+        type: UNIT_HEALED,
+        playerId: player.id,
+        unitInstanceId: unit.instanceId,
+      });
+
+      void unitName; // Used for logging if needed
+
+      return {
+        ...unit,
+        wounded: false,
+        ...(shouldReady && unit.state !== UNIT_STATE_READY
+          ? { state: UNIT_STATE_READY as const }
+          : {}),
+      };
+    }
+    return unit;
+  });
+
+  // Track units as healed this turn (for Cure spell)
+  const newlyHealed = woundedUnits
+    .map((u) => u.instanceId)
+    .filter((id) => !player.unitsHealedThisTurn.includes(id));
+  const updatedUnitsHealed = [
+    ...player.unitsHealedThisTurn,
+    ...newlyHealed,
+  ];
+
+  const updatedPlayer: Player = {
+    ...player,
+    units: updatedUnits,
+    unitsHealedThisTurn: updatedUnitsHealed,
+  };
+
+  return {
+    state: updatePlayer(state, playerIndex, updatedPlayer),
+    events,
+    description: `Healed all units (${woundedUnits.length})`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register heal all units effect handler with the effect registry.
+ */
+export function registerHealAllUnitsEffects(): void {
+  registerEffect(EFFECT_HEAL_ALL_UNITS, (state, playerId) => {
+    const { playerIndex, player } = getPlayerContext(state, playerId);
+    return handleHealAllUnits(state, playerIndex, player);
+  });
+}

--- a/packages/core/src/engine/effects/healingFilter.ts
+++ b/packages/core/src/engine/effects/healingFilter.ts
@@ -8,6 +8,7 @@ import type { CardEffect } from "../../types/cards.js";
 import {
   EFFECT_GAIN_HEALING,
   EFFECT_HEAL_UNIT,
+  EFFECT_HEAL_ALL_UNITS,
   EFFECT_ENERGY_FLOW,
   EFFECT_COMPOUND,
   EFFECT_CHOICE,
@@ -26,6 +27,7 @@ export function filterHealingEffectsForCombat(effect: CardEffect): CardEffect | 
   switch (effect.type) {
     case EFFECT_GAIN_HEALING:
     case EFFECT_HEAL_UNIT:
+    case EFFECT_HEAL_ALL_UNITS:
     case EFFECT_ENERGY_FLOW:
       return null;
 

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -176,6 +176,12 @@ export {
   registerHealUnitEffects,
 } from "./healUnitEffects.js";
 
+// Heal all units effects (Banner of Fortitude powered)
+export {
+  handleHealAllUnits,
+  registerHealAllUnitsEffects,
+} from "./healAllUnitsEffects.js";
+
 // Discard effects
 export {
   handleDiscardCard,

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -78,6 +78,7 @@ import {
   EFFECT_ENERGY_FLOW,
   EFFECT_RESOLVE_ENERGY_FLOW_TARGET,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_HEAL_ALL_UNITS,
   EFFECT_READY_UNITS_BUDGET,
   EFFECT_RESOLVE_READY_UNIT_BUDGET,
   EFFECT_SELECT_HEX_FOR_COST_REDUCTION,
@@ -436,6 +437,11 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   [EFFECT_READY_ALL_UNITS]: (state, player) => {
     // Resolvable if player has at least one spent unit
     return player.units.some((u) => u.state === UNIT_STATE_SPENT);
+  },
+
+  [EFFECT_HEAL_ALL_UNITS]: (_state, player) => {
+    // Resolvable if player has at least one wounded unit
+    return player.units.some((u) => u.wounded);
   },
 
   [EFFECT_READY_UNITS_BUDGET]: (state, player, effect) => {

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -53,6 +53,7 @@ import {
   EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
   EFFECT_TRACK_ATTACK_DEFEAT_FAME,
   EFFECT_READY_ALL_UNITS,
+  EFFECT_HEAL_ALL_UNITS,
   EFFECT_SELECT_HEX_FOR_COST_REDUCTION,
   EFFECT_SELECT_TERRAIN_FOR_COST_REDUCTION,
   EFFECT_WOUND_ACTIVATING_UNIT,
@@ -298,6 +299,12 @@ const reverseHandlers: Partial<Record<EffectType, ReverseHandler>> = {
 
   [EFFECT_READY_ALL_UNITS]: (player) => {
     // Cannot reliably reverse — we don't track which units were originally spent.
+    // Commands containing this effect should be non-reversible.
+    return player;
+  },
+
+  [EFFECT_HEAL_ALL_UNITS]: (player) => {
+    // Cannot reliably reverse — we don't track which units were originally wounded.
     // Commands containing this effect should be non-reversible.
     return player;
   },

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -107,6 +107,7 @@ import {
   EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   EFFECT_ACTIVATE_BANNER_PROTECTION,
   EFFECT_DECOMPOSE,
+  EFFECT_HEAL_ALL_UNITS,
   EFFECT_WINGS_OF_NIGHT,
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
   EFFECT_CRYSTAL_MASTERY_BASIC,
@@ -1221,6 +1222,15 @@ export interface ResolveMindStealSelectionEffect {
 }
 
 /**
+ * Heal all units completely (remove wounds from all wounded units).
+ * No unit selection needed — all wounded units are healed automatically.
+ * Used by Banner of Fortitude powered effect.
+ */
+export interface HealAllUnitsEffect {
+  readonly type: typeof EFFECT_HEAL_ALL_UNITS;
+}
+
+/**
  * Activate Banner of Protection powered effect.
  * Sets bannerOfProtectionActive flag; at end of turn, player may throw away
  * all wounds received this turn.
@@ -1356,6 +1366,7 @@ export type CardEffect =
   | MindStealEffect
   | ResolveMindStealColorEffect
   | ResolveMindStealSelectionEffect
+  | HealAllUnitsEffect
   | ActivateBannerProtectionEffect
   | WingsOfNightEffect
   | ResolveWingsOfNightTargetEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -304,6 +304,11 @@ export const EFFECT_CRYSTAL_MASTERY_BASIC = "crystal_mastery_basic" as const;
 // Powered: At end of turn, spent crystals this turn are returned to inventory.
 export const EFFECT_CRYSTAL_MASTERY_POWERED = "crystal_mastery_powered" as const;
 
+// === Heal All Units Effect ===
+// Heal all units completely (remove wounds from all wounded units).
+// Used by Banner of Fortitude powered effect.
+export const EFFECT_HEAL_ALL_UNITS = "heal_all_units" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.

--- a/packages/shared/src/events/banners.ts
+++ b/packages/shared/src/events/banners.ts
@@ -64,6 +64,19 @@ export interface BannerFearCancelAttackEvent {
 }
 
 // ============================================================================
+// BANNER_FORTITUDE_PREVENTED_WOUND
+// ============================================================================
+
+export const BANNER_FORTITUDE_PREVENTED_WOUND = "BANNER_FORTITUDE_PREVENTED_WOUND" as const;
+
+export interface BannerFortitudePreventedWoundEvent {
+  readonly type: typeof BANNER_FORTITUDE_PREVENTED_WOUND;
+  readonly playerId: string;
+  readonly unitInstanceId: string;
+  readonly damageNegated: number;
+}
+
+// ============================================================================
 // BANNERS_RESET
 // ============================================================================
 

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -292,6 +292,7 @@ import type {
   BannerAssignedEvent,
   BannerDetachedEvent,
   BannerFearCancelAttackEvent,
+  BannerFortitudePreventedWoundEvent,
   BannersResetEvent,
 } from "./banners.js";
 
@@ -476,6 +477,7 @@ export type GameEvent =
   | BannerAssignedEvent
   | BannerDetachedEvent
   | BannerFearCancelAttackEvent
+  | BannerFortitudePreventedWoundEvent
   | BannersResetEvent;
 
 /**


### PR DESCRIPTION
## Summary
Implement the Banner of Fortitude artifact card with two effects:

- **Basic (attached to unit):** Once per round, when the unit would be wounded during damage assignment, flip the banner to prevent the wound entirely. Also prevents additional effects (poison, paralyze, vampiric) since the unit is never damaged. Does NOT prevent Brutal (which doubles damage before assignment). Resets at start of each round.
- **Powered (destroy artifact):** Heal all controlled units completely. Cannot be used during combat (healing category). Artifact is destroyed after use.

## Changes
- Added Banner of Fortitude card definition with NOOP basic / HEAL_ALL_UNITS powered effects
- Added `EFFECT_HEAL_ALL_UNITS` effect type with full effect system integration (resolver, describer, resolvability, reverse, healing filter)
- Added wound prevention intercept in `processUnitAssignment()` before `processUnitDamage()` — naturally prevents poison/paralyze/vampiric since those are processed inside unit damage
- Added `BANNER_FORTITUDE_PREVENTED_WOUND` game event for client notification
- Added 17 comprehensive tests covering wound prevention, additional effect prevention, brutal interaction, round reset, powered healing, and card definition

Closes #217