### PR TITLE
feat: implement Horn of Wrath artifact

### DIFF
--- a/packages/core/src/data/artifacts/hornOfWrath.ts
+++ b/packages/core/src/data/artifacts/hornOfWrath.ts
@@ -3,12 +3,65 @@
  * Card #09 (122/377)
  *
  * Basic: Siege Attack 5. Roll mana die - Wound if black or red.
- * Powered: Siege Attack 5 + up to 5 more. Roll die per +1 added.
- *          Wound for each black or red rolled.
+ * Powered (any color, destroy): Siege Attack 5 + up to 5 more.
+ *          Roll die per +1 added. Wound for each black or red rolled.
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_COMBAT,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_ROLL_DIE_FOR_WOUND,
+  EFFECT_CHOOSE_BONUS_WITH_RISK,
+  COMBAT_TYPE_SIEGE,
+} from "../../types/effectTypes.js";
+import { siegeAttack } from "../effectHelpers.js";
+import {
+  CARD_HORN_OF_WRATH,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_BLACK,
+} from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
 
-// TODO: Implement Horn of Wrath
-export const HORN_OF_WRATH_CARDS: Record<CardId, DeedCard> = {};
+const HORN_OF_WRATH: DeedCard = {
+  id: CARD_HORN_OF_WRATH,
+  name: "Horn of Wrath",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_COMBAT],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      siegeAttack(5),
+      {
+        type: EFFECT_ROLL_DIE_FOR_WOUND,
+        diceCount: 1,
+        woundColors: [MANA_BLACK, MANA_RED],
+      },
+    ],
+  },
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      siegeAttack(5),
+      {
+        type: EFFECT_CHOOSE_BONUS_WITH_RISK,
+        maxBonus: 5,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      },
+    ],
+  },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const HORN_OF_WRATH_CARDS: Record<CardId, DeedCard> = {
+  [CARD_HORN_OF_WRATH]: HORN_OF_WRATH,
+};

