### PR TITLE
feat: implement Endless Gem Pouch artifact

### DIFF
--- a/packages/core/src/data/artifacts/endlessGemPouch.ts
+++ b/packages/core/src/data/artifacts/endlessGemPouch.ts
@@ -4,12 +4,61 @@
  *
  * Basic: Roll mana die twice. Gain crystal per color rolled (choose if gold).
  *        Fame +1 instead of crystal if black rolled.
- * Powered: Gain mana token of each basic color.
- *          Also get gold (day) or black (night) mana token.
+ * Powered (any color, destroy): Gain mana token of each basic color.
+ *          Also get gold (day) or black (night/underground) mana token.
+ *
+ * FAQ S1: In dungeon/tomb, powered effect grants black mana token (not gold).
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_ROLL_FOR_CRYSTALS,
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_MANA,
+} from "../../types/effectTypes.js";
+import { ifNightOrUnderground } from "../effectHelpers.js";
+import {
+  CARD_ENDLESS_GEM_POUCH,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_BLACK,
+  MANA_GOLD,
+} from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
 
-// TODO: Implement Endless Gem Pouch
-export const ENDLESS_GEM_POUCH_CARDS: Record<CardId, DeedCard> = {};
+const ENDLESS_GEM_POUCH: DeedCard = {
+  id: CARD_ENDLESS_GEM_POUCH,
+  name: "Endless Gem Pouch",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_SPECIAL],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: {
+    type: EFFECT_ROLL_FOR_CRYSTALS,
+    diceCount: 2,
+  },
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      { type: EFFECT_GAIN_MANA, color: MANA_RED },
+      { type: EFFECT_GAIN_MANA, color: MANA_BLUE },
+      { type: EFFECT_GAIN_MANA, color: MANA_GREEN },
+      { type: EFFECT_GAIN_MANA, color: MANA_WHITE },
+      ifNightOrUnderground(
+        { type: EFFECT_GAIN_MANA, color: MANA_BLACK },
+        { type: EFFECT_GAIN_MANA, color: MANA_GOLD },
+      ),
+    ],
+  },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const ENDLESS_GEM_POUCH_CARDS: Record<CardId, DeedCard> = {
+  [CARD_ENDLESS_GEM_POUCH]: ENDLESS_GEM_POUCH,
+};

