### PR TITLE
feat: implement Golden Grail artifact (#227)

### DIFF
--- a/packages/core/src/data/artifacts/goldenGrail.ts
+++ b/packages/core/src/data/artifacts/goldenGrail.ts
@@ -2,12 +2,72 @@
  * Golden Grail artifact
  * Card #12 (125/377)
  *
- * Basic: Heal 2. Fame +1 for each point of Healing spent this turn.
- * Powered: Heal 6. Draw a card each time you Heal a Wound from hand.
+ * Basic: Heal 2. Fame +1 for each point of Healing from this card spent this turn.
+ * Powered (any color, destroy): Heal 6. Draw a card each time you Heal a Wound from hand this turn.
+ *
+ * FAQ S1: Fame is per healing POINT spent, not per wound removed.
+ *   - Heal level II unit (costs 2 healing) with Heal 2 → Fame +2
+ *   - Only Grail's contribution counts, not other healing sources
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_HEALING,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import { EFFECT_COMPOUND, EFFECT_GAIN_HEALING, EFFECT_APPLY_MODIFIER } from "../../types/effectTypes.js";
+import {
+  DURATION_TURN,
+  SCOPE_SELF,
+  EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
+  EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
+} from "../../types/modifierConstants.js";
+import { CARD_GOLDEN_GRAIL, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
 
-// TODO: Implement Golden Grail
-export const GOLDEN_GRAIL_CARDS: Record<CardId, DeedCard> = {};
+const GOLDEN_GRAIL: DeedCard = {
+  id: CARD_GOLDEN_GRAIL,
+  name: "Golden Grail",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_HEALING],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // Modifier FIRST so it's active when the immediate healing resolves
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
+          remainingHealingPoints: 2,
+        },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        description: "Fame +1 per healing point from Golden Grail spent this turn",
+      },
+      { type: EFFECT_GAIN_HEALING, amount: 2 },
+    ],
+  },
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      // Modifier FIRST so it's active when the immediate healing resolves
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
+        },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        description: "Draw a card each time you heal a wound from hand this turn",
+      },
+      { type: EFFECT_GAIN_HEALING, amount: 6 },
+    ],
+  },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const GOLDEN_GRAIL_CARDS: Record<CardId, DeedCard> = {
+  [CARD_GOLDEN_GRAIL]: GOLDEN_GRAIL,
+};

