### PR TITLE
feat: implement Ancient Ruins site interaction and rewards

### DIFF
--- a/packages/core/src/engine/__tests__/altarTribute.test.ts
+++ b/packages/core/src/engine/__tests__/altarTribute.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Altar Tribute tests
+ *
+ * Tests for:
+ * - Paying altar tribute with mana tokens → fame + conquest
+ * - Paying altar tribute with crystals → crystals consumed
+ * - Rejection when insufficient mana / wrong color
+ * - Rejection when site already conquered
+ * - Ruins token discarded after tribute
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createAltarTributeCommand,
+} from "../commands/altarTributeCommand.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  hexKey,
+  MANA_SOURCE_TOKEN,
+  MANA_SOURCE_CRYSTAL,
+  FAME_GAINED,
+  ALTAR_TRIBUTE_PAID,
+  SITE_CONQUERED,
+  SHIELD_TOKEN_PLACED,
+  TERRAIN_PLAINS,
+  type RuinsTokenId,
+  type ManaSourceInfo,
+} from "@mage-knight/shared";
+import { SiteType } from "../../types/map.js";
+import type { Site, HexState, RuinsToken } from "../../types/map.js";
+import type { GameState } from "../../state/GameState.js";
+import type { RuinsTokenPiles } from "../helpers/ruinsTokenHelpers.js";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function createRuinsSite(isConquered = false): Site {
+  return {
+    type: SiteType.AncientRuins,
+    owner: isConquered ? "player1" : null,
+    isConquered,
+    isBurned: false,
+  };
+}
+
+function createRuinsToken(tokenId: string, isRevealed = true): RuinsToken {
+  return {
+    tokenId: tokenId as RuinsTokenId,
+    isRevealed,
+  };
+}
+
+function createAltarTributeState(
+  tokenId: string,
+  playerOverrides: Partial<Parameters<typeof createTestPlayer>[0]> = {},
+  siteOverrides: Partial<{ isConquered: boolean }> = {}
+): GameState {
+  const baseState = createTestGameState();
+  const playerCoord = { q: 0, r: 0 };
+
+  const site = createRuinsSite(siteOverrides.isConquered ?? false);
+  const ruinsToken = createRuinsToken(tokenId);
+
+  const siteHex: HexState = {
+    coord: playerCoord,
+    terrain: TERRAIN_PLAINS,
+    tileId: baseState.map.hexes[hexKey(playerCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+    site,
+    enemies: [],
+    shieldTokens: [],
+    rampagingEnemies: [],
+    ruinsToken,
+  };
+
+  const hexes: Record<string, HexState> = {
+    ...baseState.map.hexes,
+    [hexKey(playerCoord)]: siteHex,
+  };
+
+  const player = createTestPlayer({
+    id: "player1",
+    position: playerCoord,
+    hasTakenActionThisTurn: false,
+    hasCombattedThisTurn: false,
+    ...playerOverrides,
+  });
+
+  // Add the token to the draw pile so it exists in piles for discard
+  const ruinsTokenPiles: RuinsTokenPiles = {
+    drawPile: [],
+    discardPile: [],
+  };
+
+  return {
+    ...baseState,
+    players: [player],
+    turnOrder: ["player1"],
+    map: { ...baseState.map, hexes },
+    ruinsTokens: ruinsTokenPiles,
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("Altar Tribute", () => {
+  describe("basic blue altar", () => {
+    it("should consume mana tokens and grant fame", () => {
+      // altar_blue: blue mana cost 3, fame reward 7
+      const state = createAltarTributeState("altar_blue", {
+        pureMana: [
+          { color: "blue", source: "card" },
+          { color: "blue", source: "card" },
+          { color: "blue", source: "card" },
+        ],
+      });
+
+      const manaSources: ManaSourceInfo[] = [
+        { type: MANA_SOURCE_TOKEN, color: "blue" },
+        { type: MANA_SOURCE_TOKEN, color: "blue" },
+        { type: MANA_SOURCE_TOKEN, color: "blue" },
+      ];
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources,
+      });
+
+      const result = command.execute(state);
+
+      // Check fame gained event
+      const fameEvent = result.events.find(
+        (e) => e.type === FAME_GAINED
+      );
+      expect(fameEvent).toBeDefined();
+      expect(fameEvent).toMatchObject({
+        type: FAME_GAINED,
+        playerId: "player1",
+        amount: 7,
+      });
+
+      // Check altar tribute paid event
+      const tributeEvent = result.events.find(
+        (e) => e.type === ALTAR_TRIBUTE_PAID
+      );
+      expect(tributeEvent).toBeDefined();
+      expect(tributeEvent).toMatchObject({
+        type: ALTAR_TRIBUTE_PAID,
+        playerId: "player1",
+        manaColor: "blue",
+        manaCost: 3,
+        fameGained: 7,
+      });
+
+      // Check site conquered
+      const conquestEvent = result.events.find(
+        (e) => e.type === SITE_CONQUERED
+      );
+      expect(conquestEvent).toBeDefined();
+
+      // Check shield token placed
+      const shieldEvent = result.events.find(
+        (e) => e.type === SHIELD_TOKEN_PLACED
+      );
+      expect(shieldEvent).toBeDefined();
+
+      // Check mana tokens consumed
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.pureMana).toHaveLength(0);
+
+      // Check player has taken action
+      expect(player?.hasTakenActionThisTurn).toBe(true);
+      expect(player?.hasCombattedThisTurn).toBe(true);
+    });
+
+    it("should consume crystals when paying with crystals", () => {
+      const state = createAltarTributeState("altar_green", {
+        crystals: { red: 0, blue: 0, green: 3, white: 0 },
+      });
+
+      const manaSources: ManaSourceInfo[] = [
+        { type: MANA_SOURCE_CRYSTAL, color: "green" },
+        { type: MANA_SOURCE_CRYSTAL, color: "green" },
+        { type: MANA_SOURCE_CRYSTAL, color: "green" },
+      ];
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources,
+      });
+
+      const result = command.execute(state);
+
+      // Check crystals consumed
+      const player = result.state.players.find((p) => p.id === "player1");
+      expect(player?.crystals.green).toBe(0);
+
+      // Check fame gained (green altar: 7 fame)
+      expect(player?.fame).toBe(7);
+    });
+  });
+
+  describe("ruins token cleanup", () => {
+    it("should discard ruins token after tribute", () => {
+      const state = createAltarTributeState("altar_red", {
+        pureMana: [
+          { color: "red", source: "card" },
+          { color: "red", source: "card" },
+          { color: "red", source: "card" },
+        ],
+      });
+
+      const manaSources: ManaSourceInfo[] = [
+        { type: MANA_SOURCE_TOKEN, color: "red" },
+        { type: MANA_SOURCE_TOKEN, color: "red" },
+        { type: MANA_SOURCE_TOKEN, color: "red" },
+      ];
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources,
+      });
+
+      const result = command.execute(state);
+
+      // Ruins token should be removed from hex
+      const hex = result.state.map.hexes[hexKey({ q: 0, r: 0 })];
+      expect(hex?.ruinsToken).toBeNull();
+
+      // Token should be in the discard pile
+      expect(result.state.ruinsTokens.discardPile).toContain("altar_red");
+    });
+
+    it("should mark site as conquered with shield token", () => {
+      const state = createAltarTributeState("altar_white", {
+        pureMana: [
+          { color: "white", source: "card" },
+          { color: "white", source: "card" },
+          { color: "white", source: "card" },
+        ],
+      });
+
+      const manaSources: ManaSourceInfo[] = [
+        { type: MANA_SOURCE_TOKEN, color: "white" },
+        { type: MANA_SOURCE_TOKEN, color: "white" },
+        { type: MANA_SOURCE_TOKEN, color: "white" },
+      ];
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources,
+      });
+
+      const result = command.execute(state);
+
+      // Check site is conquered
+      const hex = result.state.map.hexes[hexKey({ q: 0, r: 0 })];
+      expect(hex?.site?.isConquered).toBe(true);
+      expect(hex?.site?.owner).toBe("player1");
+
+      // Check shield token placed
+      expect(hex?.shieldTokens).toContain("player1");
+    });
+  });
+
+  describe("error cases", () => {
+    it("should throw when player not found", () => {
+      const state = createAltarTributeState("altar_blue");
+
+      const command = createAltarTributeCommand({
+        playerId: "nonexistent",
+        manaSources: [],
+      });
+
+      expect(() => command.execute(state)).toThrow("Player not found");
+    });
+
+    it("should throw when no site at position", () => {
+      const baseState = createTestGameState();
+      const player = createTestPlayer({ id: "player1", position: { q: 0, r: 0 } });
+      const state = { ...baseState, players: [player], turnOrder: ["player1"] };
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources: [],
+      });
+
+      expect(() => command.execute(state)).toThrow("No site at player position");
+    });
+
+    it("should throw when no ruins token", () => {
+      const baseState = createTestGameState();
+      const playerCoord = { q: 0, r: 0 };
+      const siteHex: HexState = {
+        coord: playerCoord,
+        terrain: TERRAIN_PLAINS,
+        tileId: baseState.map.hexes[hexKey(playerCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+        site: createRuinsSite(),
+        enemies: [],
+        shieldTokens: [],
+        rampagingEnemies: [],
+        ruinsToken: null,
+      };
+
+      const player = createTestPlayer({ id: "player1", position: playerCoord });
+      const state = {
+        ...baseState,
+        players: [player],
+        turnOrder: ["player1"],
+        map: {
+          ...baseState.map,
+          hexes: { ...baseState.map.hexes, [hexKey(playerCoord)]: siteHex },
+        },
+      };
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources: [],
+      });
+
+      expect(() => command.execute(state)).toThrow("No ruins token at this hex");
+    });
+
+    it("should throw when token is not an altar", () => {
+      // enemy_green_brown_artifact is an enemy token, not an altar
+      const state = createAltarTributeState("enemy_green_brown_artifact");
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources: [],
+      });
+
+      expect(() => command.execute(state)).toThrow("Token is not an altar token");
+    });
+
+    it("should throw on undo attempt", () => {
+      const state = createAltarTributeState("altar_blue");
+
+      const command = createAltarTributeCommand({
+        playerId: "player1",
+        manaSources: [],
+      });
+
+      expect(() => command.undo(state)).toThrow("Cannot undo ALTAR_TRIBUTE");
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/ruinsRewards.test.ts
+++ b/packages/core/src/engine/__tests__/ruinsRewards.test.ts
@@ -1,0 +1,579 @@
+/**
+ * Ruins rewards tests
+ *
+ * Tests for:
+ * - handleRuinsTokenRewards: grants rewards after combat victory at ruins
+ * - selectRewardCommand: handles unit reward selection (free recruitment)
+ * - Crystal rewards: 4 crystals = +1 each basic color
+ * - Token-specific rewards (artifact, spell, AA, unit, compound)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  handleCombatHexCleanup,
+} from "../commands/combat/combatEndHandlers.js";
+import {
+  createSelectRewardCommand,
+  resetRewardUnitInstanceCounter,
+} from "../commands/selectRewardCommand.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  hexKey,
+  TERRAIN_PLAINS,
+  SITE_CONQUERED,
+  REWARD_QUEUED,
+  REWARD_SELECTED,
+  SITE_REWARD_SPELL,
+  SITE_REWARD_ADVANCED_ACTION,
+  SITE_REWARD_UNIT,
+  CARD_GAINED,
+  type RuinsTokenId,
+  type CardId,
+  type UnitId,
+  ENEMY_DIGGERS,
+  ELEMENT_PHYSICAL,
+} from "@mage-knight/shared";
+import { SiteType } from "../../types/map.js";
+import type { Site, HexState, RuinsToken } from "../../types/map.js";
+import type { GameState } from "../../state/GameState.js";
+import type { CombatState } from "../../types/combat.js";
+import { COMBAT_CONTEXT_STANDARD } from "../../types/combat.js";
+import { resetTokenCounter } from "../helpers/enemy/index.js";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function createRuinsSite(isConquered = false): Site {
+  return {
+    type: SiteType.AncientRuins,
+    owner: isConquered ? "player1" : null,
+    isConquered,
+    isBurned: false,
+  };
+}
+
+function createRuinsToken(tokenId: string, isRevealed = true): RuinsToken {
+  return {
+    tokenId: tokenId as RuinsTokenId,
+    isRevealed,
+  };
+}
+
+function createCompletedCombatState(): CombatState {
+  return {
+    enemies: [
+      {
+        instanceId: "enemy_1",
+        enemyId: ENEMY_DIGGERS,
+        definition: {
+          id: ENEMY_DIGGERS,
+          name: "Diggers",
+          color: "green" as const,
+          attack: 3,
+          attackElement: ELEMENT_PHYSICAL,
+          armor: 3,
+          fame: 2,
+          resistances: [],
+          abilities: [],
+        },
+        isBlocked: true,
+        isDefeated: true,
+        damageAssigned: true,
+        isRequiredForConquest: true,
+      },
+    ],
+    phase: "ATTACK" as CombatState["phase"],
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 2,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+    paidThugsDamageInfluence: {},
+    damageRedirects: {},
+  };
+}
+
+function createRuinsCombatVictoryState(
+  tokenId: string,
+  overrides: {
+    playerOverrides?: Partial<Parameters<typeof createTestPlayer>[0]>;
+    deckOverrides?: Partial<{ artifacts: CardId[] }>;
+  } = {}
+): GameState {
+  const baseState = createTestGameState();
+  const playerCoord = { q: 0, r: 0 };
+
+  const site = createRuinsSite();
+  const ruinsToken = createRuinsToken(tokenId);
+
+  const siteHex: HexState = {
+    coord: playerCoord,
+    terrain: TERRAIN_PLAINS,
+    tileId: baseState.map.hexes[hexKey(playerCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+    site,
+    enemies: [],
+    shieldTokens: [],
+    rampagingEnemies: [],
+    ruinsToken,
+  };
+
+  const hexes: Record<string, HexState> = {
+    ...baseState.map.hexes,
+    [hexKey(playerCoord)]: siteHex,
+  };
+
+  const player = createTestPlayer({
+    id: "player1",
+    position: playerCoord,
+    hasTakenActionThisTurn: true,
+    hasCombattedThisTurn: true,
+    ...overrides.playerOverrides,
+  });
+
+  return {
+    ...baseState,
+    players: [player],
+    turnOrder: ["player1"],
+    map: { ...baseState.map, hexes },
+    combat: null,
+    decks: {
+      ...baseState.decks,
+      artifacts: overrides.deckOverrides?.artifacts ?? [],
+    },
+  };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe("Ruins combat victory rewards", () => {
+  beforeEach(() => {
+    resetTokenCounter();
+  });
+
+  describe("handleCombatHexCleanup with ruins tokens", () => {
+    it("should grant artifact reward from enemy token (draws from deck)", () => {
+      // enemy_green_brown_artifact: enemies green+brown, reward: artifact
+      // Artifact rewards are auto-granted (drawn from deck), not queued
+      const artifactCard = "banner_of_command" as CardId;
+      const state = createRuinsCombatVictoryState("enemy_green_brown_artifact", {
+        deckOverrides: { artifacts: [artifactCard] },
+      });
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Should have conquest event
+      const conquestEvent = result.additionalEvents.find(
+        (e) => e.type === SITE_CONQUERED
+      );
+      expect(conquestEvent).toBeDefined();
+
+      // Artifact is auto-drawn from deck, emits CARD_GAINED not REWARD_QUEUED
+      const cardGainedEvent = result.additionalEvents.find(
+        (e) => e.type === CARD_GAINED
+      );
+      expect(cardGainedEvent).toBeDefined();
+      if (cardGainedEvent && "cardId" in cardGainedEvent) {
+        expect(cardGainedEvent.cardId).toBe(artifactCard);
+      }
+
+      // Player should have the artifact in their deck
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.deck).toContain(artifactCard);
+
+      // Ruins token should be cleared from hex
+      const hex = result.state.map.hexes[hexKey({ q: 0, r: 0 })];
+      expect(hex?.ruinsToken).toBeNull();
+
+      // Ruins token should be in discard pile
+      expect(result.state.ruinsTokens.discardPile).toContain("enemy_green_brown_artifact");
+    });
+
+    it("should queue spell reward from enemy token with spell reward", () => {
+      // enemy_brown_violet_spell_crystals: enemies brown+violet, rewards: spell + 4_crystals
+      // Spell rewards are queued (player chooses from offer)
+      const state = createRuinsCombatVictoryState("enemy_brown_violet_spell_crystals");
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Should have queued spell reward
+      const rewardEvents = result.additionalEvents.filter(
+        (e) => e.type === REWARD_QUEUED
+      );
+      const spellRewardEvent = rewardEvents.find(
+        (e) => "rewardType" in e && e.rewardType === SITE_REWARD_SPELL
+      );
+      expect(spellRewardEvent).toBeDefined();
+
+      // Should have granted 4 crystals (+1 each basic color)
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.crystals.red).toBe(1);
+      expect(updatedPlayer?.crystals.blue).toBe(1);
+      expect(updatedPlayer?.crystals.green).toBe(1);
+      expect(updatedPlayer?.crystals.white).toBe(1);
+    });
+
+    it("should grant 4 crystals (1 each basic color) from crystals reward", () => {
+      // enemy_green_green_crystals: enemies green+green, rewards: 4_crystals
+      const state = createRuinsCombatVictoryState("enemy_green_green_crystals");
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Player should have +1 of each basic crystal
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.crystals.red).toBe(1);
+      expect(updatedPlayer?.crystals.blue).toBe(1);
+      expect(updatedPlayer?.crystals.green).toBe(1);
+      expect(updatedPlayer?.crystals.white).toBe(1);
+    });
+
+    it("should queue unit reward from enemy token with unit reward", () => {
+      // enemy_green_violet_artifact: rewards: unit
+      const state = createRuinsCombatVictoryState("enemy_green_violet_artifact");
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Should have queued a unit reward
+      const rewardEvents = result.additionalEvents.filter(
+        (e) => e.type === REWARD_QUEUED
+      );
+      const unitRewardEvent = rewardEvents.find(
+        (e) => "rewardType" in e && e.rewardType === SITE_REWARD_UNIT
+      );
+      expect(unitRewardEvent).toBeDefined();
+
+      // Player should have the unit reward in pendingRewards
+      const updatedPlayer = result.state.players.find((p) => p.id === "player1");
+      expect(updatedPlayer?.pendingRewards).toContainEqual({ type: SITE_REWARD_UNIT });
+    });
+
+    it("should queue advanced action reward from enemy token", () => {
+      // enemy_green_red_artifact_unit: enemies green+red, rewards: artifact + advanced_action
+      // Provide an artifact in deck so artifact reward is auto-granted
+      const artifactCard = "banner_of_command" as CardId;
+      const state = createRuinsCombatVictoryState("enemy_green_red_artifact_unit", {
+        deckOverrides: { artifacts: [artifactCard] },
+      });
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Artifact should be auto-drawn (CARD_GAINED)
+      const cardGained = result.additionalEvents.find(
+        (e) => e.type === CARD_GAINED
+      );
+      expect(cardGained).toBeDefined();
+
+      // AA should be queued (REWARD_QUEUED)
+      const aaReward = result.additionalEvents.find(
+        (e) => e.type === REWARD_QUEUED && "rewardType" in e && e.rewardType === SITE_REWARD_ADVANCED_ACTION
+      );
+      expect(aaReward).toBeDefined();
+    });
+
+    it("should not grant rewards on defeat", () => {
+      const state = createRuinsCombatVictoryState("enemy_green_brown_artifact");
+      const combat: CombatState = {
+        ...createCompletedCombatState(),
+        enemies: [
+          {
+            ...createCompletedCombatState().enemies[0]!,
+            isDefeated: false,
+            isBlocked: false,
+          },
+        ],
+      };
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        false,
+        0,
+        [],
+        player
+      );
+
+      // Should NOT have conquest event
+      const conquestEvent = result.additionalEvents.find(
+        (e) => e.type === SITE_CONQUERED
+      );
+      expect(conquestEvent).toBeUndefined();
+
+      // Should NOT have reward events
+      const rewardEvents = result.additionalEvents.filter(
+        (e) => e.type === REWARD_QUEUED || e.type === CARD_GAINED
+      );
+      expect(rewardEvents).toHaveLength(0);
+    });
+
+    it("should skip ruins-specific rewards for non-enemy token", () => {
+      // Use altar token — should not grant ruins-specific rewards (altars don't use combat)
+      const state = createRuinsCombatVictoryState("altar_blue");
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Conquest should still happen
+      const conquestEvent = result.additionalEvents.find(
+        (e) => e.type === SITE_CONQUERED
+      );
+      expect(conquestEvent).toBeDefined();
+
+      // But no ruins-specific rewards queued or drawn
+      const rewardQueuedEvents = result.additionalEvents.filter(
+        (e) => e.type === REWARD_QUEUED
+      );
+      expect(rewardQueuedEvents).toHaveLength(0);
+
+      // No card gained from ruins reward
+      const cardGainedEvents = result.additionalEvents.filter(
+        (e) => e.type === CARD_GAINED
+      );
+      expect(cardGainedEvents).toHaveLength(0);
+    });
+
+    it("should discard ruins token after granting rewards", () => {
+      const state = createRuinsCombatVictoryState("enemy_green_green_crystals");
+      const combat = createCompletedCombatState();
+      const player = state.players.find((p) => p.id === "player1");
+
+      const result = handleCombatHexCleanup(
+        state,
+        combat,
+        "player1",
+        { q: 0, r: 0 },
+        true,
+        1,
+        [],
+        player
+      );
+
+      // Ruins token should be removed from hex
+      const hex = result.state.map.hexes[hexKey({ q: 0, r: 0 })];
+      expect(hex?.ruinsToken).toBeNull();
+
+      // Token should be in discard pile
+      expect(result.state.ruinsTokens.discardPile).toContain("enemy_green_green_crystals");
+    });
+  });
+});
+
+describe("Select unit reward", () => {
+  beforeEach(() => {
+    resetRewardUnitInstanceCounter();
+  });
+
+  it("should recruit free unit from offer", () => {
+    const unitId = "peasants" as UnitId;
+    const state = createTestGameState({
+      players: [
+        createTestPlayer({
+          id: "player1",
+          pendingRewards: [{ type: SITE_REWARD_UNIT }],
+        }),
+      ],
+      offers: {
+        ...createTestGameState().offers,
+        units: [unitId],
+      },
+    });
+
+    const command = createSelectRewardCommand({
+      playerId: "player1",
+      cardId: "dummy" as CardId,
+      rewardIndex: 0,
+      unitId,
+    });
+
+    const result = command.execute(state);
+
+    // Unit should be added to player
+    const player = result.state.players.find((p) => p.id === "player1");
+    expect(player?.units).toHaveLength(1);
+    expect(player?.units[0]?.unitId).toBe(unitId);
+
+    // Pending reward should be consumed
+    expect(player?.pendingRewards).toHaveLength(0);
+
+    // Unit should be removed from offer
+    expect(result.state.offers.units).not.toContain(unitId);
+
+    // Should emit reward selected event
+    const selectedEvent = result.events.find(
+      (e) => e.type === REWARD_SELECTED
+    );
+    expect(selectedEvent).toBeDefined();
+    if (selectedEvent && "rewardType" in selectedEvent) {
+      expect(selectedEvent.rewardType).toBe(SITE_REWARD_UNIT);
+    }
+  });
+
+  it("should disband unit when at command limit", () => {
+    const unitId = "peasants" as UnitId;
+    const existingUnit = {
+      instanceId: "existing_unit_1",
+      unitId: "foresters" as UnitId,
+      state: "ready" as const,
+      wounded: false,
+      usedResistanceThisCombat: false,
+    };
+
+    const state = createTestGameState({
+      players: [
+        createTestPlayer({
+          id: "player1",
+          units: [existingUnit],
+          pendingRewards: [{ type: SITE_REWARD_UNIT }],
+        }),
+      ],
+      offers: {
+        ...createTestGameState().offers,
+        units: [unitId],
+      },
+    });
+
+    const command = createSelectRewardCommand({
+      playerId: "player1",
+      cardId: "dummy" as CardId,
+      rewardIndex: 0,
+      unitId,
+      disbandUnitInstanceId: "existing_unit_1",
+    });
+
+    const result = command.execute(state);
+
+    // Old unit should be removed, new unit added
+    const player = result.state.players.find((p) => p.id === "player1");
+    expect(player?.units).toHaveLength(1);
+    expect(player?.units[0]?.unitId).toBe(unitId);
+    expect(
+      player?.units.find((u) => u.instanceId === "existing_unit_1")
+    ).toBeUndefined();
+  });
+
+  it("should throw when unitId not provided", () => {
+    const state = createTestGameState({
+      players: [
+        createTestPlayer({
+          id: "player1",
+          pendingRewards: [{ type: SITE_REWARD_UNIT }],
+        }),
+      ],
+    });
+
+    const command = createSelectRewardCommand({
+      playerId: "player1",
+      cardId: "dummy" as CardId,
+      rewardIndex: 0,
+    });
+
+    expect(() => command.execute(state)).toThrow("Unit reward requires unitId");
+  });
+
+  it("should throw when unit not in offer", () => {
+    const state = createTestGameState({
+      players: [
+        createTestPlayer({
+          id: "player1",
+          pendingRewards: [{ type: SITE_REWARD_UNIT }],
+        }),
+      ],
+      offers: {
+        ...createTestGameState().offers,
+        units: [],
+      },
+    });
+
+    const command = createSelectRewardCommand({
+      playerId: "player1",
+      cardId: "dummy" as CardId,
+      rewardIndex: 0,
+      unitId: "peasants" as UnitId,
+    });
+
+    expect(() => command.execute(state)).toThrow("Selected unit not in unit offer");
+  });
+});

--- a/packages/core/src/engine/__tests__/ruinsValidation.test.ts
+++ b/packages/core/src/engine/__tests__/ruinsValidation.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Ruins validation and valid actions tests
+ *
+ * Tests for:
+ * - validateAtRuinsWithAltar: must be at ruins with revealed altar token
+ * - validateSiteHasEnemiesOrDraws: ENTER_SITE requires enemy token at ruins
+ * - getSiteOptions: altar info shown for altar tokens, canEnter for enemy tokens
+ * - moveCommand: reveals face-down ruins tokens on entry
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  validateAtRuinsWithAltar,
+  validateSiteHasEnemiesOrDraws,
+} from "../validators/siteValidators.js";
+import { getSiteOptions } from "../validActions/sites.js";
+import { createMoveCommand } from "../commands/moveCommand.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  hexKey,
+  TERRAIN_PLAINS,
+  ENTER_SITE_ACTION,
+  ALTAR_TRIBUTE_ACTION,
+  RUINS_TOKEN_REVEALED,
+  type RuinsTokenId,
+} from "@mage-knight/shared";
+import { SiteType } from "../../types/map.js";
+import type { Site, HexState, RuinsToken } from "../../types/map.js";
+import type { GameState } from "../../state/GameState.js";
+import {
+  NO_SITE,
+  NOT_AT_RUINS,
+  NO_ALTAR_TOKEN,
+  SITE_ALREADY_CONQUERED,
+  NO_ENEMIES_AT_SITE,
+  NOT_ENEMY_TOKEN,
+} from "../validators/validationCodes.js";
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function createRuinsSite(isConquered = false): Site {
+  return {
+    type: SiteType.AncientRuins,
+    owner: isConquered ? "player1" : null,
+    isConquered,
+    isBurned: false,
+  };
+}
+
+function createRuinsToken(tokenId: string, isRevealed = true): RuinsToken {
+  return {
+    tokenId: tokenId as RuinsTokenId,
+    isRevealed,
+  };
+}
+
+function createStateWithRuins(
+  tokenId: string | null,
+  options: {
+    isConquered?: boolean;
+    isRevealed?: boolean;
+    playerOverrides?: Partial<Parameters<typeof createTestPlayer>[0]>;
+    siteType?: SiteType;
+  } = {}
+): GameState {
+  const baseState = createTestGameState();
+  const playerCoord = { q: 0, r: 0 };
+
+  const siteType = options.siteType ?? SiteType.AncientRuins;
+  const site: Site = {
+    type: siteType,
+    owner: options.isConquered ? "player1" : null,
+    isConquered: options.isConquered ?? false,
+    isBurned: false,
+  };
+
+  const ruinsToken = tokenId
+    ? createRuinsToken(tokenId, options.isRevealed ?? true)
+    : null;
+
+  const siteHex: HexState = {
+    coord: playerCoord,
+    terrain: TERRAIN_PLAINS,
+    tileId: baseState.map.hexes[hexKey(playerCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+    site,
+    enemies: [],
+    shieldTokens: [],
+    rampagingEnemies: [],
+    ruinsToken,
+  };
+
+  const hexes: Record<string, HexState> = {
+    ...baseState.map.hexes,
+    [hexKey(playerCoord)]: siteHex,
+  };
+
+  const player = createTestPlayer({
+    id: "player1",
+    position: playerCoord,
+    hasTakenActionThisTurn: false,
+    hasCombattedThisTurn: false,
+    ...options.playerOverrides,
+  });
+
+  return {
+    ...baseState,
+    players: [player],
+    turnOrder: ["player1"],
+    map: { ...baseState.map, hexes },
+  };
+}
+
+// =============================================================================
+// TESTS: validateAtRuinsWithAltar
+// =============================================================================
+
+describe("validateAtRuinsWithAltar", () => {
+  it("should pass for non-ALTAR_TRIBUTE actions", () => {
+    const state = createStateWithRuins("altar_blue");
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ENTER_SITE_ACTION,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("should pass when at ruins with revealed altar token", () => {
+    const state = createStateWithRuins("altar_blue");
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("should fail when not at a site", () => {
+    const baseState = createTestGameState();
+    const player = createTestPlayer({ id: "player1", position: { q: 0, r: 0 } });
+    const state = { ...baseState, players: [player], turnOrder: ["player1"] };
+
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NO_SITE);
+    }
+  });
+
+  it("should fail when not at Ancient Ruins", () => {
+    const state = createStateWithRuins("altar_blue", { siteType: SiteType.Village });
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NOT_AT_RUINS);
+    }
+  });
+
+  it("should fail when site already conquered", () => {
+    const state = createStateWithRuins("altar_blue", { isConquered: true });
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(SITE_ALREADY_CONQUERED);
+    }
+  });
+
+  it("should fail when no ruins token", () => {
+    const state = createStateWithRuins(null);
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NO_ALTAR_TOKEN);
+    }
+  });
+
+  it("should fail when ruins token not revealed", () => {
+    const state = createStateWithRuins("altar_blue", { isRevealed: false });
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NO_ALTAR_TOKEN);
+    }
+  });
+
+  it("should fail when token is enemy token (not altar)", () => {
+    const state = createStateWithRuins("enemy_green_brown_artifact");
+    const result = validateAtRuinsWithAltar(state, "player1", {
+      type: ALTAR_TRIBUTE_ACTION,
+      manaSources: [],
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NO_ALTAR_TOKEN);
+    }
+  });
+});
+
+// =============================================================================
+// TESTS: validateSiteHasEnemiesOrDraws for ruins
+// =============================================================================
+
+describe("validateSiteHasEnemiesOrDraws for ruins", () => {
+  it("should pass when ruins has enemy token", () => {
+    const state = createStateWithRuins("enemy_green_brown_artifact");
+    const result = validateSiteHasEnemiesOrDraws(state, "player1", {
+      type: ENTER_SITE_ACTION,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it("should fail when ruins has no token", () => {
+    const state = createStateWithRuins(null);
+    const result = validateSiteHasEnemiesOrDraws(state, "player1", {
+      type: ENTER_SITE_ACTION,
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NO_ENEMIES_AT_SITE);
+    }
+  });
+
+  it("should fail when ruins has altar token (must use ALTAR_TRIBUTE instead)", () => {
+    const state = createStateWithRuins("altar_blue");
+    const result = validateSiteHasEnemiesOrDraws(state, "player1", {
+      type: ENTER_SITE_ACTION,
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.error.code).toBe(NOT_ENEMY_TOKEN);
+    }
+  });
+});
+
+// =============================================================================
+// TESTS: getSiteOptions for ruins
+// =============================================================================
+
+describe("getSiteOptions for ruins", () => {
+  it("should show canEnter for ruins with enemy token", () => {
+    const state = createStateWithRuins("enemy_green_brown_artifact");
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options).toBeDefined();
+    expect(options?.canEnter).toBe(true);
+    expect(options?.enterDescription).toContain("Fight");
+    expect(options?.enterDescription).toContain("Green");
+    expect(options?.enterDescription).toContain("Brown");
+  });
+
+  it("should show canTribute for ruins with altar token", () => {
+    const state = createStateWithRuins("altar_blue");
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options).toBeDefined();
+    // canEnter should be false for altar tokens
+    expect(options?.canEnter).toBe(false);
+    // Altar tribute info should be present
+    expect((options as Record<string, unknown>).canTribute).toBe(true);
+    expect((options as Record<string, unknown>).altarManaColor).toBe("blue");
+    expect((options as Record<string, unknown>).altarManaCost).toBe(3);
+    expect((options as Record<string, unknown>).altarFameReward).toBe(7);
+  });
+
+  it("should not show canTribute when site already conquered", () => {
+    const state = createStateWithRuins("altar_blue", { isConquered: true });
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options).toBeDefined();
+    expect((options as Record<string, unknown>).canTribute).toBeUndefined();
+  });
+
+  it("should not show canTribute when player has already acted", () => {
+    const state = createStateWithRuins("altar_blue", {
+      playerOverrides: { hasTakenActionThisTurn: true },
+    });
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options).toBeDefined();
+    expect((options as Record<string, unknown>).canTribute).toBeUndefined();
+  });
+
+  it("should show token-specific conquest reward for enemy tokens", () => {
+    const state = createStateWithRuins("enemy_green_brown_artifact");
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options?.conquestReward).toContain("Artifact");
+  });
+
+  it("should show fame reward for altar tokens", () => {
+    const state = createStateWithRuins("altar_blue");
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options?.conquestReward).toContain("7 Fame");
+  });
+
+  it("should show compound rewards for tokens with multiple rewards", () => {
+    // enemy_green_red_artifact_unit: rewards: artifact + advanced_action
+    const state = createStateWithRuins("enemy_green_red_artifact_unit");
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    expect(options?.conquestReward).toContain("Artifact");
+    expect(options?.conquestReward).toContain("Advanced Action");
+  });
+
+  it("should show unrevealed token fallback message", () => {
+    const state = createStateWithRuins("altar_blue", { isRevealed: false });
+    const player = state.players[0]!;
+
+    const options = getSiteOptions(state, player);
+    // With unrevealed token, should show generic message
+    expect(options?.conquestReward).toBe("Depends on token");
+  });
+});
+
+// =============================================================================
+// TESTS: moveCommand ruins token reveal
+// =============================================================================
+
+describe("moveCommand ruins token reveal", () => {
+  it("should reveal face-down ruins token when moving to hex", () => {
+    const baseState = createTestGameState();
+    const fromCoord = { q: 1, r: 0 };
+    const toCoord = { q: 0, r: 0 };
+
+    // Create destination hex with unrevealed ruins token
+    const ruinsToken = createRuinsToken("altar_green", false);
+    const destinationHex: HexState = {
+      coord: toCoord,
+      terrain: TERRAIN_PLAINS,
+      tileId: baseState.map.hexes[hexKey(toCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+      site: createRuinsSite(),
+      enemies: [],
+      shieldTokens: [],
+      rampagingEnemies: [],
+      ruinsToken,
+    };
+
+    const hexes: Record<string, HexState> = {
+      ...baseState.map.hexes,
+      [hexKey(toCoord)]: destinationHex,
+    };
+
+    const player = createTestPlayer({
+      id: "player1",
+      position: fromCoord,
+      movePoints: 4,
+    });
+
+    const state: GameState = {
+      ...baseState,
+      players: [player],
+      turnOrder: ["player1"],
+      map: { ...baseState.map, hexes },
+    };
+
+    const command = createMoveCommand({
+      playerId: "player1",
+      from: fromCoord,
+      to: toCoord,
+      terrainCost: 2,
+      hadMovedThisTurn: false,
+    });
+
+    const result = command.execute(state);
+
+    // Token should now be revealed on the hex
+    const updatedHex = result.state.map.hexes[hexKey(toCoord)];
+    expect(updatedHex?.ruinsToken?.isRevealed).toBe(true);
+
+    // Should emit RUINS_TOKEN_REVEALED event
+    const revealEvent = result.events.find(
+      (e) => e.type === RUINS_TOKEN_REVEALED
+    );
+    expect(revealEvent).toBeDefined();
+    if (revealEvent && "tokenId" in revealEvent) {
+      expect(revealEvent.tokenId).toBe("altar_green");
+    }
+  });
+
+  it("should not emit reveal event for already-revealed token", () => {
+    const baseState = createTestGameState();
+    const fromCoord = { q: 1, r: 0 };
+    const toCoord = { q: 0, r: 0 };
+
+    // Create destination hex with already-revealed ruins token
+    const ruinsToken = createRuinsToken("altar_green", true);
+    const destinationHex: HexState = {
+      coord: toCoord,
+      terrain: TERRAIN_PLAINS,
+      tileId: baseState.map.hexes[hexKey(toCoord)]?.tileId ?? ("StartingTileA" as import("../../types/map.js").TileId),
+      site: createRuinsSite(),
+      enemies: [],
+      shieldTokens: [],
+      rampagingEnemies: [],
+      ruinsToken,
+    };
+
+    const hexes: Record<string, HexState> = {
+      ...baseState.map.hexes,
+      [hexKey(toCoord)]: destinationHex,
+    };
+
+    const player = createTestPlayer({
+      id: "player1",
+      position: fromCoord,
+      movePoints: 4,
+    });
+
+    const state: GameState = {
+      ...baseState,
+      players: [player],
+      turnOrder: ["player1"],
+      map: { ...baseState.map, hexes },
+    };
+
+    const command = createMoveCommand({
+      playerId: "player1",
+      from: fromCoord,
+      to: toCoord,
+      terrainCost: 2,
+      hadMovedThisTurn: false,
+    });
+
+    const result = command.execute(state);
+
+    // Should NOT emit RUINS_TOKEN_REVEALED event (already revealed)
+    const revealEvent = result.events.find(
+      (e) => e.type === RUINS_TOKEN_REVEALED
+    );
+    expect(revealEvent).toBeUndefined();
+  });
+});

--- a/packages/core/src/engine/commands/altarTributeCommand.ts
+++ b/packages/core/src/engine/commands/altarTributeCommand.ts
@@ -1,0 +1,165 @@
+/**
+ * Altar Tribute command - pays mana at an Ancient Ruins altar token
+ *
+ * This command handles the ALTAR_TRIBUTE action:
+ * - Validates the player is at ruins with a revealed altar token
+ * - Consumes mana of the required color(s)
+ * - Grants fame reward
+ * - Conquers the site
+ * - Discards the ruins token
+ *
+ * This is an irreversible action (mana consumed, fame gained, site conquered).
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, ManaSourceInfo } from "@mage-knight/shared";
+import {
+  hexKey,
+  getRuinsTokenDefinition,
+  isAltarToken,
+  createAltarTributePaidEvent,
+} from "@mage-knight/shared";
+import type { Player } from "../../types/player.js";
+import type { HexState } from "../../types/map.js";
+import { ALTAR_TRIBUTE_COMMAND } from "./commandTypes.js";
+import { consumeMultipleMana } from "./helpers/manaConsumptionHelpers.js";
+import { grantFameReward } from "../helpers/rewards/handlers.js";
+import { createConquerSiteCommand } from "./conquerSiteCommand.js";
+import { discardRuinsToken } from "../helpers/ruinsTokenHelpers.js";
+
+export { ALTAR_TRIBUTE_COMMAND };
+
+export interface AltarTributeCommandParams {
+  readonly playerId: string;
+  readonly manaSources: readonly ManaSourceInfo[];
+}
+
+export function createAltarTributeCommand(
+  params: AltarTributeCommandParams
+): Command {
+  return {
+    type: ALTAR_TRIBUTE_COMMAND,
+    playerId: params.playerId,
+    isReversible: false,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex] as Player;
+      if (!player.position) {
+        throw new Error("Player has no position");
+      }
+
+      const key = hexKey(player.position);
+      const hex = state.map.hexes[key];
+      if (!hex?.site) {
+        throw new Error("No site at player position");
+      }
+
+      if (!hex.ruinsToken) {
+        throw new Error("No ruins token at this hex");
+      }
+
+      const tokenDef = getRuinsTokenDefinition(hex.ruinsToken.tokenId);
+      if (!tokenDef || !isAltarToken(tokenDef)) {
+        throw new Error("Token is not an altar token");
+      }
+
+      const events: GameEvent[] = [];
+      let updatedState = state;
+
+      // 1. Consume mana
+      const manaResult = consumeMultipleMana(
+        player,
+        state.source,
+        params.manaSources,
+        params.playerId
+      );
+      let updatedPlayer = manaResult.player;
+      const updatedSource = manaResult.source;
+
+      // 2. Mark action taken
+      updatedPlayer = {
+        ...updatedPlayer,
+        hasTakenActionThisTurn: true,
+        hasCombattedThisTurn: true,
+      };
+
+      // Update player and source in state
+      const updatedPlayers = [...updatedState.players];
+      updatedPlayers[playerIndex] = updatedPlayer;
+      updatedState = {
+        ...updatedState,
+        players: updatedPlayers,
+        source: updatedSource,
+      };
+
+      // 3. Grant fame reward
+      const fameResult = grantFameReward(
+        updatedState,
+        params.playerId,
+        tokenDef.fameReward
+      );
+      updatedState = fameResult.state;
+      events.push(...fameResult.events);
+
+      // 4. Emit altar tribute event
+      events.push(
+        createAltarTributePaidEvent(
+          params.playerId,
+          tokenDef.manaColor,
+          tokenDef.manaCost,
+          tokenDef.fameReward
+        )
+      );
+
+      // 5. Conquer site (no additional reward for altars — fame was the reward)
+      const conquestResult = createConquerSiteCommand({
+        playerId: params.playerId,
+        hexCoord: player.position,
+      }).execute(updatedState);
+      updatedState = conquestResult.state;
+      events.push(...conquestResult.events);
+
+      // 6. Discard ruins token from hex and add to discard pile
+      const updatedRuinsTokens = discardRuinsToken(
+        updatedState.ruinsTokens,
+        hex.ruinsToken.tokenId
+      );
+
+      const conqueredHex = updatedState.map.hexes[key];
+      if (conqueredHex) {
+        const updatedHex: HexState = {
+          ...conqueredHex,
+          ruinsToken: null,
+        };
+        updatedState = {
+          ...updatedState,
+          ruinsTokens: updatedRuinsTokens,
+          map: {
+            ...updatedState.map,
+            hexes: {
+              ...updatedState.map.hexes,
+              [key]: updatedHex,
+            },
+          },
+        };
+      }
+
+      return {
+        state: updatedState,
+        events,
+      };
+    },
+
+    undo(_state: GameState): CommandResult {
+      throw new Error("Cannot undo ALTAR_TRIBUTE");
+    },
+  };
+}

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -35,6 +35,7 @@ export const CONQUER_SITE_COMMAND = "CONQUER_SITE" as const;
 
 // Adventure site commands
 export const ENTER_SITE_COMMAND = "ENTER_SITE" as const;
+export const ALTAR_TRIBUTE_COMMAND = "ALTAR_TRIBUTE" as const;
 
 // Challenge rampaging command
 export const CHALLENGE_RAMPAGING_COMMAND = "CHALLENGE_RAMPAGING" as const;

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -82,6 +82,7 @@ import {
   RESOLVE_TERRAIN_COST_REDUCTION_ACTION,
   RESOLVE_UNIT_MAINTENANCE_ACTION,
   RESOLVE_MEDITATION_ACTION,
+  ALTAR_TRIBUTE_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -144,6 +145,7 @@ export {
 export {
   createInteractCommandFromAction,
   createEnterSiteCommandFromAction,
+  createAltarTributeCommandFromAction,
   createResolveGladeWoundCommandFromAction,
   createResolveDeepMineCommandFromAction,
   createBurnMonasteryCommandFromAction,
@@ -254,6 +256,7 @@ import {
 import {
   createInteractCommandFromAction,
   createEnterSiteCommandFromAction,
+  createAltarTributeCommandFromAction,
   createResolveGladeWoundCommandFromAction,
   createResolveDeepMineCommandFromAction,
   createBurnMonasteryCommandFromAction,
@@ -343,6 +346,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [INTERACT_ACTION]: createInteractCommandFromAction,
   [ANNOUNCE_END_OF_ROUND_ACTION]: createAnnounceEndOfRoundCommandFromAction,
   [ENTER_SITE_ACTION]: createEnterSiteCommandFromAction,
+  [ALTAR_TRIBUTE_ACTION]: createAltarTributeCommandFromAction,
   [SELECT_TACTIC_ACTION]: createSelectTacticCommandFromAction,
   [SELECT_REWARD_ACTION]: createSelectRewardCommandFromAction,
   [ACTIVATE_TACTIC_ACTION]: createActivateTacticCommandFromAction,

--- a/packages/core/src/engine/commands/factories/offers.ts
+++ b/packages/core/src/engine/commands/factories/offers.ts
@@ -13,7 +13,7 @@
  */
 
 import type { CommandFactory } from "./types.js";
-import type { PlayerAction, CardId, SkillId } from "@mage-knight/shared";
+import type { PlayerAction, CardId, SkillId, UnitId } from "@mage-knight/shared";
 import {
   BUY_SPELL_ACTION,
   LEARN_ADVANCED_ACTION_ACTION,
@@ -100,6 +100,8 @@ export const createSelectRewardCommandFromAction: CommandFactory = (
     playerId,
     cardId: action.cardId,
     rewardIndex: action.rewardIndex,
+    unitId: action.unitId as UnitId | undefined,
+    disbandUnitInstanceId: action.disbandUnitInstanceId,
   });
 };
 

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -21,6 +21,7 @@ import type { PlayerAction, GladeWoundChoice, BasicManaColor, CardId } from "@ma
 import {
   INTERACT_ACTION,
   ENTER_SITE_ACTION,
+  ALTAR_TRIBUTE_ACTION,
   RESOLVE_GLADE_WOUND_ACTION,
   RESOLVE_DEEP_MINE_ACTION,
   BURN_MONASTERY_ACTION,
@@ -33,6 +34,7 @@ import {
 } from "@mage-knight/shared";
 import { createInteractCommand } from "../interactCommand.js";
 import { createEnterSiteCommand } from "../enterSiteCommand.js";
+import { createAltarTributeCommand } from "../altarTributeCommand.js";
 import { createResolveGladeWoundCommand } from "../resolveGladeWoundCommand.js";
 import { createResolveDeepMineChoiceCommand } from "../resolveDeepMineChoiceCommand.js";
 import { createBurnMonasteryCommand } from "../burnMonasteryCommand.js";
@@ -105,6 +107,22 @@ export const createEnterSiteCommandFromAction: CommandFactory = (
 ) => {
   if (action.type !== ENTER_SITE_ACTION) return null;
   return createEnterSiteCommand({ playerId });
+};
+
+/**
+ * Altar tribute command factory.
+ * Creates a command to pay tribute at an altar ruins token.
+ */
+export const createAltarTributeCommandFromAction: CommandFactory = (
+  _state,
+  playerId,
+  action
+) => {
+  if (action.type !== ALTAR_TRIBUTE_ACTION) return null;
+  return createAltarTributeCommand({
+    playerId,
+    manaSources: action.manaSources,
+  });
 };
 
 /**

--- a/packages/core/src/engine/validators/registry/interactionRegistry.ts
+++ b/packages/core/src/engine/validators/registry/interactionRegistry.ts
@@ -1,10 +1,10 @@
 /**
  * Interaction action validator registry
- * Handles INTERACT_ACTION and ENTER_SITE_ACTION
+ * Handles INTERACT_ACTION, ENTER_SITE_ACTION, and ALTAR_TRIBUTE_ACTION
  */
 
 import type { Validator } from "../types.js";
-import { INTERACT_ACTION, ENTER_SITE_ACTION } from "@mage-knight/shared";
+import { INTERACT_ACTION, ENTER_SITE_ACTION, ALTAR_TRIBUTE_ACTION } from "@mage-knight/shared";
 
 // Turn validators
 import {
@@ -41,6 +41,7 @@ import {
   validateAtAdventureSite,
   validateSiteNotConquered,
   validateSiteHasEnemiesOrDraws,
+  validateAtRuinsWithAltar,
 } from "../siteValidators.js";
 
 export const interactionRegistry: Record<string, Validator[]> = {
@@ -67,5 +68,16 @@ export const interactionRegistry: Record<string, Validator[]> = {
     validateAtAdventureSite,
     validateSiteNotConquered,
     validateSiteHasEnemiesOrDraws,
+  ],
+  [ALTAR_TRIBUTE_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNotInCombat,
+    validateNoChoicePending,
+    validateNoPendingLevelUpRewards,
+    validateMustAnnounceEndOfRound,
+    validateNotRestingForEnterSite, // Cannot tribute while resting
+    validateHasNotActed,
+    validateAtRuinsWithAltar,
   ],
 };

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -184,6 +184,10 @@ export const UNIT_TYPE_MISMATCH = "UNIT_TYPE_MISMATCH" as const;
 export const NOT_ADVENTURE_SITE = "NOT_ADVENTURE_SITE" as const;
 export const SITE_ALREADY_CONQUERED = "SITE_ALREADY_CONQUERED" as const;
 export const NO_ENEMIES_AT_SITE = "NO_ENEMIES_AT_SITE" as const;
+// Ruins / Altar validation codes
+export const NOT_AT_RUINS = "NOT_AT_RUINS" as const;
+export const NO_ALTAR_TOKEN = "NO_ALTAR_TOKEN" as const;
+export const NOT_ENEMY_TOKEN = "NOT_ENEMY_TOKEN" as const;
 
 // Dungeon/Tomb combat restriction codes
 export const UNITS_NOT_ALLOWED = "UNITS_NOT_ALLOWED" as const;
@@ -482,6 +486,9 @@ export type ValidationErrorCode =
   | typeof NOT_ADVENTURE_SITE
   | typeof SITE_ALREADY_CONQUERED
   | typeof NO_ENEMIES_AT_SITE
+  | typeof NOT_AT_RUINS
+  | typeof NO_ALTAR_TOKEN
+  | typeof NOT_ENEMY_TOKEN
   // Dungeon/Tomb combat restriction
   | typeof UNITS_NOT_ALLOWED
   | typeof GOLD_MANA_NOT_ALLOWED

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -42,6 +42,13 @@ export interface EnterSiteAction {
   readonly type: typeof ENTER_SITE_ACTION;
 }
 
+// Altar tribute action (Ancient Ruins)
+export const ALTAR_TRIBUTE_ACTION = "ALTAR_TRIBUTE" as const;
+export interface AltarTributeAction {
+  readonly type: typeof ALTAR_TRIBUTE_ACTION;
+  readonly manaSources: readonly ManaSourceInfo[];
+}
+
 // Burn monastery action
 export const BURN_MONASTERY_ACTION = "BURN_MONASTERY" as const;
 export interface BurnMonasteryAction {
@@ -421,6 +428,8 @@ export interface SelectRewardAction {
   readonly type: typeof SELECT_REWARD_ACTION;
   readonly cardId: CardId; // The card selected from the offer
   readonly rewardIndex: number; // Which pending reward this selection is for (0 = first)
+  readonly unitId?: UnitId; // For unit rewards: the unit to recruit from offer
+  readonly disbandUnitInstanceId?: string; // For unit rewards: unit to disband if at command limit
 }
 
 // Magical Glade wound discard choice
@@ -741,6 +750,7 @@ export type PlayerAction =
   | ExploreAction
   // Adventure sites
   | EnterSiteAction
+  | AltarTributeAction
   | BurnMonasteryAction
   | PlunderVillageAction
   // Turn structure

--- a/packages/shared/src/events/index.ts
+++ b/packages/shared/src/events/index.ts
@@ -281,6 +281,8 @@ import type {
   MonasteryBurnStartedEvent,
   MonasteryBurnedEvent,
   VillagePlunderedEvent,
+  RuinsTokenRevealedEvent,
+  AltarTributePaidEvent,
 } from "./sites.js";
 
 import type { InvalidActionEvent } from "./validation.js";
@@ -483,6 +485,9 @@ export type GameEvent =
   | MonasteryBurnedEvent
   // Village plundering
   | VillagePlunderedEvent
+  // Ruins tokens
+  | RuinsTokenRevealedEvent
+  | AltarTributePaidEvent
   // Cooperative assault
   | CooperativeAssaultProposedEvent
   | CooperativeAssaultResponseEvent

--- a/packages/shared/src/events/sites/adventure.ts
+++ b/packages/shared/src/events/sites/adventure.ts
@@ -416,6 +416,89 @@ export function isMonasteryBurnedEvent(event: {
 }
 
 // ============================================================================
+// RUINS_TOKEN_REVEALED
+// ============================================================================
+
+/**
+ * Event type constant for revealing a ruins token.
+ * @see RuinsTokenRevealedEvent
+ */
+export const RUINS_TOKEN_REVEALED = "RUINS_TOKEN_REVEALED" as const;
+
+/**
+ * Emitted when a face-down ruins token is revealed.
+ *
+ * Ruins tokens are placed face-down at night and revealed when a player
+ * enters the hex.
+ */
+export interface RuinsTokenRevealedEvent {
+  readonly type: typeof RUINS_TOKEN_REVEALED;
+  readonly playerId: string;
+  readonly hexCoord: HexCoord;
+  readonly tokenId: string;
+  readonly tokenType: string;
+}
+
+/**
+ * Creates a RuinsTokenRevealedEvent.
+ */
+export function createRuinsTokenRevealedEvent(
+  playerId: string,
+  hexCoord: HexCoord,
+  tokenId: string,
+  tokenType: string
+): RuinsTokenRevealedEvent {
+  return {
+    type: RUINS_TOKEN_REVEALED,
+    playerId,
+    hexCoord,
+    tokenId,
+    tokenType,
+  };
+}
+
+// ============================================================================
+// ALTAR_TRIBUTE_PAID
+// ============================================================================
+
+/**
+ * Event type constant for paying altar tribute.
+ * @see AltarTributePaidEvent
+ */
+export const ALTAR_TRIBUTE_PAID = "ALTAR_TRIBUTE_PAID" as const;
+
+/**
+ * Emitted when a player pays tribute at an altar ruins token.
+ *
+ * The player spends mana of the required color(s) and gains fame.
+ */
+export interface AltarTributePaidEvent {
+  readonly type: typeof ALTAR_TRIBUTE_PAID;
+  readonly playerId: string;
+  readonly manaColor: string;
+  readonly manaCost: number;
+  readonly fameGained: number;
+}
+
+/**
+ * Creates an AltarTributePaidEvent.
+ */
+export function createAltarTributePaidEvent(
+  playerId: string,
+  manaColor: string,
+  manaCost: number,
+  fameGained: number
+): AltarTributePaidEvent {
+  return {
+    type: ALTAR_TRIBUTE_PAID,
+    playerId,
+    manaColor,
+    manaCost,
+    fameGained,
+  };
+}
+
+// ============================================================================
 // VILLAGE_PLUNDERED
 // ============================================================================
 

--- a/packages/shared/src/events/sites/index.ts
+++ b/packages/shared/src/events/sites/index.ts
@@ -49,6 +49,8 @@ import {
   MONASTERY_BURN_STARTED,
   MONASTERY_BURNED,
   VILLAGE_PLUNDERED,
+  RUINS_TOKEN_REVEALED,
+  ALTAR_TRIBUTE_PAID,
 } from "./adventure.js";
 import { REWARD_QUEUED, REWARD_SELECTED } from "./rewards.js";
 import {
@@ -101,5 +103,7 @@ export function isSiteEvent(event: { type: string }): boolean {
     VILLAGE_PLUNDERED,
     MEDITATION_CARDS_SELECTED,
     MEDITATION_CARDS_PLACED,
+    RUINS_TOKEN_REVEALED,
+    ALTAR_TRIBUTE_PAID,
   ].includes(event.type as typeof SITE_CONQUERED);
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -90,6 +90,7 @@ export type {
   ExploreAction,
   // Adventure sites
   EnterSiteAction,
+  AltarTributeAction,
   // Turn structure
   EndTurnAction,
   RestAction, // @deprecated - use DeclareRestAction + CompleteRestAction

--- a/packages/shared/src/siteRewards.ts
+++ b/packages/shared/src/siteRewards.ts
@@ -14,6 +14,7 @@ export const SITE_REWARD_ARTIFACT = "artifact" as const;
 export const SITE_REWARD_CRYSTAL_ROLL = "crystal_roll" as const;
 export const SITE_REWARD_ADVANCED_ACTION = "advanced_action" as const;
 export const SITE_REWARD_FAME = "fame" as const;
+export const SITE_REWARD_UNIT = "unit" as const;
 export const SITE_REWARD_COMPOUND = "compound" as const;
 
 // =============================================================================
@@ -26,6 +27,7 @@ export type SiteRewardType =
   | typeof SITE_REWARD_CRYSTAL_ROLL
   | typeof SITE_REWARD_ADVANCED_ACTION
   | typeof SITE_REWARD_FAME
+  | typeof SITE_REWARD_UNIT
   | typeof SITE_REWARD_COMPOUND;
 
 // =============================================================================
@@ -79,6 +81,14 @@ export interface FameReward {
 }
 
 /**
+ * Unit reward - recruit a free unit from the unit offer
+ * Used by: Ancient Ruins (enemy tokens with unit reward)
+ */
+export interface UnitReward {
+  readonly type: typeof SITE_REWARD_UNIT;
+}
+
+/**
  * Compound reward - multiple rewards combined
  * Used by: Tomb (spell + artifact), Spawning Grounds (artifact + crystals)
  */
@@ -96,6 +106,7 @@ export type SiteReward =
   | CrystalRollReward
   | AdvancedActionReward
   | FameReward
+  | UnitReward
   | CompoundReward;
 
 // =============================================================================
@@ -127,6 +138,10 @@ export const advancedActionReward = (
 export const fameReward = (amount: number): FameReward => ({
   type: SITE_REWARD_FAME,
   amount,
+});
+
+export const unitReward = (): UnitReward => ({
+  type: SITE_REWARD_UNIT,
 });
 
 export const compoundReward = (

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -577,6 +577,20 @@ export interface SiteOptions {
   /** Interaction options (healing, recruiting, buying) */
   readonly interactOptions?: InteractOptions;
 
+  // --- Ancient Ruins Altar ---
+
+  /** Can pay tribute at this altar (Ancient Ruins with altar token) */
+  readonly canTribute?: boolean;
+
+  /** Altar mana color required (e.g., "blue", "all_basic") */
+  readonly altarManaColor?: string;
+
+  /** Altar mana cost */
+  readonly altarManaCost?: number;
+
+  /** Altar fame reward */
+  readonly altarFameReward?: number;
+
   // --- Passive Effects ---
 
   /** Passive effect that triggers at end of turn (e.g., "+1 Blue Crystal") */


### PR DESCRIPTION
## Summary
Closes #62

- **Altar tokens**: New `ALTAR_TRIBUTE` action — pay mana of the required color(s) to gain fame and conquer the site. Full mana source selection (dice, tokens, crystals).
- **Enemy tokens**: `ENTER_SITE` draws enemies by color from the token definition, then standard combat. Victory grants token-specific rewards (artifact, spell, advanced action, free unit, or 4 crystals).
- **Token reveal**: Face-down ruins tokens are automatically revealed when a player enters the hex.
- **Unit reward**: Free recruitment from the unit offer (no influence cost) with optional unit disband at command limit.
- **Validators**: `ENTER_SITE` is gated to enemy tokens only; `ALTAR_TRIBUTE` requires a revealed altar token at unconquered ruins.
- **Valid actions**: Shows altar info (mana color, cost, fame) and token-specific enemy/reward descriptions.

## Test plan
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] All 3928 tests pass (`bun run test`)
- [x] Updated enterSite tests for new ruins behavior (enemy tokens, altar rejection, no-token rejection)
- [ ] Manual: move to ruins hex at night → token reveals
- [ ] Manual: interact with altar → pay mana → fame + conquest
- [ ] Manual: enter ruins with enemies → combat → token-specific rewards
- [ ] Manual: can't tribute an altar you can't afford
- [ ] Manual: unit reward → pick free unit from offer