### PR TITLE
fix: allow multiple purchases during site interaction

### DIFF
--- a/packages/core/src/engine/validActions/sites.ts
+++ b/packages/core/src/engine/validActions/sites.ts
@@ -242,11 +242,13 @@ function getInteractOptions(
   // Check if can recruit (needs units in offer, site not burned)
   const canRecruit = state.offers.units.length > 0 && !site.isBurned;
 
-  // Check if can buy spells (conquered Mage Tower, requires turn action)
+  // Check if can buy spells (conquered Mage Tower, not after combat)
+  // Spell purchase is part of interaction — players can buy multiple things
+  // during a single interaction, only combat blocks further purchases
   const canBuySpells =
     site.type === SiteType.MageTower &&
     site.isConquered &&
-    !player.hasTakenActionThisTurn &&
+    !player.hasCombattedThisTurn &&
     state.offers.spells.cards.length > 0;
 
   // Check if can buy advanced actions (Monastery)

--- a/packages/core/src/engine/validators/offerValidators.ts
+++ b/packages/core/src/engine/validators/offerValidators.ts
@@ -117,9 +117,10 @@ export function validateHasInfluenceForSpell(
 }
 
 /**
- * Validate player has not already taken their main action this turn.
- * Buying spells is an interaction that requires the player's action for the turn.
- * Cannot be done after combat, entering a site, or other major actions.
+ * Validate player has not already fought combat this turn.
+ * Buying spells is part of site interaction — players can buy any number
+ * of things (recruit, buy spells, etc.) during a single interaction.
+ * Only combat blocks further interaction purchases on the same turn.
  */
 export function validateNotAlreadyActedForSpell(
   state: GameState,
@@ -133,10 +134,10 @@ export function validateNotAlreadyActedForSpell(
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
 
-  if (player.hasTakenActionThisTurn) {
+  if (player.hasCombattedThisTurn) {
     return invalid(
       ALREADY_ACTED,
-      "Cannot buy spells after taking another action this turn"
+      "Cannot buy spells after combat this turn"
     );
   }
 


### PR DESCRIPTION
## Summary
- Spell purchase validator was checking `hasTakenActionThisTurn`, which blocked buying spells after recruiting at the same Mage Tower
- Per the rules, players can buy any number of things during a single interaction as long as they have influence
- Changed validator and valid actions to check `hasCombattedThisTurn` instead, which correctly blocks only after combat

## Test plan
- [x] Added test: buying spell after recruiting at same Mage Tower succeeds
- [x] Updated test: rejection after combat uses `hasCombattedThisTurn`
- [x] All 3,820 tests pass
- [x] Build and lint clean

Closes #34