### PR TITLE
feat: implement Braevalar Feral Allies skill (#361)

### DIFF
--- a/packages/core/src/data/skills/braevalar/feralAllies.ts
+++ b/packages/core/src/data/skills/braevalar/feralAllies.ts
@@ -1,19 +1,82 @@
 /**
  * Feral Allies - Braevalar Skill
+ *
+ * Passive: Exploring costs 1 less Move (applies to every tile explored).
+ * Active (once per turn): Attack 1 OR reduce one enemy's attack by 1.
+ *
+ * Key rules:
+ * - Passive exploring cost reduction applies for the whole turn, every tile (Q1)
+ * - Attack reduction works on Arcane Immune enemies (S2)
+ * - Attack reduction is attack modification (happens BEFORE Brutal doubling)
+ *
  * @module data/skills/braevalar/feralAllies
  */
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_MOVEMENT, CATEGORY_COMBAT } from "../../../types/cards.js";
+import {
+  COMBAT_TYPE_MELEE,
+  EFFECT_CHOICE,
+  EFFECT_GAIN_ATTACK,
+  EFFECT_SELECT_COMBAT_ENEMY,
+} from "../../../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_ENEMY_STAT,
+  EFFECT_EXPLORE_COST_REDUCTION,
+  ENEMY_STAT_ATTACK,
+} from "../../../types/modifierConstants.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_BRAEVALAR_FERAL_ALLIES = "braevalar_feral_allies" as SkillId;
 
+/**
+ * Active effect: Choose Attack 1 (physical, melee) OR reduce one enemy's attack by 1.
+ * Attack reduction does NOT exclude Arcane Immune enemies (S2).
+ */
+const feralAlliesEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    // Option 1: Attack 1 (physical, melee)
+    {
+      type: EFFECT_GAIN_ATTACK,
+      amount: 1,
+      combatType: COMBAT_TYPE_MELEE,
+    },
+    // Option 2: Reduce one enemy's attack by 1
+    {
+      type: EFFECT_SELECT_COMBAT_ENEMY,
+      // Arcane Immune enemies CAN be targeted (S2)
+      template: {
+        modifiers: [
+          {
+            modifier: {
+              type: EFFECT_ENEMY_STAT,
+              stat: ENEMY_STAT_ATTACK,
+              amount: -1,
+              minimum: 0,
+            },
+            duration: DURATION_COMBAT,
+            description: "Feral Allies: Attack -1",
+          },
+        ],
+      },
+    },
+  ],
+} as const;
+
 export const feralAllies: SkillDefinition = {
   id: SKILL_BRAEVALAR_FERAL_ALLIES,
-    name: "Feral Allies",
-    heroId: "braevalar",
-    description: "Exploring -1 Move. Attack 1 or reduce enemy attack by 1",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_MOVEMENT, CATEGORY_COMBAT],
+  name: "Feral Allies",
+  heroId: "braevalar",
+  description: "Exploring -1 Move. Attack 1 or reduce enemy attack by 1",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  effect: feralAlliesEffect,
+  passiveModifiers: [
+    {
+      type: EFFECT_EXPLORE_COST_REDUCTION,
+      amount: -1,
+    },
+  ],
+  categories: [CATEGORY_MOVEMENT, CATEGORY_COMBAT],
 };