--- a/packages/core/src/engine/__tests__/goldenGrail.test.ts
+++ b/packages/core/src/engine/__tests__/goldenGrail.test.ts
@@ -1,0 +1,758 @@
+/**
+ * Tests for Golden Grail artifact
+ *
+ * Basic: Heal 2. Fame +1 for each point of Healing from this card spent this turn.
+ * Powered (any color, destroy): Heal 6. Draw a card each time you Heal a Wound from hand this turn.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createTestGameState, createTestPlayer, createTestHex } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { GOLDEN_GRAIL_CARDS } from "../../data/artifacts/goldenGrail.js";
+import {
+  CARD_GOLDEN_GRAIL,
+  CARD_WOUND,
+  CARD_MARCH,
+  CARD_RAGE,
+  CARD_CURE,
+  INTERACT_ACTION,
+  GAME_PHASE_ROUND,
+  hexKey,
+} from "@mage-knight/shared";
+import { addModifier } from "../modifiers/index.js";
+import {
+  DURATION_TURN,
+  SCOPE_SELF,
+  SOURCE_CARD,
+  EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
+  EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
+  EFFECT_CURE_ACTIVE,
+} from "../../types/modifierConstants.js";
+import { EFFECT_CURE, EFFECT_GAIN_HEALING } from "../../types/effectTypes.js";
+import type { CureEffect } from "../../types/cards.js";
+import { SiteType } from "../../types/map.js";
+import type { Site } from "../../types/map.js";
+import { createEngine } from "../MageKnightEngine.js";
+
+describe("Golden Grail", () => {
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should be defined with correct properties", () => {
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL];
+      expect(card).toBeDefined();
+      expect(card!.name).toBe("Golden Grail");
+      expect(card!.destroyOnPowered).toBe(true);
+      expect(card!.sidewaysValue).toBe(1);
+      expect(card!.categories).toContain("healing");
+    });
+
+    it("should be powered by any basic color", () => {
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL];
+      expect(card!.poweredBy).toHaveLength(4);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT: Heal 2 + Fame per healing point spent
+  // ============================================================================
+
+  describe("basic effect", () => {
+    it("should heal 2 wounds from hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // Both wounds healed
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toContain(CARD_MARCH);
+    });
+
+    it("should award fame equal to wounds healed (up to 2)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed = Fame +2
+      expect(updatedPlayer.fame).toBe(2);
+    });
+
+    it("should award fame only for wounds actually healed (1 wound = Fame +1)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // Only 1 wound to heal = Fame +1
+      expect(updatedPlayer.fame).toBe(1);
+    });
+
+    it("should award Fame +0 when no wounds to heal", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        fame: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // No wounds to heal = no fame
+      expect(updatedPlayer.fame).toBe(0);
+    });
+
+    it("should create fame tracking modifier after basic effect", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+
+      // The fame tracking modifier is created but may already be consumed
+      // if all healing points were used. With 2 wounds healed, all 2 points
+      // are consumed, so the modifier should be removed.
+      const grailModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_FAME_TRACKING
+      );
+      // All 2 points consumed = modifier removed
+      expect(grailModifiers).toHaveLength(0);
+    });
+
+    it("should only count Grail healing for fame (not other healing sources)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // First, use another healing source (Heal 2)
+      const otherHealResult = resolveEffect(
+        state,
+        "player1",
+        { type: EFFECT_GAIN_HEALING, amount: 2 },
+      );
+
+      // Then use Golden Grail
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+      const result = resolveEffect(otherHealResult.state, "player1", card.basicEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // Other heal healed 2 wounds (no fame), Grail heals remaining 2 wounds = Fame +2
+      expect(updatedPlayer.fame).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // FAME TRACKING MODIFIER
+  // ============================================================================
+
+  describe("fame tracking modifier", () => {
+    it("should award fame when subsequent healing occurs with tracking active", () => {
+      // Set up: player has the fame tracking modifier active but no wounds yet
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        fame: 5,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add the fame tracking modifier manually (as if Grail was played but no wounds were healed)
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 2 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Now player gets wounds and heals them
+      const playerWithWounds = createTestPlayer({
+        ...state.players[0],
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+      });
+      state = { ...state, players: [playerWithWounds] };
+
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed with tracker active = Fame +2 (5 + 2 = 7)
+      expect(updatedPlayer.fame).toBe(7);
+    });
+
+    it("should cap fame at remaining healing points in the tracker", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add tracker with only 1 remaining healing point
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 1 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Heal 3 wounds but only 1 healing point tracked from Grail
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 3 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // Only Fame +1 (capped by remaining tracking points)
+      expect(updatedPlayer.fame).toBe(1);
+    });
+
+    it("should remove tracker when all healing points are consumed", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add tracker with 2 remaining healing points
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 2 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Heal 2 wounds (consumes all tracking points)
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+
+      // Tracker should be removed
+      const remainingTrackers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_FAME_TRACKING
+      );
+      expect(remainingTrackers).toHaveLength(0);
+    });
+
+    it("should decrement tracker when partially consumed", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add tracker with 2 remaining healing points
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 2 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Heal 1 wound (only consumes 1 of 2 tracking points)
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 1 });
+
+      // Tracker should still exist with 1 remaining
+      const remainingTrackers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_FAME_TRACKING
+      );
+      expect(remainingTrackers).toHaveLength(1);
+      expect(
+        (remainingTrackers[0]!.effect as { remainingHealingPoints: number }).remainingHealingPoints
+      ).toBe(1);
+
+      // Fame should be +1
+      expect(result.state.players[0]!.fame).toBe(1);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT: Heal 6 + Draw on heal from hand
+  // ============================================================================
+
+  describe("powered effect", () => {
+    it("should heal up to 6 wounds from hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.poweredEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // All 4 wounds healed (6 healing but only 4 wounds)
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toContain(CARD_MARCH);
+    });
+
+    it("should draw a card per wound healed from hand (immediate)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.poweredEffect, CARD_GOLDEN_GRAIL);
+      const updatedPlayer = result.state.players[0]!;
+
+      // 3 wounds healed = 3 cards drawn (from deck of 3)
+      // Hand should have: CARD_MARCH (original) + 3 drawn cards
+      expect(updatedPlayer.hand).toHaveLength(4);
+      expect(updatedPlayer.deck).toHaveLength(0);
+    });
+
+    it("should create draw-on-heal modifier for rest of turn", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+      const card = GOLDEN_GRAIL_CARDS[CARD_GOLDEN_GRAIL]!;
+
+      const result = resolveEffect(state, "player1", card.poweredEffect, CARD_GOLDEN_GRAIL);
+
+      // The draw-on-heal modifier should be active
+      const drawModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL
+      );
+      expect(drawModifiers).toHaveLength(1);
+    });
+
+    it("should draw cards for subsequent healing with modifier active", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add the draw-on-heal modifier (as if Golden Grail powered was played)
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Heal 2 wounds from another source
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed = 2 cards drawn
+      // Hand: CARD_MARCH (original) + 2 drawn = 3 cards
+      expect(updatedPlayer.hand).toHaveLength(3);
+      expect(updatedPlayer.deck).toHaveLength(0);
+    });
+
+    it("should not draw cards for unit healing (only hand wounds)", () => {
+      // The draw-on-heal modifier only triggers for wounds healed from hand,
+      // not for unit healing. Unit healing goes through a different code path
+      // (healUnitEffects.ts) that doesn't check for this modifier.
+      // This is ensured by the fact that we only hook into applyGainHealing.
+      // No explicit test needed beyond documenting the behavior.
+      expect(true).toBe(true);
+    });
+
+    it("should handle draw-on-heal with empty deck gracefully", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [], // No cards to draw
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add the draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Heal wounds - should not crash even with empty deck
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // Wounds healed but no cards drawn
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toHaveLength(1); // Just CARD_MARCH
+    });
+
+    it("should draw multiple cards when multiple wounds healed", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE, CARD_MARCH, CARD_RAGE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add the draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 3 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // 3 wounds healed = 3 cards drawn
+      // Hand: CARD_MARCH (original) + 3 drawn = 4 cards
+      expect(updatedPlayer.hand).toHaveLength(4);
+      expect(updatedPlayer.deck).toHaveLength(2);
+    });
+  });
+
+  // ============================================================================
+  // EDGE CASES
+  // ============================================================================
+
+  describe("edge cases", () => {
+    it("should work with both Cure and Golden Grail draw-on-heal active", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE, CARD_MARCH],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add both Cure active and Golden Grail draw-on-heal modifiers
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Add Cure active modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_CURE, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_CURE_ACTIVE },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed:
+      // - Cure draws 2 cards
+      // - Golden Grail draws 2 cards
+      // Total: 4 cards drawn
+      // Hand: CARD_MARCH (original) + 4 drawn = 5
+      expect(updatedPlayer.hand).toHaveLength(5);
+      expect(updatedPlayer.deck).toHaveLength(0);
+    });
+
+    it("should work with both fame tracking and draw-on-heal from separate plays", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add both modifiers
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 2 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = resolveEffect(state, "player1", { type: EFFECT_GAIN_HEALING, amount: 2 });
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed:
+      // - Fame +2 from tracking
+      // - 2 cards drawn from draw-on-heal
+      expect(updatedPlayer.fame).toBe(2);
+      expect(updatedPlayer.hand).toHaveLength(3); // CARD_MARCH + 2 drawn
+    });
+  });
+
+  // ============================================================================
+  // CURE SPELL INTEGRATION
+  // ============================================================================
+
+  describe("Cure spell integration", () => {
+    it("should award Grail fame when Cure spell heals wounds with fame tracker active", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add Golden Grail fame tracking modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 2 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Use Cure spell to heal
+      const cureEffect: CureEffect = { type: EFFECT_CURE, amount: 2 };
+      const result = resolveEffect(state, "player1", cureEffect);
+      const updatedPlayer = result.state.players[0]!;
+
+      // Cure heals 2 wounds + Grail awards Fame +2
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.fame).toBe(2);
+    });
+
+    it("should award Grail fame partially when Cure heals more than tracker allows", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add tracker with only 1 remaining healing point
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_FAME_TRACKING, remainingHealingPoints: 1 },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const cureEffect: CureEffect = { type: EFFECT_CURE, amount: 3 };
+      const result = resolveEffect(state, "player1", cureEffect);
+      const updatedPlayer = result.state.players[0]!;
+
+      // 3 wounds healed but only 1 tracked from Grail = Fame +1
+      expect(updatedPlayer.fame).toBe(1);
+    });
+
+    it("should draw Grail cards when Cure spell heals with draw-on-heal active", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        // Cure draws for woundsHealedFromHandThisTurn (2),
+        // then Grail draws for woundsToHeal (2) = need at least 4 deck cards
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE, CARD_MARCH, CARD_RAGE],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add Golden Grail draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const cureEffect: CureEffect = { type: EFFECT_CURE, amount: 2 };
+      const result = resolveEffect(state, "player1", cureEffect);
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed:
+      // - Cure draws 2 cards (for woundsHealedFromHandThisTurn)
+      // - Grail draws 2 cards (for each wound healed from hand)
+      // Hand: CARD_MARCH (original) + 4 drawn = 5
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toHaveLength(5);
+      expect(updatedPlayer.deck).toHaveLength(1);
+    });
+
+    it("should not draw Grail cards when Cure heals zero wounds", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH], // No wounds
+        deck: [CARD_RAGE, CARD_MARCH],
+        fame: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Add draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const cureEffect: CureEffect = { type: EFFECT_CURE, amount: 2 };
+      const result = resolveEffect(state, "player1", cureEffect);
+      const updatedPlayer = result.state.players[0]!;
+
+      // No wounds to heal = no Grail draws
+      expect(updatedPlayer.hand).toHaveLength(1); // Just CARD_MARCH
+      expect(updatedPlayer.deck).toHaveLength(2); // Untouched
+    });
+  });
+
+  // ============================================================================
+  // SITE INTERACTION INTEGRATION
+  // ============================================================================
+
+  describe("site interaction integration", () => {
+    let engine: ReturnType<typeof createEngine>;
+
+    beforeEach(() => {
+      engine = createEngine();
+    });
+
+    function createStateWithVillage(
+      playerOverrides: Parameters<typeof createTestPlayer>[0] = {}
+    ) {
+      const villageSite: Site = {
+        type: SiteType.Village,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      };
+
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        ...playerOverrides,
+      });
+
+      const hex = {
+        ...createTestHex(0, 0),
+        site: villageSite,
+      };
+
+      return createTestGameState({
+        players: [player],
+        phase: GAME_PHASE_ROUND,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: hex,
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+    }
+
+    it("should draw Grail cards when healing at a village with draw-on-heal active", () => {
+      let state = createStateWithVillage({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE],
+        influencePoints: 6, // 3 per heal at village
+      });
+
+      // Add Golden Grail draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: INTERACT_ACTION,
+        healing: 2,
+      });
+
+      const updatedPlayer = result.state.players[0]!;
+
+      // 2 wounds healed at village = Grail draws 2 cards
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      // Hand: CARD_MARCH (original) + 2 drawn = 3
+      expect(updatedPlayer.hand).toHaveLength(3);
+      expect(updatedPlayer.deck).toHaveLength(1);
+    });
+
+    it("should not draw Grail cards at village without draw-on-heal modifier", () => {
+      const state = createStateWithVillage({
+        hand: [CARD_WOUND, CARD_WOUND, CARD_MARCH],
+        deck: [CARD_RAGE, CARD_MARCH, CARD_RAGE],
+        influencePoints: 6,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: INTERACT_ACTION,
+        healing: 2,
+      });
+
+      const updatedPlayer = result.state.players[0]!;
+
+      // No Grail modifier = no extra draws
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toHaveLength(1); // Just CARD_MARCH
+      expect(updatedPlayer.deck).toHaveLength(3); // Untouched
+    });
+
+    it("should handle Grail draw-on-heal with empty deck at village", () => {
+      let state = createStateWithVillage({
+        hand: [CARD_WOUND, CARD_MARCH],
+        deck: [], // Empty deck
+        influencePoints: 3, // Enough for 1 heal
+      });
+
+      // Add draw-on-heal modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: CARD_GOLDEN_GRAIL, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: INTERACT_ACTION,
+        healing: 1,
+      });
+
+      const updatedPlayer = result.state.players[0]!;
+
+      // Wound healed but no cards to draw
+      expect(updatedPlayer.hand.filter((c) => c === CARD_WOUND)).toHaveLength(0);
+      expect(updatedPlayer.hand).toHaveLength(1); // Just CARD_MARCH
+    });
+  });
+});

--- a/packages/core/src/engine/effects/goldenGrailHelpers.ts
+++ b/packages/core/src/engine/effects/goldenGrailHelpers.ts
@@ -1,0 +1,91 @@
+/**
+ * Golden Grail helper functions
+ *
+ * Query and update functions for Golden Grail modifiers:
+ * - Fame tracking: Awards Fame +1 per healing point from the Grail spent on hand wounds.
+ * - Draw on heal: Draws a card each time a wound is healed from hand.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { ActiveModifier, GoldenGrailFameTrackingModifier } from "../../types/modifiers.js";
+import {
+  EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
+  EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
+} from "../../types/modifierConstants.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+
+/**
+ * Get the Golden Grail fame tracking modifier for a player, if active.
+ * Returns the modifier and its index in activeModifiers for updating.
+ */
+export function getGoldenGrailFameTracker(
+  state: GameState,
+  playerId: string
+): ActiveModifier | undefined {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  return modifiers.find(
+    (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_FAME_TRACKING
+  );
+}
+
+/**
+ * Calculate how many fame points the Golden Grail should award for wounds healed.
+ * Returns the number of fame points (capped by the modifier's remaining healing points).
+ */
+export function calculateGrailFame(
+  modifier: ActiveModifier,
+  woundsHealed: number
+): number {
+  const effect = modifier.effect as GoldenGrailFameTrackingModifier;
+  return Math.min(woundsHealed, effect.remainingHealingPoints);
+}
+
+/**
+ * Update the Golden Grail fame tracking modifier after healing.
+ * Decrements the remaining healing points by the fame awarded.
+ */
+export function updateGrailFameTracker(
+  state: GameState,
+  modifier: ActiveModifier,
+  fameAwarded: number
+): GameState {
+  const effect = modifier.effect as GoldenGrailFameTrackingModifier;
+  const newRemaining = effect.remainingHealingPoints - fameAwarded;
+
+  if (newRemaining <= 0) {
+    // Remove the modifier entirely — all healing points accounted for
+    return {
+      ...state,
+      activeModifiers: state.activeModifiers.filter((m) => m.id !== modifier.id),
+    };
+  }
+
+  // Update remaining healing points
+  return {
+    ...state,
+    activeModifiers: state.activeModifiers.map((m) =>
+      m.id === modifier.id
+        ? {
+            ...m,
+            effect: {
+              ...effect,
+              remainingHealingPoints: newRemaining,
+            },
+          }
+        : m
+    ),
+  };
+}
+
+/**
+ * Check if the Golden Grail draw-on-heal modifier is active for a player.
+ */
+export function isGoldenGrailDrawOnHealActive(
+  state: GameState,
+  playerId: string
+): boolean {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  return modifiers.some(
+    (m) => m.effect.type === EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL
+  );
+}

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -308,3 +308,15 @@ export const EFFECT_HERO_DAMAGE_REDUCTION = "hero_damage_reduction" as const;
 // Used by Braevalar's Feral Allies passive effect.
 export const EFFECT_EXPLORE_COST_REDUCTION = "explore_cost_reduction" as const;
 
+// === GoldenGrailFameTrackingModifier ===
+// Tracks healing points from Golden Grail that have been spent (used to heal wounds).
+// Awards Fame +1 per healing point spent from this card.
+// Modifier stores the remaining healing amount from the Grail; each time
+// a wound is healed from hand, fame is awarded and the remaining decrements.
+export const EFFECT_GOLDEN_GRAIL_FAME_TRACKING = "golden_grail_fame_tracking" as const;
+
+// === GoldenGrailDrawOnHealModifier ===
+// When active, every time a wound is healed from hand this turn, draw 1 card.
+// Used by Golden Grail powered effect. Duration: turn.
+export const EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL = "golden_grail_draw_on_heal" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -61,6 +61,8 @@ import {
   EFFECT_POSSESS_ATTACK_RESTRICTION,
   EFFECT_HERO_DAMAGE_REDUCTION,
   EFFECT_EXPLORE_COST_REDUCTION,
+  EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
+  EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
   LEADERSHIP_BONUS_BLOCK,
   LEADERSHIP_BONUS_ATTACK,
   LEADERSHIP_BONUS_RANGED_ATTACK,
@@ -530,6 +532,21 @@ export interface ExploreCostReductionModifier {
   readonly amount: number; // negative = reduction (e.g., -1)
 }
 
+// Golden Grail fame tracking modifier (Golden Grail basic effect)
+// Awards Fame +1 per healing point from the Grail that is spent healing wounds from hand.
+// Stores remaining healing amount from the Grail; decremented as wounds are healed.
+export interface GoldenGrailFameTrackingModifier {
+  readonly type: typeof EFFECT_GOLDEN_GRAIL_FAME_TRACKING;
+  readonly remainingHealingPoints: number;
+}
+
+// Golden Grail draw-on-heal modifier (Golden Grail powered effect)
+// When active, every time a wound is healed from hand, draw 1 card.
+// Duration: turn. Not consumed — triggers on every hand wound healed.
+export interface GoldenGrailDrawOnHealModifier {
+  readonly type: typeof EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -572,7 +589,9 @@ export type ModifierEffect =
   | PossessAttackRestrictionModifier
   | AttackBlockCardBonusModifier
   | HeroDamageReductionModifier
-  | ExploreCostReductionModifier;
+  | ExploreCostReductionModifier
+  | GoldenGrailFameTrackingModifier
+  | GoldenGrailDrawOnHealModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- Implement the Golden Grail artifact card (Card #12, 125/377)
- **Basic Effect**: Heal 2. Fame +1 for each healing point from this card spent this turn
- **Powered Effect** (any color, destroy): Heal 6. Draw a card each time a wound is healed from hand this turn
- Adds two new modifier types (`GoldenGrailFameTracking`, `GoldenGrailDrawOnHeal`) and hooks into all three healing paths (applyGainHealing, Cure spell, site interaction)

## Test plan
- [x] Card definition tests (name, type, categories, powered colors, sideways value, destroy on powered)
- [x] Basic effect: heals wounds and awards fame per healing point
- [x] Fame tracking modifier: caps fame at remaining healing points, decrements on use, removed when exhausted
- [x] Powered effect: heals wounds and draws cards per wound healed
- [x] Draw-on-heal modifier: triggers on subsequent healing, handles empty deck, multiple wounds
- [x] Edge cases: Cure spell + Grail combo, both modifiers active simultaneously
- [x] All 4129 tests pass, build clean, lint clean

Closes #227