### PR TITLE
feat: implement Maximal Effect card throw-away and effect multiplication

### DIFF
--- a/packages/core/src/data/advancedActions/helpers.ts
+++ b/packages/core/src/data/advancedActions/helpers.ts
@@ -38,6 +38,7 @@ import {
   EFFECT_TAKE_WOUND,
   EFFECT_NOOP,
   EFFECT_CONVERT_MANA_TO_CRYSTAL,
+  EFFECT_MAXIMAL_EFFECT,
   COMBAT_TYPE_MELEE,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
@@ -279,6 +280,18 @@ export function noop(): CardEffect {
  */
 export function convertManaToCrystal(): CardEffect {
   return { type: EFFECT_CONVERT_MANA_TO_CRYSTAL };
+}
+
+/**
+ * Creates a Maximal Effect effect that throws away an action card and
+ * uses its effect multiple times.
+ *
+ * @param effectKind - "basic" uses the target card's basic effect, "powered" uses the stronger effect
+ * @param multiplier - How many times to repeat the effect
+ * @returns A MaximalEffectEffect
+ */
+export function maximalEffect(effectKind: "basic" | "powered", multiplier: number): CardEffect {
+  return { type: EFFECT_MAXIMAL_EFFECT, effectKind, multiplier };
 }
 
 // Re-export element constants for convenience

--- a/packages/core/src/data/advancedActions/red/maximal-effect.ts
+++ b/packages/core/src/data/advancedActions/red/maximal-effect.ts
@@ -1,7 +1,7 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_RED, CARD_MAXIMAL_EFFECT } from "@mage-knight/shared";
-import { attack } from "../helpers.js";
+import { maximalEffect } from "../helpers.js";
 
 export const MAXIMAL_EFFECT: DeedCard = {
   id: CARD_MAXIMAL_EFFECT,
@@ -9,10 +9,9 @@ export const MAXIMAL_EFFECT: DeedCard = {
   cardType: DEED_CARD_TYPE_ADVANCED_ACTION,
   poweredBy: [MANA_RED],
   categories: [CATEGORY_SPECIAL],
-  // Basic: When you play this, throw away another Action card from your hand. Use the basic effect of that card three times.
-  // Powered: When you play this, throw away another Action card from your hand. Use the stronger effect of that card two times (for free).
-  // TODO: Implement throw-away mechanic and effect multiplication
-  basicEffect: attack(3),
-  poweredEffect: attack(6),
+  // Basic: Throw away another Action card from your hand. Use the basic effect of that card three times.
+  basicEffect: maximalEffect("basic", 3),
+  // Powered: Throw away another Action card from your hand. Use the stronger effect of that card two times (for free).
+  poweredEffect: maximalEffect("powered", 2),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/maximalEffect.test.ts
+++ b/packages/core/src/engine/__tests__/maximalEffect.test.ts
@@ -1,0 +1,1080 @@
+/**
+ * Tests for Maximal Effect (red advanced action card)
+ *
+ * Maximal Effect allows throwing away (permanently removing) an action card from hand
+ * and using its effect multiple times:
+ * - Basic: Throw away action card → use its basic effect 3 times
+ * - Powered (Red): Throw away action card → use its stronger effect 2 times (for free)
+ *
+ * Key rules:
+ * - Only action cards (basic/advanced) can be thrown away (not wounds, artifacts, spells)
+ * - The Maximal Effect card itself cannot be thrown away
+ * - Thrown away cards go to removedCards (permanent, not recycled)
+ * - Effects aggregate (3x Attack 2 = Attack 6 in the accumulator)
+ * - Card destroyed event is emitted (permanent removal)
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { isEffectResolvable } from "../effects/index.js";
+import {
+  handleMaximalEffectEffect,
+  getCardsEligibleForMaximalEffect,
+} from "../effects/maximalEffectEffects.js";
+import { createResolveMaximalEffectCommand } from "../commands/resolveMaximalEffectCommand.js";
+import { createResolveMaximalEffectCommandFromAction } from "../commands/factories/cards.js";
+import { describeEffect } from "../effects/describeEffect.js";
+import {
+  validateHasPendingMaximalEffect,
+  validateMaximalEffectSelection,
+} from "../validators/maximalEffectValidators.js";
+import { getMaximalEffectOptions } from "../validActions/pending.js";
+import { getValidActions } from "../validActions/index.js";
+import { EFFECT_MAXIMAL_EFFECT } from "../../types/effectTypes.js";
+import type { MaximalEffectEffect } from "../../types/cards.js";
+import type { PendingMaximalEffect } from "../../types/player.js";
+import {
+  CARD_MAXIMAL_EFFECT,
+  CARD_MARCH,
+  CARD_RAGE,
+  CARD_COUNTERATTACK,
+  CARD_WOUND,
+  CARD_BANNER_OF_GLORY,
+  CARD_FIREBALL,
+  CARD_DESTROYED,
+  RESOLVE_MAXIMAL_EFFECT_ACTION,
+  PLAY_CARD_ACTION,
+} from "@mage-knight/shared";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function makePending(
+  overrides: Partial<PendingMaximalEffect> = {}
+): PendingMaximalEffect {
+  return {
+    sourceCardId: CARD_MAXIMAL_EFFECT,
+    multiplier: 3,
+    effectKind: "basic",
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// ELIGIBILITY
+// ============================================================================
+
+describe("Maximal Effect", () => {
+  describe("getCardsEligibleForMaximalEffect", () => {
+    it("should return action cards excluding wounds and the source card", () => {
+      const hand = [CARD_MARCH, CARD_RAGE, CARD_WOUND, CARD_MAXIMAL_EFFECT];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+
+    it("should exclude wounds", () => {
+      const hand = [CARD_WOUND, CARD_MARCH];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude the source card (Maximal Effect itself)", () => {
+      const hand = [CARD_MAXIMAL_EFFECT, CARD_MARCH];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude artifacts (not action cards)", () => {
+      const hand = [CARD_BANNER_OF_GLORY, CARD_MARCH];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude spells (not action cards)", () => {
+      const hand = [CARD_FIREBALL, CARD_MARCH];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should return empty when only wounds and Maximal Effect in hand", () => {
+      const hand = [CARD_WOUND, CARD_MAXIMAL_EFFECT];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([]);
+    });
+
+    it("should return empty for empty hand", () => {
+      const eligible = getCardsEligibleForMaximalEffect(
+        [],
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([]);
+    });
+
+    it("should include both basic and advanced action cards", () => {
+      const hand = [CARD_MARCH, CARD_RAGE];
+      const eligible = getCardsEligibleForMaximalEffect(
+        hand,
+        CARD_MAXIMAL_EFFECT
+      );
+      expect(eligible).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+  });
+
+  // ============================================================================
+  // RESOLVABILITY
+  // ============================================================================
+
+  describe("isEffectResolvable", () => {
+    const basicEffect: MaximalEffectEffect = {
+      type: EFFECT_MAXIMAL_EFFECT,
+      effectKind: "basic",
+      multiplier: 3,
+    };
+
+    it("should be resolvable when player has action cards", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should NOT be resolvable when player only has wounds", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when hand is empty", () => {
+      const player = createTestPlayer({ hand: [] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should be resolvable with mix of wounds and action cards", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH, CARD_WOUND],
+      });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should NOT be resolvable when only artifacts in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_BANNER_OF_GLORY] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when only spells in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_FIREBALL] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // EFFECT HANDLER
+  // ============================================================================
+
+  describe("handleMaximalEffectEffect", () => {
+    it("should create pending state (basic mode, multiplier 3)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH, CARD_RAGE] });
+      const state = createTestGameState({ players: [player] });
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "basic",
+        multiplier: 3,
+      };
+
+      const result = handleMaximalEffectEffect(
+        state,
+        0,
+        player,
+        effect,
+        CARD_MAXIMAL_EFFECT
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingMaximalEffect).not.toBeNull();
+      expect(result.state.players[0].pendingMaximalEffect?.effectKind).toBe(
+        "basic"
+      );
+      expect(result.state.players[0].pendingMaximalEffect?.multiplier).toBe(3);
+      expect(
+        result.state.players[0].pendingMaximalEffect?.sourceCardId
+      ).toBe(CARD_MAXIMAL_EFFECT);
+    });
+
+    it("should create pending state (powered mode, multiplier 2)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "powered",
+        multiplier: 2,
+      };
+
+      const result = handleMaximalEffectEffect(
+        state,
+        0,
+        player,
+        effect,
+        CARD_MAXIMAL_EFFECT
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingMaximalEffect?.effectKind).toBe(
+        "powered"
+      );
+      expect(result.state.players[0].pendingMaximalEffect?.multiplier).toBe(2);
+    });
+
+    it("should throw when no eligible action cards", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MAXIMAL_EFFECT],
+      });
+      const state = createTestGameState({ players: [player] });
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "basic",
+        multiplier: 3,
+      };
+
+      expect(() =>
+        handleMaximalEffectEffect(
+          state,
+          0,
+          player,
+          effect,
+          CARD_MAXIMAL_EFFECT
+        )
+      ).toThrow("No action cards available to throw away for Maximal Effect");
+    });
+
+    it("should throw when sourceCardId is null", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "basic",
+        multiplier: 3,
+      };
+
+      expect(() =>
+        handleMaximalEffectEffect(state, 0, player, effect, null)
+      ).toThrow("MaximalEffectEffect requires sourceCardId");
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE MAXIMAL EFFECT COMMAND - BASIC MODE
+  // ============================================================================
+
+  describe("resolveMaximalEffectCommand (basic mode)", () => {
+    it("should throw away card and apply its basic effect 3 times", () => {
+      // March: basic effect = Move 2
+      // 3x Move 2 = Move 6 total
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        movePoints: 0,
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH, // green basic action: Move 2
+      });
+      const result = command.execute(state);
+
+      // Card removed from hand
+      expect(result.state.players[0].hand).not.toContain(CARD_MARCH);
+      // Card added to removedCards (permanent removal)
+      expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      // Card NOT in discard
+      expect(result.state.players[0].discard).not.toContain(CARD_MARCH);
+      // Move 2 × 3 = 6 move points gained
+      expect(result.state.players[0].movePoints).toBe(6);
+      // Pending state cleared
+      expect(result.state.players[0].pendingMaximalEffect).toBeNull();
+      // Card destroyed event emitted
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_DESTROYED,
+          cardId: CARD_MARCH,
+        })
+      );
+    });
+
+    it("should throw away a card with direct attack and apply its basic effect 3 times", () => {
+      // Counterattack: basic effect = Attack 2 (direct, no choice)
+      // 3x Attack 2 → combat accumulator should have attack 6
+      const player = createTestPlayer({
+        hand: [CARD_COUNTERATTACK],
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_COUNTERATTACK,
+      });
+      const result = command.execute(state);
+
+      // Card removed and destroyed
+      expect(result.state.players[0].removedCards).toContain(CARD_COUNTERATTACK);
+      // Attack 2 × 3 = 6 attack in the accumulator
+      expect(
+        result.state.players[0].combatAccumulator.attack.normal
+      ).toBe(6);
+    });
+
+    it("should create pending choice when card basic effect has a choice", () => {
+      // Rage: basic effect = choice(attack(2), block(2))
+      // Maximal Effect with a choice card should result in a pending choice
+      const player = createTestPlayer({
+        hand: [CARD_RAGE],
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+      const result = command.execute(state);
+
+      // Card should still be removed and destroyed
+      expect(result.state.players[0].removedCards).toContain(CARD_RAGE);
+      // Effect resolution pauses on the first choice - player has pending choice
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE MAXIMAL EFFECT COMMAND - POWERED MODE
+  // ============================================================================
+
+  describe("resolveMaximalEffectCommand (powered mode)", () => {
+    it("should throw away card and apply its powered effect 2 times", () => {
+      // March: powered (green) effect = Move 4
+      // 2x Move 4 = Move 8 total
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        movePoints: 0,
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "powered",
+          multiplier: 2,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH, // green basic action: powered = Move 4
+      });
+      const result = command.execute(state);
+
+      // Card removed from hand
+      expect(result.state.players[0].hand).not.toContain(CARD_MARCH);
+      // Move 4 × 2 = 8 move points gained
+      expect(result.state.players[0].movePoints).toBe(8);
+      // Pending state cleared
+      expect(result.state.players[0].pendingMaximalEffect).toBeNull();
+    });
+
+    it("should throw away a card with direct attack and apply its powered effect 2 times", () => {
+      // Counterattack: powered effect = Attack 4 (direct, no choice)
+      // 2x Attack 4 → 8 attack
+      const player = createTestPlayer({
+        hand: [CARD_COUNTERATTACK],
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "powered",
+          multiplier: 2,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_COUNTERATTACK,
+      });
+      const result = command.execute(state);
+
+      expect(result.state.players[0].removedCards).toContain(CARD_COUNTERATTACK);
+      // Attack 4 × 2 = 8
+      expect(
+        result.state.players[0].combatAccumulator.attack.normal
+      ).toBe(8);
+    });
+  });
+
+  // ============================================================================
+  // ERROR HANDLING
+  // ============================================================================
+
+  describe("resolveMaximalEffectCommand error handling", () => {
+    it("should throw when no pending state exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: null,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+
+      expect(() => command.execute(state)).toThrow(
+        "No pending Maximal Effect to resolve"
+      );
+    });
+
+    it("should throw when card is not eligible (wound)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_WOUND,
+      });
+
+      expect(() => command.execute(state)).toThrow(
+        "not eligible for Maximal Effect"
+      );
+    });
+
+    it("should throw when card is not eligible (artifact)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_BANNER_OF_GLORY],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_BANNER_OF_GLORY,
+      });
+
+      expect(() => command.execute(state)).toThrow(
+        "not eligible for Maximal Effect"
+      );
+    });
+
+    it("should throw when player not found", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "nonexistent",
+        cardId: CARD_MARCH,
+      });
+
+      expect(() => command.execute(state)).toThrow("Player not found");
+    });
+  });
+
+  // ============================================================================
+  // UNDO
+  // ============================================================================
+
+  describe("resolveMaximalEffectCommand undo", () => {
+    it("should restore full player state after basic mode execution", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        discard: [],
+        removedCards: [],
+        movePoints: 0,
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+
+      const executed = command.execute(state);
+      // Verify execute changed state
+      expect(executed.state.players[0].movePoints).toBe(6);
+      expect(executed.state.players[0].hand).not.toContain(CARD_MARCH);
+      expect(executed.state.players[0].removedCards).toContain(CARD_MARCH);
+
+      const undone = command.undo(executed.state);
+
+      // Hand restored
+      expect(undone.state.players[0].hand).toContain(CARD_MARCH);
+      expect(undone.state.players[0].hand).toContain(CARD_RAGE);
+      // removedCards restored
+      expect(undone.state.players[0].removedCards).toEqual([]);
+      // Move points restored
+      expect(undone.state.players[0].movePoints).toBe(0);
+      // Pending state restored
+      expect(undone.state.players[0].pendingMaximalEffect).not.toBeNull();
+      expect(
+        undone.state.players[0].pendingMaximalEffect?.effectKind
+      ).toBe("basic");
+    });
+  });
+
+  // ============================================================================
+  // DESCRIBE EFFECT
+  // ============================================================================
+
+  describe("describeEffect", () => {
+    it("should describe basic maximal effect", () => {
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "basic",
+        multiplier: 3,
+      };
+      expect(describeEffect(effect)).toBe(
+        "Throw away an action card to use its basic effect 3 times"
+      );
+    });
+
+    it("should describe powered maximal effect", () => {
+      const effect: MaximalEffectEffect = {
+        type: EFFECT_MAXIMAL_EFFECT,
+        effectKind: "powered",
+        multiplier: 2,
+      };
+      expect(describeEffect(effect)).toBe(
+        "Throw away an action card to use its stronger effect 2 times"
+      );
+    });
+  });
+
+  // ============================================================================
+  // VALIDATORS
+  // ============================================================================
+
+  describe("validators", () => {
+    describe("validateHasPendingMaximalEffect", () => {
+      it("should pass when pending state exists", () => {
+        const player = createTestPlayer({
+          pendingMaximalEffect: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateHasPendingMaximalEffect(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail when no pending state", () => {
+        const player = createTestPlayer({
+          pendingMaximalEffect: null,
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateHasPendingMaximalEffect(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(false);
+      });
+    });
+
+    describe("validateMaximalEffectSelection", () => {
+      it("should pass for eligible action card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MARCH],
+          pendingMaximalEffect: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_MARCH,
+        } as const;
+
+        const result = validateMaximalEffectSelection(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(true);
+      });
+
+      it("should fail for wound card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_WOUND],
+          pendingMaximalEffect: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_WOUND,
+        } as const;
+
+        const result = validateMaximalEffectSelection(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(false);
+      });
+
+      it("should fail for artifact card", () => {
+        const player = createTestPlayer({
+          hand: [CARD_BANNER_OF_GLORY],
+          pendingMaximalEffect: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_BANNER_OF_GLORY,
+        } as const;
+
+        const result = validateMaximalEffectSelection(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(false);
+      });
+
+      it("should fail for the Maximal Effect card itself", () => {
+        const player = createTestPlayer({
+          hand: [CARD_MAXIMAL_EFFECT, CARD_MARCH],
+          pendingMaximalEffect: makePending(),
+        });
+        const state = createTestGameState({ players: [player] });
+        const action = {
+          type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+          cardId: CARD_MAXIMAL_EFFECT,
+        } as const;
+
+        const result = validateMaximalEffectSelection(
+          state,
+          "player1",
+          action
+        );
+        expect(result.valid).toBe(false);
+      });
+    });
+  });
+
+  // ============================================================================
+  // PERMANENT REMOVAL VERIFICATION
+  // ============================================================================
+
+  describe("permanent removal (throw away)", () => {
+    it("should add card to removedCards, not discard pile", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        discard: [],
+        removedCards: [],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      // Card is in removedCards (permanent)
+      expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      // Card is NOT in discard (would be recycled)
+      expect(result.state.players[0].discard).not.toContain(CARD_MARCH);
+      // Card is NOT in hand
+      expect(result.state.players[0].hand).not.toContain(CARD_MARCH);
+      // Other cards remain in hand
+      expect(result.state.players[0].hand).toContain(CARD_RAGE);
+    });
+
+    it("should emit CARD_DESTROYED event", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        removedCards: [],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toEqual({
+        type: CARD_DESTROYED,
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+    });
+
+    it("should preserve existing removedCards", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        removedCards: [CARD_RAGE],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH,
+      });
+      const result = command.execute(state);
+
+      expect(result.state.players[0].removedCards).toEqual([
+        CARD_RAGE,
+        CARD_MARCH,
+      ]);
+    });
+  });
+
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should have correct basic effect (maximal_effect, basic, 3)", () => {
+      // Import the card definition
+      const { MAXIMAL_EFFECT } = require("../../data/advancedActions/red/maximal-effect.js");
+      expect(MAXIMAL_EFFECT.basicEffect.type).toBe(EFFECT_MAXIMAL_EFFECT);
+      expect(MAXIMAL_EFFECT.basicEffect.effectKind).toBe("basic");
+      expect(MAXIMAL_EFFECT.basicEffect.multiplier).toBe(3);
+    });
+
+    it("should have correct powered effect (maximal_effect, powered, 2)", () => {
+      const { MAXIMAL_EFFECT } = require("../../data/advancedActions/red/maximal-effect.js");
+      expect(MAXIMAL_EFFECT.poweredEffect.type).toBe(EFFECT_MAXIMAL_EFFECT);
+      expect(MAXIMAL_EFFECT.poweredEffect.effectKind).toBe("powered");
+      expect(MAXIMAL_EFFECT.poweredEffect.multiplier).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // VALID ACTIONS - getMaximalEffectOptions
+  // ============================================================================
+
+  describe("getMaximalEffectOptions", () => {
+    it("should return undefined when no pending maximal effect", () => {
+      const player = createTestPlayer({ pendingMaximalEffect: null });
+      const state = createTestGameState({ players: [player] });
+      expect(getMaximalEffectOptions(state, player)).toBeUndefined();
+    });
+
+    it("should return options when pending maximal effect exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE, CARD_WOUND],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+      const options = getMaximalEffectOptions(state, player);
+
+      expect(options).toBeDefined();
+      expect(options!.sourceCardId).toBe(CARD_MAXIMAL_EFFECT);
+      expect(options!.multiplier).toBe(3);
+      expect(options!.effectKind).toBe("basic");
+      expect(options!.availableCardIds).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+  });
+
+  // ============================================================================
+  // VALID ACTIONS - getValidActions routing
+  // ============================================================================
+
+  describe("getValidActions routing", () => {
+    it("should return pending_maximal_effect mode when player has pending state", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const actions = getValidActions(state, "player1");
+      expect(actions.mode).toBe("pending_maximal_effect");
+      expect(actions.maximalEffect).toBeDefined();
+      expect(actions.maximalEffect!.availableCardIds).toEqual([
+        CARD_MARCH,
+        CARD_RAGE,
+      ]);
+    });
+  });
+
+  // ============================================================================
+  // FACTORY - createResolveMaximalEffectCommandFromAction
+  // ============================================================================
+
+  describe("createResolveMaximalEffectCommandFromAction", () => {
+    it("should return null for wrong action type", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_MARCH,
+        powered: false,
+      } as const;
+
+      const result = createResolveMaximalEffectCommandFromAction(
+        state,
+        "player1",
+        action
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should return null when player not found", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = createResolveMaximalEffectCommandFromAction(
+        state,
+        "nonexistent",
+        action
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should return null when no pending maximal effect", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: null,
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = createResolveMaximalEffectCommandFromAction(
+        state,
+        "player1",
+        action
+      );
+      expect(result).toBeNull();
+    });
+
+    it("should return command when valid", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = createResolveMaximalEffectCommandFromAction(
+        state,
+        "player1",
+        action
+      );
+      expect(result).not.toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // VALIDATOR EDGE CASES
+  // ============================================================================
+
+  describe("validator edge cases", () => {
+    it("validateMaximalEffectSelection should pass for non-RESOLVE_MAXIMAL_EFFECT action", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_MARCH,
+        powered: false,
+      } as const;
+
+      const result = validateMaximalEffectSelection(state, "player1", action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("validateMaximalEffectSelection should pass when no pending state (defers to other validator)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: null,
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = validateMaximalEffectSelection(state, "player1", action);
+      expect(result.valid).toBe(true);
+    });
+
+    it("validateMaximalEffectSelection should fail for nonexistent player", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = validateMaximalEffectSelection(
+        state,
+        "nonexistent",
+        action
+      );
+      expect(result.valid).toBe(false);
+    });
+
+    it("validateHasPendingMaximalEffect should fail for nonexistent player", () => {
+      const player = createTestPlayer({
+        pendingMaximalEffect: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+      const action = {
+        type: RESOLVE_MAXIMAL_EFFECT_ACTION,
+        cardId: CARD_MARCH,
+      } as const;
+
+      const result = validateHasPendingMaximalEffect(
+        state,
+        "nonexistent",
+        action
+      );
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // CHOICE HANDLING IN COMMAND
+  // ============================================================================
+
+  describe("resolveMaximalEffectCommand with choice effects", () => {
+    it("should set up pending choice with correct options for choice-based card", () => {
+      // Rage basic = choice(attack(2), block(2))
+      // Maximal Effect wraps 3 copies in CompoundEffect
+      // First choice should pause with options for attack or block
+      const player = createTestPlayer({
+        hand: [CARD_RAGE],
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+      const result = command.execute(state);
+
+      // Card is permanently removed
+      expect(result.state.players[0].removedCards).toContain(CARD_RAGE);
+      expect(result.state.players[0].hand).not.toContain(CARD_RAGE);
+      // Pending maximal effect cleared
+      expect(result.state.players[0].pendingMaximalEffect).toBeNull();
+      // Pending choice created with 2 options (attack or block)
+      const pendingChoice = result.state.players[0].pendingChoice;
+      expect(pendingChoice).not.toBeNull();
+      expect(pendingChoice!.options).toHaveLength(2);
+      // Should have remaining effects (2 more choice effects from the compound)
+      expect(pendingChoice!.remainingEffects).toBeDefined();
+      expect(pendingChoice!.remainingEffects!.length).toBe(2);
+    });
+
+    it("should emit CARD_DESTROYED and choice required events for choice-based card", () => {
+      const player = createTestPlayer({
+        hand: [CARD_RAGE],
+        removedCards: [],
+        pendingMaximalEffect: makePending({
+          effectKind: "basic",
+          multiplier: 3,
+        }),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveMaximalEffectCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+      const result = command.execute(state);
+
+      // Should have CARD_DESTROYED event and a choice required event
+      expect(result.events.length).toBeGreaterThanOrEqual(1);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: CARD_DESTROYED,
+          cardId: CARD_RAGE,
+        })
+      );
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -160,6 +160,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingDiscardForAttack: null,
     pendingDiscardForCrystal: null,
     pendingDecompose: null,
+    pendingMaximalEffect: null,
     pendingTerrainCostReduction: null,
     pendingAttackDefeatFame: [],
     enemiesDefeatedThisTurn: 0,

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -67,6 +67,9 @@ export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_COMMAND = "RESOLVE_ARTIFACT_CRYSTAL_
 // Decompose command (throw away action card for crystals)
 export const RESOLVE_DECOMPOSE_COMMAND = "RESOLVE_DECOMPOSE" as const;
 
+// Maximal Effect command (throw away action card and multiply its effect)
+export const RESOLVE_MAXIMAL_EFFECT_COMMAND = "RESOLVE_MAXIMAL_EFFECT" as const;
+
 // Meditation resolve command
 export const RESOLVE_MEDITATION_COMMAND = "RESOLVE_MEDITATION" as const;
 

--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -24,6 +24,7 @@ import {
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
   RESOLVE_DECOMPOSE_ACTION,
+  RESOLVE_MAXIMAL_EFFECT_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   MANA_BLACK,
 } from "@mage-knight/shared";
@@ -38,6 +39,7 @@ import { createResolveDiscardForAttackCommand } from "../resolveDiscardForAttack
 import { createResolveDiscardForCrystalCommand } from "../resolveDiscardForCrystalCommand.js";
 import { createResolveArtifactCrystalColorCommand } from "../resolveArtifactCrystalColorCommand.js";
 import { createResolveDecomposeCommand } from "../resolveDecomposeCommand.js";
+import { createResolveMaximalEffectCommand } from "../resolveMaximalEffectCommand.js";
 import { getCard } from "../../validActions/cards/index.js";
 import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
 import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
@@ -351,6 +353,26 @@ export const createResolveDecomposeCommandFromAction: CommandFactory = (
   if (!player?.pendingDecompose) return null;
 
   return createResolveDecomposeCommand({
+    playerId,
+    cardId: action.cardId,
+  });
+};
+
+/**
+ * Resolve maximal effect command factory.
+ * Creates a command to resolve a pending maximal effect (throw away action card and multiply its effect).
+ */
+export const createResolveMaximalEffectCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_MAXIMAL_EFFECT_ACTION) return null;
+
+  const player = getPlayerById(state, playerId);
+  if (!player?.pendingMaximalEffect) return null;
+
+  return createResolveMaximalEffectCommand({
     playerId,
     cardId: action.cardId,
   });

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -29,6 +29,7 @@ import {
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
   RESOLVE_DECOMPOSE_ACTION,
+  RESOLVE_MAXIMAL_EFFECT_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   REST_ACTION,
   DECLARE_REST_ACTION,
@@ -102,6 +103,7 @@ export {
   createResolveDiscardForAttackCommandFromAction,
   createResolveDiscardForCrystalCommandFromAction,
   createResolveDecomposeCommandFromAction,
+  createResolveMaximalEffectCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -216,6 +218,7 @@ import {
   createResolveDiscardForAttackCommandFromAction,
   createResolveDiscardForCrystalCommandFromAction,
   createResolveDecomposeCommandFromAction,
+  createResolveMaximalEffectCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -324,6 +327,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [RESOLVE_DISCARD_FOR_ATTACK_ACTION]: createResolveDiscardForAttackCommandFromAction,
   [RESOLVE_DISCARD_FOR_CRYSTAL_ACTION]: createResolveDiscardForCrystalCommandFromAction,
   [RESOLVE_DECOMPOSE_ACTION]: createResolveDecomposeCommandFromAction,
+  [RESOLVE_MAXIMAL_EFFECT_ACTION]: createResolveMaximalEffectCommandFromAction,
   [RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION]: createResolveArtifactCrystalColorCommandFromAction,
   [REST_ACTION]: createRestCommandFromAction,
   [DECLARE_REST_ACTION]: createDeclareRestCommandFromAction,

--- a/packages/core/src/engine/commands/index.ts
+++ b/packages/core/src/engine/commands/index.ts
@@ -250,3 +250,10 @@ export {
   type ResolveArtifactCrystalColorCommandParams,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_COMMAND,
 } from "./resolveArtifactCrystalColorCommand.js";
+
+// Maximal Effect command (throw away action card and multiply its effect)
+export {
+  createResolveMaximalEffectCommand,
+  type ResolveMaximalEffectCommandParams,
+  RESOLVE_MAXIMAL_EFFECT_COMMAND,
+} from "./resolveMaximalEffectCommand.js";

--- a/packages/core/src/engine/commands/resolveMaximalEffectCommand.ts
+++ b/packages/core/src/engine/commands/resolveMaximalEffectCommand.ts
@@ -1,0 +1,250 @@
+/**
+ * Resolve Maximal Effect Command
+ *
+ * Handles player resolution of a pending Maximal Effect (Maximal Effect advanced action).
+ * When the player selects an action card to throw away:
+ * - Card is permanently removed from the game (added to removedCards)
+ * - Basic mode: the target card's basic effect is resolved 3 times
+ * - Powered mode: the target card's powered effect is resolved 2 times (for free)
+ *
+ * The multiple uses are aggregated by wrapping N copies of the effect in a CompoundEffect
+ * which the existing effect resolver handles (including mid-resolution choices).
+ *
+ * Flow:
+ * 1. Card played creates pendingMaximalEffect via EFFECT_MAXIMAL_EFFECT
+ * 2. Player sends RESOLVE_MAXIMAL_EFFECT action with selected cardId
+ * 3. Card is removed from hand → added to removedCards (permanent)
+ * 4. Target card's effect is resolved multiplier times via CompoundEffect
+ *
+ * This command is NOT reversible since the effect resolution may involve
+ * conditionals, choices, or other state-dependent logic.
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, CardId } from "@mage-knight/shared";
+import type { Player, PendingMaximalEffect } from "../../types/player.js";
+import type { CardEffect, CompoundEffect } from "../../types/cards.js";
+import { CARD_DESTROYED } from "@mage-knight/shared";
+import { EFFECT_COMPOUND } from "../../types/effectTypes.js";
+import { RESOLVE_MAXIMAL_EFFECT_COMMAND } from "./commandTypes.js";
+import { getCardsEligibleForMaximalEffect } from "../effects/maximalEffectEffects.js";
+import { getCard } from "../helpers/cardLookup.js";
+import { resolveEffect } from "../effects/index.js";
+import {
+  getChoiceOptionsFromEffect,
+  applyChoiceOutcome,
+  buildChoiceRequiredEvent,
+} from "./choice/choiceResolution.js";
+
+export { RESOLVE_MAXIMAL_EFFECT_COMMAND };
+
+export interface ResolveMaximalEffectCommandParams {
+  readonly playerId: string;
+  /** Card ID of the action card to throw away */
+  readonly cardId: CardId;
+}
+
+export function createResolveMaximalEffectCommand(
+  params: ResolveMaximalEffectCommandParams
+): Command {
+  // Store previous state for undo
+  let previousPendingMaximalEffect: PendingMaximalEffect | null = null;
+  let previousHand: readonly CardId[] = [];
+  let previousRemovedCards: readonly CardId[] = [];
+  let previousPlayerSnapshot: Player | null = null;
+
+  return {
+    type: RESOLVE_MAXIMAL_EFFECT_COMMAND,
+    playerId: params.playerId,
+    // Not reversible: effect resolution may involve conditionals/choices
+    isReversible: false,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      if (!player.pendingMaximalEffect) {
+        throw new Error("No pending Maximal Effect to resolve");
+      }
+
+      const pending = player.pendingMaximalEffect;
+
+      // Store for undo
+      previousPendingMaximalEffect = pending;
+      previousHand = player.hand;
+      previousRemovedCards = player.removedCards;
+      previousPlayerSnapshot = player;
+
+      const events: GameEvent[] = [];
+
+      // Validate card is eligible
+      const eligibleCards = getCardsEligibleForMaximalEffect(
+        player.hand,
+        pending.sourceCardId
+      );
+      if (!eligibleCards.includes(params.cardId)) {
+        throw new Error(
+          `Card ${params.cardId} is not eligible for Maximal Effect (must be an action card in hand, not the Maximal Effect card itself)`
+        );
+      }
+
+      // Look up the target card's definition
+      const targetCard = getCard(params.cardId);
+      if (!targetCard) {
+        throw new Error(`Card definition not found for ${params.cardId}`);
+      }
+
+      // Get the appropriate effect based on effectKind
+      const targetEffect: CardEffect =
+        pending.effectKind === "basic"
+          ? targetCard.basicEffect
+          : targetCard.poweredEffect;
+
+      // Remove card from hand
+      const updatedHand = [...player.hand];
+      const cardIndex = updatedHand.indexOf(params.cardId);
+      if (cardIndex === -1) {
+        throw new Error(`Card ${params.cardId} not found in hand`);
+      }
+      updatedHand.splice(cardIndex, 1);
+
+      // Add to removedCards (permanent removal - throw away)
+      const updatedRemovedCards = [...player.removedCards, params.cardId];
+
+      // Emit card destroyed event (permanent removal)
+      events.push({
+        type: CARD_DESTROYED,
+        playerId: params.playerId,
+        cardId: params.cardId,
+      });
+
+      // Clear pending state and update hand/removedCards
+      const updatedPlayer: Player = {
+        ...player,
+        hand: updatedHand,
+        removedCards: updatedRemovedCards,
+        pendingMaximalEffect: null,
+      };
+
+      let updatedState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? updatedPlayer : p
+        ),
+      };
+
+      // Build compound effect: N copies of the target effect
+      const multipliedEffects: CardEffect[] = Array.from(
+        { length: pending.multiplier },
+        () => targetEffect
+      );
+      const compoundEffect: CompoundEffect = {
+        type: EFFECT_COMPOUND,
+        effects: multipliedEffects,
+      };
+
+      // Resolve the compound effect
+      // sourceCardId is the thrown-away card (for color-based effects like Fire/Ice)
+      const result = resolveEffect(
+        updatedState,
+        params.playerId,
+        compoundEffect,
+        params.cardId
+      );
+
+      // Handle case where the target effect requires a choice (e.g., Rage basic = choice(attack, block))
+      if (result.requiresChoice) {
+        const choiceInfo = getChoiceOptionsFromEffect(result, compoundEffect);
+        if (choiceInfo) {
+          const source = {
+            cardId: pending.sourceCardId,
+            skillId: null,
+            unitInstanceId: null,
+          };
+
+          const choiceResult = applyChoiceOutcome({
+            state: result.state,
+            playerId: params.playerId,
+            playerIndex,
+            options: choiceInfo.options,
+            source,
+            remainingEffects: choiceInfo.remainingEffects,
+            resolveEffect: (s, id, effect) => resolveEffect(s, id, effect),
+            handlers: {
+              onNoOptions: (s) => ({
+                state: s,
+                events,
+              }),
+              onAutoResolved: (autoResult) => ({
+                state: autoResult.state,
+                events,
+              }),
+              onPendingChoice: (stateWithChoice, options) => ({
+                state: stateWithChoice,
+                events: [
+                  ...events,
+                  buildChoiceRequiredEvent(params.playerId, source, options),
+                ],
+              }),
+            },
+          });
+
+          return {
+            state: choiceResult.state,
+            events: choiceResult.events,
+          };
+        }
+      }
+
+      return {
+        state: result.state,
+        events,
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      // Restore the full player snapshot since effect resolution may have
+      // changed many fields (attack, block, move, mana, etc.)
+      const restoredPlayer: Player = previousPlayerSnapshot ?? {
+        ...player,
+        hand: previousHand,
+        removedCards: previousRemovedCards,
+        pendingMaximalEffect: previousPendingMaximalEffect,
+      };
+
+      const newState: GameState = {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? restoredPlayer : p
+        ),
+      };
+
+      return {
+        state: newState,
+        events: [],
+      };
+    },
+  };
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -37,6 +37,7 @@ import {
   EFFECT_PLACE_SKILL_IN_CENTER,
   EFFECT_DISCARD_FOR_CRYSTAL,
   EFFECT_DECOMPOSE,
+  EFFECT_MAXIMAL_EFFECT,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
   EFFECT_APPLY_RECRUIT_DISCOUNT,
@@ -82,6 +83,7 @@ import {
 import type {
   DiscardForCrystalEffect,
   DecomposeEffect,
+  MaximalEffectEffect,
   RecruitDiscountEffect,
   ReadyUnitsForInfluenceEffect,
   ResolveReadyUnitForInfluenceEffect,
@@ -334,6 +336,13 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     return e.mode === "basic"
       ? "Throw away an action card to gain 2 crystals of matching color"
       : "Throw away an action card to gain 1 crystal of each non-matching color";
+  },
+
+  [EFFECT_MAXIMAL_EFFECT]: (effect) => {
+    const e = effect as MaximalEffectEffect;
+    return e.effectKind === "basic"
+      ? `Throw away an action card to use its basic effect ${e.multiplier} times`
+      : `Throw away an action card to use its stronger effect ${e.multiplier} times`;
   },
 
   [EFFECT_CRYSTAL_MASTERY_BASIC]: () => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -58,6 +58,7 @@ import { registerPossessEffects } from "./possessEffects.js";
 import { registerManaStormEffects } from "./manaStormEffects.js";
 import { registerSourceOpeningEffects } from "./sourceOpeningEffects.js";
 import { registerHornOfWrathEffects } from "./hornOfWrathEffects.js";
+import { registerMaximalEffectEffects } from "./maximalEffectEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -214,4 +215,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Horn of Wrath effects (die rolling with wound risk)
   registerHornOfWrathEffects();
+
+  // Maximal Effect effects (throw away action card and multiply its effect)
+  registerMaximalEffectEffects();
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -339,6 +339,13 @@ export {
   registerHornOfWrathEffects,
 } from "./hornOfWrathEffects.js";
 
+// Maximal Effect effects (throw away action card and multiply its effect)
+export {
+  getCardsEligibleForMaximalEffect,
+  handleMaximalEffectEffect,
+  registerMaximalEffectEffects,
+} from "./maximalEffectEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/maximalEffectEffects.ts
+++ b/packages/core/src/engine/effects/maximalEffectEffects.ts
@@ -1,0 +1,120 @@
+/**
+ * Maximal Effect Effect Handlers
+ *
+ * Handles the Maximal Effect advanced action card:
+ * - Throw away an action card from hand (permanent removal)
+ * - Basic: use target card's basic effect 3 times
+ * - Powered: use target card's powered effect 2 times (for free)
+ *
+ * Only action cards (basic or advanced) can be thrown away.
+ * Wounds, artifacts, spells, and the Maximal Effect card itself are excluded.
+ *
+ * @module effects/maximalEffectEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, PendingMaximalEffect } from "../../types/player.js";
+import type { MaximalEffectEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { CardId } from "@mage-knight/shared";
+import { CARD_WOUND } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_MAXIMAL_EFFECT } from "../../types/effectTypes.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+
+// ============================================================================
+// ELIGIBILITY HELPERS
+// ============================================================================
+
+/**
+ * Get cards eligible for Maximal Effect (action cards in hand, excluding
+ * wounds and the source Maximal Effect card itself).
+ *
+ * Same eligibility as Decompose: only action cards (those with a color).
+ */
+export function getCardsEligibleForMaximalEffect(
+  hand: readonly CardId[],
+  sourceCardId: CardId
+): CardId[] {
+  return hand.filter((cardId) => {
+    if (cardId === CARD_WOUND) return false;
+    if (cardId === sourceCardId) return false;
+    // Only action cards (those with a color) can be thrown away
+    return getActionCardColor(cardId) !== null;
+  });
+}
+
+// ============================================================================
+// EFFECT HANDLER
+// ============================================================================
+
+/**
+ * Handle the EFFECT_MAXIMAL_EFFECT effect.
+ *
+ * Creates a pendingMaximalEffect state on the player, blocking other actions
+ * until the player resolves it via RESOLVE_MAXIMAL_EFFECT action.
+ */
+export function handleMaximalEffectEffect(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: MaximalEffectEffect,
+  sourceCardId: CardId | null
+): EffectResolutionResult {
+  if (!sourceCardId) {
+    throw new Error("MaximalEffectEffect requires sourceCardId");
+  }
+
+  const eligibleCards = getCardsEligibleForMaximalEffect(player.hand, sourceCardId);
+
+  // If no action cards available, the effect cannot resolve
+  if (eligibleCards.length === 0) {
+    throw new Error("No action cards available to throw away for Maximal Effect");
+  }
+
+  // Create pending state for card selection
+  const pending: PendingMaximalEffect = {
+    sourceCardId,
+    multiplier: effect.multiplier,
+    effectKind: effect.effectKind,
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingMaximalEffect: pending,
+  };
+
+  const updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+
+  return {
+    state: updatedState,
+    description: `Maximal Effect (${effect.effectKind} ×${effect.multiplier}) requires throwing away an action card`,
+    requiresChoice: true, // Blocks further resolution until player selects
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register maximal effect handler with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerMaximalEffectEffects(): void {
+  registerEffect(
+    EFFECT_MAXIMAL_EFFECT,
+    (state, playerId, effect, sourceCardId) => {
+      const { playerIndex, player } = getPlayerContext(state, playerId);
+      return handleMaximalEffectEffect(
+        state,
+        playerIndex,
+        player,
+        effect as MaximalEffectEffect,
+        (sourceCardId as CardId | undefined) ?? null
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -105,6 +105,7 @@ import {
   EFFECT_WINGS_OF_NIGHT,
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
   EFFECT_DECOMPOSE,
+  EFFECT_MAXIMAL_EFFECT,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
   EFFECT_POSSESS_ENEMY,
@@ -243,6 +244,15 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
     // Decompose is resolvable if player has at least one action card in hand
     // (excluding wounds and the decompose card itself - but we approximate here
     // since sourceCardId may not be in hand yet when checking resolvability)
+    const hasActionCards = player.hand.some(
+      (c) => c !== CARD_WOUND && getActionCardColor(c) !== null
+    );
+    return hasActionCards;
+  },
+
+  [EFFECT_MAXIMAL_EFFECT]: (state, player, _effect) => {
+    // Maximal Effect is resolvable if player has at least one action card in hand
+    // (same eligibility as Decompose - action cards with a color)
     const hasActionCards = player.hand.some(
       (c) => c !== CARD_WOUND && getActionCardColor(c) !== null
     );

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -42,6 +42,7 @@ import {
   getDiscardForAttackOptions,
   getDiscardForCrystalOptions,
   getDecomposeOptions,
+  getMaximalEffectOptions,
   getArtifactCrystalColorOptions,
   getCrystalJoyReclaimOptions,
   getSteadyTempoOptions,
@@ -174,6 +175,13 @@ export function getValidActions(
       mode: "pending_decompose",
       turn: { canUndo: getTurnOptions(state, player).canUndo },
       decompose: getDecomposeOptions(state, player),
+    };
+  }
+  if (player.pendingMaximalEffect) {
+    return {
+      mode: "pending_maximal_effect",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      maximalEffect: getMaximalEffectOptions(state, player),
     };
   }
   if (player.pendingLevelUpRewards.length > 0) {

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -19,6 +19,7 @@ import type {
   DiscardForAttackOptions,
   DiscardForCrystalOptions,
   DecomposeOptions,
+  MaximalEffectOptions,
   ArtifactCrystalColorOptions,
   CrystalJoyReclaimOptions,
   SteadyTempoOptions,
@@ -34,6 +35,7 @@ import { getCardsEligibleForDiscardCost } from "../effects/discardEffects.js";
 import { getCardsEligibleForDiscardForAttack } from "../effects/swordOfJusticeEffects.js";
 import { getCardsEligibleForDiscardForCrystal } from "../effects/discardForCrystalEffects.js";
 import { getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
+import { getCardsEligibleForMaximalEffect } from "../effects/maximalEffectEffects.js";
 import { getCard } from "../helpers/cardLookup.js";
 import { isCardEligibleForReclaim } from "../rules/crystalJoyReclaim.js";
 
@@ -213,6 +215,29 @@ export function getDecomposeOptions(
     sourceCardId,
     availableCardIds,
     mode,
+  };
+}
+
+/**
+ * Get Maximal Effect options for the player.
+ * Returns options if player has a pending maximal effect state (Maximal Effect card).
+ */
+export function getMaximalEffectOptions(
+  _state: GameState,
+  player: Player
+): MaximalEffectOptions | undefined {
+  if (!player.pendingMaximalEffect) {
+    return undefined;
+  }
+
+  const { sourceCardId, multiplier, effectKind } = player.pendingMaximalEffect;
+  const availableCardIds = getCardsEligibleForMaximalEffect(player.hand, sourceCardId);
+
+  return {
+    sourceCardId,
+    availableCardIds,
+    multiplier,
+    effectKind,
   };
 }
 

--- a/packages/core/src/engine/validators/maximalEffectValidators.ts
+++ b/packages/core/src/engine/validators/maximalEffectValidators.ts
@@ -1,0 +1,77 @@
+/**
+ * Maximal Effect validators
+ *
+ * Validates RESOLVE_MAXIMAL_EFFECT actions for the Maximal Effect advanced action card,
+ * which requires throwing away an action card from hand to multiply its effect.
+ */
+
+import type { Validator, ValidationResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import { RESOLVE_MAXIMAL_EFFECT_ACTION } from "@mage-knight/shared";
+import { valid, invalid } from "./types.js";
+import {
+  MAXIMAL_EFFECT_REQUIRED,
+  MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+import { getCardsEligibleForMaximalEffect } from "../effects/maximalEffectEffects.js";
+
+/**
+ * Validate that the player has a pending maximal effect state
+ */
+export const validateHasPendingMaximalEffect: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingMaximalEffect) {
+    return invalid(
+      MAXIMAL_EFFECT_REQUIRED,
+      "No pending Maximal Effect to resolve"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate the maximal effect card selection
+ */
+export const validateMaximalEffectSelection: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_MAXIMAL_EFFECT_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingMaximalEffect) {
+    return valid(); // Let the other validator handle this
+  }
+
+  const cardId = action.cardId;
+
+  // Check card is eligible (action card, in hand, not the Maximal Effect card itself)
+  const eligibleCards = getCardsEligibleForMaximalEffect(player.hand, player.pendingMaximalEffect.sourceCardId);
+  if (!eligibleCards.includes(cardId)) {
+    return invalid(
+      MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE,
+      `Card ${cardId} is not eligible for Maximal Effect (must be an action card in hand, not the Maximal Effect card itself)`
+    );
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -16,6 +16,7 @@ import {
   RESOLVE_DISCARD_FOR_ATTACK_ACTION,
   RESOLVE_DISCARD_FOR_CRYSTAL_ACTION,
   RESOLVE_DECOMPOSE_ACTION,
+  RESOLVE_MAXIMAL_EFFECT_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   RESOLVE_HEX_COST_REDUCTION_ACTION,
   RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
@@ -81,6 +82,12 @@ import {
   validateHasPendingDecompose,
   validateDecomposeSelection,
 } from "../decomposeValidators.js";
+
+// Maximal Effect validators
+import {
+  validateHasPendingMaximalEffect,
+  validateMaximalEffectSelection,
+} from "../maximalEffectValidators.js";
 
 // Crystal Joy validators
 import {
@@ -167,6 +174,11 @@ export const choiceRegistry: Record<string, Validator[]> = {
     validateIsPlayersTurn,
     validateHasPendingDecompose,
     validateDecomposeSelection,
+  ],
+  [RESOLVE_MAXIMAL_EFFECT_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingMaximalEffect,
+    validateMaximalEffectSelection,
   ],
   [RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION]: [
     validateIsPlayersTurn,

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -259,6 +259,10 @@ export const ARTIFACT_CRYSTAL_INVALID_COLOR = "ARTIFACT_CRYSTAL_INVALID_COLOR" a
 export const DECOMPOSE_REQUIRED = "DECOMPOSE_REQUIRED" as const;
 export const DECOMPOSE_CARD_NOT_ELIGIBLE = "DECOMPOSE_CARD_NOT_ELIGIBLE" as const;
 
+// Maximal Effect validation codes
+export const MAXIMAL_EFFECT_REQUIRED = "MAXIMAL_EFFECT_REQUIRED" as const;
+export const MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE = "MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE" as const;
+
 // Meditation validation codes
 export const MEDITATION_PENDING_REQUIRED = "MEDITATION_PENDING_REQUIRED" as const;
 export const MEDITATION_INVALID_CARD_SELECTION = "MEDITATION_INVALID_CARD_SELECTION" as const;
@@ -539,6 +543,9 @@ export type ValidationErrorCode =
   // Decompose validation
   | typeof DECOMPOSE_REQUIRED
   | typeof DECOMPOSE_CARD_NOT_ELIGIBLE
+  // Maximal Effect validation
+  | typeof MAXIMAL_EFFECT_REQUIRED
+  | typeof MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE
   // Meditation validation
   | typeof MEDITATION_PENDING_REQUIRED
   | typeof MEDITATION_INVALID_CARD_SELECTION

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -112,6 +112,7 @@ import {
   EFFECT_RESOLVE_MIND_STEAL_SELECTION,
   EFFECT_ACTIVATE_BANNER_PROTECTION,
   EFFECT_DECOMPOSE,
+  EFFECT_MAXIMAL_EFFECT,
   EFFECT_HEAL_ALL_UNITS,
   EFFECT_WINGS_OF_NIGHT,
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
@@ -748,6 +749,29 @@ export interface DecomposeEffect {
   readonly type: typeof EFFECT_DECOMPOSE;
   /** "basic" = 2 crystals of matching color, "powered" = 1 of each non-matching color */
   readonly mode: "basic" | "powered";
+}
+
+/**
+ * Maximal Effect - throw away an action card from hand and use its effect multiple times.
+ * Used by the Maximal Effect advanced action card.
+ *
+ * Resolution:
+ * - Player selects an action card from hand (excluding Maximal Effect itself and wounds)
+ * - Card is permanently removed from the game (added to removedCards)
+ * - Basic mode: use target card's basic effect 3 times
+ * - Powered mode: use target card's powered effect 2 times (for free)
+ *
+ * Effects aggregate: e.g., 3x Attack 2 = single Attack 6.
+ * Cards with choices allow different choices per use.
+ *
+ * Creates pendingMaximalEffect state. Player selects card via RESOLVE_MAXIMAL_EFFECT action.
+ */
+export interface MaximalEffectEffect {
+  readonly type: typeof EFFECT_MAXIMAL_EFFECT;
+  /** How many times to execute the target card's effect */
+  readonly multiplier: number;
+  /** Whether to use the target card's "basic" or "powered" effect */
+  readonly effectKind: "basic" | "powered";
 }
 
 /**
@@ -1435,6 +1459,7 @@ export type CardEffect =
   | PolarizeManaEffect
   | DiscardForCrystalEffect
   | DecomposeEffect
+  | MaximalEffectEffect
   | RecruitDiscountEffect
   | ReadyUnitsForInfluenceEffect
   | ResolveReadyUnitForInfluenceEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -342,6 +342,12 @@ export const EFFECT_CHOOSE_BONUS_WITH_RISK = "choose_bonus_with_risk" as const;
 // Internal: resolve after player selects a bonus amount.
 export const EFFECT_RESOLVE_BONUS_CHOICE = "resolve_bonus_choice" as const;
 
+// === Maximal Effect ===
+// Throw away an action card from hand, then execute its effect multiple times.
+// Basic: use target card's basic effect 3 times.
+// Powered: use target card's powered effect 2 times (for free).
+export const EFFECT_MAXIMAL_EFFECT = "maximal_effect" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -245,6 +245,21 @@ export interface PendingDecompose {
 }
 
 /**
+ * Pending Maximal Effect resolution (Maximal Effect advanced action card).
+ * Player must select an action card from hand to throw away and execute its effect multiple times.
+ * - Basic mode: use target card's basic effect 3 times
+ * - Powered mode: use target card's powered effect 2 times (for free)
+ */
+export interface PendingMaximalEffect {
+  /** Source card that triggered the effect (Maximal Effect card) */
+  readonly sourceCardId: CardId;
+  /** How many times to execute the target card's effect */
+  readonly multiplier: number;
+  /** Whether to use the target card's "basic" or "powered" effect */
+  readonly effectKind: "basic" | "powered";
+}
+
+/**
  * Pending terrain cost reduction choice (Druidic Paths and similar effects).
  * Player must choose a hex coordinate or terrain type to apply cost reduction.
  */
@@ -453,6 +468,9 @@ export interface Player {
 
   // Decompose pending (throw away action card for crystals)
   readonly pendingDecompose: PendingDecompose | null;
+
+  // Maximal Effect pending (throw away action card and execute its effect multiple times)
+  readonly pendingMaximalEffect: PendingMaximalEffect | null;
 
   // Attack-based fame tracking (e.g., Axe Throw powered effect)
   readonly pendingAttackDefeatFame: readonly AttackDefeatFameTracker[];

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -570,6 +570,7 @@ export class GameServer {
       pendingDiscardForAttack: null,
       pendingDiscardForCrystal: null,
       pendingDecompose: null,
+      pendingMaximalEffect: null,
       pendingAttackDefeatFame: [],
       enemiesDefeatedThisTurn: 0,
       healingPoints: 0,

--- a/packages/server/src/__tests__/stateFilters.test.ts
+++ b/packages/server/src/__tests__/stateFilters.test.ts
@@ -100,6 +100,7 @@ function createMinimalGameState(): GameState {
         pendingDiscardForAttack: null,
         pendingDiscardForCrystal: null,
         pendingDecompose: null,
+        pendingMaximalEffect: null,
         pendingTerrainCostReduction: null,
         pendingAttackDefeatFame: [],
         enemiesDefeatedThisTurn: 0,

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -526,6 +526,14 @@ export interface ResolveDecomposeAction {
   readonly cardId: CardId;
 }
 
+// Maximal Effect action (throw away action card and use its effect multiple times)
+export const RESOLVE_MAXIMAL_EFFECT_ACTION = "RESOLVE_MAXIMAL_EFFECT" as const;
+export interface ResolveMaximalEffectAction {
+  readonly type: typeof RESOLVE_MAXIMAL_EFFECT_ACTION;
+  /** Card ID of the action card to throw away */
+  readonly cardId: CardId;
+}
+
 // Artifact crystal color choice action (Savage Harvesting - second step for artifacts)
 export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION = "RESOLVE_ARTIFACT_CRYSTAL_COLOR" as const;
 export interface ResolveArtifactCrystalColorAction {
@@ -811,6 +819,8 @@ export type PlayerAction =
   | ResolveMeditationAction
   // Decompose (throw away action card for crystals)
   | ResolveDecomposeAction
+  // Maximal Effect (throw away action card and multiply its effect)
+  | ResolveMaximalEffectAction
   // Artifact crystal color choice (Savage Harvesting - for artifacts)
   | ResolveArtifactCrystalColorAction
   // Combat

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -260,6 +260,9 @@ export type {
   ArtifactCrystalColorOptions,
   // Decompose options (throw away action card for crystals)
   DecomposeOptions,
+  // Maximal Effect options (throw away action card and multiply its effect)
+  MaximalEffectOptions,
+  PendingMaximalEffectState,
   // Crystal Joy reclaim options
   CrystalJoyReclaimOptions,
   // Steady Tempo deck placement options

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -860,6 +860,26 @@ export interface DecomposeOptions {
 }
 
 // ============================================================================
+// Maximal Effect (throw away action card and multiply its effect)
+// ============================================================================
+
+/**
+ * Options for Maximal Effect card resolution.
+ * Only present when player has a pending maximal effect state.
+ * Player must select an action card from hand to throw away.
+ */
+export interface MaximalEffectOptions {
+  /** Source card that triggered the effect (Maximal Effect card) */
+  readonly sourceCardId: CardId;
+  /** Action cards available to throw away (excludes Maximal Effect itself and wounds) */
+  readonly availableCardIds: readonly CardId[];
+  /** How many times the selected card's effect will be executed */
+  readonly multiplier: number;
+  /** Whether the target card's basic or powered effect will be used */
+  readonly effectKind: "basic" | "powered";
+}
+
+// ============================================================================
 // Unit Maintenance (Magic Familiars round-start)
 // ============================================================================
 
@@ -1137,6 +1157,12 @@ export interface PendingDecomposeState {
   readonly decompose: DecomposeOptions;
 }
 
+export interface PendingMaximalEffectState {
+  readonly mode: "pending_maximal_effect";
+  readonly turn: BlockingTurnOptions;
+  readonly maximalEffect: MaximalEffectOptions;
+}
+
 export interface PendingCrystalJoyState {
   readonly mode: "pending_crystal_joy_reclaim";
   readonly turn: BlockingTurnOptions;
@@ -1256,6 +1282,7 @@ export type ValidActions =
   | PendingDiscardForAttackState
   | PendingDiscardForCrystalState
   | PendingDecomposeState
+  | PendingMaximalEffectState
   | PendingArtifactCrystalColorState
   | PendingCrystalJoyState
   | PendingSteadyTempoState


### PR DESCRIPTION
## Summary
- Implement the Maximal Effect red advanced action card's core throw-away and effect multiplication system
- Basic: throw away an action card from hand, use its basic effect 3 times
- Powered (Red mana): throw away an action card, use its stronger effect 2 times (for free)
- Effects aggregate via CompoundEffect wrapping (e.g., 3× Attack 2 = Attack 6)
- Cards with choice effects (e.g., Rage) properly create pending choices for player resolution

## Changes
- **Type system**: Added `EFFECT_MAXIMAL_EFFECT` effect type, `MaximalEffectEffect` interface, `PendingMaximalEffect` on Player, `RESOLVE_MAXIMAL_EFFECT_ACTION` action, `MaximalEffectOptions` valid actions
- **Effect handler** (`maximalEffectEffects.ts`): Eligibility check (action cards only, no wounds/artifacts/spells/self), creates pending state
- **Command** (`resolveMaximalEffectCommand.ts`): Removes card permanently to `removedCards`, wraps N copies of target effect in CompoundEffect, resolves via existing effect system, handles choice effects via `applyChoiceOutcome`
- **Validators** (`maximalEffectValidators.ts`): Validates pending state exists and selected card is eligible
- **Valid actions** (`pending.ts`): Computes eligible cards for throw-away selection
- **Card definition**: Updated from placeholder `attack(3)`/`attack(6)` to proper `maximalEffect("basic", 3)`/`maximalEffect("powered", 2)`
- **Registration**: Effect handler, validators, factory, command type all wired into existing registries

## Test Plan
- 41 tests covering: eligibility filtering, resolvability, effect handler, basic/powered command execution, choice-based cards, error handling, undo, describeEffect, validators, permanent removal verification, card definition correctness
- Full suite: 4,030 tests pass, 0 failures

Closes #166