### PR TITLE
feat: implement Meditation/Trance spell

### DIFF
--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -21,6 +21,7 @@ import { SparingPowerDecision } from "./Overlays/SparingPowerDecision";
 import { ManaSearchReroll } from "./Overlays/ManaSearchReroll";
 import { GladeWoundDecision } from "./Overlays/GladeWoundDecision";
 import { CrystalJoyReclaimDecision } from "./Overlays/CrystalJoyReclaimDecision";
+import { MeditationDecision } from "./Overlays/MeditationDecision";
 import { RestCompletionOverlay } from "./Overlays/RestCompletionOverlay";
 import { DiscardCostOverlay } from "./Overlays/DiscardCostOverlay";
 import { HexCostReductionOverlay } from "./Overlays/HexCostReductionOverlay";
@@ -107,6 +108,7 @@ export function GameView() {
       <ManaSearchReroll />
       <GladeWoundDecision />
       <CrystalJoyReclaimDecision />
+      <MeditationDecision />
       <RestCompletionOverlay />
       <DiscardCostOverlay />
       <HexCostReductionOverlay />

--- a/packages/client/src/components/Overlays/MeditationDecision.tsx
+++ b/packages/client/src/components/Overlays/MeditationDecision.tsx
@@ -1,0 +1,94 @@
+/**
+ * MeditationDecision - Card selection and placement UI for Meditation/Trance spell
+ *
+ * Shown when validActions.mode === "pending_meditation".
+ *
+ * Phase "select_cards" (powered mode): Player selects cards from discard pile.
+ * Phase "place_cards": Player chooses to place selected cards on top or bottom of deck.
+ *
+ * Sends RESOLVE_MEDITATION_ACTION with selectedCardIds (phase 1) or placeOnTop (phase 2).
+ */
+
+import { useCallback } from "react";
+import { RESOLVE_MEDITATION_ACTION } from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import { useGame } from "../../hooks/useGame";
+import { CardSelectionOverlay } from "./CardSelectionOverlay";
+import { useRegisterOverlay } from "../../contexts/OverlayContext";
+
+export function MeditationDecision() {
+  const { state, sendAction } = useGame();
+
+  const isActive =
+    state?.validActions?.mode === "pending_meditation" &&
+    state.validActions.meditation != null;
+
+  const options = isActive ? state.validActions.meditation : null;
+
+  // Register overlay to block background interactions
+  useRegisterOverlay(isActive);
+
+  const handleSelectCards = useCallback(
+    (selectedCards: readonly CardId[]) => {
+      sendAction({
+        type: RESOLVE_MEDITATION_ACTION,
+        selectedCardIds: selectedCards,
+      });
+    },
+    [sendAction]
+  );
+
+  const handlePlaceOnTop = useCallback(() => {
+    sendAction({
+      type: RESOLVE_MEDITATION_ACTION,
+      placeOnTop: true,
+    });
+  }, [sendAction]);
+
+  const handlePlaceOnBottom = useCallback(() => {
+    sendAction({
+      type: RESOLVE_MEDITATION_ACTION,
+      placeOnTop: false,
+    });
+  }, [sendAction]);
+
+  if (!isActive || !options) {
+    return null;
+  }
+
+  // Phase 1: Select cards from discard (powered mode)
+  if (options.phase === "select_cards" && options.eligibleCardIds && options.selectCount) {
+    const instruction = `Select ${options.selectCount} card(s) from discard to place in deck`;
+    return (
+      <CardSelectionOverlay
+        cards={options.eligibleCardIds}
+        instruction={instruction}
+        minSelect={options.selectCount}
+        maxSelect={options.selectCount}
+        canSkip={false}
+        onSelect={handleSelectCards}
+      />
+    );
+  }
+
+  // Phase 2: Choose top or bottom placement
+  if (options.phase === "place_cards") {
+    return (
+      <div className="overlay overlay--meditation-placement">
+        <div className="overlay__content">
+          <h3>Place cards on top or bottom of deck?</h3>
+          <div className="overlay__buttons">
+            <button className="btn btn--primary" onClick={handlePlaceOnTop}>
+              Top of Deck
+            </button>
+            <button className="btn btn--secondary" onClick={handlePlaceOnBottom}>
+              Bottom of Deck
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/packages/core/src/data/spells/green/index.ts
+++ b/packages/core/src/data/spells/green/index.ts
@@ -6,15 +6,17 @@
 
 import type { DeedCard } from "../../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
-import { CARD_RESTORATION, CARD_ENERGY_FLOW, CARD_UNDERGROUND_TRAVEL } from "@mage-knight/shared";
+import { CARD_RESTORATION, CARD_ENERGY_FLOW, CARD_UNDERGROUND_TRAVEL, CARD_MEDITATION } from "@mage-knight/shared";
 import { RESTORATION } from "./restoration.js";
 import { ENERGY_FLOW } from "./energyFlow.js";
 import { UNDERGROUND_TRAVEL } from "./undergroundTravel.js";
+import { MEDITATION } from "./meditation.js";
 
 export const GREEN_SPELLS: Record<CardId, DeedCard> = {
   [CARD_RESTORATION]: RESTORATION,
   [CARD_ENERGY_FLOW]: ENERGY_FLOW,
   [CARD_UNDERGROUND_TRAVEL]: UNDERGROUND_TRAVEL,
+  [CARD_MEDITATION]: MEDITATION,
 };
 
-export { RESTORATION, ENERGY_FLOW, UNDERGROUND_TRAVEL };
+export { RESTORATION, ENERGY_FLOW, UNDERGROUND_TRAVEL, MEDITATION };

--- a/packages/core/src/data/spells/green/meditation.ts
+++ b/packages/core/src/data/spells/green/meditation.ts
@@ -1,0 +1,28 @@
+/**
+ * Meditation / Trance (Green Spell #06)
+ *
+ * Basic (Meditation): Randomly pick 2 cards from discard pile → place on top or bottom of deck.
+ *   Hand limit +2 on next draw.
+ * Powered (Trance): Choose 2 cards from discard pile → place on top or bottom of deck.
+ *   Hand limit +2 on next draw.
+ *
+ * Effect uses NOOP — actual logic is in playCardCommand.ts (sets pendingMeditation state)
+ * and resolveMeditationCommand.ts (resolves placement choice).
+ */
+
+import type { DeedCard } from "../../../types/cards.js";
+import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
+import { MANA_GREEN, MANA_BLACK, CARD_MEDITATION } from "@mage-knight/shared";
+import { EFFECT_NOOP } from "../../../types/effectTypes.js";
+
+export const MEDITATION: DeedCard = {
+  id: CARD_MEDITATION,
+  name: "Meditation",
+  poweredName: "Trance",
+  cardType: DEED_CARD_TYPE_SPELL,
+  categories: [],
+  poweredBy: [MANA_BLACK, MANA_GREEN],
+  basicEffect: { type: EFFECT_NOOP },
+  poweredEffect: { type: EFFECT_NOOP },
+  sidewaysValue: 1,
+};

--- a/packages/core/src/engine/__tests__/meditation.test.ts
+++ b/packages/core/src/engine/__tests__/meditation.test.ts
@@ -1,0 +1,613 @@
+/**
+ * Tests for Meditation/Trance spell (Green Spell #06)
+ *
+ * Meditation (basic): Randomly pick 2 cards from discard → place on top or bottom of deck.
+ *   Hand limit +2 on next draw.
+ * Trance (powered): Choose 2 cards from discard → place on top or bottom of deck.
+ *   Hand limit +2 on next draw.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  CARD_MEDITATION,
+  CARD_MARCH,
+  CARD_RAGE,
+  CARD_STAMINA,
+  CARD_WOUND,
+  RESOLVE_MEDITATION_ACTION,
+  MEDITATION_CARDS_SELECTED,
+  MEDITATION_CARDS_PLACED,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import { getMeditationSelectCount, canPlayMeditation } from "../rules/meditation.js";
+import {
+  validateHasPendingMeditation,
+  validateMeditationChoice,
+} from "../validators/meditationValidators.js";
+import { getMeditationOptions } from "../validActions/pending.js";
+import { getValidActions } from "../validActions/index.js";
+import { createPlayCardCommand } from "../commands/playCardCommand.js";
+import { createResolveMeditationCommand } from "../commands/resolveMeditationCommand.js";
+import type { GameState } from "../../state/GameState.js";
+
+// ============================================================================
+// 1. Rule Unit Tests
+// ============================================================================
+
+describe("Meditation rules", () => {
+  it("getMeditationSelectCount returns min(2, discard.length)", () => {
+    const player0 = createTestPlayer({ discard: [] });
+    expect(getMeditationSelectCount(player0)).toBe(0);
+
+    const player1 = createTestPlayer({ discard: [CARD_MARCH] });
+    expect(getMeditationSelectCount(player1)).toBe(1);
+
+    const player2 = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE],
+    });
+    expect(getMeditationSelectCount(player2)).toBe(2);
+
+    const player3 = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE, CARD_STAMINA],
+    });
+    expect(getMeditationSelectCount(player3)).toBe(2);
+  });
+
+  it("canPlayMeditation requires at least 1 card in discard", () => {
+    const empty = createTestPlayer({ discard: [] });
+    expect(canPlayMeditation(empty)).toBe(false);
+
+    const hasOne = createTestPlayer({ discard: [CARD_MARCH] });
+    expect(canPlayMeditation(hasOne)).toBe(true);
+  });
+});
+
+// ============================================================================
+// 2. Validator Tests
+// ============================================================================
+
+describe("Meditation validators", () => {
+  it("validateHasPendingMeditation rejects when no pending state", () => {
+    const player = createTestPlayer({ pendingMeditation: undefined });
+    const state = createTestGameState({ players: [player] });
+    const result = validateHasPendingMeditation(state, "player1", {} as never);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validateHasPendingMeditation passes when pending state exists", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const result = validateHasPendingMeditation(state, "player1", {} as never);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validateMeditationChoice rejects missing card selection in select_cards phase", () => {
+    const player = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE],
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = { type: RESOLVE_MEDITATION_ACTION } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validateMeditationChoice rejects wrong count in select_cards phase", () => {
+    const player = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE],
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = {
+      type: RESOLVE_MEDITATION_ACTION,
+      selectedCardIds: [CARD_MARCH],
+    } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validateMeditationChoice rejects cards not in discard", () => {
+    const player = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE],
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = {
+      type: RESOLVE_MEDITATION_ACTION,
+      selectedCardIds: [CARD_MARCH, CARD_STAMINA],
+    } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validateMeditationChoice accepts valid selection in select_cards phase", () => {
+    const player = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE],
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = {
+      type: RESOLVE_MEDITATION_ACTION,
+      selectedCardIds: [CARD_MARCH, CARD_RAGE],
+    } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(true);
+  });
+
+  it("validateMeditationChoice rejects missing placeOnTop in place_cards phase", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH, CARD_RAGE],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = { type: RESOLVE_MEDITATION_ACTION } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(false);
+  });
+
+  it("validateMeditationChoice accepts placeOnTop in place_cards phase", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH, CARD_RAGE],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const action = {
+      type: RESOLVE_MEDITATION_ACTION,
+      placeOnTop: true,
+    } as never;
+    const result = validateMeditationChoice(state, "player1", action);
+    expect(result.valid).toBe(true);
+  });
+});
+
+// ============================================================================
+// 3. ValidActions Tests
+// ============================================================================
+
+describe("Meditation validActions", () => {
+  it("returns pending_meditation mode with select_cards phase (powered)", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+      discard: [CARD_MARCH, CARD_RAGE, CARD_STAMINA],
+    });
+    const state = createTestGameState({ players: [player] });
+    const validActions = getValidActions(state, "player1");
+
+    expect(validActions.mode).toBe("pending_meditation");
+    if (validActions.mode === "pending_meditation") {
+      expect(validActions.meditation.phase).toBe("select_cards");
+      expect(validActions.meditation.version).toBe("powered");
+      expect(validActions.meditation.selectCount).toBe(2);
+      expect(validActions.meditation.eligibleCardIds).toHaveLength(3);
+    }
+  });
+
+  it("returns pending_meditation mode with place_cards phase (basic)", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH, CARD_RAGE],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const validActions = getValidActions(state, "player1");
+
+    expect(validActions.mode).toBe("pending_meditation");
+    if (validActions.mode === "pending_meditation") {
+      expect(validActions.meditation.phase).toBe("place_cards");
+      expect(validActions.meditation.version).toBe("basic");
+      expect(validActions.meditation.selectedCardIds).toEqual([
+        CARD_MARCH,
+        CARD_RAGE,
+      ]);
+    }
+  });
+
+  it("getMeditationOptions returns correct data for select_cards phase", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+      discard: [CARD_MARCH, CARD_RAGE],
+    });
+    const state = createTestGameState({ players: [player] });
+    const options = getMeditationOptions(state, player);
+
+    expect(options.phase).toBe("select_cards");
+    expect(options.version).toBe("powered");
+    expect(options.selectCount).toBe(2);
+    expect(options.eligibleCardIds).toEqual([CARD_MARCH, CARD_RAGE]);
+  });
+
+  it("getMeditationOptions returns correct data for place_cards phase", () => {
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH],
+      },
+    });
+    const state = createTestGameState({ players: [player] });
+    const options = getMeditationOptions(state, player);
+
+    expect(options.phase).toBe("place_cards");
+    expect(options.version).toBe("basic");
+    expect(options.selectedCardIds).toEqual([CARD_MARCH]);
+  });
+});
+
+// ============================================================================
+// 4. PlayCardCommand Integration Tests
+// ============================================================================
+
+describe("Meditation playCardCommand integration", () => {
+  function createMeditationState(
+    discardCards: CardId[]
+  ): GameState {
+    const player = createTestPlayer({
+      hand: [CARD_MEDITATION, CARD_MARCH],
+      discard: discardCards,
+    });
+    return createTestGameState({ players: [player] });
+  }
+
+  it("basic mode: sets pendingMeditation with place_cards phase and random selection", () => {
+    const state = createMeditationState(
+      [CARD_MARCH, CARD_RAGE, CARD_STAMINA]
+    );
+    const cmd = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MEDITATION,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = cmd.execute(state);
+    const player = result.state.players[0]!;
+
+    expect(player.pendingMeditation).toBeDefined();
+    expect(player.pendingMeditation!.version).toBe("basic");
+    expect(player.pendingMeditation!.phase).toBe("place_cards");
+    expect(player.pendingMeditation!.selectedCardIds).toHaveLength(2);
+    expect(player.meditationHandLimitBonus).toBe(2);
+
+    // Cards selected should be from the discard pile
+    for (const cardId of player.pendingMeditation!.selectedCardIds) {
+      expect(state.players[0]!.discard).toContain(cardId);
+    }
+
+    // Should emit MEDITATION_CARDS_SELECTED event
+    const selectEvent = result.events.find(
+      (e) => e.type === MEDITATION_CARDS_SELECTED
+    );
+    expect(selectEvent).toBeDefined();
+  });
+
+  it("basic mode: RNG advances (non-reversible)", () => {
+    const state = createMeditationState(
+      [CARD_MARCH, CARD_RAGE]
+    );
+    const cmd = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MEDITATION,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = cmd.execute(state);
+    // RNG should have advanced
+    expect(result.state.rng).not.toEqual(state.rng);
+  });
+
+  it("powered mode: sets pendingMeditation with select_cards phase", () => {
+    const playerWithCrystals = createTestPlayer({
+      hand: [CARD_MEDITATION, CARD_MARCH],
+      discard: [CARD_MARCH, CARD_RAGE],
+      crystals: { red: 0, blue: 0, green: 1, white: 0 },
+    });
+    const stateWithCrystals = createTestGameState({
+      players: [playerWithCrystals],
+    });
+    const cmd = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MEDITATION,
+      handIndex: 0,
+      powered: true,
+      manaSources: [
+        { type: "crystal", color: "black" },
+        { type: "crystal", color: "green" },
+      ],
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = cmd.execute(stateWithCrystals);
+    const player = result.state.players[0]!;
+
+    expect(player.pendingMeditation).toBeDefined();
+    expect(player.pendingMeditation!.version).toBe("powered");
+    expect(player.pendingMeditation!.phase).toBe("select_cards");
+    expect(player.pendingMeditation!.selectedCardIds).toEqual([]);
+    expect(player.meditationHandLimitBonus).toBe(2);
+  });
+
+  it("basic mode with only 1 card in discard: selects 1 card", () => {
+    const state = createMeditationState([CARD_MARCH]);
+    const cmd = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MEDITATION,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    });
+
+    const result = cmd.execute(state);
+    const player = result.state.players[0]!;
+
+    expect(player.pendingMeditation!.selectedCardIds).toHaveLength(1);
+    expect(player.pendingMeditation!.selectedCardIds[0]).toBe(CARD_MARCH);
+  });
+
+  it("undo clears pendingMeditation and meditationHandLimitBonus", () => {
+    const state = createMeditationState(
+      [CARD_MARCH, CARD_RAGE]
+    );
+    const cmd = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MEDITATION,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    });
+
+    const executeResult = cmd.execute(state);
+    const player = executeResult.state.players[0]!;
+    expect(player.pendingMeditation).toBeDefined();
+    expect(player.meditationHandLimitBonus).toBe(2);
+
+    const undoResult = cmd.undo(executeResult.state);
+    const undoPlayer = undoResult.state.players[0]!;
+    expect(undoPlayer.pendingMeditation).toBeUndefined();
+    expect(undoPlayer.meditationHandLimitBonus).toBe(0);
+  });
+});
+
+// ============================================================================
+// 5. ResolveMeditationCommand Tests
+// ============================================================================
+
+describe("resolveMeditationCommand", () => {
+  it("phase 1: stores selectedCardIds and advances to place_cards", () => {
+    const player = createTestPlayer({
+      discard: [CARD_MARCH, CARD_RAGE, CARD_STAMINA],
+      pendingMeditation: {
+        version: "powered",
+        phase: "select_cards",
+        selectedCardIds: [],
+      },
+      meditationHandLimitBonus: 2,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const cmd = createResolveMeditationCommand({
+      playerId: "player1",
+      selectedCardIds: [CARD_MARCH, CARD_RAGE],
+    });
+
+    const result = cmd.execute(state);
+    const updatedPlayer = result.state.players[0]!;
+
+    expect(updatedPlayer.pendingMeditation!.phase).toBe("place_cards");
+    expect(updatedPlayer.pendingMeditation!.selectedCardIds).toEqual([
+      CARD_MARCH,
+      CARD_RAGE,
+    ]);
+
+    const selectEvent = result.events.find(
+      (e) => e.type === MEDITATION_CARDS_SELECTED
+    );
+    expect(selectEvent).toBeDefined();
+  });
+
+  it("phase 2: places cards on top of deck", () => {
+    const player = createTestPlayer({
+      deck: [CARD_WOUND],
+      discard: [CARD_MARCH, CARD_RAGE, CARD_STAMINA],
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH, CARD_RAGE],
+      },
+      meditationHandLimitBonus: 2,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const cmd = createResolveMeditationCommand({
+      playerId: "player1",
+      placeOnTop: true,
+    });
+
+    const result = cmd.execute(state);
+    const updatedPlayer = result.state.players[0]!;
+
+    // Cards should be on top of deck
+    expect(updatedPlayer.deck[0]).toBe(CARD_MARCH);
+    expect(updatedPlayer.deck[1]).toBe(CARD_RAGE);
+    expect(updatedPlayer.deck[2]).toBe(CARD_WOUND);
+
+    // Cards should be removed from discard
+    expect(updatedPlayer.discard).not.toContain(CARD_MARCH);
+    expect(updatedPlayer.discard).not.toContain(CARD_RAGE);
+    expect(updatedPlayer.discard).toContain(CARD_STAMINA);
+
+    // Pending state should be cleared
+    expect(updatedPlayer.pendingMeditation).toBeUndefined();
+
+    const placeEvent = result.events.find(
+      (e) => e.type === MEDITATION_CARDS_PLACED
+    );
+    expect(placeEvent).toBeDefined();
+    if (placeEvent && placeEvent.type === MEDITATION_CARDS_PLACED) {
+      expect(placeEvent.position).toBe("top");
+    }
+  });
+
+  it("phase 2: places cards on bottom of deck", () => {
+    const player = createTestPlayer({
+      deck: [CARD_WOUND],
+      discard: [CARD_MARCH, CARD_RAGE, CARD_STAMINA],
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH, CARD_RAGE],
+      },
+      meditationHandLimitBonus: 2,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const cmd = createResolveMeditationCommand({
+      playerId: "player1",
+      placeOnTop: false,
+    });
+
+    const result = cmd.execute(state);
+    const updatedPlayer = result.state.players[0]!;
+
+    // Cards should be on bottom of deck
+    expect(updatedPlayer.deck[0]).toBe(CARD_WOUND);
+    expect(updatedPlayer.deck[1]).toBe(CARD_MARCH);
+    expect(updatedPlayer.deck[2]).toBe(CARD_RAGE);
+
+    // Pending state should be cleared
+    expect(updatedPlayer.pendingMeditation).toBeUndefined();
+
+    const placeEvent = result.events.find(
+      (e) => e.type === MEDITATION_CARDS_PLACED
+    );
+    if (placeEvent && placeEvent.type === MEDITATION_CARDS_PLACED) {
+      expect(placeEvent.position).toBe("bottom");
+    }
+  });
+
+  it("phase 2: preserves meditationHandLimitBonus (consumed at end of turn)", () => {
+    const player = createTestPlayer({
+      deck: [],
+      discard: [CARD_MARCH],
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH],
+      },
+      meditationHandLimitBonus: 2,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const cmd = createResolveMeditationCommand({
+      playerId: "player1",
+      placeOnTop: true,
+    });
+
+    const result = cmd.execute(state);
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.meditationHandLimitBonus).toBe(2);
+  });
+});
+
+// ============================================================================
+// 6. Hand Limit Integration
+// ============================================================================
+
+describe("Meditation hand limit bonus", () => {
+  it("getEndTurnDrawLimit includes meditationHandLimitBonus", async () => {
+    const { getEndTurnDrawLimit } = await import("../helpers/handLimitHelpers.js");
+
+    const player = createTestPlayer({
+      meditationHandLimitBonus: 2,
+      handLimit: 5,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const limit = getEndTurnDrawLimit(state, "player1", 0);
+    // Base 5 + meditation bonus 2 = 7
+    expect(limit).toBe(7);
+  });
+
+  it("getEndTurnDrawLimit works without meditationHandLimitBonus", async () => {
+    const { getEndTurnDrawLimit } = await import("../helpers/handLimitHelpers.js");
+
+    const player = createTestPlayer({
+      meditationHandLimitBonus: 0,
+      handLimit: 5,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const limit = getEndTurnDrawLimit(state, "player1", 0);
+    expect(limit).toBe(5);
+  });
+});
+
+// ============================================================================
+// 7. Player Reset Tests
+// ============================================================================
+
+describe("Meditation player reset", () => {
+  it("createResetPlayer clears meditation state", async () => {
+    const { createResetPlayer } = await import("../commands/endTurn/playerReset.js");
+
+    const player = createTestPlayer({
+      pendingMeditation: {
+        version: "basic",
+        phase: "place_cards",
+        selectedCardIds: [CARD_MARCH],
+      },
+      meditationHandLimitBonus: 2,
+    });
+
+    const resetPlayer = createResetPlayer(player, {
+      hand: [],
+      deck: [],
+      discard: [],
+      playArea: [],
+    });
+
+    expect(resetPlayer.pendingMeditation).toBeUndefined();
+    expect(resetPlayer.meditationHandLimitBonus).toBe(0);
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -177,6 +177,8 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingBannerProtectionChoice: false,
     spentCrystalsThisTurn: { red: 0, blue: 0, green: 0, white: 0 },
     crystalMasteryPoweredActive: false,
+    pendingMeditation: undefined,
+    meditationHandLimitBonus: 0,
     ...rest,
   };
 }

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -67,6 +67,9 @@ export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_COMMAND = "RESOLVE_ARTIFACT_CRYSTAL_
 // Decompose command (throw away action card for crystals)
 export const RESOLVE_DECOMPOSE_COMMAND = "RESOLVE_DECOMPOSE" as const;
 
+// Meditation resolve command
+export const RESOLVE_MEDITATION_COMMAND = "RESOLVE_MEDITATION" as const;
+
 // Burn monastery command
 export const BURN_MONASTERY_COMMAND = "BURN_MONASTERY" as const;
 

--- a/packages/core/src/engine/commands/endTurn/playerReset.ts
+++ b/packages/core/src/engine/commands/endTurn/playerReset.ts
@@ -68,6 +68,9 @@ export function createResetPlayer(
     // Crystal Mastery resets
     spentCrystalsThisTurn: { red: 0, blue: 0, green: 0, white: 0 },
     crystalMasteryPoweredActive: false,
+    // Meditation spell resets
+    pendingMeditation: undefined,
+    meditationHandLimitBonus: 0,
     // Skill cooldown reset for Time Bending: refresh once-per-turn skills
     // (usedThisTurn is cleared when isTimeBentTurn is being set up in turnAdvancement)
   };

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -80,6 +80,7 @@ import {
   RESOLVE_HEX_COST_REDUCTION_ACTION,
   RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
   RESOLVE_UNIT_MAINTENANCE_ACTION,
+  RESOLVE_MEDITATION_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -149,6 +150,7 @@ export {
   createResolveCrystalJoyReclaimCommandFromAction,
   createResolveSteadyTempoCommandFromAction,
   createResolveBannerProtectionCommandFromAction,
+  createResolveMeditationCommandFromAction,
 } from "./sites.js";
 
 // Tactics factories
@@ -257,6 +259,7 @@ import {
   createResolveCrystalJoyReclaimCommandFromAction,
   createResolveSteadyTempoCommandFromAction,
   createResolveBannerProtectionCommandFromAction,
+  createResolveMeditationCommandFromAction,
 } from "./sites.js";
 
 import {
@@ -380,4 +383,6 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [USE_BANNER_FEAR_ACTION]: createUseBannerFearCommandFromAction,
   // Unit maintenance actions (Magic Familiars round-start)
   [RESOLVE_UNIT_MAINTENANCE_ACTION]: createResolveUnitMaintenanceCommandFromAction,
+  // Meditation resolve action
+  [RESOLVE_MEDITATION_ACTION]: createResolveMeditationCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -28,6 +28,7 @@ import {
   RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION,
   RESOLVE_STEADY_TEMPO_ACTION,
   RESOLVE_BANNER_PROTECTION_ACTION,
+  RESOLVE_MEDITATION_ACTION,
 } from "@mage-knight/shared";
 import { createInteractCommand } from "../interactCommand.js";
 import { createEnterSiteCommand } from "../enterSiteCommand.js";
@@ -38,6 +39,7 @@ import { createPlunderVillageCommand } from "../plunderVillageCommand.js";
 import { createResolveCrystalJoyReclaimCommand } from "../resolveCrystalJoyReclaimCommand.js";
 import { createResolveSteadyTempoCommand } from "../resolveSteadyTempoCommand.js";
 import { createResolveBannerProtectionCommand } from "../resolveBannerProtectionCommand.js";
+import { createResolveMeditationCommand } from "../resolveMeditationCommand.js";
 import { getPlayerById } from "../../helpers/playerHelpers.js";
 
 /**
@@ -224,5 +226,23 @@ export const createResolveBannerProtectionCommandFromAction: CommandFactory = (
   return createResolveBannerProtectionCommand({
     playerId,
     removeAll: action.removeAll,
+  });
+};
+
+/**
+ * Resolve Meditation card selection/placement command factory.
+ * Creates a command to resolve the Meditation spell pending state.
+ */
+export const createResolveMeditationCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_MEDITATION_ACTION) return null;
+
+  return createResolveMeditationCommand({
+    playerId,
+    selectedCardIds: action.selectedCardIds,
+    placeOnTop: action.placeOnTop,
   });
 };

--- a/packages/core/src/engine/commands/resolveMeditationCommand.ts
+++ b/packages/core/src/engine/commands/resolveMeditationCommand.ts
@@ -1,0 +1,141 @@
+/**
+ * Resolve Meditation spell card selection and placement.
+ *
+ * Two phases:
+ * - Phase 1 (select_cards): Powered mode only. Player selects cards from discard.
+ *   Stores selectedCardIds, advances to phase "place_cards".
+ * - Phase 2 (place_cards): Player chooses top or bottom of deck.
+ *   Removes selected cards from discard, places on top or bottom of deck, clears pending.
+ *
+ * This command is irreversible since card placement affects hidden information.
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, CardId } from "@mage-knight/shared";
+import {
+  MEDITATION_CARDS_SELECTED,
+  MEDITATION_CARDS_PLACED,
+} from "@mage-knight/shared";
+import type { Player } from "../../types/player.js";
+import { RESOLVE_MEDITATION_COMMAND } from "./commandTypes.js";
+
+export { RESOLVE_MEDITATION_COMMAND };
+
+export interface ResolveMeditationCommandParams {
+  readonly playerId: string;
+  readonly selectedCardIds?: readonly CardId[]; // Phase 1 (powered)
+  readonly placeOnTop?: boolean; // Phase 2
+}
+
+export function createResolveMeditationCommand(
+  params: ResolveMeditationCommandParams
+): Command {
+  return {
+    type: RESOLVE_MEDITATION_COMMAND,
+    playerId: params.playerId,
+    isReversible: false,
+
+    execute(state: GameState): CommandResult {
+      const player = state.players.find((p) => p.id === params.playerId);
+      if (!player) {
+        throw new Error("Player not found");
+      }
+
+      if (!player.pendingMeditation) {
+        throw new Error("No pending Meditation to resolve");
+      }
+
+      const { phase, version } = player.pendingMeditation;
+      const events: GameEvent[] = [];
+
+      if (phase === "select_cards") {
+        // Phase 1: Store selected cards and advance to place_cards
+        const selectedCardIds = params.selectedCardIds;
+        if (!selectedCardIds || selectedCardIds.length === 0) {
+          throw new Error("Must select cards for phase 1");
+        }
+
+        const updatedPlayer: Player = {
+          ...player,
+          pendingMeditation: {
+            version,
+            phase: "place_cards",
+            selectedCardIds,
+          },
+        };
+
+        events.push({
+          type: MEDITATION_CARDS_SELECTED,
+          playerId: params.playerId,
+          cardIds: selectedCardIds,
+          version,
+        });
+
+        return {
+          state: {
+            ...state,
+            players: state.players.map((p) =>
+              p.id === params.playerId ? updatedPlayer : p
+            ),
+          },
+          events,
+        };
+      }
+
+      if (phase === "place_cards") {
+        // Phase 2: Remove cards from discard, place on top/bottom of deck
+        const placeOnTop = params.placeOnTop;
+        if (placeOnTop === undefined) {
+          throw new Error("Must specify placement for phase 2");
+        }
+
+        const selectedCardIds = player.pendingMeditation.selectedCardIds;
+
+        // Remove selected cards from discard
+        const remainingDiscard = [...player.discard];
+        for (const cardId of selectedCardIds) {
+          const idx = remainingDiscard.indexOf(cardId);
+          if (idx !== -1) {
+            remainingDiscard.splice(idx, 1);
+          }
+        }
+
+        // Place cards on top or bottom of deck
+        const newDeck = placeOnTop
+          ? [...selectedCardIds, ...player.deck]
+          : [...player.deck, ...selectedCardIds];
+
+        const updatedPlayer: Player = {
+          ...player,
+          discard: remainingDiscard,
+          deck: newDeck,
+          pendingMeditation: undefined,
+        };
+
+        events.push({
+          type: MEDITATION_CARDS_PLACED,
+          playerId: params.playerId,
+          cardIds: selectedCardIds,
+          position: placeOnTop ? "top" : "bottom",
+        });
+
+        return {
+          state: {
+            ...state,
+            players: state.players.map((p) =>
+              p.id === params.playerId ? updatedPlayer : p
+            ),
+          },
+          events,
+        };
+      }
+
+      throw new Error(`Unknown meditation phase: ${phase}`);
+    },
+
+    undo(_state: GameState): CommandResult {
+      throw new Error("Cannot undo RESOLVE_MEDITATION");
+    },
+  };
+}

--- a/packages/core/src/engine/helpers/handLimitHelpers.ts
+++ b/packages/core/src/engine/helpers/handLimitHelpers.ts
@@ -104,5 +104,10 @@ export function getEndTurnDrawLimit(
     limit += PLANNING_HAND_LIMIT_BONUS;
   }
 
+  // Meditation/Trance spell: +2 on next draw
+  if (player?.meditationHandLimitBonus) {
+    limit += player.meditationHandLimitBonus;
+  }
+
   return limit;
 }

--- a/packages/core/src/engine/rules/meditation.ts
+++ b/packages/core/src/engine/rules/meditation.ts
@@ -1,0 +1,22 @@
+/**
+ * Meditation spell rules.
+ *
+ * Pure functions for determining Meditation/Trance eligibility and parameters.
+ */
+
+import type { Player } from "../../types/player.js";
+
+/**
+ * Get the number of cards to select from discard for Meditation.
+ * Returns min(2, discard.length).
+ */
+export function getMeditationSelectCount(player: Player): number {
+  return Math.min(2, player.discard.length);
+}
+
+/**
+ * Check if Meditation can be played (requires at least 1 card in discard).
+ */
+export function canPlayMeditation(player: Player): boolean {
+  return player.discard.length > 0;
+}

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -47,6 +47,7 @@ import {
   getSteadyTempoOptions,
   getBannerProtectionOptions,
   getUnitMaintenanceOptions,
+  getMeditationOptions,
 } from "./pending.js";
 import { getChallengeOptions } from "./challenge.js";
 import { getCooperativeAssaultOptions } from "./cooperativeAssault.js";
@@ -200,6 +201,13 @@ export function getValidActions(
       mode: "pending_steady_tempo",
       turn: { canUndo: false },
       steadyTempo: getSteadyTempoOptions(state, player),
+    };
+  }
+  if (player.pendingMeditation) {
+    return {
+      mode: "pending_meditation",
+      turn: { canUndo: false },
+      meditation: getMeditationOptions(state, player),
     };
   }
   if (player.pendingBannerProtectionChoice) {

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -24,6 +24,7 @@ import type {
   SteadyTempoOptions,
   BannerProtectionOptions,
   UnitMaintenanceOptions,
+  MeditationOptions,
   CardId,
 } from "@mage-knight/shared";
 import { mineColorToBasicManaColor } from "../../types/map.js";
@@ -298,4 +299,33 @@ export function getUnitMaintenanceOptions(
   });
 
   return { units };
+}
+
+/**
+ * Get Meditation options for the player.
+ * Returns options based on current phase (select_cards or place_cards).
+ */
+export function getMeditationOptions(
+  _state: GameState,
+  player: Player
+): MeditationOptions {
+  const pending = player.pendingMeditation!;
+
+  if (pending.phase === "select_cards") {
+    // Phase 1: player selects cards from discard (powered mode)
+    const selectCount = Math.min(2, player.discard.length);
+    return {
+      phase: "select_cards",
+      version: pending.version,
+      eligibleCardIds: [...player.discard],
+      selectCount,
+    };
+  }
+
+  // Phase 2: player chooses top or bottom
+  return {
+    phase: "place_cards",
+    version: pending.version,
+    selectedCardIds: pending.selectedCardIds,
+  };
 }

