### PR TITLE
feat: implement Learning card discounted AA acquisition (#168)

### DIFF
--- a/packages/core/src/data/advancedActions/white/learning.ts
+++ b/packages/core/src/data/advancedActions/white/learning.ts
@@ -5,7 +5,8 @@ import {
   DEED_CARD_TYPE_ADVANCED_ACTION,
 } from "../../../types/cards.js";
 import { MANA_WHITE, CARD_LEARNING } from "@mage-knight/shared";
-import { influence } from "../helpers.js";
+import { influence, compound } from "../helpers.js";
+import { EFFECT_APPLY_LEARNING_DISCOUNT } from "../../../types/effectTypes.js";
 
 export const LEARNING: DeedCard = {
   id: CARD_LEARNING,
@@ -15,8 +16,13 @@ export const LEARNING: DeedCard = {
   categories: [CATEGORY_INFLUENCE, CATEGORY_SPECIAL],
   // Basic: Influence 2. Once during this turn, you may pay Influence 6 to gain an Advanced Action card from the Advanced Actions offer to your discard pile.
   // Powered: Influence 4. Once during this turn, you may pay Influence 9 to gain an Advanced Action card from the Advanced Actions offer to your hand.
-  // TODO: Implement advanced action purchase at discount
-  basicEffect: influence(2),
-  poweredEffect: influence(4),
+  basicEffect: compound(
+    influence(2),
+    { type: EFFECT_APPLY_LEARNING_DISCOUNT, cost: 6, destination: "discard" },
+  ),
+  poweredEffect: compound(
+    influence(4),
+    { type: EFFECT_APPLY_LEARNING_DISCOUNT, cost: 9, destination: "hand" },
+  ),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/learningCard.test.ts
+++ b/packages/core/src/engine/__tests__/learningCard.test.ts
@@ -1,0 +1,588 @@
+/**
+ * Tests for Learning advanced action card
+ *
+ * RULES:
+ * - Basic: Influence 2 + once per turn, pay 6 influence for AA → discard pile
+ * - Powered: Influence 4 + once per turn, pay 9 influence for AA → hand
+ * - The "once per turn" ability is tracked via a modifier (consumed on use)
+ * - Uses the regular AA offer (not monastery), with replenishment
+ * - Works anywhere (not site-dependent)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createTestHex } from "./testHelpers.js";
+import {
+  LEARN_ADVANCED_ACTION_ACTION,
+  PLAY_CARD_ACTION,
+  UNDO_ACTION,
+  INVALID_ACTION,
+  ADVANCED_ACTION_GAINED,
+  OFFER_REFRESHED,
+  GAME_PHASE_ROUND,
+  CARD_MARCH,
+  CARD_FIRE_BOLT,
+  CARD_ICE_BOLT,
+  CARD_BLOOD_RAGE,
+  CARD_LEARNING,
+  MANA_WHITE,
+  MANA_SOURCE_TOKEN,
+  MANA_TOKEN_SOURCE_CARD,
+  hexKey,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import type { ActiveModifier } from "../../types/modifiers.js";
+import {
+  EFFECT_LEARNING_DISCOUNT,
+  DURATION_TURN,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+
+describe("Learning Card - Discounted AA Acquisition", () => {
+  let engine: ReturnType<typeof createEngine>;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  /**
+   * Create a learning discount modifier for testing.
+   */
+  function createLearningDiscountModifier(
+    playerId: string,
+    cost: number,
+    destination: "hand" | "discard",
+    round = 1,
+  ): ActiveModifier {
+    return {
+      id: `mod_learning_test_${cost}`,
+      source: { type: SOURCE_CARD, cardId: CARD_LEARNING, playerId },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: {
+        type: EFFECT_LEARNING_DISCOUNT,
+        cost,
+        destination,
+      },
+      createdAtRound: round,
+      createdByPlayerId: playerId,
+    };
+  }
+
+  /**
+   * Create a test state with AA offer and an active learning discount modifier.
+   */
+  function createStateWithLearningDiscount(
+    cost: number,
+    destination: "hand" | "discard",
+    playerOverrides: Parameters<typeof createTestPlayer>[0] = {},
+    aaOffer: CardId[] = [CARD_FIRE_BOLT, CARD_ICE_BOLT],
+    aaDeck: CardId[] = [CARD_BLOOD_RAGE],
+  ) {
+    const player = createTestPlayer({
+      position: { q: 0, r: 0 },
+      hand: [CARD_MARCH],
+      ...playerOverrides,
+    });
+
+    const hex = {
+      ...createTestHex(0, 0),
+      site: undefined,
+    };
+
+    return createTestGameState({
+      players: [player],
+      phase: GAME_PHASE_ROUND,
+      map: {
+        hexes: {
+          [hexKey({ q: 0, r: 0 })]: hex,
+        },
+        tiles: [],
+        tileDeck: { countryside: [], core: [] },
+      },
+      offers: {
+        units: [],
+        advancedActions: { cards: aaOffer },
+        spells: { cards: [] },
+        commonSkills: [],
+        monasteryAdvancedActions: [],
+      },
+      decks: {
+        units: [],
+        advancedActions: aaDeck,
+        spells: [],
+        artifacts: [],
+      },
+      activeModifiers: [
+        createLearningDiscountModifier(player.id, cost, destination),
+      ],
+    });
+  }
+
+  describe("Basic effect (cost 6, discard pile)", () => {
+    it("should buy AA from regular offer via Learning and add to discard pile", () => {
+      const state = createStateWithLearningDiscount(6, "discard", {
+        influencePoints: 6,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // AA should be in discard pile (not deck)
+      expect(result.state.players[0]?.discard).toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.deck).not.toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.hand).not.toContain(CARD_FIRE_BOLT);
+
+      // Influence should be consumed
+      expect(result.state.players[0]?.influencePoints).toBe(0);
+
+      // Card should be removed from offer
+      expect(result.state.offers.advancedActions.cards).not.toContain(CARD_FIRE_BOLT);
+
+      // Check events
+      const gainedEvent = result.events.find((e) => e.type === ADVANCED_ACTION_GAINED);
+      expect(gainedEvent).toBeDefined();
+    });
+
+    it("should consume the learning discount modifier after use", () => {
+      const state = createStateWithLearningDiscount(6, "discard", {
+        influencePoints: 6,
+      });
+
+      // Verify modifier exists before
+      expect(state.activeModifiers).toHaveLength(1);
+      expect(state.activeModifiers[0]?.effect.type).toBe(EFFECT_LEARNING_DISCOUNT);
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // Modifier should be consumed (removed)
+      const learningModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      );
+      expect(learningModifiers).toHaveLength(0);
+    });
+
+    it("should replenish the regular offer from deck", () => {
+      const state = createStateWithLearningDiscount(
+        6,
+        "discard",
+        { influencePoints: 6 },
+        [CARD_FIRE_BOLT],
+        [CARD_ICE_BOLT],
+      );
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // Offer should be replenished
+      expect(result.state.offers.advancedActions.cards).toContain(CARD_ICE_BOLT);
+      expect(result.state.decks.advancedActions).toHaveLength(0);
+
+      const refreshedEvent = result.events.find((e) => e.type === OFFER_REFRESHED);
+      expect(refreshedEvent).toBeDefined();
+    });
+
+    it("should work with excess influence", () => {
+      const state = createStateWithLearningDiscount(6, "discard", {
+        influencePoints: 10,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      expect(result.state.players[0]?.discard).toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.influencePoints).toBe(4); // 10 - 6
+    });
+  });
+
+  describe("Powered effect (cost 9, hand)", () => {
+    it("should buy AA from regular offer via Learning and add to hand", () => {
+      const state = createStateWithLearningDiscount(9, "hand", {
+        influencePoints: 9,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // AA should be in hand (not deck or discard)
+      expect(result.state.players[0]?.hand).toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.deck).not.toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.discard).not.toContain(CARD_FIRE_BOLT);
+
+      // Influence should be consumed
+      expect(result.state.players[0]?.influencePoints).toBe(0);
+    });
+
+    it("should consume the learning discount modifier for powered too", () => {
+      const state = createStateWithLearningDiscount(9, "hand", {
+        influencePoints: 9,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      const learningModifiers = result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      );
+      expect(learningModifiers).toHaveLength(0);
+    });
+  });
+
+  describe("Validation", () => {
+    it("should reject Learning purchase without active modifier", () => {
+      // Create state with NO learning modifier
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        hand: [CARD_MARCH],
+        influencePoints: 10,
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        phase: GAME_PHASE_ROUND,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              ...createTestHex(0, 0),
+              site: undefined,
+            },
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+        offers: {
+          units: [],
+          advancedActions: { cards: [CARD_FIRE_BOLT] },
+          spells: { cards: [] },
+          commonSkills: [],
+          monasteryAdvancedActions: [],
+        },
+        activeModifiers: [], // No modifiers
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+
+    it("should reject Learning purchase with insufficient influence", () => {
+      const state = createStateWithLearningDiscount(6, "discard", {
+        influencePoints: 5, // Need 6
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("influence");
+      }
+    });
+
+    it("should reject Learning purchase for AA not in offer", () => {
+      const state = createStateWithLearningDiscount(
+        6,
+        "discard",
+        { influencePoints: 6 },
+        [CARD_ICE_BOLT], // CARD_FIRE_BOLT not in offer
+      );
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+      if (invalidEvent && invalidEvent.type === INVALID_ACTION) {
+        expect(invalidEvent.reason).toContain("not available");
+      }
+    });
+
+    it("should reject Learning purchase for powered cost with basic cost influence", () => {
+      const state = createStateWithLearningDiscount(9, "hand", {
+        influencePoints: 8, // Need 9
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      const invalidEvent = result.events.find((e) => e.type === INVALID_ACTION);
+      expect(invalidEvent).toBeDefined();
+    });
+  });
+
+  describe("Undo", () => {
+    it("should undo Learning purchase and restore all state", () => {
+      const state = createStateWithLearningDiscount(6, "discard", {
+        influencePoints: 6,
+      });
+
+      // Execute the action
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // Verify action succeeded
+      expect(result.state.players[0]?.discard).toContain(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.influencePoints).toBe(0);
+      expect(result.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      )).toHaveLength(0);
+
+      // Undo the action
+      const undoResult = engine.processAction(result.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      // All state should be restored
+      expect(undoResult.state.players[0]?.discard).not.toContain(CARD_FIRE_BOLT);
+      expect(undoResult.state.players[0]?.influencePoints).toBe(6);
+      expect(undoResult.state.offers.advancedActions.cards).toContain(CARD_FIRE_BOLT);
+
+      // Learning discount modifier should be restored
+      const learningModifiers = undoResult.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      );
+      expect(learningModifiers).toHaveLength(1);
+    });
+
+    it("should undo Learning powered purchase (hand) and restore all state", () => {
+      const state = createStateWithLearningDiscount(9, "hand", {
+        influencePoints: 9,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      expect(result.state.players[0]?.hand).toContain(CARD_FIRE_BOLT);
+
+      const undoResult = engine.processAction(result.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      expect(undoResult.state.players[0]?.hand).not.toContain(CARD_FIRE_BOLT);
+      expect(undoResult.state.players[0]?.influencePoints).toBe(9);
+      expect(undoResult.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      )).toHaveLength(1);
+    });
+  });
+
+  describe("Does not interfere with other paths", () => {
+    it("should still allow level-up AA selection (fromLearning not set)", () => {
+      const player = createTestPlayer({
+        position: { q: 0, r: 0 },
+        hand: [CARD_MARCH],
+        pendingRewards: [{ type: "advanced_action" as const, count: 1 }],
+      });
+
+      const state = createTestGameState({
+        players: [player],
+        phase: GAME_PHASE_ROUND,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: {
+              ...createTestHex(0, 0),
+              site: undefined,
+            },
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+        offers: {
+          units: [],
+          advancedActions: { cards: [CARD_FIRE_BOLT] },
+          spells: { cards: [] },
+          commonSkills: [],
+          monasteryAdvancedActions: [],
+        },
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        // No fromLearning flag
+      });
+
+      // Should go to deck (level-up behavior)
+      expect(result.state.players[0]?.deck[0]).toBe(CARD_FIRE_BOLT);
+      expect(result.state.players[0]?.pendingRewards).toHaveLength(0);
+    });
+  });
+
+  describe("End-to-end: play Learning card then buy AA", () => {
+    it("basic: playing Learning creates modifier and grants influence", () => {
+      const player = createTestPlayer({
+        hand: [CARD_LEARNING, CARD_MARCH],
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          units: [],
+          advancedActions: { cards: [CARD_FIRE_BOLT, CARD_ICE_BOLT] },
+          spells: { cards: [] },
+          commonSkills: [],
+          monasteryAdvancedActions: [],
+        },
+      });
+
+      // Play Learning card (basic)
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_LEARNING,
+        powered: false,
+      });
+
+      // Should resolve the compound effect: influence(2) + learning discount modifier
+      // The compound effect auto-resolves both sub-effects
+
+      // Check that influence was gained
+      expect(playResult.state.players[0]?.influencePoints).toBe(2);
+
+      // Check that Learning discount modifier was created
+      const learningModifiers = playResult.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      );
+      expect(learningModifiers).toHaveLength(1);
+      expect(learningModifiers[0]?.effect).toMatchObject({
+        type: EFFECT_LEARNING_DISCOUNT,
+        cost: 6,
+        destination: "discard",
+      });
+    });
+
+    it("basic: full flow - play Learning then buy AA to discard", () => {
+      const player = createTestPlayer({
+        hand: [CARD_LEARNING, CARD_MARCH],
+        influencePoints: 4, // + 2 from Learning = 6, enough for AA purchase
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          units: [],
+          advancedActions: { cards: [CARD_FIRE_BOLT, CARD_ICE_BOLT] },
+          spells: { cards: [] },
+          commonSkills: [],
+          monasteryAdvancedActions: [],
+        },
+      });
+
+      // Step 1: Play Learning card (basic)
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_LEARNING,
+        powered: false,
+      });
+
+      expect(playResult.state.players[0]?.influencePoints).toBe(6); // 4 + 2
+
+      // Step 2: Buy AA via Learning
+      const buyResult = engine.processAction(playResult.state, "player1", {
+        type: LEARN_ADVANCED_ACTION_ACTION,
+        cardId: CARD_FIRE_BOLT,
+        fromMonastery: false,
+        fromLearning: true,
+      });
+
+      // AA in discard pile
+      expect(buyResult.state.players[0]?.discard).toContain(CARD_FIRE_BOLT);
+      // Influence consumed
+      expect(buyResult.state.players[0]?.influencePoints).toBe(0);
+      // Modifier consumed
+      expect(buyResult.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      )).toHaveLength(0);
+    });
+
+    it("powered: playing Learning creates modifier for hand destination", () => {
+      const player = createTestPlayer({
+        hand: [CARD_LEARNING, CARD_MARCH],
+        pureMana: [{ color: MANA_WHITE, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          units: [],
+          advancedActions: { cards: [CARD_FIRE_BOLT, CARD_ICE_BOLT] },
+          spells: { cards: [] },
+          commonSkills: [],
+          monasteryAdvancedActions: [],
+        },
+      });
+
+      // Play Learning card (powered with white mana)
+      const playResult = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_LEARNING,
+        powered: true,
+        manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_WHITE },
+      });
+
+      // Check influence gained (powered: 4)
+      expect(playResult.state.players[0]?.influencePoints).toBe(4);
+
+      // Check Learning discount modifier was created for hand
+      const learningModifiers = playResult.state.activeModifiers.filter(
+        (m) => m.effect.type === EFFECT_LEARNING_DISCOUNT
+      );
+      expect(learningModifiers).toHaveLength(1);
+      expect(learningModifiers[0]?.effect).toMatchObject({
+        type: EFFECT_LEARNING_DISCOUNT,
+        cost: 9,
+        destination: "hand",
+      });
+    });
+  });
+});