--- a/packages/core/src/engine/__tests__/endlessGemPouch.test.ts
+++ b/packages/core/src/engine/__tests__/endlessGemPouch.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Tests for Endless Gem Pouch artifact
+ *
+ * Basic: Roll mana die twice. Gain crystal per color (choose if gold, Fame +1 if black).
+ * Powered (any color, destroy): Gain mana token of each basic color + gold (day) or black (night/underground).
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import {
+  EFFECT_ROLL_FOR_CRYSTALS,
+  EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+  EFFECT_COMPOUND,
+} from "../../types/effectTypes.js";
+import type {
+  RollForCrystalsEffect,
+  ResolveCrystalRollChoiceEffect,
+} from "../../types/cards.js";
+import {
+  CARD_ENDLESS_GEM_POUCH,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_GOLD,
+  MANA_BLACK,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+} from "@mage-knight/shared";
+import { createRng } from "../../utils/rng.js";
+import { ENDLESS_GEM_POUCH_CARDS } from "../../data/artifacts/endlessGemPouch.js";
+import { COMBAT_PHASE_RANGED_SIEGE } from "../../types/combat.js";
+
+describe("Endless Gem Pouch", () => {
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should be defined with correct properties", () => {
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH];
+      expect(card).toBeDefined();
+      expect(card!.name).toBe("Endless Gem Pouch");
+      expect(card!.destroyOnPowered).toBe(true);
+      expect(card!.sidewaysValue).toBe(1);
+      expect(card!.categories).toContain("special");
+    });
+
+    it("should be powered by any basic color", () => {
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH];
+      expect(card!.poweredBy).toEqual([MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE]);
+    });
+
+    it("should have roll for crystals basic effect with 2 dice", () => {
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH];
+      expect(card!.basicEffect).toEqual({
+        type: EFFECT_ROLL_FOR_CRYSTALS,
+        diceCount: 2,
+      });
+    });
+
+    it("should have compound powered effect with all basic mana + conditional", () => {
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH];
+      expect(card!.poweredEffect.type).toBe(EFFECT_COMPOUND);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT: Roll for Crystals
+  // ============================================================================
+
+  describe("Roll for Crystals", () => {
+    it("should roll specified number of dice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        rng: createRng(42),
+      });
+
+      const effect: RollForCrystalsEffect = {
+        type: EFFECT_ROLL_FOR_CRYSTALS,
+        diceCount: 2,
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      // RNG should have advanced by at least 2 (for 2 dice)
+      expect(result.state.rng.counter).toBeGreaterThanOrEqual(state.rng.counter + 2);
+      expect(result.description).toContain("Rolled:");
+    });
+
+    it("should gain crystal for basic color rolls (red/blue/green/white)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+
+      // Find a seed where both rolls are basic colors (not gold or black)
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollForCrystalsEffect = {
+          type: EFFECT_ROLL_FOR_CRYSTALS,
+          diceCount: 2,
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        // If no choice required and crystals gained, we found basic color rolls
+        if (!result.requiresChoice) {
+          const p = result.state.players[0]!;
+          const totalCrystals = p.crystals.red + p.crystals.blue + p.crystals.green + p.crystals.white;
+          const totalFame = p.fame;
+
+          // Should have gained some crystals and/or fame (from black rolls)
+          if (totalCrystals > 0 && totalFame === 0) {
+            // Pure crystal gain (no black rolls, no gold choices)
+            found = true;
+            expect(totalCrystals).toBeGreaterThanOrEqual(1);
+            break;
+          }
+        }
+      }
+
+      expect(found).toBe(true);
+    });
+
+    it("should gain Fame +1 for black roll instead of crystal", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+        fame: 0,
+      });
+
+      // Find a seed that produces at least one black roll
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollForCrystalsEffect = {
+          type: EFFECT_ROLL_FOR_CRYSTALS,
+          diceCount: 2,
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        // Check if fame was gained (indicates black roll)
+        if (result.state.players[0]!.fame > 0 && !result.requiresChoice) {
+          found = true;
+          expect(result.state.players[0]!.fame).toBeGreaterThanOrEqual(1);
+          expect(result.description).toContain("Black");
+          expect(result.description).toContain("Fame");
+          break;
+        }
+      }
+
+      expect(found).toBe(true);
+    });
+
+    it("should present choice when gold is rolled", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+
+      // Find a seed that produces at least one gold roll
+      let found = false;
+      for (let seed = 0; seed < 200; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollForCrystalsEffect = {
+          type: EFFECT_ROLL_FOR_CRYSTALS,
+          diceCount: 2,
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        if (result.requiresChoice) {
+          found = true;
+
+          // Should offer 4 basic color choices
+          expect(result.dynamicChoiceOptions).toHaveLength(4);
+
+          const options = result.dynamicChoiceOptions as readonly ResolveCrystalRollChoiceEffect[];
+          expect(options![0]!.type).toBe(EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE);
+          expect(options![0]!.chosenColor).toBe(MANA_RED);
+          expect(options![1]!.chosenColor).toBe(MANA_BLUE);
+          expect(options![2]!.chosenColor).toBe(MANA_GREEN);
+          expect(options![3]!.chosenColor).toBe(MANA_WHITE);
+          break;
+        }
+      }
+
+      expect(found).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // RESOLVE CRYSTAL ROLL CHOICE (Gold → Player Chooses)
+  // ============================================================================
+
+  describe("Resolve Crystal Roll Choice", () => {
+    it("should gain crystal of chosen color for gold roll", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      const effect: ResolveCrystalRollChoiceEffect = {
+        type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+        chosenColor: MANA_BLUE,
+        remainingResults: [],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      expect(result.state.players[0]!.crystals.blue).toBe(1);
+      expect(result.description).toContain("blue crystal");
+    });
+
+    it("should process remaining results after gold choice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      // Gold was first, red is remaining
+      const effect: ResolveCrystalRollChoiceEffect = {
+        type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+        chosenColor: MANA_GREEN,
+        remainingResults: [MANA_RED],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      expect(result.state.players[0]!.crystals.green).toBe(1);
+      expect(result.state.players[0]!.crystals.red).toBe(1);
+      expect(result.requiresChoice).toBeFalsy();
+    });
+
+    it("should handle remaining black result after gold choice (fame)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+        fame: 0,
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      const effect: ResolveCrystalRollChoiceEffect = {
+        type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+        chosenColor: MANA_WHITE,
+        remainingResults: [MANA_BLACK],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      expect(result.state.players[0]!.crystals.white).toBe(1);
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+
+    it("should chain another choice if remaining results contain gold", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+      });
+
+      // First gold resolved, but remaining has another gold
+      const effect: ResolveCrystalRollChoiceEffect = {
+        type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+        chosenColor: MANA_RED,
+        remainingResults: [MANA_GOLD],
+      };
+
+      const result = resolveEffect(state, "player1", effect);
+
+      expect(result.state.players[0]!.crystals.red).toBe(1);
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(4);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT: Rainbow Mana
+  // ============================================================================
+
+  describe("Powered Effect", () => {
+    it("should gain all basic mana tokens during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH]!;
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      const tokens = result.state.players[0]!.pureMana;
+      const colors = tokens.map((t) => t.color);
+
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLUE);
+      expect(colors).toContain(MANA_GREEN);
+      expect(colors).toContain(MANA_WHITE);
+      expect(colors).toContain(MANA_GOLD);
+      expect(colors).not.toContain(MANA_BLACK);
+      expect(tokens).toHaveLength(5);
+    });
+
+    it("should gain black mana instead of gold during night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH]!;
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      const tokens = result.state.players[0]!.pureMana;
+      const colors = tokens.map((t) => t.color);
+
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLUE);
+      expect(colors).toContain(MANA_GREEN);
+      expect(colors).toContain(MANA_WHITE);
+      expect(colors).toContain(MANA_BLACK);
+      expect(colors).not.toContain(MANA_GOLD);
+      expect(tokens).toHaveLength(5);
+    });
+
+    it("should gain black mana in dungeon/tomb (underground) even during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        combat: {
+          ...createUnitCombatState(COMBAT_PHASE_RANGED_SIEGE),
+          nightManaRules: true,  // Dungeon/Tomb
+          unitsAllowed: false,   // Dungeon/Tomb
+        },
+      });
+
+      const card = ENDLESS_GEM_POUCH_CARDS[CARD_ENDLESS_GEM_POUCH]!;
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      const tokens = result.state.players[0]!.pureMana;
+      const colors = tokens.map((t) => t.color);
+
+      expect(colors).toContain(MANA_RED);
+      expect(colors).toContain(MANA_BLUE);
+      expect(colors).toContain(MANA_GREEN);
+      expect(colors).toContain(MANA_WHITE);
+      expect(colors).toContain(MANA_BLACK);
+      expect(colors).not.toContain(MANA_GOLD);
+      expect(tokens).toHaveLength(5);
+    });
+  });
+
+  // ============================================================================
+  // PROBABILITY VERIFICATION
+  // ============================================================================
+
+  describe("probability distribution", () => {
+    it("should produce each mana color roughly equally (1/6 each)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_ENDLESS_GEM_POUCH],
+      });
+
+      const colorCounts: Record<string, number> = {
+        red: 0, blue: 0, green: 0, white: 0, gold: 0, black: 0,
+      };
+      const totalRolls = 600;
+
+      for (let seed = 0; seed < totalRolls; seed++) {
+        const state = createTestGameState({
+          players: [player],
+          rng: createRng(seed),
+        });
+
+        const effect: RollForCrystalsEffect = {
+          type: EFFECT_ROLL_FOR_CRYSTALS,
+          diceCount: 1,
+        };
+
+        const result = resolveEffect(state, "player1", effect);
+
+        // Check what happened
+        const p = result.state.players[0]!;
+        if (result.requiresChoice) {
+          // Gold roll
+          colorCounts["gold"]!++;
+        } else if (p.fame > 0) {
+          // Black roll
+          colorCounts["black"]!++;
+        } else if (p.crystals.red > 0) {
+          colorCounts["red"]!++;
+        } else if (p.crystals.blue > 0) {
+          colorCounts["blue"]!++;
+        } else if (p.crystals.green > 0) {
+          colorCounts["green"]!++;
+        } else if (p.crystals.white > 0) {
+          colorCounts["white"]!++;
+        }
+      }
+
+      // Each color should appear roughly 1/6 = 16.67% of the time
+      // Allow wide margin: 8-28% (48-168 out of 600)
+      for (const [color, count] of Object.entries(colorCounts)) {
+        const percentage = (count / totalRolls) * 100;
+        expect(percentage, `${color} at ${percentage.toFixed(1)}%`).toBeGreaterThan(8);
+        expect(percentage, `${color} at ${percentage.toFixed(1)}%`).toBeLessThan(28);
+      }
+    });
+  });
+});

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -59,6 +59,7 @@ import { registerManaStormEffects } from "./manaStormEffects.js";
 import { registerSourceOpeningEffects } from "./sourceOpeningEffects.js";
 import { registerHornOfWrathEffects } from "./hornOfWrathEffects.js";
 import { registerMaximalEffectEffects } from "./maximalEffectEffects.js";