--- a/packages/core/src/engine/validators/meditationValidators.ts
+++ b/packages/core/src/engine/validators/meditationValidators.ts
@@ -1,0 +1,103 @@
+/**
+ * Validators for Meditation spell resolve action
+ */
+
+import type { Validator } from "./types.js";
+import { invalid, valid } from "./types.js";
+import {
+  MEDITATION_PENDING_REQUIRED,
+  MEDITATION_INVALID_CARD_SELECTION,
+  MEDITATION_INVALID_PHASE,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+import type { ResolveMeditationAction } from "@mage-knight/shared";
+
+/**
+ * Validate that player has pending Meditation state
+ */
+export const validateHasPendingMeditation: Validator = (
+  state,
+  playerId,
+  _action
+) => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingMeditation) {
+    return invalid(
+      MEDITATION_PENDING_REQUIRED,
+      "No pending Meditation to resolve"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate the Meditation choice based on current phase.
+ * Phase 1 (select_cards): selectedCardIds must be valid cards in discard, correct count
+ * Phase 2 (place_cards): placeOnTop must be defined (boolean)
+ */
+export const validateMeditationChoice: Validator = (
+  state,
+  playerId,
+  actionInput
+) => {
+  const action = actionInput as ResolveMeditationAction;
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const pending = player.pendingMeditation;
+  if (!pending) {
+    return invalid(MEDITATION_PENDING_REQUIRED, "No pending Meditation");
+  }
+
+  if (pending.phase === "select_cards") {
+    // Phase 1: validate card selection (powered mode only)
+    if (!action.selectedCardIds || action.selectedCardIds.length === 0) {
+      return invalid(
+        MEDITATION_INVALID_CARD_SELECTION,
+        "Must select cards from discard"
+      );
+    }
+
+    const selectCount = Math.min(2, player.discard.length);
+    if (action.selectedCardIds.length !== selectCount) {
+      return invalid(
+        MEDITATION_INVALID_CARD_SELECTION,
+        `Must select exactly ${selectCount} card(s)`
+      );
+    }
+
+    // Verify all selected cards are in discard
+    for (const cardId of action.selectedCardIds) {
+      if (!player.discard.includes(cardId)) {
+        return invalid(
+          MEDITATION_INVALID_CARD_SELECTION,
+          `Card ${cardId} not in discard pile`
+        );
+      }
+    }
+
+    return valid();
+  }
+
+  if (pending.phase === "place_cards") {
+    // Phase 2: validate placement choice
+    if (action.placeOnTop === undefined) {
+      return invalid(
+        MEDITATION_INVALID_PHASE,
+        "Must choose top or bottom placement"
+      );
+    }
+
+    return valid();
+  }
+
+  return invalid(MEDITATION_INVALID_PHASE, "Invalid meditation phase");
+};

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -11,6 +11,7 @@ import {
   RESOLVE_DEEP_MINE_ACTION,
   RESOLVE_CRYSTAL_JOY_RECLAIM_ACTION,
   RESOLVE_STEADY_TEMPO_ACTION,
+  RESOLVE_MEDITATION_ACTION,
   RESOLVE_DISCARD_ACTION,
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
@@ -111,6 +112,12 @@ import {
   validateHasPendingBannerProtection,
 } from "../bannerProtectionValidators.js";
 
+// Meditation validators
+import {
+  validateHasPendingMeditation,
+  validateMeditationChoice,
+} from "../meditationValidators.js";
+
 export const choiceRegistry: Record<string, Validator[]> = {
   [RESOLVE_CHOICE_ACTION]: [
     validateIsPlayersTurn,
@@ -188,5 +195,10 @@ export const choiceRegistry: Record<string, Validator[]> = {
   [RESOLVE_BANNER_PROTECTION_ACTION]: [
     validateIsPlayersTurn,
     validateHasPendingBannerProtection,
+  ],
+  [RESOLVE_MEDITATION_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingMeditation,
+    validateMeditationChoice,
   ],
 };

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -252,6 +252,11 @@ export const ARTIFACT_CRYSTAL_INVALID_COLOR = "ARTIFACT_CRYSTAL_INVALID_COLOR" a
 export const DECOMPOSE_REQUIRED = "DECOMPOSE_REQUIRED" as const;
 export const DECOMPOSE_CARD_NOT_ELIGIBLE = "DECOMPOSE_CARD_NOT_ELIGIBLE" as const;
 
+// Meditation validation codes
+export const MEDITATION_PENDING_REQUIRED = "MEDITATION_PENDING_REQUIRED" as const;
+export const MEDITATION_INVALID_CARD_SELECTION = "MEDITATION_INVALID_CARD_SELECTION" as const;
+export const MEDITATION_INVALID_PHASE = "MEDITATION_INVALID_PHASE" as const;
+
 // Spell purchase validation codes
 export const SPELL_NOT_IN_OFFER = "SPELL_NOT_IN_OFFER" as const;
 export const NOT_AT_SPELL_SITE = "NOT_AT_SPELL_SITE" as const;
@@ -520,6 +525,10 @@ export type ValidationErrorCode =
   // Decompose validation
   | typeof DECOMPOSE_REQUIRED
   | typeof DECOMPOSE_CARD_NOT_ELIGIBLE
+  // Meditation validation
+  | typeof MEDITATION_PENDING_REQUIRED
+  | typeof MEDITATION_INVALID_CARD_SELECTION
+  | typeof MEDITATION_INVALID_PHASE
   // Spell purchase validation
   | typeof SPELL_NOT_IN_OFFER
   | typeof NOT_AT_SPELL_SITE

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -546,4 +546,18 @@ export interface Player {
   // Crystal Mastery: powered effect active this turn
   // When true, at end of turn spent crystals are returned to inventory (capped at 3).
   readonly crystalMasteryPoweredActive: boolean;
+
+  // Meditation spell pending state
+  // Set when Meditation/Trance spell is played to track card selection and placement
+  readonly pendingMeditation:
+    | {
+        readonly version: "basic" | "powered";
+        readonly phase: "select_cards" | "place_cards";
+        readonly selectedCardIds: readonly CardId[];
+      }
+    | undefined;
+
+  // Meditation spell hand limit bonus
+  // Added to hand limit at end-of-turn draw, consumed by getEndTurnDrawLimit()
+  readonly meditationHandLimitBonus: number;
 }

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -494,6 +494,14 @@ export interface ResolveDiscardForCrystalAction {
   readonly cardId: CardId | null;
 }
 
+// Meditation spell resolution action
+export const RESOLVE_MEDITATION_ACTION = "RESOLVE_MEDITATION" as const;
+export interface ResolveMeditationAction {
+  readonly type: typeof RESOLVE_MEDITATION_ACTION;
+  readonly selectedCardIds?: readonly CardId[]; // Phase 1 (powered): cards selected from discard
+  readonly placeOnTop?: boolean; // Phase 2: true = top of deck, false = bottom
+}
+
 // Decompose action (throw away action card for crystals)
 export const RESOLVE_DECOMPOSE_ACTION = "RESOLVE_DECOMPOSE" as const;
 export interface ResolveDecomposeAction {
@@ -781,6 +789,8 @@ export type PlayerAction =
   | ResolveDiscardForAttackAction
   // Discard for crystal (Savage Harvesting)
   | ResolveDiscardForCrystalAction
+  // Meditation spell
+  | ResolveMeditationAction
   // Decompose (throw away action card for crystals)
   | ResolveDecomposeAction
   // Artifact crystal color choice (Savage Harvesting - for artifacts)

--- a/packages/shared/src/cardIds.ts
+++ b/packages/shared/src/cardIds.ts
@@ -120,6 +120,7 @@ export const CARD_RESTORATION = cardId("restoration"); // #05 - Heal 3 (5 in for
 export const CARD_WHIRLWIND = cardId("whirlwind"); // #07 - Target doesn't attack / defeat
 export const CARD_ENERGY_FLOW = cardId("energy_flow"); // #12 - Ready unit + spend opponent units
 export const CARD_UNDERGROUND_TRAVEL = cardId("underground_travel"); // #04 - Move 3 no swamp/lake / Assault ignore fortification
+export const CARD_MEDITATION = cardId("meditation"); // #06 - Select cards from discard to deck + hand limit +2
 
 // White spells
 export const CARD_EXPOSE = cardId("expose"); // #19 - Lose fortification/resistances
@@ -189,6 +190,7 @@ export type SpellCardId =
   | typeof CARD_WHIRLWIND
   | typeof CARD_ENERGY_FLOW
   | typeof CARD_UNDERGROUND_TRAVEL
+  | typeof CARD_MEDITATION
   // White spells
   | typeof CARD_EXPOSE
   | typeof CARD_CURE
@@ -282,6 +284,7 @@ export const ALL_SPELL_IDS = [
   CARD_WHIRLWIND,
   CARD_ENERGY_FLOW,
   CARD_UNDERGROUND_TRAVEL,
+  CARD_MEDITATION,
   CARD_EXPOSE,
   CARD_CURE,
   CARD_CALL_TO_ARMS,

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -273,6 +273,8 @@ import type {
   SteadyTempoPlacementSkippedEvent,
   BannerProtectionWoundsRemovedEvent,
   BannerProtectionSkippedEvent,
+  MeditationCardsSelectedEvent,
+  MeditationCardsPlacedEvent,
   MonasteryBurnStartedEvent,
   MonasteryBurnedEvent,
   VillagePlunderedEvent,
@@ -462,6 +464,9 @@ export type GameEvent =
   // Banner of Protection
   | BannerProtectionWoundsRemovedEvent
   | BannerProtectionSkippedEvent
+  // Meditation spell
+  | MeditationCardsSelectedEvent
+  | MeditationCardsPlacedEvent
   // Monastery burning
   | MonasteryBurnStartedEvent
   | MonasteryBurnedEvent

--- a/packages/shared/src/events/sites/index.ts
+++ b/packages/shared/src/events/sites/index.ts
@@ -67,6 +67,8 @@ import {
   STEADY_TEMPO_PLACEMENT_SKIPPED,
   BANNER_PROTECTION_WOUNDS_REMOVED,
   BANNER_PROTECTION_SKIPPED,
+  MEDITATION_CARDS_SELECTED,
+  MEDITATION_CARDS_PLACED,
 } from "./special.js";
 
 /**
@@ -97,5 +99,7 @@ export function isSiteEvent(event: { type: string }): boolean {
     MONASTERY_BURN_STARTED,
     MONASTERY_BURNED,
     VILLAGE_PLUNDERED,
+    MEDITATION_CARDS_SELECTED,
+    MEDITATION_CARDS_PLACED,
   ].includes(event.type as typeof SITE_CONQUERED);
 }

--- a/packages/shared/src/events/sites/special.ts
+++ b/packages/shared/src/events/sites/special.ts
@@ -287,3 +287,37 @@ export interface BannerProtectionSkippedEvent {
   /** ID of the player who skipped */
   readonly playerId: string;
 }
+
+// ============================================================================
+// MEDITATION SPELL EVENTS
+// ============================================================================
+
+/**
+ * Event type constant for Meditation cards selected (phase 1).
+ */
+export const MEDITATION_CARDS_SELECTED = "MEDITATION_CARDS_SELECTED" as const;
+
+/**
+ * Emitted when cards are selected for Meditation spell (basic: auto-selected, powered: player-selected).
+ */
+export interface MeditationCardsSelectedEvent {
+  readonly type: typeof MEDITATION_CARDS_SELECTED;
+  readonly playerId: string;
+  readonly cardIds: readonly import("../../ids.js").CardId[];
+  readonly version: "basic" | "powered";
+}
+
+/**
+ * Event type constant for Meditation cards placed into deck (phase 2).
+ */
+export const MEDITATION_CARDS_PLACED = "MEDITATION_CARDS_PLACED" as const;
+
+/**
+ * Emitted when selected cards are placed into the deed deck.
+ */
+export interface MeditationCardsPlacedEvent {
+  readonly type: typeof MEDITATION_CARDS_PLACED;
+  readonly playerId: string;
+  readonly cardIds: readonly import("../../ids.js").CardId[];
+  readonly position: "top" | "bottom";
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -264,6 +264,9 @@ export type {
   // Steady Tempo deck placement options
   SteadyTempoOptions,
   PendingSteadyTempoState,
+  // Meditation options
+  MeditationOptions,
+  PendingMeditationState,
   // Banner of Protection options
   BannerProtectionOptions,
   PendingBannerProtectionState,

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -1147,6 +1147,32 @@ export interface PendingSteadyTempoState {
   readonly steadyTempo: SteadyTempoOptions;
 }
 
+// ============================================================================
+// Meditation Spell
+// ============================================================================
+
+/**
+ * Options for Meditation spell resolution.
+ * Phase "select_cards": player chooses cards from discard (powered only).
+ * Phase "place_cards": player chooses top or bottom of deck.
+ */
+export interface MeditationOptions {
+  readonly phase: "select_cards" | "place_cards";
+  readonly version: "basic" | "powered";
+  /** Phase 1: cards in discard eligible for selection */
+  readonly eligibleCardIds?: readonly CardId[];
+  /** Phase 1: how many cards to select */
+  readonly selectCount?: number;
+  /** Phase 2: the cards that will be placed */
+  readonly selectedCardIds?: readonly CardId[];
+}
+
+export interface PendingMeditationState {
+  readonly mode: "pending_meditation";
+  readonly turn: BlockingTurnOptions;
+  readonly meditation: MeditationOptions;
+}
+
 /**
  * Options for Banner of Protection wound removal at end of turn.
  * Present when player has activated Banner of Protection powered effect
@@ -1226,6 +1252,7 @@ export type ValidActions =
   | PendingArtifactCrystalColorState
   | PendingCrystalJoyState
   | PendingSteadyTempoState
+  | PendingMeditationState
   | PendingBannerProtectionState
   | PendingLevelUpState
   | PendingChoiceState


### PR DESCRIPTION
## Summary
- Implement Meditation (basic) / Trance (powered) green spell (#06)
- **Basic (Meditation):** Randomly pick 2 cards from discard → place on top or bottom of deck → hand limit +2 next draw
- **Trance (powered):** Choose 2 cards from discard → place on top or bottom of deck → hand limit +2 next draw

## Implementation
- Uses NOOP effect + pending state pattern (same as Crystal Joy, Steady Tempo)
- Two-phase resolution: card selection (powered only) → deck placement
- Basic mode uses RNG for random selection (non-reversible)
- Hand limit bonus via simple counter consumed at end-of-turn draw
- 26 new tests covering rules, validators, validActions, commands, hand limit, and reset

Closes #188

## Test plan
- [x] Rules: `getMeditationSelectCount` returns min(2, discard.length)
- [x] Rules: `canPlayMeditation` requires at least 1 card in discard
- [x] Validators: reject missing/invalid card selection, wrong phase
- [x] ValidActions: correct pending mode and options for each phase
- [x] PlayCardCommand: basic sets place_cards phase with random selection
- [x] PlayCardCommand: powered sets select_cards phase
- [x] PlayCardCommand: undo clears pending state and bonus
- [x] ResolveMeditationCommand: phase 1 stores cards and advances
- [x] ResolveMeditationCommand: phase 2 places cards top/bottom of deck
- [x] Hand limit: bonus applied at end-of-turn draw
- [x] Player reset: clears meditation state at turn end
- [x] All 3695 existing tests continue to pass