### PR TITLE
feat: implement Goldyx Motivation skill

### DIFF
--- a/packages/core/src/data/skills/goldyx/motivation.ts
+++ b/packages/core/src/data/skills/goldyx/motivation.ts
@@ -1,19 +1,36 @@
 /**
  * Motivation - Goldyx Skill
  * @module data/skills/goldyx/motivation
+ *
+ * Once a round, on any player's turn: flip this to draw two cards.
+ * If you have the least Fame (not tied), also gain a green mana token.
+ *
+ * Identical to other heroes' Motivation except green mana,
+ * fitting Goldyx's green crystal theme (Green, Green, Blue).
  */
 
 import type { SkillId } from "@mage-knight/shared";
+import { MANA_GREEN } from "@mage-knight/shared";
 import { CATEGORY_SPECIAL } from "../../../types/cards.js";
+import { EFFECT_DRAW_CARDS, EFFECT_GAIN_MANA } from "../../../types/effectTypes.js";
+import { CONDITION_LOWEST_FAME } from "../../../types/conditions.js";
+import { compound, conditional } from "../../effectHelpers.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_ROUND } from "../types.js";
 
 export const SKILL_GOLDYX_MOTIVATION = "goldyx_motivation" as SkillId;
 
 export const goldyxMotivation: SkillDefinition = {
   id: SKILL_GOLDYX_MOTIVATION,
-    name: "Motivation",
-    heroId: "goldyx",
-    description: "On any player's turn: flip to draw 2 cards. If lowest Fame: +1 green mana",
-    usageType: SKILL_USAGE_ONCE_PER_ROUND,
-    categories: [CATEGORY_SPECIAL],
+  name: "Motivation",
+  heroId: "goldyx",
+  description: "On any player's turn: flip to draw 2 cards. If lowest Fame: +1 green mana",
+  usageType: SKILL_USAGE_ONCE_PER_ROUND,
+  categories: [CATEGORY_SPECIAL],
+  effect: compound([
+    { type: EFFECT_DRAW_CARDS, amount: 2 },
+    conditional(
+      { type: CONDITION_LOWEST_FAME },
+      { type: EFFECT_GAIN_MANA, color: MANA_GREEN },
+    ),
+  ]),
 };

