### PR TITLE
feat: implement Amulet of the Sun artifact

### DIFF
--- a/packages/core/src/data/artifacts/amuletOfTheSun.ts
+++ b/packages/core/src/data/artifacts/amuletOfTheSun.ts
@@ -2,13 +2,119 @@
  * Amulet of the Sun artifact
  * Card #14 (127/377)
  *
- * Basic: Gain gold mana token. At Night: forests cost 3 to move,
- *        can use gold mana, reveal garrisons as if Day.
- * Powered: Same as basic but gain three gold mana tokens.
+ * Basic: Gain 1 gold mana token. At Night: forests cost 3 to move,
+ *        can use gold mana, reveal garrisons of nearby fortified sites as if Day.
+ * Powered (any color, destroy): Same as basic but gain 3 gold mana tokens.
+ *
+ * FAQ S1:
+ * - Desert movement cost remains 3 at night (already 3)
+ * - Can still use black mana at night
+ * - Gold mana CANNOT be converted to black mana
+ * - Day/night Skills (Day Sharpshooting, Dark Negotiation, etc.) still use NIGHT values
+ * - See Amulet of Darkness for counterpart
  */
 
-import type { DeedCard } from "../../types/cards.js";
+import type { DeedCard, CardEffect } from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_MANA,
+  EFFECT_APPLY_MODIFIER,
+  EFFECT_REVEAL_TILES,
+} from "../../types/effectTypes.js";
+import { ifNight } from "../effectHelpers.js";
+import {
+  CARD_AMULET_OF_THE_SUN,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_GOLD,
+  TERRAIN_FOREST,
+  REVEAL_TILE_TYPE_GARRISON,
+} from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
+import {
+  DURATION_TURN,
+  EFFECT_TERRAIN_COST,
+  EFFECT_RULE_OVERRIDE,
+  RULE_ALLOW_GOLD_AT_NIGHT,
+} from "../../types/modifierConstants.js";
 
-// TODO: Implement Amulet of the Sun
-export const AMULET_OF_THE_SUN_CARDS: Record<CardId, DeedCard> = {};
+/**
+ * Night modifiers applied by the Amulet of the Sun:
+ * 1. Forest movement cost reduced to 3 (day cost)
+ * 2. Gold mana can be used
+ * 3. Reveal garrisons of nearby fortified sites and ruins as if day
+ */
+const nightModifiers: CardEffect = {
+  type: EFFECT_COMPOUND,
+  effects: [
+    // Forest movement cost reduced to 3 (replaces night cost of 5)
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_TERRAIN_COST,
+        terrain: TERRAIN_FOREST,
+        amount: 0,
+        minimum: 0,
+        replaceCost: 3,
+      },
+      duration: DURATION_TURN,
+      description: "Forests cost 3 movement",
+    },
+    // Allow gold mana usage at night
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_RULE_OVERRIDE,
+        rule: RULE_ALLOW_GOLD_AT_NIGHT,
+      },
+      duration: DURATION_TURN,
+      description: "Gold mana can be used at night",
+    },
+    // Reveal garrisons of nearby fortified sites and ruins as if day
+    {
+      type: EFFECT_REVEAL_TILES,
+      distance: 1,
+      tileType: REVEAL_TILE_TYPE_GARRISON,
+    },
+  ],
+};
+
+/**
+ * Create the full effect: gain gold mana + conditional night modifiers
+ */
+function createAmuletEffect(manaCount: number): CardEffect {
+  const manaEffects: CardEffect[] = [];
+  for (let i = 0; i < manaCount; i++) {
+    manaEffects.push({ type: EFFECT_GAIN_MANA, color: MANA_GOLD });
+  }
+
+  return {
+    type: EFFECT_COMPOUND,
+    effects: [
+      ...manaEffects,
+      ifNight(nightModifiers),
+    ],
+  };
+}
+
+const AMULET_OF_THE_SUN: DeedCard = {
+  id: CARD_AMULET_OF_THE_SUN,
+  name: "Amulet of the Sun",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_SPECIAL],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: createAmuletEffect(1),
+  poweredEffect: createAmuletEffect(3),
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const AMULET_OF_THE_SUN_CARDS: Record<CardId, DeedCard> = {
+  [CARD_AMULET_OF_THE_SUN]: AMULET_OF_THE_SUN,
+};