--- a/packages/core/src/engine/__tests__/hornOfWrath.test.ts
+++ b/packages/core/src/engine/__tests__/hornOfWrath.test.ts
@@ -1,0 +1,434 @@
+/**
+ * Tests for Horn of Wrath artifact
+ *
+ * Basic: Siege Attack 5. Roll mana die - wound if black or red.
+ * Powered (destroy): Siege Attack 5 + choose 0-5 bonus.
+ *   Roll 1 die per bonus chosen. Wound per black/red result.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import {
+  EFFECT_ROLL_DIE_FOR_WOUND,
+  EFFECT_CHOOSE_BONUS_WITH_RISK,
+  EFFECT_RESOLVE_BONUS_CHOICE,
+  COMBAT_TYPE_SIEGE,
+} from "../../types/effectTypes.js";
+import type {
+  RollDieForWoundEffect,
+  ChooseBonusWithRiskEffect,
+  ResolveBonusChoiceEffect,
+} from "../../types/cards.js";
+import {
+  CARD_WOUND,
+  CARD_HORN_OF_WRATH,
+  MANA_RED,
+  MANA_BLACK,
+} from "@mage-knight/shared";
+import { createRng } from "../../utils/rng.js";
+import { HORN_OF_WRATH_CARDS } from "../../data/artifacts/hornOfWrath.js";
+
+describe("Horn of Wrath", () => {
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should be defined with correct properties", () => {
+      const card = HORN_OF_WRATH_CARDS[CARD_HORN_OF_WRATH];
+      expect(card).toBeDefined();
+      expect(card!.name).toBe("Horn of Wrath");
+      expect(card!.destroyOnPowered).toBe(true);
+      expect(card!.sidewaysValue).toBe(1);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT: Roll Die for Wound
+  // ============================================================================
+
+  describe("Roll Die for Wound", () => {
+    it("should roll specified number of dice and apply wounds for matching colors", () => {
+      // Use a seed that produces a known result — we'll test the mechanics
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: RollDieForWoundEffect = {
+        type: EFFECT_ROLL_DIE_FOR_WOUND,
+        diceCount: 1,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // Result should describe the roll
+      expect(result.description).toContain("Rolled:");
+
+      // RNG should have advanced
+      expect(result.state.rng.counter).toBeGreaterThan(state.rng.counter);
+    });
+
+    it("should not add wounds when rolling a safe color", () => {
+      // We need a seed that produces a non-black, non-red result
+      // Let's try multiple seeds and find one that gives a safe color
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+
+      // Try seeds until we find one that rolls a safe color (blue, green, white, gold)
+      let safeState: ReturnType<typeof resolveEffect> | null = null;
+      for (let seed = 0; seed < 100; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollDieForWoundEffect = {
+          type: EFFECT_ROLL_DIE_FOR_WOUND,
+          diceCount: 1,
+          woundColors: [MANA_BLACK, MANA_RED],
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        // Check if no wound was added
+        const woundsInHand = result.state.players[0]!.hand.filter(
+          (c) => c === CARD_WOUND
+        ).length;
+
+        if (woundsInHand === 0) {
+          safeState = result;
+          break;
+        }
+      }
+
+      expect(safeState).not.toBeNull();
+      expect(safeState!.description).toContain("No wounds");
+    });
+
+    it("should add wound when rolling black or red", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+
+      // Try seeds until we find one that rolls black or red
+      let woundState: ReturnType<typeof resolveEffect> | null = null;
+      for (let seed = 0; seed < 100; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollDieForWoundEffect = {
+          type: EFFECT_ROLL_DIE_FOR_WOUND,
+          diceCount: 1,
+          woundColors: [MANA_BLACK, MANA_RED],
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        const woundsInHand = result.state.players[0]!.hand.filter(
+          (c) => c === CARD_WOUND
+        ).length;
+
+        if (woundsInHand > 0) {
+          woundState = result;
+          break;
+        }
+      }
+
+      expect(woundState).not.toBeNull();
+      expect(woundState!.description).toContain("Gained 1 wound");
+    });
+
+    it("should handle multiple dice correctly", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: RollDieForWoundEffect = {
+        type: EFFECT_ROLL_DIE_FOR_WOUND,
+        diceCount: 5,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // Should have advanced RNG by at least 5 steps
+      expect(result.state.rng.counter).toBeGreaterThanOrEqual(
+        state.rng.counter + 5
+      );
+
+      // Description should show all roll results
+      expect(result.description).toContain("Rolled:");
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT: Choose Bonus with Risk
+  // ============================================================================
+
+  describe("Choose Bonus with Risk", () => {
+    it("should present choices from 0 to maxBonus", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      const effect: ChooseBonusWithRiskEffect = {
+        type: EFFECT_CHOOSE_BONUS_WITH_RISK,
+        maxBonus: 5,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(6); // 0, 1, 2, 3, 4, 5
+    });
+
+    it("should generate ResolveBonusChoice options with correct bonus values", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      const effect: ChooseBonusWithRiskEffect = {
+        type: EFFECT_CHOOSE_BONUS_WITH_RISK,
+        maxBonus: 5,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      const options = result.dynamicChoiceOptions as readonly ResolveBonusChoiceEffect[];
+      expect(options![0]!.bonus).toBe(0);
+      expect(options![1]!.bonus).toBe(1);
+      expect(options![5]!.bonus).toBe(5);
+      expect(options![0]!.type).toBe(EFFECT_RESOLVE_BONUS_CHOICE);
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE BONUS CHOICE
+  // ============================================================================
+
+  describe("Resolve Bonus Choice", () => {
+    it("should add siege attack when bonus > 0", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: ResolveBonusChoiceEffect = {
+        type: EFFECT_RESOLVE_BONUS_CHOICE,
+        bonus: 3,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // Should have gained +3 siege attack
+      const siegeAttack = result.state.players[0]!.combatAccumulator.attack.siege;
+      expect(siegeAttack).toBe(3);
+    });
+
+    it("should not roll dice when bonus is 0", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: ResolveBonusChoiceEffect = {
+        type: EFFECT_RESOLVE_BONUS_CHOICE,
+        bonus: 0,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // No siege attack added
+      expect(result.state.players[0]!.combatAccumulator.attack.siege).toBe(0);
+      // No wounds added
+      const woundsInHand = result.state.players[0]!.hand.filter(
+        (c) => c === CARD_WOUND
+      ).length;
+      expect(woundsInHand).toBe(0);
+      // RNG should not have advanced (no dice rolled)
+      expect(result.state.rng.counter).toBe(state.rng.counter);
+      expect(result.description).toContain("No bonus chosen");
+    });
+
+    it("should roll dice and potentially add wounds for bonus > 0", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: ResolveBonusChoiceEffect = {
+        type: EFFECT_RESOLVE_BONUS_CHOICE,
+        bonus: 5,
+        attackType: COMBAT_TYPE_SIEGE,
+        woundColors: [MANA_BLACK, MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // Should have gained +5 siege attack regardless of roll results
+      expect(result.state.players[0]!.combatAccumulator.attack.siege).toBe(5);
+
+      // RNG should have advanced by at least 5 (for 5 dice rolls)
+      expect(result.state.rng.counter).toBeGreaterThanOrEqual(
+        state.rng.counter + 5
+      );
+
+      // Description should include roll results
+      expect(result.description).toContain("Rolled:");
+    });
+
+    it("should add wounds for each black/red result in multi-die roll", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+
+      // Find a seed that produces at least 1 wound with 5 dice
+      // (very likely with 5 dice — 33% chance each = ~1.67 expected)
+      let foundWoundSeed = false;
+      for (let seed = 0; seed < 50; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: ResolveBonusChoiceEffect = {
+          type: EFFECT_RESOLVE_BONUS_CHOICE,
+          bonus: 5,
+          attackType: COMBAT_TYPE_SIEGE,
+          woundColors: [MANA_BLACK, MANA_RED],
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        const woundsInHand = result.state.players[0]!.hand.filter(
+          (c) => c === CARD_WOUND
+        ).length;
+
+        if (woundsInHand > 0) {
+          foundWoundSeed = true;
+          // Verify wounds were tracked for Banner of Protection
+          expect(
+            result.state.players[0]!.woundsReceivedThisTurn.hand
+          ).toBe(woundsInHand);
+          break;
+        }
+      }
+
+      expect(foundWoundSeed).toBe(true);
+    });
+
+    it("should track wounds received for Banner of Protection", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+
+      // Find a seed that produces wounds
+      for (let seed = 0; seed < 50; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollDieForWoundEffect = {
+          type: EFFECT_ROLL_DIE_FOR_WOUND,
+          diceCount: 1,
+          woundColors: [MANA_BLACK, MANA_RED],
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+        const woundsInHand = result.state.players[0]!.hand.filter(
+          (c) => c === CARD_WOUND
+        ).length;
+
+        if (woundsInHand > 0) {
+          expect(
+            result.state.players[0]!.woundsReceivedThisTurn.hand
+          ).toBe(1);
+          return;
+        }
+      }
+
+      // If we get here, no seed produced a wound (extremely unlikely)
+      throw new Error("Could not find a seed that produces a wound");
+    });
+  });
+
+  // ============================================================================
+  // PROBABILITY VERIFICATION
+  // ============================================================================
+
+  describe("probability distribution", () => {
+    it("should produce wound roughly 33% of the time (2 of 6 colors)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_HORN_OF_WRATH],
+      });
+
+      let woundCount = 0;
+      const totalRolls = 600;
+
+      for (let seed = 0; seed < totalRolls; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollDieForWoundEffect = {
+          type: EFFECT_ROLL_DIE_FOR_WOUND,
+          diceCount: 1,
+          woundColors: [MANA_BLACK, MANA_RED],
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+        const woundsInHand = result.state.players[0]!.hand.filter(
+          (c) => c === CARD_WOUND
+        ).length;
+
+        if (woundsInHand > 0) {
+          woundCount++;
+        }
+      }
+
+      // Expected: ~200 wounds out of 600 rolls (33.3%)
+      // Allow wide margin: 20-47% (120-280 wounds)
+      const percentage = (woundCount / totalRolls) * 100;
+      expect(percentage).toBeGreaterThan(20);
+      expect(percentage).toBeLessThan(47);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -57,6 +57,7 @@ import { registerCrystalMasteryEffects } from "./crystalMasteryEffects.js";
 import { registerPossessEffects } from "./possessEffects.js";
 import { registerManaStormEffects } from "./manaStormEffects.js";
 import { registerSourceOpeningEffects } from "./sourceOpeningEffects.js";
+import { registerHornOfWrathEffects } from "./hornOfWrathEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -210,4 +211,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Source Opening effects (Goldyx interactive skill - reroll a Source die)
   registerSourceOpeningEffects();
+
+  // Horn of Wrath effects (die rolling with wound risk)
+  registerHornOfWrathEffects();
 }

--- a/packages/core/src/engine/effects/hornOfWrathEffects.ts
+++ b/packages/core/src/engine/effects/hornOfWrathEffects.ts
@@ -1,0 +1,213 @@
+/**
+ * Horn of Wrath Effect Handlers
+ *
+ * Handles effects for the Horn of Wrath artifact:
+ * - RollDieForWound: Roll mana dice and gain wounds for black/red results
+ * - ChooseBonusWithRisk: Choose bonus attack amount, then roll dice for wound risk
+ * - ResolveBonusChoice: Internal resolver after bonus selection
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type {
+  RollDieForWoundEffect,
+  ChooseBonusWithRiskEffect,
+  ResolveBonusChoiceEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { registerEffect } from "./effectRegistry.js";
+import {
+  EFFECT_ROLL_DIE_FOR_WOUND,
+  EFFECT_CHOOSE_BONUS_WITH_RISK,
+  EFFECT_RESOLVE_BONUS_CHOICE,
+} from "../../types/effectTypes.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { applyTakeWound } from "./atomicCardEffects.js";
+import { applyGainAttack } from "./atomicCombatEffects.js";
+import { nextRandom } from "../../utils/rng.js";
+import type { ManaColor } from "@mage-knight/shared";
+import { ALL_MANA_COLORS } from "@mage-knight/shared";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Roll a single mana die and return the color.
+ */
+function rollManaDie(rng: GameState["rng"]): { color: ManaColor; rng: GameState["rng"] } {
+  const { value, rng: newRng } = nextRandom(rng);
+  const index = Math.floor(value * ALL_MANA_COLORS.length);
+  const color = ALL_MANA_COLORS[index];
+  if (!color) {
+    const fallbackColor = ALL_MANA_COLORS[0];
+    if (!fallbackColor) {
+      throw new Error("ALL_MANA_COLORS is empty");
+    }
+    return { color: fallbackColor, rng: newRng };
+  }
+  return { color, rng: newRng };
+}
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Roll mana dice and gain wounds for each black or red result.
+ * Used by Horn of Wrath basic effect.
+ */
+function handleRollDieForWound(
+  state: GameState,
+  playerId: string,
+  effect: RollDieForWoundEffect
+): EffectResolutionResult {
+  const { playerIndex } = getPlayerContext(state, playerId);
+
+  let currentState = state;
+  let currentRng = state.rng;
+  let woundsGained = 0;
+  const rollResults: ManaColor[] = [];
+
+  for (let i = 0; i < effect.diceCount; i++) {
+    const { color, rng: newRng } = rollManaDie(currentRng);
+    currentRng = newRng;
+    rollResults.push(color);
+
+    if ((effect.woundColors as readonly string[]).includes(color)) {
+      woundsGained++;
+    }
+  }
+
+  currentState = { ...currentState, rng: currentRng };
+
+  if (woundsGained > 0) {
+    const currentPlayer = currentState.players[playerIndex];
+    if (!currentPlayer) {
+      throw new Error(`Player not found at index: ${playerIndex}`);
+    }
+    const woundResult = applyTakeWound(currentState, playerIndex, currentPlayer, woundsGained);
+    currentState = woundResult.state;
+  }
+
+  const rollStr = rollResults.join(", ");
+  const woundStr = woundsGained > 0
+    ? `Gained ${woundsGained} wound${woundsGained > 1 ? "s" : ""}`
+    : "No wounds";
+
+  return {
+    state: currentState,
+    description: `Rolled: ${rollStr}. ${woundStr}`,
+  };
+}
+
+/**
+ * Present choices for bonus amount (0 to max).
+ * Each option represents a different bonus + dice count.
+ */
+function handleChooseBonusWithRisk(
+  state: GameState,
+  _playerId: string,
+  effect: ChooseBonusWithRiskEffect
+): EffectResolutionResult {
+  const options: ResolveBonusChoiceEffect[] = [];
+
+  for (let bonus = 0; bonus <= effect.maxBonus; bonus++) {
+    options.push({
+      type: EFFECT_RESOLVE_BONUS_CHOICE,
+      bonus,
+      attackType: effect.attackType,
+      woundColors: effect.woundColors,
+    });
+  }
+
+  return {
+    state,
+    description: `Choose bonus Siege Attack (0 to +${effect.maxBonus}), rolling 1 die per +1`,
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+/**
+ * Resolve the bonus choice: gain siege attack and roll dice for wound risk.
+ */
+function handleResolveBonusChoice(
+  state: GameState,
+  playerId: string,
+  effect: ResolveBonusChoiceEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  let currentState = state;
+  const descriptions: string[] = [];
+
+  // Apply bonus siege attack
+  if (effect.bonus > 0) {
+    const attackResult = applyGainAttack(currentState, playerIndex, player, {
+      type: "gain_attack" as const,
+      amount: effect.bonus,
+      combatType: effect.attackType,
+    });
+    currentState = attackResult.state;
+    descriptions.push(`+${effect.bonus} Siege Attack`);
+  } else {
+    descriptions.push("No bonus chosen");
+  }
+
+  // Roll dice for wound risk
+  if (effect.bonus > 0) {
+    let currentRng = currentState.rng;
+    let woundsGained = 0;
+    const rollResults: ManaColor[] = [];
+
+    for (let i = 0; i < effect.bonus; i++) {
+      const { color, rng: newRng } = rollManaDie(currentRng);
+      currentRng = newRng;
+      rollResults.push(color);
+
+      if ((effect.woundColors as readonly string[]).includes(color)) {
+        woundsGained++;
+      }
+    }
+
+    currentState = { ...currentState, rng: currentRng };
+
+    if (woundsGained > 0) {
+      const currentPlayer = currentState.players[playerIndex];
+      if (!currentPlayer) {
+        throw new Error(`Player not found at index: ${playerIndex}`);
+      }
+      const woundResult = applyTakeWound(currentState, playerIndex, currentPlayer, woundsGained);
+      currentState = woundResult.state;
+    }
+
+    const rollStr = rollResults.join(", ");
+    const woundStr = woundsGained > 0
+      ? `${woundsGained} wound${woundsGained > 1 ? "s" : ""}`
+      : "no wounds";
+    descriptions.push(`Rolled: ${rollStr} (${woundStr})`);
+  }
+
+  return {
+    state: currentState,
+    description: descriptions.join(". "),
+  };
+}
+
+// ============================================================================
+// REGISTRATION
+// ============================================================================
+
+export function registerHornOfWrathEffects(): void {
+  registerEffect(EFFECT_ROLL_DIE_FOR_WOUND, (state, playerId, effect) => {
+    return handleRollDieForWound(state, playerId, effect as RollDieForWoundEffect);
+  });
+
+  registerEffect(EFFECT_CHOOSE_BONUS_WITH_RISK, (state, playerId, effect) => {
+    return handleChooseBonusWithRisk(state, playerId, effect as ChooseBonusWithRiskEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_BONUS_CHOICE, (state, playerId, effect) => {
+    return handleResolveBonusChoice(state, playerId, effect as ResolveBonusChoiceEffect);
+  });
+}

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -334,6 +334,11 @@ export {
   registerPossessEffects,
 } from "./possessEffects.js";
 
+// Horn of Wrath effects (die rolling with wound risk)
+export {
+  registerHornOfWrathEffects,
+} from "./hornOfWrathEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -119,6 +119,9 @@ import {
   EFFECT_CRYSTAL_MASTERY_POWERED,
   EFFECT_POSSESS_ENEMY,
   EFFECT_RESOLVE_POSSESS_ENEMY,
+  EFFECT_ROLL_DIE_FOR_WOUND,
+  EFFECT_CHOOSE_BONUS_WITH_RISK,
+  EFFECT_RESOLVE_BONUS_CHOICE,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1354,6 +1357,39 @@ export interface ResolvePossessEnemyEffect {
   readonly enemyName: string;
 }
 
+/**
+ * Roll mana dice and gain wounds for black or red results.
+ * Used by Horn of Wrath basic effect.
+ */
+export interface RollDieForWoundEffect {
+  readonly type: typeof EFFECT_ROLL_DIE_FOR_WOUND;
+  readonly diceCount: number;
+  readonly woundColors: readonly ManaColor[];
+}
+
+/**
+ * Choose a bonus amount (0 to max), then roll dice per bonus chosen.
+ * Gain siege attack for the bonus and wounds for black/red results.
+ * Used by Horn of Wrath powered effect.
+ */
+export interface ChooseBonusWithRiskEffect {
+  readonly type: typeof EFFECT_CHOOSE_BONUS_WITH_RISK;
+  readonly maxBonus: number;
+  readonly attackType: CombatType;
+  readonly woundColors: readonly ManaColor[];
+}
+
+/**
+ * Internal: resolve after player selects a bonus amount.
+ * Applies siege attack bonus and rolls dice for wound risk.
+ */
+export interface ResolveBonusChoiceEffect {
+  readonly type: typeof EFFECT_RESOLVE_BONUS_CHOICE;
+  readonly bonus: number;
+  readonly attackType: CombatType;
+  readonly woundColors: readonly ManaColor[];
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1451,7 +1487,10 @@ export type CardEffect =
   | SourceOpeningRerollEffect
   | SourceOpeningSelectDieEffect
   | PossessEnemyEffect
-  | ResolvePossessEnemyEffect;
+  | ResolvePossessEnemyEffect
+  | RollDieForWoundEffect
+  | ChooseBonusWithRiskEffect
+  | ResolveBonusChoiceEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -332,6 +332,16 @@ export const EFFECT_SOURCE_OPENING_REROLL = "source_opening_reroll" as const;
 // Internal: Player selected a die to reroll (or skip)
 export const EFFECT_SOURCE_OPENING_SELECT_DIE = "source_opening_select_die" as const;
 
+// === Horn of Wrath Die Rolling Effects ===
+// Roll mana dice and gain wounds for black/red results.
+// Used by Horn of Wrath basic effect (1 die) and internally by the bonus resolver.
+export const EFFECT_ROLL_DIE_FOR_WOUND = "roll_die_for_wound" as const;
+// Choose a bonus amount (0 to max), then roll dice and gain siege attack + wounds.
+// Used by Horn of Wrath powered effect.
+export const EFFECT_CHOOSE_BONUS_WITH_RISK = "choose_bonus_with_risk" as const;
+// Internal: resolve after player selects a bonus amount.
+export const EFFECT_RESOLVE_BONUS_CHOICE = "resolve_bonus_choice" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.


### PR DESCRIPTION
## Summary
- Implement Horn of Wrath artifact card with risky die-rolling siege attack mechanics
- Add three new effect types: `EFFECT_ROLL_DIE_FOR_WOUND`, `EFFECT_CHOOSE_BONUS_WITH_RISK`, `EFFECT_RESOLVE_BONUS_CHOICE`
- Basic effect: Siege Attack 5 + roll 1 mana die (wound on black/red, ~33% chance)
- Powered effect (destroy): Siege Attack 5 + choose 0-5 bonus, roll 1 die per +1 chosen

## Changes
- `packages/core/src/data/artifacts/hornOfWrath.ts` — Card definition with basic/powered effects
- `packages/core/src/types/effectTypes.ts` — New effect type constants
- `packages/core/src/types/cards.ts` — New effect interfaces + CardEffect union additions
- `packages/core/src/engine/effects/hornOfWrathEffects.ts` — Effect resolver with RNG-based die rolling
- `packages/core/src/engine/effects/effectRegistrations.ts` — Register new effects
- `packages/core/src/engine/effects/index.ts` — Re-export new module
- `packages/core/src/engine/__tests__/hornOfWrath.test.ts` — 13 tests covering card definition, basic/powered effects, wound tracking, and probability distribution

Closes #224