--- a/packages/core/src/engine/__tests__/skillMotivationGoldyx.test.ts
+++ b/packages/core/src/engine/__tests__/skillMotivationGoldyx.test.ts
@@ -1,0 +1,706 @@
+/**
+ * Tests for Motivation skill (Goldyx)
+ *
+ * Skill effect: Once a round, on any player's turn: flip this to draw two cards.
+ * If you have the least Fame (not tied), also gain a green mana token.
+ *
+ * Key rules:
+ * - Once per round (flip to activate)
+ * - Can be used on any player's turn
+ * - Always draws 2 cards (no reshuffle if deck empty)
+ * - Green mana if player has lowest or tied-for-lowest fame
+ * - In solo play, always counts as lowest fame
+ * - Sets Motivation cooldown after use (cross-hero)
+ * - Cannot use any Motivation skill while cooldown active
+ * - Cooldown expires at end of player's next turn
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  CARD_MARCH,
+  CARD_STAMINA,
+  CARD_RAGE,
+  MANA_GREEN,
+  MANA_TOKEN_SOURCE_CARD,
+  END_TURN_ACTION,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_GOLDYX_MOTIVATION } from "../../data/skills/index.js";
+import { SKILL_TOVAK_MOTIVATION } from "../../data/skills/index.js";
+import { SKILL_ARYTHEA_MOTIVATION } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+
+describe("Motivation skill (Goldyx)", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation - draws 2 cards", () => {
+    it("should draw 2 cards from deck", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_GOLDYX_MOTIVATION,
+        })
+      );
+
+      // Should have drawn 2 cards (hand started with 1, now 3)
+      expect(result.state.players[0].hand).toHaveLength(3);
+      // Deck should be empty (started with 2, drew 2)
+      expect(result.state.players[0].deck).toHaveLength(0);
+    });
+
+    it("should draw fewer cards if deck has less than 2", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].hand).toHaveLength(2);
+      expect(result.state.players[0].deck).toHaveLength(0);
+    });
+
+    it("should draw 0 cards if deck is empty", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+        })
+      );
+      expect(result.state.players[0].hand).toHaveLength(1);
+    });
+  });
+
+  describe("green mana - solo play (always lowest fame)", () => {
+    it("should grant green mana token in solo play", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+        fame: 5,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+  });
+
+  describe("green mana - multiplayer", () => {
+    it("should grant green mana when player has lowest fame", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+        fame: 0,
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 10,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should not grant green mana when player has higher fame", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+        fame: 10,
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 5,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].pureMana).toHaveLength(0);
+    });
+
+    it("should grant green mana when tied for lowest fame", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+        fame: 5,
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 5,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+  });
+
+  describe("cooldown", () => {
+    it("should add skill to usedThisRound cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(
+        result.state.players[0].skillCooldowns.usedThisRound
+      ).toContain(SKILL_GOLDYX_MOTIVATION);
+    });
+
+    it("should reject if skill already used this round", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_GOLDYX_MOTIVATION],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if skill not learned", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("Motivation cross-hero cooldown", () => {
+    it("should set activeUntilNextTurn for all Motivation skills after use", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      const cooldowns = result.state.players[0].skillCooldowns.activeUntilNextTurn;
+      expect(cooldowns).toContain(SKILL_GOLDYX_MOTIVATION);
+      expect(cooldowns).toContain(SKILL_TOVAK_MOTIVATION);
+      expect(cooldowns).toContain(SKILL_ARYTHEA_MOTIVATION);
+    });
+
+    it("should reject using another Motivation skill while cooldown active", () => {
+      // Goldyx has learned both Goldyx Motivation and (hypothetically) Tovak Motivation
+      // After using Goldyx Motivation, Tovak Motivation should be blocked
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION, SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_GOLDYX_MOTIVATION],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [
+            SKILL_GOLDYX_MOTIVATION,
+            SKILL_TOVAK_MOTIVATION,
+            SKILL_ARYTHEA_MOTIVATION,
+          ],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should clear activeUntilNextTurn cooldown at end of turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_GOLDYX_MOTIVATION],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [
+            SKILL_GOLDYX_MOTIVATION,
+            SKILL_TOVAK_MOTIVATION,
+            SKILL_ARYTHEA_MOTIVATION,
+          ],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        playedCardFromHandThisTurn: true,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: END_TURN_ACTION,
+      });
+
+      // After ending turn, activeUntilNextTurn should be cleared
+      expect(
+        result.state.players[0].skillCooldowns.activeUntilNextTurn
+      ).toHaveLength(0);
+    });
+
+    it("should not show Motivation in valid actions when cooldown active", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [
+            SKILL_GOLDYX_MOTIVATION,
+            SKILL_TOVAK_MOTIVATION,
+            SKILL_ARYTHEA_MOTIVATION,
+          ],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_GOLDYX_MOTIVATION,
+          })
+        );
+      }
+    });
+  });
+
+  describe("any player's turn", () => {
+    it("should allow Motivation to be used on another player's turn", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 10,
+      });
+      // player2 is the current player (index 1 in turn order)
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player2", "player1"],
+        currentPlayerIndex: 0, // player2's turn
+      });
+
+      // player1 uses Motivation on player2's turn
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      // Should succeed (not rejected for "not your turn")
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_GOLDYX_MOTIVATION,
+        })
+      );
+      expect(result.events).not.toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+
+      // Should have drawn 2 cards
+      expect(result.state.players[0].hand).toHaveLength(3);
+    });
+
+    it("should grant green mana when player has lowest fame on another player's turn", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+        fame: 0, // Lowest fame
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 10,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player2", "player1"],
+        currentPlayerIndex: 0, // player2's turn
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      expect(result.state.players[0].pureMana).toContainEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should reject non-Motivation skill on another player's turn", () => {
+      // Verify that only Motivation skills bypass the turn check
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Tovak,
+        skills: [SKILL_TOVAK_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player2", "player1"],
+        currentPlayerIndex: 0, // player2's turn
+      });
+
+      // Tovak's Motivation should also work on another player's turn
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_MOTIVATION,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+        })
+      );
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill in valid actions when available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_GOLDYX_MOTIVATION,
+        })
+      );
+    });
+
+    it("should not show skill in valid actions when on cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [SKILL_GOLDYX_MOTIVATION],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_GOLDYX_MOTIVATION,
+          })
+        );
+      }
+    });
+  });
+
+  describe("undo", () => {
+    it("should not be undoable (draw cards is irreversible)", () => {
+      const player = createTestPlayer({
+        hero: Hero.Goldyx,
+        skills: [SKILL_GOLDYX_MOTIVATION],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+        hand: [CARD_MARCH],
+        deck: [CARD_STAMINA, CARD_RAGE],
+        pureMana: [],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_GOLDYX_MOTIVATION,
+      });
+
+      // Verify activation
+      expect(afterSkill.state.players[0].hand).toHaveLength(3);
+      expect(
+        afterSkill.state.players[0].skillCooldowns.usedThisRound
+      ).toContain(SKILL_GOLDYX_MOTIVATION);
+
+      // Undo should fail (draw cards creates checkpoint)
+      const afterUndo = engine.processAction(afterSkill.state, "player1", {
+        type: "UNDO" as const,
+      });
+
+      // Skill should still be on cooldown — undo was blocked
+      expect(
+        afterUndo.state.players[0].skillCooldowns.usedThisRound
+      ).toContain(SKILL_GOLDYX_MOTIVATION);
+
+      // Hand should still have drawn cards
+      expect(afterUndo.state.players[0].hand).toHaveLength(3);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/endTurn/playerReset.ts
+++ b/packages/core/src/engine/commands/endTurn/playerReset.ts
@@ -70,5 +70,10 @@ export function createResetPlayer(
     crystalMasteryPoweredActive: false,
     // Skill cooldown reset for Time Bending: refresh once-per-turn skills
     // (usedThisTurn is cleared when isTimeBentTurn is being set up in turnAdvancement)
+    // Clear "until next turn" cooldowns (e.g., Motivation cross-hero cooldown)
+    skillCooldowns: {
+      ...player.skillCooldowns,
+      activeUntilNextTurn: [],
+    },
   };
 }

--- a/packages/core/src/engine/rules/motivation.ts
+++ b/packages/core/src/engine/rules/motivation.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared Motivation skill rules.
+ *
+ * Motivation skills share a cross-hero cooldown: after using any Motivation
+ * skill, you cannot use another Motivation skill until the end of your next turn.
+ *
+ * These helpers are used by both validators and ValidActions computation
+ * to prevent rule drift.
+ */
+
+import type { SkillId } from "@mage-knight/shared";
+import type { Player } from "../../types/player.js";
+import {
+  SKILL_ARYTHEA_MOTIVATION,
+  SKILL_TOVAK_MOTIVATION,
+  SKILL_NOROWAS_MOTIVATION,
+  SKILL_GOLDYX_MOTIVATION,
+} from "../../data/skills/index.js";
+
+/**
+ * All Motivation skill IDs across heroes.
+ * Used for cross-hero cooldown enforcement.
+ */
+export const ALL_MOTIVATION_SKILLS: readonly SkillId[] = [
+  SKILL_ARYTHEA_MOTIVATION,
+  SKILL_TOVAK_MOTIVATION,
+  SKILL_NOROWAS_MOTIVATION,
+  SKILL_GOLDYX_MOTIVATION,
+];
+
+/**
+ * Check if a skill is a Motivation skill.
+ */
+export function isMotivationSkill(skillId: SkillId): boolean {
+  return (ALL_MOTIVATION_SKILLS as readonly string[]).includes(skillId);
+}
+
+/**
+ * Check if the Motivation cooldown is active for a player.
+ * Returns true if any Motivation skill is in the activeUntilNextTurn cooldown.
+ */
+export function isMotivationCooldownActive(player: Player): boolean {
+  return player.skillCooldowns.activeUntilNextTurn.some((id) =>
+    isMotivationSkill(id)
+  );
+}

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -54,6 +54,7 @@ import {
   SKILL_TOVAK_MANA_OVERLOAD,
   SKILL_GOLDYX_GLITTERING_FORTUNE,
   SKILL_GOLDYX_UNIVERSAL_POWER,
+  SKILL_GOLDYX_MOTIVATION,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -68,6 +69,7 @@ import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasin
 import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { hexKey } from "@mage-knight/shared";
 import { canActivateUniversalPower } from "../commands/skills/universalPowerEffect.js";
+import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
 /**
  * Skills that have effect implementations and can be activated.
@@ -110,6 +112,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_TOVAK_MANA_OVERLOAD,
   SKILL_GOLDYX_GLITTERING_FORTUNE,
   SKILL_GOLDYX_UNIVERSAL_POWER,
+  SKILL_GOLDYX_MOTIVATION,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER]);
@@ -236,6 +239,11 @@ export function getSkillOptions(
       }
     } else {
       // Passive and interactive skills are not directly activatable via USE_SKILL
+      continue;
+    }
+
+    // Motivation cross-hero cooldown check
+    if (isMotivationSkill(skillId) && isMotivationCooldownActive(player)) {
       continue;
     }
 

--- a/packages/core/src/engine/validators/registry/skillRegistry.ts
+++ b/packages/core/src/engine/validators/registry/skillRegistry.ts
@@ -14,6 +14,7 @@ import { validateNoChoicePending } from "../choiceValidators.js";
 
 // Skill validators
 import {
+  validateSkillTurnRequirement,
   validateSkillLearned,
   validateSkillCooldown,
   validateCombatSkillInCombat,
@@ -31,7 +32,7 @@ import {
 
 export const skillRegistry: Record<string, Validator[]> = {
   [USE_SKILL_ACTION]: [
-    validateIsPlayersTurn,
+    validateSkillTurnRequirement,
     validateRoundPhase,
     validateNoChoicePending,
     validateSkillLearned,


### PR DESCRIPTION
## Summary
- Implement Goldyx Motivation skill with draw 2 cards + conditional green mana (if lowest fame)
- Add "any player's turn" support for all Motivation skills (validator bypass)
- Implement cross-hero Motivation cooldown via `activeUntilNextTurn`
- Cooldown expires at end of player's next turn

## Changes
- `packages/core/src/data/skills/goldyx/motivation.ts` - Add compound effect (draw 2 + conditional green mana)
- `packages/core/src/engine/rules/motivation.ts` - New shared rules: `isMotivationSkill()`, `isMotivationCooldownActive()`, `ALL_MOTIVATION_SKILLS`
- `packages/core/src/engine/validators/skillValidators.ts` - Add `validateSkillTurnRequirement` (bypasses turn check for Motivation), add Motivation cooldown check to `validateSkillCooldown`
- `packages/core/src/engine/validators/registry/skillRegistry.ts` - Use `validateSkillTurnRequirement` instead of `validateIsPlayersTurn` for USE_SKILL
- `packages/core/src/engine/commands/useSkillCommand.ts` - When Motivation used, add all Motivation skills to `activeUntilNextTurn`
- `packages/core/src/engine/validActions/skills.ts` - Check Motivation cooldown, add to IMPLEMENTED_SKILLS
- `packages/core/src/engine/commands/endTurn/playerReset.ts` - Clear `activeUntilNextTurn` at end of turn
- `packages/core/src/engine/__tests__/skillMotivationGoldyx.test.ts` - 20 tests covering all acceptance criteria

Closes #338