--- a/packages/core/src/engine/commands/factories/offers.ts
+++ b/packages/core/src/engine/commands/factories/offers.ts
@@ -40,13 +40,17 @@ function getBuySpellParams(action: PlayerAction): { cardId: CardId } | null {
  */
 function getLearnAdvancedActionParams(
   action: PlayerAction
-): { cardId: CardId; fromMonastery: boolean } | null {
+): { cardId: CardId; fromMonastery: boolean; fromLearning?: boolean } | null {
   if (
     action.type === LEARN_ADVANCED_ACTION_ACTION &&
     "cardId" in action &&
     "fromMonastery" in action
   ) {
-    return { cardId: action.cardId, fromMonastery: action.fromMonastery };
+    return {
+      cardId: action.cardId,
+      fromMonastery: action.fromMonastery,
+      fromLearning: action.fromLearning,
+    };
   }
   return null;
 }
@@ -83,6 +87,7 @@ export const createLearnAdvancedActionCommandFromAction: CommandFactory = (
     playerId,
     cardId: params.cardId,
     fromMonastery: params.fromMonastery,
+    fromLearning: params.fromLearning,
   });
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -61,6 +61,7 @@ import { registerHornOfWrathEffects } from "./hornOfWrathEffects.js";
 import { registerMaximalEffectEffects } from "./maximalEffectEffects.js";
 import { registerEndlessGemPouchEffects } from "./endlessGemPouchEffects.js";
 import { registerMagicTalentEffects } from "./magicTalentEffects.js";