--- a/packages/core/src/engine/__tests__/skillFeralAllies.test.ts
+++ b/packages/core/src/engine/__tests__/skillFeralAllies.test.ts
@@ -1,0 +1,409 @@
+/**
+ * Tests for Feral Allies skill (Braevalar)
+ *
+ * Passive: Exploring costs 1 less Move for all tiles explored.
+ * Active (once per turn): Attack 1 (physical, melee) OR reduce enemy attack by 1.
+ *
+ * Key rules:
+ * - Passive exploring reduction applies for the entire turn, every tile (Q1)
+ * - Active is once per turn
+ * - Attack reduction works on Arcane Immune enemies (S2)
+ * - Attack reduction is attack modification (before Brutal doubling)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createTestHex,
+} from "./testHelpers.js";
+import type { GameState } from "../../state/GameState.js";
+import { TileId } from "../../types/map.js";
+import {
+  USE_SKILL_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  EXPLORE_ACTION,
+  ENTER_COMBAT_ACTION,
+  INVALID_ACTION,
+  TERRAIN_PLAINS,
+  hexKey,
+  ENEMY_DIGGERS,
+  ENEMY_SORCERERS,
+  ENEMY_ORC_SKIRMISHERS,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_BRAEVALAR_FERAL_ALLIES } from "../../data/skills/index.js";
+import { getEffectiveExploreCost } from "../modifiers/index.js";
+import { getEffectiveEnemyAttack } from "../modifiers/combat.js";
+import { getValidExploreOptions } from "../validActions/exploration.js";
+
+describe("Feral Allies skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ============================================================================
+  // PASSIVE: Exploring cost reduction
+  // ============================================================================
+
+  describe("passive: exploring cost reduction", () => {
+    function createExploreState(
+      playerOverrides: Partial<ReturnType<typeof createTestPlayer>> = {}
+    ): GameState {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        position: { q: 1, r: 0 },
+        movePoints: 4,
+        ...playerOverrides,
+      });
+
+      const baseState = createTestGameState();
+
+      const hexes: Record<string, ReturnType<typeof createTestHex>> = {
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+        [hexKey({ q: 1, r: 0 })]: createTestHex(1, 0, TERRAIN_PLAINS),
+      };
+
+      return {
+        ...baseState,
+        players: [player],
+        map: {
+          ...baseState.map,
+          hexes,
+          tileDeck: {
+            countryside: [TileId.Countryside1, TileId.Countryside2],
+            core: [TileId.Core1],
+          },
+        },
+      };
+    }
+
+    it("should reduce effective explore cost from 2 to 1", () => {
+      const state = createExploreState();
+      const cost = getEffectiveExploreCost(state, "player1");
+      expect(cost).toBe(1);
+    });
+
+    it("should have default explore cost of 2 without the skill", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [],
+        position: { q: 1, r: 0 },
+        movePoints: 4,
+      });
+      const state = createTestGameState({ players: [player] });
+      const cost = getEffectiveExploreCost(state, "player1");
+      expect(cost).toBe(2);
+    });
+
+    it("should deduct only 1 move point when exploring with skill", () => {
+      const state = createExploreState();
+      expect(state.players[0]?.movePoints).toBe(4);
+
+      const result = engine.processAction(state, "player1", {
+        type: EXPLORE_ACTION,
+        direction: "E",
+        fromTileCoord: { q: 0, r: 0 },
+      });
+
+      // Should deduct 1 instead of 2
+      expect(result.state.players[0]?.movePoints).toBe(3);
+    });
+
+    it("should allow exploring with only 1 move point", () => {
+      const state = createExploreState({ movePoints: 1 });
+      const player = state.players[0]!;
+      const options = getValidExploreOptions(state, player);
+
+      // Should be able to explore with just 1 move point
+      expect(options).toBeDefined();
+    });
+
+    it("should NOT allow exploring with 0 move points", () => {
+      const state = createExploreState({ movePoints: 0 });
+      const player = state.players[0]!;
+      const options = getValidExploreOptions(state, player);
+
+      expect(options).toBeUndefined();
+    });
+
+    it("should apply to every tile explored (Q1)", () => {
+      // Start with 4 move points
+      let state = createExploreState({ movePoints: 4 });
+
+      // First explore: deducts 1 (not 2)
+      const result1 = engine.processAction(state, "player1", {
+        type: EXPLORE_ACTION,
+        direction: "E",
+        fromTileCoord: { q: 0, r: 0 },
+      });
+      expect(result1.state.players[0]?.movePoints).toBe(3);
+    });
+  });
+
+  // ============================================================================
+  // ACTIVE: Attack 1 or enemy attack -1
+  // ============================================================================
+
+  describe("active: combat choice", () => {
+    const defaultCooldowns = {
+      usedThisRound: [] as string[],
+      usedThisTurn: [] as string[],
+      usedThisCombat: [] as string[],
+      activeUntilNextTurn: [] as string[],
+    };
+
+    it("should present 2 choices when activated in combat", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Activate skill
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      });
+
+      // Should present 2 options: Attack 1 or enemy attack -1
+      expect(result.state.players[0].pendingChoice).not.toBeNull();
+      expect(result.state.players[0].pendingChoice?.options).toHaveLength(2);
+    });
+
+    it("should grant Attack 1 when first option is chosen", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Activate skill
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      }).state;
+
+      // Choose Attack 1 (index 0)
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // Should have 1 melee attack accumulated
+      expect(state.players[0].combatAccumulator.attack.normal).toBe(1);
+    });
+
+    it("should reduce enemy attack by 1 when second option is chosen", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      expect(baseAttack).toBe(3);
+
+      // Activate skill
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      }).state;
+
+      // Choose enemy attack reduction (index 1)
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      }).state;
+
+      // Select the target enemy
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Verify attack was reduced by 1
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(
+        2
+      );
+    });
+
+    it("should be usable once per turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: {
+          ...defaultCooldowns,
+          usedThisTurn: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Try to activate skill again - should fail
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      });
+
+      // Should be invalid action (already used this turn)
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+  });
+
+  // ============================================================================
+  // ARCANE IMMUNITY (S2)
+  // ============================================================================
+
+  describe("Arcane Immunity interaction (S2)", () => {
+    const defaultCooldowns = {
+      usedThisRound: [] as string[],
+      usedThisTurn: [] as string[],
+      usedThisCombat: [] as string[],
+      activeUntilNextTurn: [] as string[],
+    };
+
+    it("should allow targeting Arcane Immune enemies with attack reduction", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Sorcerers (has Arcane Immunity, Attack 6)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_SORCERERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      expect(baseAttack).toBe(6);
+
+      // Activate skill
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      }).state;
+
+      // Choose enemy attack reduction (index 1)
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      }).state;
+
+      // Select the Sorcerers as target
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Attack reduction should work on Arcane Immune enemies (S2)
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(
+        5
+      );
+    });
+  });
+
+  // ============================================================================
+  // MULTI-ENEMY combat
+  // ============================================================================
+
+  describe("multi-enemy combat", () => {
+    const defaultCooldowns = {
+      usedThisRound: [] as string[],
+      usedThisTurn: [] as string[],
+      usedThisCombat: [] as string[],
+      activeUntilNextTurn: [] as string[],
+    };
+
+    it("should only reduce attack of the selected enemy", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_FERAL_ALLIES],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with two enemies
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_ORC_SKIRMISHERS],
+      }).state;
+
+      const enemy1InstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const enemy2InstanceId = state.combat?.enemies[1].instanceId ?? "";
+      const enemy1BaseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      const enemy2BaseAttack = state.combat?.enemies[1].definition.attack ?? 0;
+
+      // Activate skill
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_FERAL_ALLIES,
+      }).state;
+
+      // Choose enemy attack reduction (index 1)
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      }).state;
+
+      // Should have 2 enemy selection options
+      expect(state.players[0].pendingChoice?.options).toHaveLength(2);
+
+      // Select first enemy
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // First enemy should have reduced attack
+      expect(
+        getEffectiveEnemyAttack(state, enemy1InstanceId, enemy1BaseAttack)
+      ).toBe(enemy1BaseAttack - 1);
+
+      // Second enemy should have unchanged attack
+      expect(
+        getEffectiveEnemyAttack(state, enemy2InstanceId, enemy2BaseAttack)
+      ).toBe(enemy2BaseAttack);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/unitShocktroops.test.ts
+++ b/packages/core/src/engine/__tests__/unitShocktroops.test.ts
@@ -656,7 +656,7 @@ describe("Shocktroops Unit", () => {
       expect(assignableUnits[0].unitInstanceId).toBe("shocktroops_1");
     });
 
-    it("should allow targeting Arcane Immune enemy (attack reduction blocked but redirect works)", () => {
+    it("should allow targeting Arcane Immune enemy (attack reduction works, redirect works)", () => {
       const unit = createPlayerUnit(UNIT_SHOCKTROOPS, "shocktroops_1");
       const player = createTestPlayer({
         units: [unit],
@@ -677,15 +677,15 @@ describe("Shocktroops Unit", () => {
         abilityIndex: 2,
       });
 
-      // Attack reduction should be blocked by Arcane Immunity
+      // Attack reduction bypasses Arcane Immunity (FAQ Arcane Immunity S1)
       const effectiveAttack = getEffectiveEnemyAttack(
         result.state,
         "enemy_0",
         sorcererDef.attack
       );
-      expect(effectiveAttack).toBe(sorcererDef.attack); // Unchanged
+      expect(effectiveAttack).toBe(sorcererDef.attack - 3); // Reduced by 3
 
-      // But damage redirect should still work (not blocked by AI)
+      // Damage redirect should also work (not blocked by AI)
       expect(result.state.combat?.damageRedirects["enemy_0"]).toBe("shocktroops_1");
     });
 

--- a/packages/core/src/engine/modifiers/combat.ts
+++ b/packages/core/src/engine/modifiers/combat.ts
@@ -147,18 +147,16 @@ export function getEffectiveEnemyArmor(
 /**
  * Get effective enemy attack after modifiers.
  *
- * Note: Arcane Immunity blocks attack modification effects (non-Attack/Block effect).
+ * Note: Arcane Immunity does NOT block attack reductions per FAQ ruling
+ * (Arcane Immunity S1: attack reductions are attack modifications, not
+ * non-Attack/non-Block effects). This differs from armor reductions
+ * which ARE blocked by Arcane Immunity.
  */
 export function getEffectiveEnemyAttack(
   state: GameState,
   enemyId: string,
   baseAttack: number
 ): number {
-  // Arcane Immunity blocks attack modification effects
-  if (hasArcaneImmunity(state, enemyId)) {
-    return baseAttack;
-  }
-
   const modifiers = getModifiersForEnemy(state, enemyId)
     .filter(
       (m) =>

--- a/packages/core/src/engine/modifiers/index.ts
+++ b/packages/core/src/engine/modifiers/index.ts
@@ -38,6 +38,7 @@ export {
   isTerrainSafe,
   getProhibitedTerrains,
   isTerrainProhibited,
+  getEffectiveExploreCost,
 } from "./terrain.js";
 
 // Unit effective values

--- a/packages/core/src/engine/validActions/exploration.ts
+++ b/packages/core/src/engine/validActions/exploration.ts
@@ -27,11 +27,8 @@ import { isCoastlineSlot, getColumnRangeForShape } from "../explore/tileGrid.js"
 import { peekNextTileType } from "../../data/tileDeckSetup.js";
 import { TILE_TYPE_CORE } from "../../data/tileConstants.js";
 import { mustAnnounceEndOfRound } from "./helpers.js";
-import { isRuleActive } from "../modifiers/index.js";
+import { isRuleActive, getEffectiveExploreCost } from "../modifiers/index.js";
 import { RULE_EXTENDED_EXPLORE, RULE_SPACE_BENDING_ADJACENCY, RULE_NO_EXPLORATION } from "../../types/modifierConstants.js";
-
-/** Exploration costs 2 move points from a safe space */
-const EXPLORE_COST = 2;
 
 /**
  * Get valid explore options for a player.
@@ -77,7 +74,8 @@ export function getValidExploreOptions(
   }
 
   // Must have enough move points
-  if (player.movePoints < EXPLORE_COST) {
+  const exploreCost = getEffectiveExploreCost(state, player.id);
+  if (player.movePoints < exploreCost) {
     return undefined;
   }
 

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -302,3 +302,9 @@ export const RULE_NO_EXPLORATION = "no_exploration" as const;
 // Used by Braevalar's Elemental Resistance, Krang's Battle Hardened.
 export const EFFECT_HERO_DAMAGE_REDUCTION = "hero_damage_reduction" as const;
 
+// === ExploreCostReductionModifier ===
+// Reduces the move point cost of exploring (revealing a new tile).
+// Base exploration cost is 2; this modifier reduces it by the specified amount.
+// Used by Braevalar's Feral Allies passive effect.
+export const EFFECT_EXPLORE_COST_REDUCTION = "explore_cost_reduction" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -60,6 +60,7 @@ import {
   EFFECT_LEADERSHIP_BONUS,
   EFFECT_POSSESS_ATTACK_RESTRICTION,
   EFFECT_HERO_DAMAGE_REDUCTION,
+  EFFECT_EXPLORE_COST_REDUCTION,
   LEADERSHIP_BONUS_BLOCK,
   LEADERSHIP_BONUS_ATTACK,
   LEADERSHIP_BONUS_RANGED_ATTACK,
@@ -521,6 +522,14 @@ export interface HeroDamageReductionModifier {
   )[];
 }
 
+// Explore cost reduction modifier (Braevalar's Feral Allies)
+// Reduces the move point cost of exploring (revealing a new tile).
+// Base exploration cost is 2; this reduces it by the specified amount (min 0).
+export interface ExploreCostReductionModifier {
+  readonly type: typeof EFFECT_EXPLORE_COST_REDUCTION;
+  readonly amount: number; // negative = reduction (e.g., -1)
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -562,7 +571,8 @@ export type ModifierEffect =
   | BannerGloryFameTrackingModifier
   | PossessAttackRestrictionModifier
   | AttackBlockCardBonusModifier
-  | HeroDamageReductionModifier;
+  | HeroDamageReductionModifier
+  | ExploreCostReductionModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- **Passive**: Exploring costs 1 less Move for all tiles explored (applies every tile, entire turn)
- **Active (once per turn)**: Choice between Attack 1 (physical, melee) OR reduce one enemy's attack by 1
- **Arcane Immunity**: Attack reduction works on Arcane Immune enemies per FAQ S2 ruling (attack reductions are attack modifications, not non-Attack/Block effects)

## Changes
- Added `EFFECT_EXPLORE_COST_REDUCTION` modifier type and `getEffectiveExploreCost()` query function
- Updated explore command and valid actions to use dynamic explore cost instead of hardcoded 2
- Updated Arcane Immunity handling to allow attack reductions through (both at application in `combatEffects.ts` and query in `combat.ts`)
- Full skill definition with passive modifiers and active choice effect
- 12 tests covering passive exploration, active combat, Arcane Immunity, and multi-enemy scenarios

## Test plan
- [x] Explore cost reduced from 2 to 1 with skill
- [x] Default explore cost is 2 without skill
- [x] Only 1 move point deducted when exploring
- [x] Can explore with only 1 move point
- [x] Cannot explore with 0 move points
- [x] Applies to every tile explored (Q1)
- [x] Presents 2 choices in combat (Attack 1 or enemy attack -1)
- [x] Grants Attack 1 melee when first option chosen
- [x] Reduces enemy attack by 1 when second option chosen
- [x] Once per turn cooldown
- [x] Works on Arcane Immune enemies (S2)
- [x] Only affects selected enemy in multi-enemy combat
- [x] Updated Shocktroops test to match new Arcane Immunity behavior

Closes #361