--- a/packages/core/src/engine/__tests__/amuletOfTheSun.test.ts
+++ b/packages/core/src/engine/__tests__/amuletOfTheSun.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Tests for Amulet of the Sun artifact
+ *
+ * Basic: Gain 1 gold mana token. At night: forests cost 3, gold mana usable, garrisons revealed.
+ * Powered (any color, destroy): Same but gain 3 gold mana tokens.
+ *
+ * Edge cases:
+ * - Desert stays at cost 3 (no change)
+ * - Black mana still usable at night
+ * - Day/Night skills still use night values
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createTestHex,
+  createHexEnemy,
+} from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { AMULET_OF_THE_SUN_CARDS } from "../../data/artifacts/amuletOfTheSun.js";
+import { getEffectiveTerrainCost } from "../modifiers/terrain.js";
+import { isRuleActive } from "../modifiers/index.js";
+import { isManaColorAllowed, canUseGoldAsWild } from "../rules/mana.js";
+import {
+  CARD_AMULET_OF_THE_SUN,
+  MANA_GOLD,
+  MANA_BLACK,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+  TERRAIN_FOREST,
+  TERRAIN_DESERT,
+  TERRAIN_PLAINS,
+  TERRAIN_HILLS,
+  hexKey,
+} from "@mage-knight/shared";
+import type { EnemyTokenId } from "../../types/enemy.js";
+import { RULE_ALLOW_GOLD_AT_NIGHT } from "../../types/modifierConstants.js";
+import { SiteType } from "../../types/map.js";
+
+describe("Amulet of the Sun", () => {
+  const card = AMULET_OF_THE_SUN_CARDS[CARD_AMULET_OF_THE_SUN]!;
+
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should be defined with correct properties", () => {
+      expect(card).toBeDefined();
+      expect(card.name).toBe("Amulet of the Sun");
+      expect(card.destroyOnPowered).toBe(true);
+      expect(card.sidewaysValue).toBe(1);
+      expect(card.categories).toContain("special");
+    });
+
+    it("should be powered by any basic color", () => {
+      expect(card.poweredBy).toEqual(["red", "blue", "green", "white"]);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT - DAY
+  // ============================================================================
+
+  describe("basic effect during day", () => {
+    it("should gain 1 gold mana token", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      const tokens = result.state.players[0]!.pureMana;
+      expect(tokens).toHaveLength(1);
+      expect(tokens[0]!.color).toBe(MANA_GOLD);
+    });
+
+    it("should not apply night modifiers during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // No modifiers should be applied during day
+      expect(result.state.activeModifiers).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT - NIGHT
+  // ============================================================================
+
+  describe("basic effect during night", () => {
+    it("should gain 1 gold mana token", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      const goldTokens = result.state.players[0]!.pureMana.filter(
+        (t) => t.color === MANA_GOLD
+      );
+      expect(goldTokens).toHaveLength(1);
+    });
+
+    it("should reduce forest movement cost to 3", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // At night, forest normally costs 5
+      const nightForestCost = getEffectiveTerrainCost(
+        state,
+        TERRAIN_FOREST,
+        "player1"
+      );
+      expect(nightForestCost).toBe(5);
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // After Amulet, forest should cost 3
+      const modifiedForestCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_FOREST,
+        "player1"
+      );
+      expect(modifiedForestCost).toBe(3);
+    });
+
+    it("should allow gold mana usage at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // Before: gold mana not allowed at night
+      expect(isManaColorAllowed(state, MANA_GOLD, "player1")).toBe(false);
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // After: gold mana allowed for this player
+      expect(
+        isManaColorAllowed(result.state, MANA_GOLD, "player1")
+      ).toBe(true);
+      expect(
+        isRuleActive(result.state, "player1", RULE_ALLOW_GOLD_AT_NIGHT)
+      ).toBe(true);
+    });
+
+    it("should allow gold mana as wild at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // Before: gold not wild at night
+      expect(canUseGoldAsWild(state, "player1")).toBe(false);
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // After: gold is wild for this player
+      expect(canUseGoldAsWild(result.state, "player1")).toBe(true);
+    });
+
+    it("should reveal garrisons of nearby sites", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+        position: { q: 0, r: 0 },
+      });
+
+      // Create a hex with unrevealed garrison enemies adjacent to player
+      const keepHex = createTestHex(1, 0, TERRAIN_PLAINS, {
+        type: SiteType.Keep,
+        owner: null,
+        isConquered: false,
+        isBurned: false,
+      });
+      const enemyToken = createHexEnemy("orc_summoners_0" as EnemyTokenId, false);
+      keepHex.enemies = [enemyToken];
+
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        map: {
+          hexes: {
+            [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+            [hexKey({ q: 1, r: 0 })]: keepHex,
+          },
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      // Before: enemy not revealed
+      expect(
+        state.map.hexes[hexKey({ q: 1, r: 0 })]!.enemies[0]!.isRevealed
+      ).toBe(false);
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // After: garrison revealed
+      expect(
+        result.state.map.hexes[hexKey({ q: 1, r: 0 })]!.enemies[0]!.isRevealed
+      ).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT
+  // ============================================================================
+
+  describe("powered effect", () => {
+    it("should gain 3 gold mana tokens during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      const goldTokens = result.state.players[0]!.pureMana.filter(
+        (t) => t.color === MANA_GOLD
+      );
+      expect(goldTokens).toHaveLength(3);
+    });
+
+    it("should gain 3 gold mana tokens during night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      const goldTokens = result.state.players[0]!.pureMana.filter(
+        (t) => t.color === MANA_GOLD
+      );
+      expect(goldTokens).toHaveLength(3);
+    });
+
+    it("should apply night modifiers when used at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      // Forest should cost 3
+      const forestCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_FOREST,
+        "player1"
+      );
+      expect(forestCost).toBe(3);
+
+      // Gold mana should be allowed
+      expect(
+        isManaColorAllowed(result.state, MANA_GOLD, "player1")
+      ).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // EDGE CASES
+  // ============================================================================
+
+  describe("edge cases", () => {
+    it("should not change desert movement cost at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+
+      // Add desert hex to map
+      const hexes = {
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+        [hexKey({ q: 1, r: 0 })]: createTestHex(1, 0, TERRAIN_DESERT),
+      };
+
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        map: {
+          hexes,
+          tiles: [],
+          tileDeck: { countryside: [], core: [] },
+        },
+      });
+
+      // Desert at night costs 3 (already the "day" equivalent)
+      const desertCostBefore = getEffectiveTerrainCost(
+        state,
+        TERRAIN_DESERT,
+        "player1"
+      );
+      expect(desertCostBefore).toBe(3);
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Desert should still cost 3 (Amulet only affects forest)
+      const desertCostAfter = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_DESERT,
+        "player1"
+      );
+      expect(desertCostAfter).toBe(3);
+    });
+
+    it("should not affect other terrain costs at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Hills at night = 4, should be unchanged
+      const hillsCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_HILLS,
+        "player1"
+      );
+      expect(hillsCost).toBe(4);
+
+      // Plains at night = 3, should be unchanged
+      const plainsCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_PLAINS,
+        "player1"
+      );
+      expect(plainsCost).toBe(3);
+    });
+
+    it("should still allow black mana at night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Black mana should still be allowed at night
+      expect(isManaColorAllowed(result.state, MANA_BLACK)).toBe(true);
+    });
+
+    it("should not affect gold mana for other players", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [],
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Player 1 can use gold mana
+      expect(
+        isManaColorAllowed(result.state, MANA_GOLD, "player1")
+      ).toBe(true);
+
+      // Player 2 cannot use gold mana
+      expect(
+        isManaColorAllowed(result.state, MANA_GOLD, "player2")
+      ).toBe(false);
+    });
+
+    it("should have no effect on modifiers during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_THE_SUN],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // No modifiers at day (conditional is false, no else branch)
+      expect(result.state.activeModifiers).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/manaBoltEffects.ts
+++ b/packages/core/src/engine/effects/manaBoltEffects.ts
@@ -60,7 +60,7 @@ function handleManaBolt(
 ): EffectResolutionResult {
   const { player } = getPlayerContext(state, playerId);
   const base = effect.baseValue;
-  const goldIsWild = canUseGoldAsWild(state);
+  const goldIsWild = canUseGoldAsWild(state, playerId);
 
   // Per-color attack values: Blue = base, Red = base-1, White = base-2, Green = base-3
   const blueValue = base;

--- a/packages/core/src/engine/effects/pureMagicEffects.ts
+++ b/packages/core/src/engine/effects/pureMagicEffects.ts
@@ -54,7 +54,7 @@ function handlePureMagic(
   const { player } = getPlayerContext(state, playerId);
   const value = effect.value;
   const inCombat = state.combat !== null;
-  const goldIsWild = canUseGoldAsWild(state);
+  const goldIsWild = canUseGoldAsWild(state, playerId);
 
   // Check which basic colors the player has tokens for
   const hasGreen = countManaTokens(player, MANA_GREEN) >= 1;

--- a/packages/core/src/engine/rules/mana.ts
+++ b/packages/core/src/engine/rules/mana.ts
@@ -12,6 +12,8 @@ import {
   MANA_GOLD,
   TIME_OF_DAY_DAY,
 } from "@mage-knight/shared";
+import { isRuleActive } from "../modifiers/index.js";
+import { RULE_ALLOW_GOLD_AT_NIGHT } from "../../types/modifierConstants.js";
 
 export interface ManaTimeRules {
   readonly blackAllowed: boolean;
@@ -31,17 +33,28 @@ export function getManaTimeRules(state: GameState): ManaTimeRules {
   return { blackAllowed: true, goldAllowed: false };
 }
 
-export function isManaColorAllowed(state: GameState, color: ManaColor): boolean {
+export function isManaColorAllowed(state: GameState, color: ManaColor, playerId?: string): boolean {
   const rules = getManaTimeRules(state);
   if (color === MANA_BLACK) {
     return rules.blackAllowed;
   }
   if (color === MANA_GOLD) {
-    return rules.goldAllowed;
+    if (rules.goldAllowed) return true;
+    // Amulet of the Sun: allow gold mana usage at night for this player
+    if (playerId && isRuleActive(state, playerId, RULE_ALLOW_GOLD_AT_NIGHT)) {
+      return true;
+    }
+    return false;
   }
   return true;
 }
 
-export function canUseGoldAsWild(state: GameState): boolean {
-  return getManaTimeRules(state).goldAllowed;
+export function canUseGoldAsWild(state: GameState, playerId?: string): boolean {
+  const goldAllowed = getManaTimeRules(state).goldAllowed;
+  if (goldAllowed) return true;
+  // Amulet of the Sun: allow gold mana as wild at night for this player
+  if (playerId && isRuleActive(state, playerId, RULE_ALLOW_GOLD_AT_NIGHT)) {
+    return true;
+  }
+  return false;
 }

--- a/packages/core/src/engine/validActions/mana.ts
+++ b/packages/core/src/engine/validActions/mana.ts
@@ -39,7 +39,7 @@ export function getManaOptions(
 
   const addAvailableDie = (dieId: string, color: ManaColor) => {
     const colorAllowed =
-      isManaColorAllowed(state, color) || (color === MANA_BLACK && blackAsAnyColor);
+      isManaColorAllowed(state, color, player.id) || (color === MANA_BLACK && blackAsAnyColor);
     if (!colorAllowed) {
       return;
     }
@@ -139,7 +139,7 @@ export function canPayForMana(
   requiredColor: ManaColor
 ): boolean {
   const blackAsAnyColor = isRuleActive(state, player.id, RULE_BLACK_AS_ANY_COLOR);
-  if (!isManaColorAllowed(state, requiredColor) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
+  if (!isManaColorAllowed(state, requiredColor, player.id) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
     return false;
   }
 
@@ -165,7 +165,7 @@ export function canPayForMana(
       return true;
     }
     // Gold mana is wild (can be any basic color)
-    if (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state)) {
+    if (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id)) {
       return true;
     }
     // Note: Black mana is NOT wild - it can only power spells (match exact color MANA_BLACK)
@@ -206,7 +206,7 @@ export function canPayForMana(
           return true;
         }
         // Gold dice are wild (can substitute for basic colors) during the day
-        if (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state)) {
+        if (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id)) {
           return true;
         }
         // Mana Storm powered: gold dice can be used as any basic color
@@ -324,7 +324,7 @@ function countManaSourcesForColor(
   let count = 0;
   const forSpellPowered = options?.forSpellPowered ?? false;
   const blackAsAnyColor = isRuleActive(state, player.id, RULE_BLACK_AS_ANY_COLOR);
-  if (!isManaColorAllowed(state, requiredColor) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
+  if (!isManaColorAllowed(state, requiredColor, player.id) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
     return 0;
   }
 
@@ -347,7 +347,7 @@ function countManaSourcesForColor(
         continue;
       }
       count++;
-    } else if (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state)) {
+    } else if (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id)) {
       // Gold mana is wild for basic colors
       count++;
     }
@@ -381,7 +381,7 @@ function countManaSourcesForColor(
           count++;
         } else if (die.color === MANA_BLACK && requiredColor !== MANA_BLACK && blackAsAnyColor) {
           count++;
-        } else if (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state)) {
+        } else if (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id)) {
           // Gold dice are wild for basic colors
           count++;
         } else if (die.color === MANA_GOLD && isBasicMana(requiredColor) && goldAsAnyColor3) {
@@ -409,7 +409,7 @@ export function getAvailableManaSourcesForColor(
   const sources: import("@mage-knight/shared").ManaSourceInfo[] = [];
   const forSpellPowered = options?.forSpellPowered ?? false;
   const blackAsAnyColor = isRuleActive(state, player.id, RULE_BLACK_AS_ANY_COLOR);
-  if (!isManaColorAllowed(state, requiredColor) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
+  if (!isManaColorAllowed(state, requiredColor, player.id) && !(requiredColor === MANA_BLACK && blackAsAnyColor)) {
     return [];
   }
 
@@ -428,7 +428,7 @@ export function getAvailableManaSourcesForColor(
     // Match exact color, or gold die for basic colors (gold is wild)
     // Note: Black dice are NOT wild - they only match exact MANA_BLACK
     if (storedDie.color === requiredColor ||
-        (storedDie.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state))) {
+        (storedDie.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id))) {
       sources.push({
         type: "die" as const,
         dieId: storedDie.dieId,
@@ -451,7 +451,7 @@ export function getAvailableManaSourcesForColor(
       continue;
     }
     if (token.color === requiredColor ||
-        (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state))) {
+        (token.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id))) {
       sources.push({
         type: "token" as const,
         color: token.color,
@@ -495,7 +495,7 @@ export function getAvailableManaSourcesForColor(
         // Match exact color, or gold die for basic colors (gold is wild), or black as any color,
         // or gold as any basic color (Mana Storm)
         if (die.color === requiredColor ||
-            (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state)) ||
+            (die.color === MANA_GOLD && isBasicMana(requiredColor) && canUseGoldAsWild(state, player.id)) ||
             canUseBlackAsAny ||
             canUseGoldAsAny) {
           const useAsColor = canUseBlackAsAny || canUseGoldAsAny ? requiredColor : die.color;

--- a/packages/core/src/engine/validators/mana/rulesValidators.ts
+++ b/packages/core/src/engine/validators/mana/rulesValidators.ts
@@ -25,7 +25,7 @@ import {
   GOLD_MANA_NIGHT,
   GOLD_MANA_NOT_ALLOWED,
 } from "../validationCodes.js";
-import { getManaTimeRules } from "../../rules/mana.js";
+import { isManaColorAllowed } from "../../rules/mana.js";
 
 function getManaSources(action: PlayerAction): ManaSourceInfo[] {
   if (action.type !== PLAY_CARD_ACTION) {
@@ -97,7 +97,7 @@ export function validateManaColorMatch(
  */
 export function validateManaTimeOfDay(
   state: GameState,
-  _playerId: string,
+  playerId: string,
   action: PlayerAction
 ): ValidationResult {
   if (action.type !== PLAY_CARD_ACTION) return valid();
@@ -114,7 +114,7 @@ export function validateManaTimeOfDay(
     }
 
     // Gold mana cannot be used at night
-    if (manaColor === MANA_GOLD && state.timeOfDay !== TIME_OF_DAY_DAY) {
+    if (manaColor === MANA_GOLD && !isManaColorAllowed(state, MANA_GOLD, playerId)) {
       return invalid(GOLD_MANA_NIGHT, "Gold mana cannot be used at night");
     }
   }
@@ -183,12 +183,11 @@ export function validateManaTimeOfDayWithDungeonOverride(
   }
 
   const blackAsAnyColor = isRuleActive(state, playerId, RULE_BLACK_AS_ANY_COLOR);
-  const rules = getManaTimeRules(state);
   for (const source of manaSources) {
-    if (source.color === MANA_BLACK && !rules.blackAllowed && !blackAsAnyColor) {
+    if (source.color === MANA_BLACK && !isManaColorAllowed(state, MANA_BLACK) && !blackAsAnyColor) {
       return invalid(BLACK_MANA_DAY, "Black mana cannot be used during the day");
     }
-    if (source.color === MANA_GOLD && !rules.goldAllowed) {
+    if (source.color === MANA_GOLD && !isManaColorAllowed(state, MANA_GOLD, playerId)) {
       return invalid(GOLD_MANA_NIGHT, "Gold mana cannot be used at night");
     }
   }

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -295,6 +295,11 @@ export const EFFECT_ATTACK_BLOCK_CARD_BONUS = "attack_block_card_bonus" as const
 // Prevents tile exploration (Wings of Wind flight)
 export const RULE_NO_EXPLORATION = "no_exploration" as const;
 
+// === RuleOverrideModifier["rule"] - Amulet of the Sun ===
+// Allows using gold mana at night (normally gold is only available during day)
+// Does NOT change time of day for skills, does NOT allow gold→black conversion
+export const RULE_ALLOW_GOLD_AT_NIGHT = "allow_gold_at_night" as const;
+
 // === HeroDamageReductionModifier ===
 // Reduces incoming damage to the hero from a single enemy attack.
 // Element-specific: different reduction amounts based on attack element.

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -86,6 +86,7 @@ import {
   RULE_MOVE_CARDS_IN_COMBAT,
   RULE_INFLUENCE_CARDS_IN_COMBAT,
   RULE_NO_EXPLORATION,
+  RULE_ALLOW_GOLD_AT_NIGHT,
   RULE_SOURCE_BLOCKED,
   RULE_TERRAIN_DAY_NIGHT_SWAP,
   RULE_UNITS_CANNOT_ABSORB_DAMAGE,
@@ -229,7 +230,8 @@ export interface RuleOverrideModifier {
     | typeof RULE_UNITS_CANNOT_ABSORB_DAMAGE
     | typeof RULE_SPACE_BENDING_ADJACENCY
     | typeof RULE_TIME_BENDING_ACTIVE
-    | typeof RULE_NO_EXPLORATION;
+    | typeof RULE_NO_EXPLORATION
+    | typeof RULE_ALLOW_GOLD_AT_NIGHT;
 }
 
 // Ability nullifier (e.g., "ignore Swift on one enemy")


### PR DESCRIPTION
## Summary
- Implement Amulet of the Sun artifact with basic (1 gold mana) and powered (3 gold mana, destroy) effects
- At night: forests cost 3 movement, gold mana usable, nearby garrisons revealed as if day
- Add `RULE_ALLOW_GOLD_AT_NIGHT` per-player modifier for gold mana at night
- Update mana rules to support player-specific gold mana overrides

## Changes
- `amuletOfTheSun.ts` — Full card definition with conditional night modifiers
- `modifierConstants.ts` / `modifiers.ts` — New `RULE_ALLOW_GOLD_AT_NIGHT` rule
- `rules/mana.ts` — `isManaColorAllowed` and `canUseGoldAsWild` accept optional `playerId` to check per-player rules
- `validators/mana/rulesValidators.ts` — Updated gold mana validators to use player-aware checks
- `validActions/mana.ts` — Pass `playerId` to all gold mana availability checks
- `pureMagicEffects.ts` / `manaBoltEffects.ts` — Pass `playerId` to `canUseGoldAsWild`
- `amuletOfTheSun.test.ts` — 17 tests covering basic/powered effects, night modifiers, edge cases

Closes #229