+import { registerEndlessGemPouchEffects } from "./endlessGemPouchEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -218,4 +219,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Maximal Effect effects (throw away action card and multiply its effect)
   registerMaximalEffectEffects();
+
+  // Endless Gem Pouch effects (crystal rolling with gold choice and black fame)
+  registerEndlessGemPouchEffects();
 }

--- a/packages/core/src/engine/effects/endlessGemPouchEffects.ts
+++ b/packages/core/src/engine/effects/endlessGemPouchEffects.ts
@@ -1,0 +1,239 @@
+/**
+ * Endless Gem Pouch Effect Handlers
+ *
+ * Handles the basic effect: Roll mana dice and gain crystals based on results.
+ * - Basic colors (red/blue/green/white) → gain crystal of that color
+ * - Gold → player chooses which basic color crystal
+ * - Black → Fame +1 instead of crystal
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type {
+  RollForCrystalsEffect,
+  ResolveCrystalRollChoiceEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import { registerEffect } from "./effectRegistry.js";
+import {
+  EFFECT_ROLL_FOR_CRYSTALS,
+  EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
+} from "../../types/effectTypes.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { applyGainCrystal } from "./atomicResourceEffects.js";
+import { applyGainFame } from "./atomicProgressionEffects.js";
+import { nextRandom } from "../../utils/rng.js";
+import type { ManaColor, BasicManaColor } from "@mage-knight/shared";
+import {
+  ALL_MANA_COLORS,
+  MANA_GOLD,
+  MANA_BLACK,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  BASIC_MANA_COLORS,
+} from "@mage-knight/shared";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Roll a single mana die and return the color.
+ */
+function rollManaDie(rng: GameState["rng"]): { color: ManaColor; rng: GameState["rng"] } {
+  const { value, rng: newRng } = nextRandom(rng);
+  const index = Math.floor(value * ALL_MANA_COLORS.length);
+  const color = ALL_MANA_COLORS[index];
+  if (!color) {
+    const fallbackColor = ALL_MANA_COLORS[0];
+    if (!fallbackColor) {
+      throw new Error("ALL_MANA_COLORS is empty");
+    }
+    return { color: fallbackColor, rng: newRng };
+  }
+  return { color, rng: newRng };
+}
+
+/**
+ * Check if a mana color is a basic color (red/blue/green/white).
+ */
+function isBasicColor(color: ManaColor): color is BasicManaColor {
+  return (BASIC_MANA_COLORS as readonly string[]).includes(color);
+}
+
+/**
+ * Apply a single die result: basic color → crystal, black → fame.
+ * Returns null for gold (requires player choice).
+ */
+function applySingleResult(
+  state: GameState,
+  playerIndex: number,
+  color: ManaColor
+): { state: GameState; description: string } | null {
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  if (color === MANA_BLACK) {
+    const result = applyGainFame(state, playerIndex, player, 1);
+    return { state: result.state, description: `Black → Fame +1` };
+  }
+
+  if (isBasicColor(color)) {
+    const result = applyGainCrystal(state, playerIndex, player, color);
+    return { state: result.state, description: `${color} → ${color} crystal` };
+  }
+
+  // Gold requires player choice
+  return null;
+}
+
+// ============================================================================
+// EFFECT HANDLERS
+// ============================================================================
+
+/**
+ * Roll mana dice and process results.
+ * If any gold is rolled, presents a choice for the first gold.
+ * Otherwise, applies all results directly.
+ */
+function handleRollForCrystals(
+  state: GameState,
+  playerId: string,
+  effect: RollForCrystalsEffect
+): EffectResolutionResult {
+  const { playerIndex } = getPlayerContext(state, playerId);
+
+  let currentRng = state.rng;
+  const rollResults: ManaColor[] = [];
+
+  // Roll all dice
+  for (let i = 0; i < effect.diceCount; i++) {
+    const { color, rng: newRng } = rollManaDie(currentRng);
+    currentRng = newRng;
+    rollResults.push(color);
+  }
+
+  let currentState: GameState = { ...state, rng: currentRng };
+  const descriptions: string[] = [];
+
+  // Process each result in order, stopping at first gold for choice
+  for (let i = 0; i < rollResults.length; i++) {
+    const color = rollResults[i]!;
+
+    if (color === MANA_GOLD) {
+      // Collect remaining results (after this gold) to pass along
+      const remainingResults = rollResults.slice(i + 1);
+
+      // Present choice for this gold roll
+      const options: ResolveCrystalRollChoiceEffect[] = [
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_RED, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_BLUE, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_GREEN, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_WHITE, remainingResults },
+      ];
+
+      const rollStr = rollResults.join(", ");
+      const prevDesc = descriptions.length > 0 ? ` ${descriptions.join(". ")}.` : "";
+
+      return {
+        state: currentState,
+        description: `Rolled: ${rollStr}.${prevDesc} Choose crystal color for gold roll`,
+        requiresChoice: true,
+        dynamicChoiceOptions: options,
+      };
+    }
+
+    // Apply non-gold result
+    const result = applySingleResult(currentState, playerIndex, color);
+    if (result) {
+      currentState = result.state;
+      descriptions.push(result.description);
+    }
+  }
+
+  // No gold rolled — all results applied directly
+  const rollStr = rollResults.join(", ");
+  return {
+    state: currentState,
+    description: `Rolled: ${rollStr}. ${descriptions.join(". ")}`,
+  };
+}
+
+/**
+ * Resolve after player chooses a crystal color for a gold roll.
+ * Applies the chosen crystal, then processes remaining results.
+ */
+function handleResolveCrystalRollChoice(
+  state: GameState,
+  playerId: string,
+  effect: ResolveCrystalRollChoiceEffect
+): EffectResolutionResult {
+  const { playerIndex } = getPlayerContext(state, playerId);
+
+  let currentState = state;
+  const descriptions: string[] = [];
+
+  // Apply chosen crystal for the gold roll
+  const player = currentState.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+  const crystalResult = applyGainCrystal(currentState, playerIndex, player, effect.chosenColor);
+  currentState = crystalResult.state;
+  descriptions.push(`Gold → ${effect.chosenColor} crystal`);
+
+  // Process remaining results
+  for (let i = 0; i < effect.remainingResults.length; i++) {
+    const color = effect.remainingResults[i]!;
+
+    if (color === MANA_GOLD) {
+      // Another gold — present another choice
+      const remainingResults = effect.remainingResults.slice(i + 1);
+
+      const options: ResolveCrystalRollChoiceEffect[] = [
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_RED, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_BLUE, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_GREEN, remainingResults },
+        { type: EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, chosenColor: MANA_WHITE, remainingResults },
+      ];
+
+      const prevDesc = descriptions.join(". ");
+
+      return {
+        state: currentState,
+        description: `${prevDesc}. Choose crystal color for gold roll`,
+        requiresChoice: true,
+        dynamicChoiceOptions: options,
+      };
+    }
+
+    // Apply non-gold result
+    const result = applySingleResult(currentState, playerIndex, color);
+    if (result) {
+      currentState = result.state;
+      descriptions.push(result.description);
+    }
+  }
+
+  return {
+    state: currentState,
+    description: descriptions.join(". "),
+  };
+}
+
+// ============================================================================
+// REGISTRATION
+// ============================================================================
+
+export function registerEndlessGemPouchEffects(): void {
+  registerEffect(EFFECT_ROLL_FOR_CRYSTALS, (state, playerId, effect) => {
+    return handleRollForCrystals(state, playerId, effect as RollForCrystalsEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE, (state, playerId, effect) => {
+    return handleResolveCrystalRollChoice(state, playerId, effect as ResolveCrystalRollChoiceEffect);
+  });
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -123,6 +123,8 @@ import {
   EFFECT_ROLL_DIE_FOR_WOUND,
   EFFECT_CHOOSE_BONUS_WITH_RISK,
   EFFECT_RESOLVE_BONUS_CHOICE,
+  EFFECT_ROLL_FOR_CRYSTALS,
+  EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1414,6 +1416,26 @@ export interface ResolveBonusChoiceEffect {
   readonly woundColors: readonly ManaColor[];
 }
 
+/**
+ * Roll mana dice and gain crystals based on results.
+ * Basic colors → crystal of that color, gold → player chooses, black → Fame +1.
+ * Used by Endless Gem Pouch basic effect.
+ */
+export interface RollForCrystalsEffect {
+  readonly type: typeof EFFECT_ROLL_FOR_CRYSTALS;
+  readonly diceCount: number;
+}
+
+/**
+ * Internal: resolve after player chooses a crystal color for a gold roll.
+ * Applies the remaining crystal gains and fame from the roll results.
+ */
+export interface ResolveCrystalRollChoiceEffect {
+  readonly type: typeof EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE;
+  readonly chosenColor: BasicManaColor;
+  readonly remainingResults: readonly ManaColor[];
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1515,7 +1537,9 @@ export type CardEffect =
   | ResolvePossessEnemyEffect
   | RollDieForWoundEffect
   | ChooseBonusWithRiskEffect
-  | ResolveBonusChoiceEffect;
+  | ResolveBonusChoiceEffect
+  | RollForCrystalsEffect
+  | ResolveCrystalRollChoiceEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -348,6 +348,14 @@ export const EFFECT_RESOLVE_BONUS_CHOICE = "resolve_bonus_choice" as const;
 // Powered: use target card's powered effect 2 times (for free).
 export const EFFECT_MAXIMAL_EFFECT = "maximal_effect" as const;
 
+// === Endless Gem Pouch Crystal Rolling Effects ===
+// Roll mana dice and gain crystals based on results.
+// Basic colors → crystal of that color, gold → player chooses color, black → Fame +1.
+// Entry point: presents roll results and handles gold choices.
+export const EFFECT_ROLL_FOR_CRYSTALS = "roll_for_crystals" as const;
+// Internal: resolve after player chooses crystal color for a gold roll.
+export const EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE = "resolve_crystal_roll_choice" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.


### PR DESCRIPTION
## Summary
- Implement Endless Gem Pouch artifact card (#226)
- Basic effect: Roll mana die twice — basic colors gain crystal, gold lets player choose crystal color, black gives Fame +1
- Powered effect (destroy): Gain red, blue, green, white mana tokens + gold (day) or black (night/underground) mana token

## Changes
- New effect types: `EFFECT_ROLL_FOR_CRYSTALS` and `EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE`
- New effect handler: `endlessGemPouchEffects.ts` with crystal rolling logic and gold choice chaining
- Card definition in `endlessGemPouch.ts` with compound powered effect using `ifNightOrUnderground` conditional
- 16 tests covering card definition, basic effect rolls, gold choices, powered effect day/night/underground, and probability distribution

Closes #226