### PR TITLE
feat: implement Training card throw-away and AA acquisition

### DIFF
--- a/packages/core/src/data/advancedActions/green/training.ts
+++ b/packages/core/src/data/advancedActions/green/training.ts
@@ -1,7 +1,7 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_GREEN, CARD_TRAINING } from "@mage-knight/shared";
-import { influence } from "../helpers.js";
+import { EFFECT_TRAINING } from "../../../types/effectTypes.js";
 
 export const TRAINING: DeedCard = {
   id: CARD_TRAINING,
@@ -9,10 +9,11 @@ export const TRAINING: DeedCard = {
   cardType: DEED_CARD_TYPE_ADVANCED_ACTION,
   poweredBy: [MANA_GREEN],
   categories: [CATEGORY_SPECIAL],
-  // Basic: Throw away an Action card from your hand, then take a card of the same color from the Advanced Actions offer and put it into your discard pile.
-  // Powered: Throw away an Action card from your hand, then take a card of the same color from the Advanced Actions offer and put it into your hand.
-  // TODO: Implement throw-away and card acquisition
-  basicEffect: influence(3),
-  poweredEffect: influence(5),
+  // Basic: Throw away an Action card from your hand, then take a card of the same color
+  //        from the Advanced Actions offer and put it into your discard pile.
+  basicEffect: { type: EFFECT_TRAINING, mode: "basic" },
+  // Powered: Throw away an Action card from your hand, then take a card of the same color
+  //          from the Advanced Actions offer and put it into your hand.
+  poweredEffect: { type: EFFECT_TRAINING, mode: "powered" },
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -162,6 +162,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     pendingDecompose: null,
     pendingMaximalEffect: null,
     pendingBookOfWisdom: null,
+    pendingTraining: null,
     pendingTerrainCostReduction: null,
     pendingAttackDefeatFame: [],
     enemiesDefeatedThisTurn: 0,

--- a/packages/core/src/engine/__tests__/training.test.ts
+++ b/packages/core/src/engine/__tests__/training.test.ts
@@ -1,0 +1,874 @@
+/**
+ * Tests for Training (green advanced action card)
+ *
+ * Training allows throwing away (permanently removing) an action card from hand
+ * to gain an AA of the same color from the offer:
+ * - Basic: Throw away action card -> gain AA of same color from offer to discard pile
+ * - Powered: Throw away action card -> gain AA of same color from offer to hand
+ *
+ * Key rules:
+ * - Only action cards (basic/advanced) can be thrown away (not wounds, artifacts, spells)
+ * - The Training card itself cannot be thrown away
+ * - Thrown away cards go to removedCards (permanent, not recycled)
+ * - Basic: gained card goes to DISCARD PILE
+ * - Powered: gained card goes to HAND
+ * - Two-phase resolution: select card to throw, then select from AA offer
+ * - Dual-color AAs match if EITHER color matches
+ * - Offer is replenished from deck after taking a card
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { isEffectResolvable } from "../effects/index.js";
+import { handleTrainingEffect, getCardsEligibleForTraining } from "../effects/trainingEffects.js";
+import { createResolveTrainingCommand } from "../commands/resolveTrainingCommand.js";
+import { createResolveTrainingCommandFromAction } from "../commands/factories/cards.js";
+import { describeEffect } from "../effects/describeEffect.js";
+import {
+  validateHasPendingTraining,
+  validateTrainingSelection,
+} from "../validators/trainingValidators.js";
+import { getTrainingOptions } from "../validActions/pending.js";
+import { getValidActions } from "../validActions/index.js";
+import { EFFECT_TRAINING } from "../../types/effectTypes.js";
+import type { TrainingEffect } from "../../types/cards.js";
+import type { PendingTraining } from "../../types/player.js";
+import {
+  CARD_TRAINING,
+  CARD_MARCH,
+  CARD_RAGE,
+  CARD_WOUND,
+  CARD_BANNER_OF_GLORY,
+  CARD_FIREBALL,
+  CARD_DESTROYED,
+  CARD_GAINED,
+  CARD_STAMINA,
+  RESOLVE_TRAINING_ACTION,
+  PLAY_CARD_ACTION,
+} from "@mage-knight/shared";
+import { CARD_PATH_FINDING } from "@mage-knight/shared";
+import { CARD_DECOMPOSE } from "@mage-knight/shared";
+import { CARD_REFRESHING_WALK } from "@mage-knight/shared";
+import { CARD_BLOOD_RAGE } from "@mage-knight/shared";
+import { CARD_IN_NEED } from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function makePending(overrides: Partial<PendingTraining> = {}): PendingTraining {
+  return {
+    sourceCardId: CARD_TRAINING,
+    mode: "basic",
+    phase: "select_card",
+    thrownCardColor: null,
+    availableOfferCards: [],
+    ...overrides,
+  };
+}
+
+function makePhase2Pending(
+  mode: "basic" | "powered",
+  thrownCardColor: "red" | "blue" | "green" | "white",
+  availableOfferCards: readonly CardId[]
+): PendingTraining {
+  return {
+    sourceCardId: CARD_TRAINING,
+    mode,
+    phase: "select_from_offer",
+    thrownCardColor,
+    availableOfferCards,
+  };
+}
+
+// ============================================================================
+// ELIGIBILITY
+// ============================================================================
+
+describe("Training", () => {
+  describe("getCardsEligibleForTraining", () => {
+    it("should return action cards excluding wounds and the source card", () => {
+      const hand = [CARD_MARCH, CARD_RAGE, CARD_WOUND, CARD_TRAINING];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH, CARD_RAGE]);
+    });
+
+    it("should exclude wounds", () => {
+      const hand = [CARD_WOUND, CARD_MARCH];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude the source card (Training itself)", () => {
+      const hand = [CARD_TRAINING, CARD_MARCH];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude artifacts (not action cards)", () => {
+      const hand = [CARD_BANNER_OF_GLORY, CARD_MARCH];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should exclude spells (not action cards)", () => {
+      const hand = [CARD_FIREBALL, CARD_MARCH];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH]);
+    });
+
+    it("should return empty when only wounds and Training in hand", () => {
+      const hand = [CARD_WOUND, CARD_TRAINING];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([]);
+    });
+
+    it("should include both basic and advanced action cards", () => {
+      const hand = [CARD_MARCH, CARD_DECOMPOSE];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([CARD_MARCH, CARD_DECOMPOSE]);
+    });
+  });
+
+  // ============================================================================
+  // RESOLVABILITY
+  // ============================================================================
+
+  describe("isEffectResolvable", () => {
+    const basicEffect: TrainingEffect = {
+      type: EFFECT_TRAINING,
+      mode: "basic",
+    };
+
+    it("should be resolvable when player has action cards", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should NOT be resolvable when player only has wounds", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when hand is empty", () => {
+      const player = createTestPlayer({ hand: [] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+
+    it("should NOT be resolvable when only artifacts in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_BANNER_OF_GLORY] });
+      const state = createTestGameState({ players: [player] });
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // EFFECT HANDLER
+  // ============================================================================
+
+  describe("handleTrainingEffect", () => {
+    it("should create pending state (basic mode)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH, CARD_RAGE] });
+      const state = createTestGameState({ players: [player] });
+      const effect: TrainingEffect = {
+        type: EFFECT_TRAINING,
+        mode: "basic",
+      };
+
+      const result = handleTrainingEffect(
+        state, 0, player, effect, CARD_TRAINING
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingTraining).not.toBeNull();
+      expect(result.state.players[0].pendingTraining?.mode).toBe("basic");
+      expect(result.state.players[0].pendingTraining?.phase).toBe("select_card");
+      expect(result.state.players[0].pendingTraining?.sourceCardId).toBe(CARD_TRAINING);
+    });
+
+    it("should create pending state (powered mode)", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: TrainingEffect = {
+        type: EFFECT_TRAINING,
+        mode: "powered",
+      };
+
+      const result = handleTrainingEffect(
+        state, 0, player, effect, CARD_TRAINING
+      );
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.state.players[0].pendingTraining?.mode).toBe("powered");
+    });
+
+    it("should throw when no action cards in hand", () => {
+      const player = createTestPlayer({ hand: [CARD_WOUND] });
+      const state = createTestGameState({ players: [player] });
+      const effect: TrainingEffect = {
+        type: EFFECT_TRAINING,
+        mode: "basic",
+      };
+
+      expect(() =>
+        handleTrainingEffect(state, 0, player, effect, CARD_TRAINING)
+      ).toThrow("No action cards available to throw away for Training");
+    });
+
+    it("should throw when sourceCardId is null", () => {
+      const player = createTestPlayer({ hand: [CARD_MARCH] });
+      const state = createTestGameState({ players: [player] });
+      const effect: TrainingEffect = {
+        type: EFFECT_TRAINING,
+        mode: "basic",
+      };
+
+      expect(() =>
+        handleTrainingEffect(state, 0, player, effect, null)
+      ).toThrow("TrainingEffect requires sourceCardId");
+    });
+  });
+
+  // ============================================================================
+  // COMMAND: PHASE 1 (select card to throw away)
+  // ============================================================================
+
+  describe("resolveTrainingCommand - phase 1", () => {
+    it("should throw away the selected card and transition to phase 2", () => {
+      // CARD_RAGE is red, so put a red AA in the offer
+      const player = createTestPlayer({
+        hand: [CARD_RAGE, CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE, CARD_REFRESHING_WALK, CARD_PATH_FINDING] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      // Card removed from hand
+      expect(result.state.players[0].hand).not.toContain(CARD_RAGE);
+      expect(result.state.players[0].hand).toContain(CARD_MARCH);
+
+      // Card added to removedCards (permanent removal)
+      expect(result.state.players[0].removedCards).toContain(CARD_RAGE);
+
+      // CARD_DESTROYED event emitted
+      expect(result.events).toContainEqual({
+        type: CARD_DESTROYED,
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+
+      // Transitions to phase 2 with matching red AA
+      const pending = result.state.players[0].pendingTraining;
+      expect(pending?.phase).toBe("select_from_offer");
+      expect(pending?.thrownCardColor).toBe("red");
+      expect(pending?.availableOfferCards).toContain(CARD_BLOOD_RAGE);
+      // Green AAs should NOT be in the available offer
+      expect(pending?.availableOfferCards).not.toContain(CARD_REFRESHING_WALK);
+    });
+
+    it("should clear pending if no matching AA in offer after throwing card", () => {
+      // Throw away a green card, but no green AAs in offer
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] }, // Only red AAs
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH, // green card
+      });
+
+      const result = command.execute(state);
+
+      // Card still thrown away
+      expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+      // Pending cleared (nothing to gain)
+      expect(result.state.players[0].pendingTraining).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // COMMAND: PHASE 2 (select AA from offer)
+  // ============================================================================
+
+  describe("resolveTrainingCommand - phase 2 basic (AA to discard)", () => {
+    it("should add selected AA to discard pile (basic mode)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_STAMINA], // remaining hand
+        discard: [],
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE, CARD_REFRESHING_WALK] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [CARD_IN_NEED],
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      // AA added to DISCARD PILE (not hand - basic mode)
+      expect(result.state.players[0].discard).toContain(CARD_BLOOD_RAGE);
+      // AA NOT added to hand
+      expect(result.state.players[0].hand).not.toContain(CARD_BLOOD_RAGE);
+
+      // Pending cleared
+      expect(result.state.players[0].pendingTraining).toBeNull();
+
+      // AA removed from offer
+      expect(result.state.offers.advancedActions.cards).not.toContain(CARD_BLOOD_RAGE);
+
+      // Offer replenished from deck
+      expect(result.state.offers.advancedActions.cards).toContain(CARD_IN_NEED);
+
+      // Deck decremented
+      expect(result.state.decks.advancedActions).not.toContain(CARD_IN_NEED);
+
+      // CARD_GAINED event emitted
+      expect(result.events).toContainEqual({
+        type: CARD_GAINED,
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+    });
+  });
+
+  describe("resolveTrainingCommand - phase 2 powered (AA to hand)", () => {
+    it("should add selected AA to hand (powered mode)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_STAMINA],
+        discard: [],
+        pendingTraining: makePhase2Pending("powered", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE, CARD_REFRESHING_WALK] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [],
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      // AA added to HAND (powered mode)
+      expect(result.state.players[0].hand).toContain(CARD_BLOOD_RAGE);
+      // AA NOT in discard
+      expect(result.state.players[0].discard).not.toContain(CARD_BLOOD_RAGE);
+
+      // Pending cleared
+      expect(result.state.players[0].pendingTraining).toBeNull();
+
+      // AA removed from offer
+      expect(result.state.offers.advancedActions.cards).not.toContain(CARD_BLOOD_RAGE);
+    });
+
+    it("should not replenish offer when deck is empty", () => {
+      const player = createTestPlayer({
+        hand: [CARD_STAMINA],
+        pendingTraining: makePhase2Pending("powered", "green", [CARD_REFRESHING_WALK]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_REFRESHING_WALK, CARD_BLOOD_RAGE] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [], // empty deck
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_REFRESHING_WALK,
+      });
+
+      const result = command.execute(state);
+
+      // Offer only has 1 card left (no replenishment)
+      expect(result.state.offers.advancedActions.cards).toHaveLength(1);
+      expect(result.state.offers.advancedActions.cards).toContain(CARD_BLOOD_RAGE);
+    });
+  });
+
+  // ============================================================================
+  // UNDO
+  // ============================================================================
+
+  describe("resolveTrainingCommand - undo", () => {
+    it("should undo phase 1 (restore hand and removedCards)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_RAGE, CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+
+      const afterExecute = command.execute(state);
+      const afterUndo = command.undo(afterExecute.state);
+
+      // Hand restored
+      expect(afterUndo.state.players[0].hand).toContain(CARD_RAGE);
+      expect(afterUndo.state.players[0].hand).toContain(CARD_MARCH);
+
+      // removedCards restored
+      expect(afterUndo.state.players[0].removedCards).not.toContain(CARD_RAGE);
+
+      // Pending restored to phase 1
+      expect(afterUndo.state.players[0].pendingTraining?.phase).toBe("select_card");
+    });
+
+    it("should undo phase 2 (restore hand, discard, offer, deck)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_STAMINA],
+        discard: [],
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE, CARD_REFRESHING_WALK] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [CARD_IN_NEED],
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      const afterExecute = command.execute(state);
+      const afterUndo = command.undo(afterExecute.state);
+
+      // Discard restored (AA removed)
+      expect(afterUndo.state.players[0].discard).not.toContain(CARD_BLOOD_RAGE);
+
+      // Offer restored
+      expect(afterUndo.state.offers.advancedActions.cards).toContain(CARD_BLOOD_RAGE);
+
+      // Deck restored
+      expect(afterUndo.state.decks.advancedActions).toContain(CARD_IN_NEED);
+
+      // Pending restored to phase 2
+      expect(afterUndo.state.players[0].pendingTraining?.phase).toBe("select_from_offer");
+    });
+  });
+
+  // ============================================================================
+  // VALIDATORS
+  // ============================================================================
+
+  describe("validators", () => {
+    it("should reject when no pending Training", () => {
+      const player = createTestPlayer({ pendingTraining: null });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateHasPendingTraining(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_MARCH,
+      });
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept when pending Training exists", () => {
+      const player = createTestPlayer({
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateHasPendingTraining(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_MARCH,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject phase 1 selection of non-eligible card (wound)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateTrainingSelection(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_WOUND,
+      });
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should reject phase 1 selection of Training itself", () => {
+      const player = createTestPlayer({
+        hand: [CARD_TRAINING, CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateTrainingSelection(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_TRAINING,
+      });
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept phase 1 selection of valid action card", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateTrainingSelection(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_MARCH,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject phase 2 selection of card not in available offer", () => {
+      const player = createTestPlayer({
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateTrainingSelection(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_REFRESHING_WALK, // green, not in available
+      });
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should accept phase 2 selection of card in available offer", () => {
+      const player = createTestPlayer({
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateTrainingSelection(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  // ============================================================================
+  // VALID ACTIONS
+  // ============================================================================
+
+  describe("validActions", () => {
+    it("should return training options in phase 1", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE, CARD_WOUND],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const options = getTrainingOptions(state, player);
+
+      expect(options).toBeDefined();
+      expect(options?.phase).toBe("select_card");
+      expect(options?.availableCardIds).toContain(CARD_MARCH);
+      expect(options?.availableCardIds).toContain(CARD_RAGE);
+      expect(options?.availableCardIds).not.toContain(CARD_WOUND);
+    });
+
+    it("should return training options in phase 2", () => {
+      const player = createTestPlayer({
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const options = getTrainingOptions(state, player);
+
+      expect(options).toBeDefined();
+      expect(options?.phase).toBe("select_from_offer");
+      expect(options?.availableOfferCards).toContain(CARD_BLOOD_RAGE);
+    });
+
+    it("should return undefined when no pending Training", () => {
+      const player = createTestPlayer({ pendingTraining: null });
+      const state = createTestGameState({ players: [player] });
+
+      const options = getTrainingOptions(state, player);
+      expect(options).toBeUndefined();
+    });
+
+    it("should return pending_training mode from getValidActions", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      expect(validActions.mode).toBe("pending_training");
+    });
+  });
+
+  // ============================================================================
+  // COMMAND FACTORY
+  // ============================================================================
+
+  describe("command factory", () => {
+    it("should create command from action when pending Training exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveTrainingCommandFromAction(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_MARCH,
+      });
+
+      expect(command).not.toBeNull();
+    });
+
+    it("should return null when no pending Training", () => {
+      const player = createTestPlayer({ pendingTraining: null });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveTrainingCommandFromAction(state, "player1", {
+        type: RESOLVE_TRAINING_ACTION,
+        cardId: CARD_MARCH,
+      });
+
+      expect(command).toBeNull();
+    });
+
+    it("should return null for non-training action type", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createResolveTrainingCommandFromAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_MARCH,
+        powered: false,
+      });
+
+      expect(command).toBeNull();
+    });
+  });
+
+  // ============================================================================
+  // DESCRIBE EFFECT
+  // ============================================================================
+
+  describe("describeEffect", () => {
+    it("should describe basic effect", () => {
+      const effect: TrainingEffect = { type: EFFECT_TRAINING, mode: "basic" };
+      const desc = describeEffect(effect);
+      expect(desc).toContain("discard pile");
+    });
+
+    it("should describe powered effect", () => {
+      const effect: TrainingEffect = { type: EFFECT_TRAINING, mode: "powered" };
+      const desc = describeEffect(effect);
+      expect(desc).toContain("hand");
+    });
+  });
+
+  // ============================================================================
+  // EDGE CASES / FAQ RULINGS
+  // ============================================================================
+
+  describe("edge cases", () => {
+    it("S2: cannot throw away Training itself (excluded from eligibility)", () => {
+      const hand = [CARD_TRAINING, CARD_WOUND];
+      const eligible = getCardsEligibleForTraining(hand, CARD_TRAINING);
+      expect(eligible).toEqual([]);
+    });
+
+    it("S3: thrown-away card MUST match color of AA in offer", () => {
+      // Player throws a green card, but only red AAs in offer
+      const player = createTestPlayer({
+        hand: [CARD_MARCH, CARD_RAGE],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] }, // Only red
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_MARCH, // green card
+      });
+
+      const result = command.execute(state);
+
+      // No matching green AAs → pending cleared, nothing to gain
+      expect(result.state.players[0].pendingTraining).toBeNull();
+      // But card still thrown away
+      expect(result.state.players[0].removedCards).toContain(CARD_MARCH);
+    });
+
+    it("card is permanently removed (in removedCards, not discard)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_RAGE, CARD_MARCH],
+        removedCards: [],
+        pendingTraining: makePending(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      // In removedCards (permanent)
+      expect(result.state.players[0].removedCards).toContain(CARD_RAGE);
+      // NOT in discard (not recycled)
+      expect(result.state.players[0].discard).not.toContain(CARD_RAGE);
+    });
+
+    it("basic: gained AA goes to discard (NOT hand)", () => {
+      const player = createTestPlayer({
+        hand: [],
+        discard: [],
+        pendingTraining: makePhase2Pending("basic", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [],
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      expect(result.state.players[0].discard).toContain(CARD_BLOOD_RAGE);
+      expect(result.state.players[0].hand).not.toContain(CARD_BLOOD_RAGE);
+    });
+
+    it("powered: gained AA goes to hand (NOT discard)", () => {
+      const player = createTestPlayer({
+        hand: [],
+        discard: [],
+        pendingTraining: makePhase2Pending("powered", "red", [CARD_BLOOD_RAGE]),
+      });
+      const state = createTestGameState({
+        players: [player],
+        offers: {
+          advancedActions: { cards: [CARD_BLOOD_RAGE] },
+          spells: { cards: [] },
+          units: { cards: [] },
+        },
+        decks: {
+          advancedActions: [],
+          spells: [],
+        },
+      });
+
+      const command = createResolveTrainingCommand({
+        playerId: "player1",
+        cardId: CARD_BLOOD_RAGE,
+      });
+
+      const result = command.execute(state);
+
+      expect(result.state.players[0].hand).toContain(CARD_BLOOD_RAGE);
+      expect(result.state.players[0].discard).not.toContain(CARD_BLOOD_RAGE);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/commandTypes.ts
+++ b/packages/core/src/engine/commands/commandTypes.ts
@@ -74,6 +74,9 @@ export const RESOLVE_MAXIMAL_EFFECT_COMMAND = "RESOLVE_MAXIMAL_EFFECT" as const;
 // Book of Wisdom command (throw away action card, gain from offer)
 export const RESOLVE_BOOK_OF_WISDOM_COMMAND = "RESOLVE_BOOK_OF_WISDOM" as const;
 
+// Training command (throw away action card, gain same-color AA from offer)
+export const RESOLVE_TRAINING_COMMAND = "RESOLVE_TRAINING" as const;
+
 // Meditation resolve command
 export const RESOLVE_MEDITATION_COMMAND = "RESOLVE_MEDITATION" as const;
 

--- a/packages/core/src/engine/commands/factories/cards.ts
+++ b/packages/core/src/engine/commands/factories/cards.ts
@@ -26,6 +26,7 @@ import {
   RESOLVE_DECOMPOSE_ACTION,
   RESOLVE_MAXIMAL_EFFECT_ACTION,
   RESOLVE_BOOK_OF_WISDOM_ACTION,
+  RESOLVE_TRAINING_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   MANA_BLACK,
 } from "@mage-knight/shared";
@@ -42,6 +43,7 @@ import { createResolveArtifactCrystalColorCommand } from "../resolveArtifactCrys
 import { createResolveDecomposeCommand } from "../resolveDecomposeCommand.js";
 import { createResolveMaximalEffectCommand } from "../resolveMaximalEffectCommand.js";
 import { createResolveBookOfWisdomCommand } from "../resolveBookOfWisdomCommand.js";
+import { createResolveTrainingCommand } from "../resolveTrainingCommand.js";
 import { getCard } from "../../validActions/cards/index.js";
 import { DEED_CARD_TYPE_SPELL } from "../../../types/cards.js";
 import { getAvailableManaSourcesForColor } from "../../validActions/mana.js";
@@ -395,6 +397,26 @@ export const createResolveBookOfWisdomCommandFromAction: CommandFactory = (
   if (!player?.pendingBookOfWisdom) return null;
 
   return createResolveBookOfWisdomCommand({
+    playerId,
+    cardId: action.cardId,
+  });
+};
+
+/**
+ * Resolve Training command factory.
+ * Creates a command to resolve a pending Training (throw away action card, gain same-color AA).
+ */
+export const createResolveTrainingCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== RESOLVE_TRAINING_ACTION) return null;
+
+  const player = getPlayerById(state, playerId);
+  if (!player?.pendingTraining) return null;
+
+  return createResolveTrainingCommand({
     playerId,
     cardId: action.cardId,
   });

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -31,6 +31,7 @@ import {
   RESOLVE_DECOMPOSE_ACTION,
   RESOLVE_MAXIMAL_EFFECT_ACTION,
   RESOLVE_BOOK_OF_WISDOM_ACTION,
+  RESOLVE_TRAINING_ACTION,
   RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION,
   REST_ACTION,
   DECLARE_REST_ACTION,
@@ -107,6 +108,7 @@ export {
   createResolveDecomposeCommandFromAction,
   createResolveMaximalEffectCommandFromAction,
   createResolveBookOfWisdomCommandFromAction,
+  createResolveTrainingCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -224,6 +226,7 @@ import {
   createResolveDecomposeCommandFromAction,
   createResolveMaximalEffectCommandFromAction,
   createResolveBookOfWisdomCommandFromAction,
+  createResolveTrainingCommandFromAction,
   createResolveArtifactCrystalColorCommandFromAction,
 } from "./cards.js";
 
@@ -335,6 +338,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [RESOLVE_DECOMPOSE_ACTION]: createResolveDecomposeCommandFromAction,
   [RESOLVE_MAXIMAL_EFFECT_ACTION]: createResolveMaximalEffectCommandFromAction,
   [RESOLVE_BOOK_OF_WISDOM_ACTION]: createResolveBookOfWisdomCommandFromAction,
+  [RESOLVE_TRAINING_ACTION]: createResolveTrainingCommandFromAction,
   [RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION]: createResolveArtifactCrystalColorCommandFromAction,
   [REST_ACTION]: createRestCommandFromAction,
   [DECLARE_REST_ACTION]: createDeclareRestCommandFromAction,

--- a/packages/core/src/engine/commands/resolveTrainingCommand.ts
+++ b/packages/core/src/engine/commands/resolveTrainingCommand.ts
@@ -1,0 +1,384 @@
+/**
+ * Resolve Training Command
+ *
+ * Handles player resolution of a pending Training effect.
+ * Two-phase resolution:
+ *
+ * Phase 1 (select_card): Player selects an action card to throw away.
+ *   - Card is permanently removed from the game (added to removedCards)
+ *   - Determines card color and filters matching AA offer cards
+ *   - Transitions to phase 2 (select_from_offer)
+ *
+ * Phase 2 (select_from_offer): Player selects an AA from the offer.
+ *   - Basic: AA goes to discard pile
+ *   - Powered: AA goes to hand
+ *   - Selected card removed from offer, offer replenished from deck
+ *   - Pending state cleared
+ *
+ * This command is reversible since it's part of normal card play flow.
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, CardId, BasicManaColor } from "@mage-knight/shared";
+import { CARD_DESTROYED, CARD_GAINED, MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE } from "@mage-knight/shared";
+import type { Player, PendingTraining } from "../../types/player.js";
+import type { BasicCardColor } from "../../types/effectTypes.js";
+import { RESOLVE_TRAINING_COMMAND } from "./commandTypes.js";
+import { getCardsEligibleForTraining } from "../effects/trainingEffects.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+import { getCard } from "../helpers/cardLookup.js";
+
+export { RESOLVE_TRAINING_COMMAND };
+
+export interface ResolveTrainingCommandParams {
+  readonly playerId: string;
+  /** Card ID: action card to throw away (phase 1) or AA from offer to gain (phase 2) */
+  readonly cardId: CardId;
+}
+
+export function createResolveTrainingCommand(
+  params: ResolveTrainingCommandParams
+): Command {
+  // Store previous state for undo
+  let previousPendingTraining: PendingTraining | null = null;
+  let previousHand: readonly CardId[] = [];
+  let previousDiscard: readonly CardId[] = [];
+  let previousRemovedCards: readonly CardId[] = [];
+  let previousOfferCards: readonly CardId[] = [];
+  let previousDeck: readonly CardId[] = [];
+  let previousPhase: "select_card" | "select_from_offer" = "select_card";
+
+  return {
+    type: RESOLVE_TRAINING_COMMAND,
+    playerId: params.playerId,
+    isReversible: true,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      if (!player.pendingTraining) {
+        throw new Error("No pending Training to resolve");
+      }
+
+      const pending = player.pendingTraining;
+      previousPhase = pending.phase;
+
+      if (pending.phase === "select_card") {
+        return executePhase1(state, player, playerIndex, pending);
+      } else {
+        return executePhase2(state, player, playerIndex, pending);
+      }
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error("Player not found");
+      }
+
+      const player = state.players[playerIndex];
+      if (!player) {
+        throw new Error("Player not found at index");
+      }
+
+      if (previousPhase === "select_card") {
+        // Undo phase 1: restore hand, removedCards, and pending state
+        const restoredPlayer: Player = {
+          ...player,
+          hand: previousHand,
+          removedCards: previousRemovedCards,
+          pendingTraining: previousPendingTraining,
+        };
+
+        return {
+          state: {
+            ...state,
+            players: state.players.map((p, i) =>
+              i === playerIndex ? restoredPlayer : p
+            ),
+          },
+          events: [],
+        };
+      } else {
+        // Undo phase 2: restore hand, discard, offer, deck, and pending state
+        const restoredPlayer: Player = {
+          ...player,
+          hand: previousHand,
+          discard: previousDiscard,
+          pendingTraining: previousPendingTraining,
+        };
+
+        return {
+          state: {
+            ...state,
+            players: state.players.map((p, i) =>
+              i === playerIndex ? restoredPlayer : p
+            ),
+            offers: {
+              ...state.offers,
+              advancedActions: { cards: previousOfferCards },
+            },
+            decks: {
+              ...state.decks,
+              advancedActions: previousDeck,
+            },
+          },
+          events: [],
+        };
+      }
+    },
+  };
+
+  // ============================================================================
+  // PHASE 1: Select action card to throw away
+  // ============================================================================
+
+  function executePhase1(
+    state: GameState,
+    player: Player,
+    playerIndex: number,
+    pending: PendingTraining
+  ): CommandResult {
+    // Store for undo
+    previousPendingTraining = pending;
+    previousHand = player.hand;
+    previousRemovedCards = player.removedCards;
+
+    const events: GameEvent[] = [];
+
+    // Validate card is eligible
+    const eligibleCards = getCardsEligibleForTraining(player.hand, pending.sourceCardId);
+    if (!eligibleCards.includes(params.cardId)) {
+      throw new Error(
+        `Card ${params.cardId} is not eligible for Training (must be an action card in hand, not the Training card itself)`
+      );
+    }
+
+    // Remove card from hand
+    const updatedHand = [...player.hand];
+    const cardIndex = updatedHand.indexOf(params.cardId);
+    if (cardIndex === -1) {
+      throw new Error(`Card ${params.cardId} not found in hand`);
+    }
+    updatedHand.splice(cardIndex, 1);
+
+    // Add to removedCards (permanent removal - throw away)
+    const updatedRemovedCards = [...player.removedCards, params.cardId];
+
+    // Emit card destroyed event
+    events.push({
+      type: CARD_DESTROYED,
+      playerId: params.playerId,
+      cardId: params.cardId,
+    });
+
+    // Get the action card color
+    const cardColor = getActionCardColor(params.cardId);
+    if (!cardColor) {
+      throw new Error(`Card ${params.cardId} has no color (not an action card)`);
+    }
+
+    // Find matching AA cards in the offer
+    const availableOfferCards = getMatchingAAOfferCards(state, cardColor);
+
+    // If no matching cards in offer, clear pending (nothing to gain)
+    if (availableOfferCards.length === 0) {
+      const updatedPlayer: Player = {
+        ...player,
+        hand: updatedHand,
+        removedCards: updatedRemovedCards,
+        pendingTraining: null,
+      };
+
+      return {
+        state: {
+          ...state,
+          players: state.players.map((p, i) =>
+            i === playerIndex ? updatedPlayer : p
+          ),
+        },
+        events,
+      };
+    }
+
+    // Transition to phase 2
+    const updatedPending: PendingTraining = {
+      ...pending,
+      phase: "select_from_offer",
+      thrownCardColor: cardColor,
+      availableOfferCards,
+    };
+
+    const updatedPlayer: Player = {
+      ...player,
+      hand: updatedHand,
+      removedCards: updatedRemovedCards,
+      pendingTraining: updatedPending,
+    };
+
+    return {
+      state: {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? updatedPlayer : p
+        ),
+      },
+      events,
+    };
+  }
+
+  // ============================================================================
+  // PHASE 2: Select AA from offer
+  // ============================================================================
+
+  function executePhase2(
+    state: GameState,
+    player: Player,
+    playerIndex: number,
+    pending: PendingTraining
+  ): CommandResult {
+    // Store for undo
+    previousPendingTraining = pending;
+    previousHand = player.hand;
+    previousDiscard = player.discard;
+
+    const events: GameEvent[] = [];
+    const selectedCardId = params.cardId;
+
+    // Validate card is in the available offer cards
+    if (!pending.availableOfferCards.includes(selectedCardId)) {
+      throw new Error(
+        `Card ${selectedCardId} is not available in the AA offer for Training`
+      );
+    }
+
+    const aaOffer = state.offers.advancedActions.cards;
+    const offerIndex = aaOffer.indexOf(selectedCardId);
+    if (offerIndex === -1) {
+      throw new Error("Selected card not in advanced action offer");
+    }
+
+    // Store for undo
+    previousOfferCards = aaOffer;
+    previousDeck = state.decks.advancedActions;
+
+    // Remove from offer
+    const newOffer = [
+      ...aaOffer.slice(0, offerIndex),
+      ...aaOffer.slice(offerIndex + 1),
+    ];
+
+    // Replenish from deck if available
+    let newDeck = state.decks.advancedActions;
+    let finalOffer = newOffer;
+    if (newDeck.length > 0) {
+      const newCard = newDeck[0];
+      if (newCard) {
+        finalOffer = [...newOffer, newCard];
+        newDeck = newDeck.slice(1);
+      }
+    }
+
+    // Basic: AA to discard pile, Powered: AA to hand
+    let updatedPlayer: Player;
+    if (pending.mode === "basic") {
+      updatedPlayer = {
+        ...player,
+        discard: [...player.discard, selectedCardId],
+        pendingTraining: null,
+      };
+    } else {
+      updatedPlayer = {
+        ...player,
+        hand: [...player.hand, selectedCardId],
+        pendingTraining: null,
+      };
+    }
+
+    events.push({
+      type: CARD_GAINED,
+      playerId: params.playerId,
+      cardId: selectedCardId,
+    });
+
+    return {
+      state: {
+        ...state,
+        players: state.players.map((p, i) =>
+          i === playerIndex ? updatedPlayer : p
+        ),
+        offers: {
+          ...state.offers,
+          advancedActions: { cards: finalOffer },
+        },
+        decks: {
+          ...state.decks,
+          advancedActions: newDeck,
+        },
+      },
+      events,
+    };
+  }
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Get matching AA cards from the offer based on the thrown card's color.
+ * Dual-color AAs match if EITHER color matches.
+ */
+function getMatchingAAOfferCards(
+  state: GameState,
+  cardColor: BasicCardColor
+): CardId[] {
+  return state.offers.advancedActions.cards.filter((cardId) => {
+    const aaColor = getActionCardColor(cardId);
+    if (aaColor === cardColor) return true;
+    // Check if it's a dual-color card powered by this color
+    return isDualColorMatch(cardId, cardColor);
+  });
+}
+
+/**
+ * Check if a card is a dual-color AA that matches via its secondary color.
+ */
+function isDualColorMatch(cardId: CardId, targetColor: BasicCardColor): boolean {
+  const card = getCard(cardId);
+  if (!card) return false;
+
+  const manaColor = cardColorToManaColor(targetColor);
+  return card.poweredBy.includes(manaColor);
+}
+
+/**
+ * Convert card color to mana color.
+ */
+function cardColorToManaColor(cardColor: BasicCardColor): BasicManaColor {
+  switch (cardColor) {
+    case "red":
+      return MANA_RED;
+    case "blue":
+      return MANA_BLUE;
+    case "green":
+      return MANA_GREEN;
+    case "white":
+      return MANA_WHITE;
+    default:
+      throw new Error(`Unknown card color: ${cardColor}`);
+  }
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -39,6 +39,7 @@ import {
   EFFECT_DECOMPOSE,
   EFFECT_MAXIMAL_EFFECT,
   EFFECT_BOOK_OF_WISDOM,
+  EFFECT_TRAINING,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
   EFFECT_APPLY_RECRUIT_DISCOUNT,
@@ -356,6 +357,13 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     return e.mode === "basic"
       ? "Throw away an action card, gain Advanced Action of same color from offer"
       : "Throw away an action card, gain Spell of same color from offer + crystal";
+  },
+
+  [EFFECT_TRAINING]: (effect) => {
+    const e = effect as import("../../types/cards.js").TrainingEffect;
+    return e.mode === "basic"
+      ? "Throw away an action card, gain AA of same color from offer to discard pile"
+      : "Throw away an action card, gain AA of same color from offer to hand";
   },
 
   [EFFECT_CRYSTAL_MASTERY_BASIC]: () => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -63,6 +63,7 @@ import { registerEndlessGemPouchEffects } from "./endlessGemPouchEffects.js";
 import { registerBookOfWisdomEffects } from "./bookOfWisdomEffects.js";
 import { registerMagicTalentEffects } from "./magicTalentEffects.js";
 import { registerLearningEffects } from "./learningEffects.js";
+import { registerTrainingEffects } from "./trainingEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -234,4 +235,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Learning effects (discounted AA purchase modifier)
   registerLearningEffects();
+
+  // Training effects (throw away action card, gain same-color AA from offer)
+  registerTrainingEffects();
 }

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -107,6 +107,7 @@ import {
   EFFECT_DECOMPOSE,
   EFFECT_MAXIMAL_EFFECT,
   EFFECT_BOOK_OF_WISDOM,
+  EFFECT_TRAINING,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
   EFFECT_POSSESS_ENEMY,
@@ -267,6 +268,15 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   [EFFECT_BOOK_OF_WISDOM]: (state, player, _effect) => {
     // Book of Wisdom is resolvable if player has at least one action card in hand
+    // (excluding wounds - the source card exclusion happens at resolution time)
+    const hasActionCards = player.hand.some(
+      (c) => c !== CARD_WOUND && getActionCardColor(c) !== null
+    );
+    return hasActionCards;
+  },
+
+  [EFFECT_TRAINING]: (state, player, _effect) => {
+    // Training is resolvable if player has at least one action card in hand
     // (excluding wounds - the source card exclusion happens at resolution time)
     const hasActionCards = player.hand.some(
       (c) => c !== CARD_WOUND && getActionCardColor(c) !== null

--- a/packages/core/src/engine/effects/trainingEffects.ts
+++ b/packages/core/src/engine/effects/trainingEffects.ts
@@ -1,0 +1,123 @@
+/**
+ * Training Effect Handler
+ *
+ * Handles the EFFECT_TRAINING effect:
+ * - Basic: Throw away an action card from hand, gain AA of same color from offer to discard pile.
+ * - Powered: Throw away an action card from hand, gain AA of same color from offer to hand.
+ *
+ * Only action cards (basic or advanced) can be thrown away (not wounds, artifacts, spells).
+ * The Training card itself cannot be thrown away.
+ *
+ * @module effects/trainingEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player, PendingTraining } from "../../types/player.js";
+import type { TrainingEffect } from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { CardId } from "@mage-knight/shared";
+import { CARD_WOUND } from "@mage-knight/shared";
+import { updatePlayer } from "./atomicHelpers.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { EFFECT_TRAINING } from "../../types/effectTypes.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+
+// ============================================================================
+// ELIGIBILITY HELPERS
+// ============================================================================
+
+/**
+ * Get cards eligible for Training (action cards in hand, excluding
+ * wounds and the source Training card itself).
+ *
+ * Additionally, a card's color must match at least one AA in the offer
+ * for it to be eligible. However, this offer-matching check is NOT done
+ * here — it is handled during phase 1 resolution after the card is selected.
+ * This function only checks hand eligibility.
+ */
+export function getCardsEligibleForTraining(
+  hand: readonly CardId[],
+  sourceCardId: CardId
+): CardId[] {
+  return hand.filter((cardId) => {
+    if (cardId === CARD_WOUND) return false;
+    if (cardId === sourceCardId) return false;
+    // Only action cards (those with a color) can be thrown away
+    return getActionCardColor(cardId) !== null;
+  });
+}
+
+// ============================================================================
+// EFFECT HANDLER
+// ============================================================================
+
+/**
+ * Handle the EFFECT_TRAINING effect.
+ *
+ * Creates a pendingTraining state on the player, blocking other actions
+ * until the player resolves it via RESOLVE_TRAINING action.
+ */
+export function handleTrainingEffect(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: TrainingEffect,
+  sourceCardId: CardId | null
+): EffectResolutionResult {
+  if (!sourceCardId) {
+    throw new Error("TrainingEffect requires sourceCardId");
+  }
+
+  const eligibleCards = getCardsEligibleForTraining(player.hand, sourceCardId);
+
+  // If no action cards available, the effect cannot resolve
+  if (eligibleCards.length === 0) {
+    throw new Error("No action cards available to throw away for Training");
+  }
+
+  // Create pending state for card selection (phase 1)
+  const pending: PendingTraining = {
+    sourceCardId,
+    mode: effect.mode,
+    phase: "select_card",
+    thrownCardColor: null,
+    availableOfferCards: [],
+  };
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingTraining: pending,
+  };
+
+  const updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+
+  return {
+    state: updatedState,
+    description: `Training (${effect.mode}) requires throwing away an action card`,
+    requiresChoice: true,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Training effect handler with the effect registry.
+ */
+export function registerTrainingEffects(): void {
+  registerEffect(
+    EFFECT_TRAINING,
+    (state, playerId, effect, sourceCardId) => {
+      const { playerIndex, player } = getPlayerContext(state, playerId);
+      return handleTrainingEffect(
+        state,
+        playerIndex,
+        player,
+        effect as TrainingEffect,
+        (sourceCardId as CardId | undefined) ?? null
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/validActions/index.ts
+++ b/packages/core/src/engine/validActions/index.ts
@@ -44,6 +44,7 @@ import {
   getDecomposeOptions,
   getMaximalEffectOptions,
   getBookOfWisdomOptions,
+  getTrainingOptions,
   getArtifactCrystalColorOptions,
   getCrystalJoyReclaimOptions,
   getSteadyTempoOptions,
@@ -191,6 +192,13 @@ export function getValidActions(
       mode: "pending_book_of_wisdom",
       turn: { canUndo: getTurnOptions(state, player).canUndo },
       bookOfWisdom: getBookOfWisdomOptions(state, player),
+    };
+  }
+  if (player.pendingTraining) {
+    return {
+      mode: "pending_training",
+      turn: { canUndo: getTurnOptions(state, player).canUndo },
+      training: getTrainingOptions(state, player),
     };
   }
   if (player.pendingLevelUpRewards.length > 0) {

--- a/packages/core/src/engine/validActions/pending.ts
+++ b/packages/core/src/engine/validActions/pending.ts
@@ -21,6 +21,7 @@ import type {
   DecomposeOptions,
   MaximalEffectOptions,
   BookOfWisdomOptions,
+  TrainingOptions,
   ArtifactCrystalColorOptions,
   CrystalJoyReclaimOptions,
   SteadyTempoOptions,
@@ -38,6 +39,7 @@ import { getCardsEligibleForDiscardForCrystal } from "../effects/discardForCryst
 import { getCardsEligibleForDecompose } from "../effects/decomposeEffects.js";
 import { getCardsEligibleForMaximalEffect } from "../effects/maximalEffectEffects.js";
 import { getCardsEligibleForBookOfWisdom } from "../effects/bookOfWisdomEffects.js";
+import { getCardsEligibleForTraining } from "../effects/trainingEffects.js";
 import { getCard } from "../helpers/cardLookup.js";
 import { isCardEligibleForReclaim } from "../rules/crystalJoyReclaim.js";
 
@@ -345,6 +347,42 @@ export function getBookOfWisdomOptions(
   if (phase === "select_card") {
     // Phase 1: show eligible action cards from hand
     const availableCardIds = getCardsEligibleForBookOfWisdom(player.hand, sourceCardId);
+    return {
+      sourceCardId,
+      mode,
+      phase,
+      availableCardIds,
+      availableOfferCards: [],
+    };
+  }
+
+  // Phase 2: show available offer cards
+  return {
+    sourceCardId,
+    mode,
+    phase,
+    availableCardIds: [],
+    availableOfferCards,
+  };
+}
+
+/**
+ * Get Training options for the player.
+ * Returns options if player has a pending Training state.
+ */
+export function getTrainingOptions(
+  state: GameState,
+  player: Player
+): TrainingOptions | undefined {
+  if (!player.pendingTraining) {
+    return undefined;
+  }
+
+  const { sourceCardId, mode, phase, availableOfferCards } = player.pendingTraining;
+
+  if (phase === "select_card") {
+    // Phase 1: show eligible action cards from hand
+    const availableCardIds = getCardsEligibleForTraining(player.hand, sourceCardId);
     return {
       sourceCardId,
       mode,

--- a/packages/core/src/engine/validators/registry/choiceRegistry.ts
+++ b/packages/core/src/engine/validators/registry/choiceRegistry.ts
@@ -24,6 +24,7 @@ import {
   RESOLVE_BANNER_PROTECTION_ACTION,
   RESOLVE_SOURCE_OPENING_REROLL_ACTION,
   RESOLVE_BOOK_OF_WISDOM_ACTION,
+  RESOLVE_TRAINING_ACTION,
 } from "@mage-knight/shared";
 
 // Turn validators
@@ -138,6 +139,12 @@ import {
   validateBookOfWisdomSelection,
 } from "../bookOfWisdomValidators.js";
 
+// Training validators
+import {
+  validateHasPendingTraining,
+  validateTrainingSelection,
+} from "../trainingValidators.js";
+
 export const choiceRegistry: Record<string, Validator[]> = {
   [RESOLVE_CHOICE_ACTION]: [
     validateIsPlayersTurn,
@@ -234,5 +241,10 @@ export const choiceRegistry: Record<string, Validator[]> = {
     validateIsPlayersTurn,
     validateHasPendingBookOfWisdom,
     validateBookOfWisdomSelection,
+  ],
+  [RESOLVE_TRAINING_ACTION]: [
+    validateIsPlayersTurn,
+    validateHasPendingTraining,
+    validateTrainingSelection,
   ],
 };

--- a/packages/core/src/engine/validators/trainingValidators.ts
+++ b/packages/core/src/engine/validators/trainingValidators.ts
@@ -1,0 +1,90 @@
+/**
+ * Training validators
+ *
+ * Validates RESOLVE_TRAINING actions for the Training advanced action card,
+ * which requires throwing away an action card from hand and then selecting
+ * a matching AA from the offer.
+ */
+
+import type { Validator, ValidationResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import { RESOLVE_TRAINING_ACTION } from "@mage-knight/shared";
+import { valid, invalid } from "./types.js";
+import {
+  TRAINING_REQUIRED,
+  TRAINING_CARD_NOT_ELIGIBLE,
+  TRAINING_CARD_NOT_IN_OFFER,
+  PLAYER_NOT_FOUND,
+} from "./validationCodes.js";
+import { getPlayerById } from "../helpers/playerHelpers.js";
+import { getCardsEligibleForTraining } from "../effects/trainingEffects.js";
+
+/**
+ * Validate that the player has a pending Training state
+ */
+export const validateHasPendingTraining: Validator = (
+  state: GameState,
+  playerId: string,
+  _action: PlayerAction
+): ValidationResult => {
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTraining) {
+    return invalid(
+      TRAINING_REQUIRED,
+      "No pending Training to resolve"
+    );
+  }
+
+  return valid();
+};
+
+/**
+ * Validate the Training card selection (both phases)
+ */
+export const validateTrainingSelection: Validator = (
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult => {
+  if (action.type !== RESOLVE_TRAINING_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  if (!player.pendingTraining) {
+    return valid(); // Let the other validator handle this
+  }
+
+  const pending = player.pendingTraining;
+  const cardId = action.cardId;
+
+  if (pending.phase === "select_card") {
+    // Phase 1: validate card is eligible action card in hand
+    const eligibleCards = getCardsEligibleForTraining(player.hand, pending.sourceCardId);
+    if (!eligibleCards.includes(cardId)) {
+      return invalid(
+        TRAINING_CARD_NOT_ELIGIBLE,
+        `Card ${cardId} is not eligible for Training (must be an action card in hand, not the Training card itself)`
+      );
+    }
+  } else {
+    // Phase 2: validate card is in the available offer cards
+    if (!pending.availableOfferCards.includes(cardId)) {
+      return invalid(
+        TRAINING_CARD_NOT_IN_OFFER,
+        `Card ${cardId} is not available in the AA offer for Training`
+      );
+    }
+  }
+
+  return valid();
+};

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -268,6 +268,11 @@ export const BOOK_OF_WISDOM_REQUIRED = "BOOK_OF_WISDOM_REQUIRED" as const;
 export const BOOK_OF_WISDOM_CARD_NOT_ELIGIBLE = "BOOK_OF_WISDOM_CARD_NOT_ELIGIBLE" as const;
 export const BOOK_OF_WISDOM_CARD_NOT_IN_OFFER = "BOOK_OF_WISDOM_CARD_NOT_IN_OFFER" as const;
 
+// Training validation codes
+export const TRAINING_REQUIRED = "TRAINING_REQUIRED" as const;
+export const TRAINING_CARD_NOT_ELIGIBLE = "TRAINING_CARD_NOT_ELIGIBLE" as const;
+export const TRAINING_CARD_NOT_IN_OFFER = "TRAINING_CARD_NOT_IN_OFFER" as const;
+
 // Maximal Effect validation codes
 export const MAXIMAL_EFFECT_REQUIRED = "MAXIMAL_EFFECT_REQUIRED" as const;
 export const MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE = "MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE" as const;
@@ -560,6 +565,10 @@ export type ValidationErrorCode =
   | typeof BOOK_OF_WISDOM_REQUIRED
   | typeof BOOK_OF_WISDOM_CARD_NOT_ELIGIBLE
   | typeof BOOK_OF_WISDOM_CARD_NOT_IN_OFFER
+  // Training validation
+  | typeof TRAINING_REQUIRED
+  | typeof TRAINING_CARD_NOT_ELIGIBLE
+  | typeof TRAINING_CARD_NOT_IN_OFFER
   // Maximal Effect validation
   | typeof MAXIMAL_EFFECT_REQUIRED
   | typeof MAXIMAL_EFFECT_CARD_NOT_ELIGIBLE

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -127,6 +127,7 @@ import {
   EFFECT_ROLL_FOR_CRYSTALS,
   EFFECT_RESOLVE_CRYSTAL_ROLL_CHOICE,
   EFFECT_BOOK_OF_WISDOM,
+  EFFECT_TRAINING,
   EFFECT_MAGIC_TALENT_BASIC,
   EFFECT_RESOLVE_MAGIC_TALENT_SPELL,
   EFFECT_MAGIC_TALENT_POWERED,
@@ -1455,6 +1456,16 @@ export interface BookOfWisdomEffect {
 }
 
 /**
+ * Training: throw away an action card, then gain an AA of the same color from the offer.
+ * Basic: gained AA goes to discard pile.
+ * Powered: gained AA goes to hand.
+ */
+export interface TrainingEffect {
+  readonly type: typeof EFFECT_TRAINING;
+  readonly mode: "basic" | "powered";
+}
+
+/**
  * Magic Talent basic effect entry point.
  * Discard a card of any color from hand. Then play one Spell card of the
  * same color from the Spells Offer as if it were in your hand.
@@ -1633,6 +1644,7 @@ export type CardEffect =
   | RollForCrystalsEffect
   | ResolveCrystalRollChoiceEffect
   | BookOfWisdomEffect
+  | TrainingEffect
   | MagicTalentBasicEffect
   | ResolveMagicTalentSpellEffect
   | MagicTalentPoweredEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -379,6 +379,12 @@ export const EFFECT_RESOLVE_MAGIC_TALENT_GAIN = "resolve_magic_talent_gain" as c
 // from the offer, then resolve the spell's basic effect.
 export const EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA = "resolve_magic_talent_spell_mana" as const;
 
+// === Training Effect ===
+// Throw away an action card from hand, then gain an AA of the same color from the offer.
+// Basic: gained AA goes to discard pile.
+// Powered: gained AA goes to hand.
+export const EFFECT_TRAINING = "training" as const;
+
 // === Learning Discount Effect ===
 // Adds a turn-scoped modifier enabling one discounted AA purchase from the regular offer.
 // Basic: pay 6 influence, AA to discard pile. Powered: pay 9 influence, AA to hand.

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -281,6 +281,27 @@ export interface PendingBookOfWisdom {
 }
 
 /**
+ * Pending Training resolution.
+ * Phase 1 (select_card): Player selects an action card from hand to throw away.
+ * Phase 2 (select_from_offer): Player selects a matching AA from the offer.
+ *
+ * Basic mode: gained AA goes to discard pile.
+ * Powered mode: gained AA goes to hand.
+ */
+export interface PendingTraining {
+  /** Source card (Training) */
+  readonly sourceCardId: CardId;
+  /** Whether this is "basic" or "powered" mode */
+  readonly mode: "basic" | "powered";
+  /** Current phase of the two-step resolution */
+  readonly phase: "select_card" | "select_from_offer";
+  /** Color of the thrown-away card (set after phase 1) */
+  readonly thrownCardColor: import("../types/effectTypes.js").BasicCardColor | null;
+  /** Cards available in the AA offer matching the thrown card color (set after phase 1) */
+  readonly availableOfferCards: readonly CardId[];
+}
+
+/**
  * Pending terrain cost reduction choice (Druidic Paths and similar effects).
  * Player must choose a hex coordinate or terrain type to apply cost reduction.
  */
@@ -495,6 +516,9 @@ export interface Player {
 
   // Book of Wisdom pending (throw away action card, gain card from offer)
   readonly pendingBookOfWisdom: PendingBookOfWisdom | null;
+
+  // Training pending (throw away action card, gain same-color AA from offer)
+  readonly pendingTraining: PendingTraining | null;
 
   // Attack-based fame tracking (e.g., Axe Throw powered effect)
   readonly pendingAttackDefeatFame: readonly AttackDefeatFameTracker[];

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -579,6 +579,7 @@ export class GameServer {
       pendingDecompose: null,
       pendingMaximalEffect: null,
       pendingBookOfWisdom: null,
+      pendingTraining: null,
       pendingAttackDefeatFame: [],
       enemiesDefeatedThisTurn: 0,
       healingPoints: 0,

--- a/packages/server/src/__tests__/stateFilters.test.ts
+++ b/packages/server/src/__tests__/stateFilters.test.ts
@@ -102,6 +102,7 @@ function createMinimalGameState(): GameState {
         pendingDecompose: null,
         pendingMaximalEffect: null,
         pendingBookOfWisdom: null,
+        pendingTraining: null,
         pendingTerrainCostReduction: null,
         pendingAttackDefeatFame: [],
         enemiesDefeatedThisTurn: 0,

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -553,6 +553,14 @@ export interface ResolveBookOfWisdomAction {
   readonly cardId: CardId;
 }
 
+// Training action (throw away action card / select AA of same color from offer)
+export const RESOLVE_TRAINING_ACTION = "RESOLVE_TRAINING" as const;
+export interface ResolveTrainingAction {
+  readonly type: typeof RESOLVE_TRAINING_ACTION;
+  /** Card ID to throw away (phase 1) or AA card ID from offer to gain (phase 2) */
+  readonly cardId: CardId;
+}
+
 // Artifact crystal color choice action (Savage Harvesting - second step for artifacts)
 export const RESOLVE_ARTIFACT_CRYSTAL_COLOR_ACTION = "RESOLVE_ARTIFACT_CRYSTAL_COLOR" as const;
 export interface ResolveArtifactCrystalColorAction {
@@ -843,6 +851,8 @@ export type PlayerAction =
   | ResolveMaximalEffectAction
   // Book of Wisdom (throw away action card, gain from offer)
   | ResolveBookOfWisdomAction
+  // Training (throw away action card, gain same-color AA from offer)
+  | ResolveTrainingAction
   // Artifact crystal color choice (Savage Harvesting - for artifacts)
   | ResolveArtifactCrystalColorAction
   // Combat

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -267,6 +267,9 @@ export type {
   // Book of Wisdom options (throw away action card, gain from offer)
   BookOfWisdomOptions,
   PendingBookOfWisdomState,
+  // Training options (throw away action card, gain same-color AA from offer)
+  TrainingOptions,
+  PendingTrainingState,
   // Crystal Joy reclaim options
   CrystalJoyReclaimOptions,
   // Steady Tempo deck placement options

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -916,6 +916,28 @@ export interface BookOfWisdomOptions {
 }
 
 // ============================================================================
+// Training (throw away action card, gain same-color AA from offer)
+// ============================================================================
+
+/**
+ * Options for Training resolution.
+ * Phase "select_card": Player selects an action card from hand to throw away.
+ * Phase "select_from_offer": Player selects a matching AA card from the offer.
+ */
+export interface TrainingOptions {
+  /** Source card (Training) */
+  readonly sourceCardId: CardId;
+  /** Whether the effect is basic (AA to discard) or powered (AA to hand) */
+  readonly mode: "basic" | "powered";
+  /** Current resolution phase */
+  readonly phase: "select_card" | "select_from_offer";
+  /** Action cards available to throw away (phase 1 only) */
+  readonly availableCardIds: readonly CardId[];
+  /** AA cards from offer matching thrown card's color (phase 2 only) */
+  readonly availableOfferCards: readonly CardId[];
+}
+
+// ============================================================================
 // Unit Maintenance (Magic Familiars round-start)
 // ============================================================================
 
@@ -1205,6 +1227,12 @@ export interface PendingBookOfWisdomState {
   readonly bookOfWisdom: BookOfWisdomOptions;
 }
 
+export interface PendingTrainingState {
+  readonly mode: "pending_training";
+  readonly turn: BlockingTurnOptions;
+  readonly training: TrainingOptions;
+}
+
 export interface PendingCrystalJoyState {
   readonly mode: "pending_crystal_joy_reclaim";
   readonly turn: BlockingTurnOptions;
@@ -1348,6 +1376,7 @@ export type ValidActions =
   | PendingDecomposeState
   | PendingMaximalEffectState
   | PendingBookOfWisdomState
+  | PendingTrainingState
   | PendingArtifactCrystalColorState
   | PendingCrystalJoyState
   | PendingSteadyTempoState


### PR DESCRIPTION
## Summary
- Implements the Training green Advanced Action card (#169) with proper two-phase throw-away and AA color-matching acquisition
- **Basic:** Throw away an action card from hand, then take a same-color AA from the offer into the discard pile
- **Powered:** Throw away an action card from hand, then take a same-color AA from the offer into the hand
- Replaces placeholder `influence(3)`/`influence(5)` effects with the correct mechanic

## Implementation
- New effect type `EFFECT_TRAINING` with two-phase pending state (`select_card` → `select_from_offer`)
- Follows the Book of Wisdom pattern: effect handler creates pending state, command resolves each phase
- Dual-color AA matching: cards match if either their primary color or `poweredBy` mana color matches
- Thrown-away cards go to `removedCards` (permanent removal, not recycled)
- Full undo support for both phases
- 43 tests covering eligibility, both phases, undo, validators, validActions, and edge cases

## Files Changed
**New files (4):**
- `packages/core/src/engine/effects/trainingEffects.ts` - Effect handler
- `packages/core/src/engine/commands/resolveTrainingCommand.ts` - Two-phase command
- `packages/core/src/engine/validators/trainingValidators.ts` - Validators
- `packages/core/src/engine/__tests__/training.test.ts` - Tests

**Modified files (20):** Effect types, card types, player state, shared actions/types, command/validator/validActions registries, describe/resolvability, server state initialization

## Test plan
- [x] All 43 Training-specific tests pass
- [x] Full test suite passes (4,354+ tests)
- [x] Build passes across all packages
- [x] Lint passes with zero warnings

Closes #169