+import { registerLearningEffects } from "./learningEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -226,4 +227,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Magic Talent effects (spell offer interaction)
   registerMagicTalentEffects(resolver);
+
+  // Learning effects (discounted AA purchase modifier)
+  registerLearningEffects();
 }

--- a/packages/core/src/engine/effects/learningEffects.ts
+++ b/packages/core/src/engine/effects/learningEffects.ts
@@ -1,0 +1,74 @@
+/**
+ * Learning card effect handlers
+ *
+ * Handles Learning card effects:
+ * - EFFECT_APPLY_LEARNING_DISCOUNT: Grants a turn-scoped modifier that enables
+ *   a one-time discounted AA purchase from the regular offer.
+ *   Basic: pay 6 influence, AA to discard pile.
+ *   Powered: pay 9 influence, AA to hand.
+ *   The modifier is consumed when the purchase is made.
+ *
+ * @module effects/learningEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { ApplyLearningDiscountEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { LearningDiscountModifier } from "../../types/modifiers.js";
+import { registerEffect } from "./effectRegistry.js";
+import { addModifier } from "../modifiers/lifecycle.js";
+import { EFFECT_APPLY_LEARNING_DISCOUNT } from "../../types/effectTypes.js";
+import {
+  EFFECT_LEARNING_DISCOUNT,
+  DURATION_TURN,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { CARD_LEARNING } from "@mage-knight/shared";
+
+// ============================================================================
+// LEARNING DISCOUNT EFFECT
+// ============================================================================
+
+/**
+ * Handle EFFECT_APPLY_LEARNING_DISCOUNT - adds a turn-scoped modifier that enables
+ * a one-time discounted AA purchase from the regular offer.
+ */
+function handleApplyLearningDiscount(
+  state: GameState,
+  playerId: string,
+  effect: ApplyLearningDiscountEffect,
+): EffectResolutionResult {
+  const newState = addModifier(state, {
+    source: { type: SOURCE_CARD, cardId: CARD_LEARNING, playerId },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_LEARNING_DISCOUNT,
+      cost: effect.cost,
+      destination: effect.destination,
+    } satisfies LearningDiscountModifier,
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  const destDesc = effect.destination === "hand" ? "hand" : "discard pile";
+
+  return {
+    state: newState,
+    description: `May pay ${effect.cost} Influence to gain an AA to ${destDesc} this turn`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register all Learning card effect handlers with the effect registry.
+ */
+export function registerLearningEffects(): void {
+  registerEffect(EFFECT_APPLY_LEARNING_DISCOUNT, (state, playerId, effect) => {
+    return handleApplyLearningDiscount(state, playerId, effect as ApplyLearningDiscountEffect);
+  });
+}

--- a/packages/core/src/engine/rules/unitRecruitment.ts
+++ b/packages/core/src/engine/rules/unitRecruitment.ts
@@ -26,8 +26,8 @@ import {
   type UnitDefinition,
 } from "@mage-knight/shared";
 import { SiteType } from "../../types/map.js";
-import { EFFECT_RECRUIT_DISCOUNT, EFFECT_RECRUITMENT_BONUS, EFFECT_INTERACTION_BONUS } from "../../types/modifierConstants.js";
-import type { UnitRecruitmentBonusModifier, InteractionBonusModifier } from "../../types/modifiers.js";
+import { EFFECT_RECRUIT_DISCOUNT, EFFECT_RECRUITMENT_BONUS, EFFECT_INTERACTION_BONUS, EFFECT_LEARNING_DISCOUNT } from "../../types/modifierConstants.js";
+import type { UnitRecruitmentBonusModifier, InteractionBonusModifier, LearningDiscountModifier } from "../../types/modifiers.js";
 import { getModifiersForPlayer } from "../modifiers/queries.js";
 
 /**
@@ -344,4 +344,32 @@ export function getActiveInteractionBonusModifierIds(
   return modifiers
     .filter((m) => m.effect.type === EFFECT_INTERACTION_BONUS)
     .map((m) => m.id);
+}
+
+/**
+ * Get the active learning discount for a player, if any.
+ * Returns the first learning discount modifier found, or null if none.
+ *
+ * Used by Learning card — once per turn, pay influence for AA from regular offer.
+ */
+export function getActiveLearningDiscount(
+  state: GameState,
+  playerId: string,
+): LearningDiscountModifier | null {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const discountMod = modifiers.find((m) => m.effect.type === EFFECT_LEARNING_DISCOUNT);
+  if (!discountMod) return null;
+  return discountMod.effect as LearningDiscountModifier;
+}
+
+/**
+ * Get the active learning discount modifier ID, for removing it after use.
+ */
+export function getActiveLearningDiscountModifierId(
+  state: GameState,
+  playerId: string,
+): string | null {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const discountMod = modifiers.find((m) => m.effect.type === EFFECT_LEARNING_DISCOUNT);
+  return discountMod?.id ?? null;
 }

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -59,6 +59,7 @@ import {
 } from "./terrainCostReduction.js";
 import { getBannerOptions } from "./banners.js";
 import { getReturnableSkillOptions } from "./returnableSkills.js";
+import { getLearningAAPurchaseOptions } from "./learningAAPurchase.js";
 
 // Re-export helpers for use in other modules
 export {
@@ -301,5 +302,6 @@ export function getValidActions(
     skills: getSkillOptions(state, player),
     banners: getBannerOptions(state, player),
     returnableSkills: getReturnableSkillOptions(state, player),
+    learningAAPurchase: getLearningAAPurchaseOptions(state, player),
   };
 }

--- a/packages/core/src/engine/validActions/learningAAPurchase.ts
+++ b/packages/core/src/engine/validActions/learningAAPurchase.ts
@@ -1,0 +1,33 @@
+/**
+ * Learning card AA purchase valid actions computation.
+ *
+ * Computes whether the player can use a Learning card discount modifier
+ * to purchase an Advanced Action from the regular offer.
+ */
+
+import type { LearningAAPurchaseOptions } from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { getActiveLearningDiscount } from "../rules/unitRecruitment.js";
+
+/**
+ * Compute Learning AA purchase options, if a Learning discount modifier is active.
+ * Returns undefined if no Learning discount is available.
+ */
+export function getLearningAAPurchaseOptions(
+  state: GameState,
+  player: Player,
+): LearningAAPurchaseOptions | undefined {
+  const discount = getActiveLearningDiscount(state, player.id);
+  if (!discount) return undefined;
+
+  const availableCards = state.offers.advancedActions.cards;
+  if (availableCards.length === 0) return undefined;
+
+  return {
+    cost: discount.cost,
+    destination: discount.destination,
+    canAfford: player.influencePoints >= discount.cost,
+    availableCards,
+  };
+}

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -283,6 +283,7 @@ export const NOT_AT_AA_SITE = "NOT_AT_AA_SITE" as const;
 export const AA_NOT_IN_MONASTERY_OFFER = "AA_NOT_IN_MONASTERY_OFFER" as const;
 export const INSUFFICIENT_INFLUENCE_FOR_AA = "INSUFFICIENT_INFLUENCE_FOR_AA" as const;
 export const NOT_IN_LEVEL_UP_CONTEXT = "NOT_IN_LEVEL_UP_CONTEXT" as const;
+export const NO_LEARNING_DISCOUNT_ACTIVE = "NO_LEARNING_DISCOUNT_ACTIVE" as const;
 
 // Level up rewards validation codes
 export const LEVEL_UP_REWARDS_PENDING = "LEVEL_UP_REWARDS_PENDING" as const;
@@ -567,6 +568,7 @@ export type ValidationErrorCode =
   | typeof AA_NOT_IN_MONASTERY_OFFER
   | typeof INSUFFICIENT_INFLUENCE_FOR_AA
   | typeof NOT_IN_LEVEL_UP_CONTEXT
+  | typeof NO_LEARNING_DISCOUNT_ACTIVE
   // Level up rewards validation
   | typeof LEVEL_UP_REWARDS_PENDING
   | typeof NO_PENDING_LEVEL_UP_REWARDS

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -131,6 +131,7 @@ import {
   EFFECT_MAGIC_TALENT_POWERED,
   EFFECT_RESOLVE_MAGIC_TALENT_GAIN,
   EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA,
+  EFFECT_APPLY_LEARNING_DISCOUNT,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1504,6 +1505,17 @@ export interface ResolveMagicTalentSpellManaEffect {
   readonly manaSource: ManaSourceInfo;
 }
 
+/**
+ * Apply a learning discount modifier enabling one discounted AA purchase this turn.
+ * Used by Learning advanced action card.
+ * Basic: pay 6 influence, AA to discard pile.
+ * Powered: pay 9 influence, AA to hand.
+ */
+export interface ApplyLearningDiscountEffect {
+  readonly type: typeof EFFECT_APPLY_LEARNING_DISCOUNT;
+  readonly cost: number; // Influence cost (6 for basic, 9 for powered)
+  readonly destination: "hand" | "discard"; // Where the AA goes
+}
 
 // Union of all card effects
 export type CardEffect =
@@ -1613,7 +1625,8 @@ export type CardEffect =
   | ResolveMagicTalentSpellEffect
   | MagicTalentPoweredEffect
   | ResolveMagicTalentGainEffect
-  | ResolveMagicTalentSpellManaEffect;
+  | ResolveMagicTalentSpellManaEffect
+  | ApplyLearningDiscountEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -373,6 +373,11 @@ export const EFFECT_RESOLVE_MAGIC_TALENT_GAIN = "resolve_magic_talent_gain" as c
 // from the offer, then resolve the spell's basic effect.
 export const EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA = "resolve_magic_talent_spell_mana" as const;
 
+// === Learning Discount Effect ===
+// Adds a turn-scoped modifier enabling one discounted AA purchase from the regular offer.
+// Basic: pay 6 influence, AA to discard pile. Powered: pay 9 influence, AA to hand.
+export const EFFECT_APPLY_LEARNING_DISCOUNT = "apply_learning_discount" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -320,3 +320,11 @@ export const EFFECT_GOLDEN_GRAIL_FAME_TRACKING = "golden_grail_fame_tracking" as
 // Used by Golden Grail powered effect. Duration: turn.
 export const EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL = "golden_grail_draw_on_heal" as const;
 
+// === LearningDiscountModifier ===
+// Enables a one-time discounted AA purchase from the regular offer.
+// Created by the Learning advanced action card.
+// Basic: pay 6 influence, AA goes to discard pile.
+// Powered: pay 9 influence, AA goes to hand.
+// Consumed on first use. Does not require being at a site.
+export const EFFECT_LEARNING_DISCOUNT = "learning_discount" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -63,6 +63,7 @@ import {
   EFFECT_EXPLORE_COST_REDUCTION,
   EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
   EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
+  EFFECT_LEARNING_DISCOUNT,
   LEADERSHIP_BONUS_BLOCK,
   LEADERSHIP_BONUS_ATTACK,
   LEADERSHIP_BONUS_RANGED_ATTACK,
@@ -547,6 +548,17 @@ export interface GoldenGrailDrawOnHealModifier {
   readonly type: typeof EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL;
 }
 
+// Learning discount modifier (Learning advanced action card)
+// Enables a one-time discounted AA purchase from the regular offer.
+// Basic: pay 6 influence, AA goes to discard pile.
+// Powered: pay 9 influence, AA goes to hand.
+// Consumed on first use. Does not require being at a site.
+export interface LearningDiscountModifier {
+  readonly type: typeof EFFECT_LEARNING_DISCOUNT;
+  readonly cost: number; // Influence cost (6 for basic, 9 for powered)
+  readonly destination: "hand" | "discard"; // Where the AA goes
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -591,7 +603,8 @@ export type ModifierEffect =
   | HeroDamageReductionModifier
   | ExploreCostReductionModifier
   | GoldenGrailFameTrackingModifier
-  | GoldenGrailDrawOnHealModifier;
+  | GoldenGrailDrawOnHealModifier
+  | LearningDiscountModifier;
 
 // === Active Modifier (live in game state) ===
 

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -338,6 +338,8 @@ export interface LearnAdvancedActionAction {
   readonly type: typeof LEARN_ADVANCED_ACTION_ACTION;
   readonly cardId: CardId;
   readonly fromMonastery: boolean;
+  /** If true, this purchase is via the Learning card's special ability */
+  readonly fromLearning?: boolean;
 }
 
 export const BUY_HEALING_ACTION = "BUY_HEALING" as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -280,6 +280,8 @@ export type {
   UnitMaintenanceEntry,
   // Level up rewards options
   LevelUpRewardsOptions,
+  // Learning card AA purchase options
+  LearningAAPurchaseOptions,
   // Terrain cost reduction options
   HexCostReductionOptions,
   TerrainCostReductionOptions,

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -1279,6 +1279,28 @@ export interface NormalTurnState
   readonly cooperativeAssault: CooperativeAssaultOptions | undefined;
   readonly banners: BannerOptions | undefined;
   readonly returnableSkills: ReturnableSkillOptions | undefined;
+  /** Learning card AA purchase option (available when Learning discount modifier active) */
+  readonly learningAAPurchase: LearningAAPurchaseOptions | undefined;
+}
+
+// ============================================================================
+// Learning Card AA Purchase
+// ============================================================================
+
+/**
+ * Options for purchasing an Advanced Action via Learning card's special ability.
+ * Present when the Learning discount modifier is active (once per turn).
+ * Not tied to any site — available anywhere on the map.
+ */
+export interface LearningAAPurchaseOptions {
+  /** Influence cost to purchase an AA (6 for basic, 9 for powered) */
+  readonly cost: number;
+  /** Whether the AA goes to hand (powered) or discard pile (basic) */
+  readonly destination: "hand" | "discard";
+  /** Whether the player can afford the purchase */
+  readonly canAfford: boolean;
+  /** Available AA cards in the offer */
+  readonly availableCards: readonly CardId[];
 }
 
 /**


### PR DESCRIPTION
## Summary
Implements the Learning advanced action card's missing discounted AA acquisition ability:
- **Basic**: Influence 2 + once per turn, pay 6 influence for an AA from the regular offer → discard pile
- **Powered**: Influence 4 + once per turn, pay 9 influence for an AA from the regular offer → hand

## Changes
- Updated Learning card definition to use compound effects (influence + learning discount modifier)
- Added `LearningDiscountModifier` (consumable, turn-scoped) to track the once-per-turn ability
- Added `EFFECT_APPLY_LEARNING_DISCOUNT` effect type and resolver
- Extended `LearnAdvancedActionAction` with `fromLearning` flag for the learning purchase path
- Updated `learnAdvancedActionCommand` to support card-to-hand / card-to-discard destinations
- Updated validators to allow Learning path (no site required, checks modifier + influence)
- Added `LearningAAPurchaseOptions` to `NormalTurnState` validActions for UI integration
- Full undo support (restores modifier, influence, card placement, and offers)

## Key Design Decisions
- Uses the consumable modifier pattern (same as `RecruitDiscountModifier`, `InteractionBonusModifier`)
- Learning works anywhere — not tied to site interaction — so `learningAAPurchase` is a top-level field in `NormalTurnState` rather than nested in `SiteOptions`
- Reputation rules don't apply since this bypasses normal site interaction

## Test Plan
- 16 new tests covering:
  - Basic effect: AA to discard pile, influence consumed, modifier consumed, offer replenished
  - Powered effect: AA to hand, influence consumed, modifier consumed
  - Validation: no modifier, insufficient influence, AA not in offer
  - Undo: full state restoration including modifier
  - End-to-end: play Learning card → modifier created → buy AA
  - Non-interference with level-up AA path

Closes #168