### PR TITLE
feat: implement unit disbanding on recruitment

### DIFF
--- a/packages/core/src/engine/__tests__/unitDisbandOnRecruit.test.ts
+++ b/packages/core/src/engine/__tests__/unitDisbandOnRecruit.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Unit Disbanding on Recruitment tests
+ *
+ * Tests for disbanding a unit when recruiting at the command limit.
+ * Per the rulebook, players can recruit when at their command limit
+ * by disbanding an existing unit to make room.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createTestHex,
+  createVillageSite,
+} from "./testHelpers.js";
+import {
+  RECRUIT_UNIT_ACTION,
+  UNIT_RECRUITED,
+  UNIT_DISBANDED,
+  INVALID_ACTION,
+  UNIT_PEASANTS,
+  UNIT_FORESTERS,
+  UNDO_ACTION,
+  TERRAIN_PLAINS,
+  hexKey,
+} from "@mage-knight/shared";
+import { createPlayerUnit } from "../../types/unit.js";
+import { resetUnitInstanceCounter } from "../commands/units/index.js";
+import { getUnitOptions } from "../validActions/units/recruitment.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+
+/**
+ * Create a state at a village with units in the unit offer.
+ * Standard createStateWithVillage doesn't populate the offers.
+ */
+function createVillageStateWithOffer(
+  playerOverrides: Partial<Player> = {},
+  offerUnits = [UNIT_PEASANTS, UNIT_FORESTERS, UNIT_PEASANTS]
+): GameState {
+  const player = createTestPlayer({
+    position: { q: 0, r: 0 },
+    ...playerOverrides,
+  });
+
+  const hexWithVillage = createTestHex(0, 0, TERRAIN_PLAINS, createVillageSite());
+
+  const state = createTestGameState({
+    players: [player],
+    map: {
+      hexes: {
+        [hexKey({ q: 0, r: 0 })]: hexWithVillage,
+      },
+      tiles: [],
+      tileDeck: { countryside: [], core: [] },
+    },
+  });
+
+  // Add units to the offer
+  return {
+    ...state,
+    offers: {
+      ...state.offers,
+      units: offerUnits,
+    },
+  };
+}
+
+describe("Unit Disbanding on Recruitment", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+    resetUnitInstanceCounter();
+  });
+
+  describe("recruiting at command limit with disband", () => {
+    it("should allow recruitment when disbanding a unit at command limit", () => {
+      const existingUnit = createPlayerUnit(UNIT_FORESTERS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1, // 1 slot, already full
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+        disbandUnitInstanceId: "existing_1",
+      });
+
+      // Should have 1 unit: the newly recruited one (old one was disbanded)
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].units[0].unitId).toBe(UNIT_PEASANTS);
+
+      // Check disband event was emitted before recruit event
+      const disbandEvent = result.events.find(
+        (e) => e.type === UNIT_DISBANDED
+      );
+      expect(disbandEvent).toBeDefined();
+      if (disbandEvent && disbandEvent.type === UNIT_DISBANDED) {
+        expect(disbandEvent.unitInstanceId).toBe("existing_1");
+      }
+
+      // Check recruit event was emitted
+      const recruitEvent = result.events.find(
+        (e) => e.type === UNIT_RECRUITED
+      );
+      expect(recruitEvent).toBeDefined();
+    });
+
+    it("should reject recruitment at command limit without disband", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+      });
+
+      // Should still have only the original unit
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].units[0].instanceId).toBe("existing_1");
+
+      // Check for invalid action event
+      const invalidEvent = result.events.find(
+        (e) => e.type === INVALID_ACTION
+      );
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("disband");
+      }
+    });
+
+    it("should reject disband of a unit not owned by the player", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+        disbandUnitInstanceId: "nonexistent_unit",
+      });
+
+      // Should still have only the original unit
+      expect(result.state.players[0].units).toHaveLength(1);
+
+      const invalidEvent = result.events.find(
+        (e) => e.type === INVALID_ACTION
+      );
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should not require disband when command slots are available", () => {
+      const state = createVillageStateWithOffer({
+        units: [],
+        commandTokens: 1,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+      });
+
+      // Should recruit normally without needing disband
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].units[0].unitId).toBe(UNIT_PEASANTS);
+    });
+  });
+
+  describe("disbanded unit is permanently removed", () => {
+    it("should remove disbanded unit from player completely", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "unit_a");
+      const unit2 = createPlayerUnit(UNIT_FORESTERS, "unit_b");
+      const state = createVillageStateWithOffer({
+        units: [unit1, unit2],
+        commandTokens: 2, // Both slots full
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+        disbandUnitInstanceId: "unit_a",
+      });
+
+      // Should have 2 units: unit_b (kept) + newly recruited
+      expect(result.state.players[0].units).toHaveLength(2);
+      expect(
+        result.state.players[0].units.find((u) => u.instanceId === "unit_a")
+      ).toBeUndefined();
+      expect(
+        result.state.players[0].units.find((u) => u.instanceId === "unit_b")
+      ).toBeDefined();
+    });
+  });
+
+  describe("valid actions show requiresDisband", () => {
+    it("should set requiresDisband when at command limit", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1,
+        influencePoints: 10,
+      });
+
+      const options = getUnitOptions(state, state.players[0]);
+      expect(options).toBeDefined();
+      if (options) {
+        for (const unit of options.recruitable) {
+          expect(unit.requiresDisband).toBe(true);
+          expect(unit.canAfford).toBe(true);
+        }
+      }
+    });
+
+    it("should not set requiresDisband when slots are available", () => {
+      const state = createVillageStateWithOffer({
+        units: [],
+        commandTokens: 1,
+        influencePoints: 10,
+      });
+
+      const options = getUnitOptions(state, state.players[0]);
+      expect(options).toBeDefined();
+      if (options) {
+        for (const unit of options.recruitable) {
+          expect(unit.requiresDisband).toBe(false);
+        }
+      }
+    });
+
+    it("should show canAfford=true at command limit when player has enough influence", () => {
+      const existingUnit = createPlayerUnit(UNIT_PEASANTS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1,
+        influencePoints: 10,
+      });
+
+      const options = getUnitOptions(state, state.players[0]);
+      expect(options).toBeDefined();
+      if (options) {
+        const peasantOption = options.recruitable.find(
+          (u) => u.unitId === UNIT_PEASANTS
+        );
+        expect(peasantOption).toBeDefined();
+        if (peasantOption) {
+          expect(peasantOption.canAfford).toBe(true);
+          expect(peasantOption.requiresDisband).toBe(true);
+        }
+      }
+    });
+  });
+
+  describe("undo support", () => {
+    it("should restore disbanded unit on undo", () => {
+      const existingUnit = createPlayerUnit(UNIT_FORESTERS, "existing_1");
+      const state = createVillageStateWithOffer({
+        units: [existingUnit],
+        commandTokens: 1,
+      });
+
+      // Recruit with disband
+      const result = engine.processAction(state, "player1", {
+        type: RECRUIT_UNIT_ACTION,
+        unitId: UNIT_PEASANTS,
+        influenceSpent: 4,
+        disbandUnitInstanceId: "existing_1",
+      });
+
+      expect(result.state.players[0].units).toHaveLength(1);
+      expect(result.state.players[0].units[0].unitId).toBe(UNIT_PEASANTS);
+
+      // Undo by sending UNDO action
+      const undoResult = engine.processAction(result.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // Original unit should be restored
+      expect(undoResult.state.players[0].units).toHaveLength(1);
+      expect(
+        undoResult.state.players[0].units.find(
+          (u) => u.instanceId === "existing_1"
+        )
+      ).toBeDefined();
+      expect(undoResult.state.players[0].units[0].unitId).toBe(UNIT_FORESTERS);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/factories/units.ts
+++ b/packages/core/src/engine/commands/factories/units.ts
@@ -35,6 +35,7 @@ export const createRecruitUnitCommandFromAction: CommandFactory = (
     influenceSpent: action.influenceSpent,
     ...(action.manaSource && { manaSource: action.manaSource }),
     ...(action.manaTokenColor && { manaTokenColor: action.manaTokenColor }),
+    ...(action.disbandUnitInstanceId && { disbandUnitInstanceId: action.disbandUnitInstanceId }),
   });
 };
 

--- a/packages/core/src/engine/validActions/units/recruitment.ts
+++ b/packages/core/src/engine/validActions/units/recruitment.ts
@@ -88,6 +88,10 @@ export function getUnitOptions(
   // Check command token availability (including Bonds of Loyalty extra slot)
   const effectiveTokens = getEffectiveCommandTokens(player);
   const hasCommandTokens = player.units.length < effectiveTokens;
+  const atCommandLimit = player.units.length >= effectiveTokens;
+
+  // If at command limit but player has units to disband, recruitment is still available
+  const canDisband = atCommandLimit && player.units.length > 0;
 
   // Track if Hero has been recruited this interaction (for doubled reputation)
   const heroAlreadyRecruited = hasRecruitedHeroThisInteraction(
@@ -151,14 +155,15 @@ export function getUnitOptions(
       baseCost + refugeeCampModifier + reputationModifier - recruitDiscountAmount - bondsDiscount
     );
 
-    // Check if player can afford it
+    // Check if player can afford it (either has free slot or can disband to make room)
     const canAfford =
-      hasCommandTokens && player.influencePoints >= adjustedCost;
+      (hasCommandTokens || canDisband) && player.influencePoints >= adjustedCost;
 
     recruitable.push({
       unitId: unit.id,
       cost: adjustedCost,
       canAfford,
+      requiresDisband: !hasCommandTokens && canDisband,
     });
   }
 

--- a/packages/core/src/engine/validators/registry/unitRegistry.ts
+++ b/packages/core/src/engine/validators/registry/unitRegistry.ts
@@ -19,6 +19,7 @@ import { validateMustAnnounceEndOfRound } from "../roundValidators.js";
 import {
   validateReputationNotX,
   validateCommandSlots,
+  validateDisbandTarget,
   validateInfluenceCost,
   validateUnitExists,
   validateUnitCanActivate,
@@ -42,7 +43,8 @@ export const unitRegistry: Record<string, Validator[]> = {
     validateNoChoicePending,
     validateMustAnnounceEndOfRound, // Must announce if deck+hand empty
     validateReputationNotX, // At "X" reputation, inhabitants refuse to interact
-    validateCommandSlots,
+    validateCommandSlots, // Requires disband if at command limit
+    validateDisbandTarget, // Validates disband unit when provided
     validateInfluenceCost,
     validateAtRecruitmentSite,
     validateUnitTypeMatchesSite,

--- a/packages/core/src/engine/validators/units/index.ts
+++ b/packages/core/src/engine/validators/units/index.ts
@@ -9,6 +9,7 @@
 export {
   validateReputationNotX,
   validateCommandSlots,
+  validateDisbandTarget,
   validateInfluenceCost,
   validateAtRecruitmentSite,
   validateUnitTypeMatchesSite,

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -151,6 +151,10 @@ export const PASSIVE_ABILITY = "PASSIVE_ABILITY" as const;
 export const SIEGE_REQUIRED = "SIEGE_REQUIRED" as const;
 export const UNIT_ABILITY_REQUIRES_MANA = "UNIT_ABILITY_REQUIRES_MANA" as const;
 export const UNIT_ABILITY_MANA_UNAVAILABLE = "UNIT_ABILITY_MANA_UNAVAILABLE" as const;
+// Unit disband codes
+export const DISBAND_REQUIRED = "DISBAND_REQUIRED" as const;
+export const DISBAND_UNIT_NOT_FOUND = "DISBAND_UNIT_NOT_FOUND" as const;
+export const CANNOT_DISBAND_BONDS_UNIT = "CANNOT_DISBAND_BONDS_UNIT" as const;
 // Reputation recruitment restriction
 export const REPUTATION_TOO_LOW_TO_RECRUIT = "REPUTATION_TOO_LOW_TO_RECRUIT" as const;
 // Heroes unit special rules
@@ -436,6 +440,9 @@ export type ValidationErrorCode =
   // Unit validation
   | typeof NO_COMMAND_SLOTS
   | typeof INSUFFICIENT_INFLUENCE
+  | typeof DISBAND_REQUIRED
+  | typeof DISBAND_UNIT_NOT_FOUND
+  | typeof CANNOT_DISBAND_BONDS_UNIT
   | typeof UNIT_NOT_FOUND
   | typeof UNIT_NOT_READY
   | typeof UNIT_IS_WOUNDED

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -256,6 +256,11 @@ export interface RecruitUnitAction {
    * this specifies which basic color the token becomes.
    */
   readonly manaTokenColor?: BasicManaColor;
+  /**
+   * Instance ID of a unit to disband to make room for the new recruit.
+   * Required when the player is at their command limit.
+   */
+  readonly disbandUnitInstanceId?: string;
 }
 
 export const DISBAND_UNIT_ACTION = "DISBAND_UNIT" as const;

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -516,6 +516,8 @@ export interface RecruitableUnit {
   readonly unitId: string;
   readonly cost: number;
   readonly canAfford: boolean;
+  /** True when the player must disband an existing unit to recruit this one. */
+  readonly requiresDisband: boolean;
 }
 
 export interface ActivatableUnit {


### PR DESCRIPTION
## Summary
- Allow players to recruit units when at their command limit by disbanding an existing unit
- Add `disbandUnitInstanceId` field to `RecruitUnitAction` for specifying which unit to disband
- Add `requiresDisband` flag to `RecruitableUnit` valid actions so the UI knows when disband is needed

## Changes
- **shared**: Added `disbandUnitInstanceId` to `RecruitUnitAction` and `requiresDisband` to `RecruitableUnit`
- **validators**: Updated `validateCommandSlots` to allow recruitment with disband; added `validateDisbandTarget` for ownership and Bonds of Loyalty checks
- **validActions**: Updated `getUnitOptions` to compute `requiresDisband` and allow `canAfford` based on influence when at command limit with units to disband
- **command**: Updated `recruitUnitCommand` to remove disbanded unit (with banner detachment), emit `UNIT_DISBANDED` event, and restore unit on undo
- **factory**: Pass `disbandUnitInstanceId` through command factory
- **tests**: 9 new tests covering recruit-with-disband, reject-without-disband, invalid disband targets, valid actions flags, and undo restoration

Closes #59