### PR TITLE
feat: implement Braevalar Regenerate skill

### DIFF
--- a/packages/core/src/data/skills/braevalar/regenerate.ts
+++ b/packages/core/src/data/skills/braevalar/regenerate.ts
@@ -13,7 +13,7 @@ export const braevalarRegenerate: SkillDefinition = {
   id: SKILL_BRAEVALAR_REGENERATE,
     name: "Regenerate",
     heroId: "braevalar",
-    description: "Pay mana, discard Wound. Red mana or lowest Fame: draw card",
+    description: "Pay mana, discard Wound. Green mana or lowest Fame: draw card",
     usageType: SKILL_USAGE_ONCE_PER_TURN,
     categories: [CATEGORY_HEALING],
 };

--- a/packages/core/src/engine/__tests__/skillRegenerate.test.ts
+++ b/packages/core/src/engine/__tests__/skillRegenerate.test.ts
@@ -1,0 +1,652 @@
+/**
+ * Tests for Regenerate skill (Braevalar)
+ *
+ * Skill effect: Pay mana of any color, throw away a Wound from hand.
+ * If green mana was used, or player has the least Fame (not tied), draw a card.
+ *
+ * FAQ:
+ * S1: Must throw away a Wound - cannot just pay mana to draw.
+ * S2: Black mana permitted at night.
+ * S3: Healing effect - cannot be used during combat.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  CARD_WOUND,
+  CARD_MARCH,
+  CARD_RAGE,
+  MANA_RED,
+  MANA_GREEN,
+  MANA_BLUE,
+  MANA_BLACK,
+  MANA_SOURCE_TOKEN,
+  TIME_OF_DAY_NIGHT,
+} from "@mage-knight/shared";
+import type { ManaSourceInfo } from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_BRAEVALAR_REGENERATE } from "../../data/skills/index.js";
+import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
+import { getValidActions } from "../validActions/index.js";
+import { getSkillsFromValidActions } from "@mage-knight/shared";
+
+/** Helper to create a mana source info for a token of a given color */
+function tokenMana(color: string): ManaSourceInfo {
+  return { type: MANA_SOURCE_TOKEN, color: color as ManaSourceInfo["color"] };
+}
+
+describe("Regenerate skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate with mana and wound in hand", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_BRAEVALAR_REGENERATE,
+        })
+      );
+    });
+
+    it("should consume the mana token", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(result.state.players[0]?.pureMana).toHaveLength(0);
+    });
+
+    it("should remove wound from hand", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(result.state.players[0]?.hand).not.toContain(CARD_WOUND);
+    });
+
+    it("should return wound to wound pile", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const initialWoundPile = 10;
+      const state = createTestGameState({
+        players: [player],
+        woundPileCount: initialWoundPile,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(result.state.woundPileCount).toBe(initialWoundPile + 1);
+    });
+
+    it("should add skill to usedThisTurn cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(
+        result.state.players[0]?.skillCooldowns.usedThisTurn
+      ).toContain(SKILL_BRAEVALAR_REGENERATE);
+    });
+  });
+
+  describe("card draw bonus - green mana", () => {
+    it("should draw a card when green mana is spent", () => {
+      const deckCard = CARD_RAGE;
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      // Wound removed, deck card drawn
+      expect(result.state.players[0]?.hand).toContain(deckCard);
+      expect(result.state.players[0]?.hand).not.toContain(CARD_WOUND);
+      expect(result.state.players[0]?.deck).toHaveLength(0);
+    });
+
+    it("should not draw a card when non-green mana is spent (solo play)", () => {
+      const deckCard = CARD_RAGE;
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      // Wound removed but no card drawn (solo = no lowest fame bonus)
+      expect(result.state.players[0]?.hand).toEqual([CARD_MARCH]);
+      expect(result.state.players[0]?.deck).toEqual([deckCard]);
+    });
+
+    it("should handle empty deck when green mana draw is triggered", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      // Wound removed, no card drawn (empty deck)
+      expect(result.state.players[0]?.hand).toEqual([CARD_MARCH]);
+    });
+  });
+
+  describe("card draw bonus - lowest fame", () => {
+    it("should draw a card when player has strictly lowest fame", () => {
+      const deckCard = CARD_RAGE;
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        fame: 5,
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 15,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      // Card drawn because player1 has strictly lowest fame
+      expect(result.state.players[0]?.hand).toContain(deckCard);
+    });
+
+    it("should NOT draw a card when fame is tied for lowest", () => {
+      const deckCard = CARD_RAGE;
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        fame: 10,
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 10,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      // No card drawn - fame is tied
+      expect(result.state.players[0]?.hand).toEqual([CARD_MARCH]);
+      expect(result.state.players[0]?.deck).toEqual([deckCard]);
+    });
+
+    it("should NOT draw a card for lowest fame in solo play", () => {
+      const deckCard = CARD_RAGE;
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        fame: 0,
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      // No card drawn in solo play (no comparison possible)
+      expect(result.state.players[0]?.hand).toEqual([CARD_MARCH]);
+    });
+
+    it("should draw a card when green mana AND lowest fame both apply", () => {
+      const deckCard = CARD_RAGE;
+      const player1 = createTestPlayer({
+        id: "player1",
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        deck: [deckCard],
+        fame: 0,
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+        fame: 10,
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      // Still only draws one card (both conditions met but effect is the same)
+      expect(result.state.players[0]?.hand).toContain(deckCard);
+      expect(result.state.players[0]?.deck).toHaveLength(0);
+    });
+  });
+
+  describe("wound requirement (S1)", () => {
+    it("should reject activation when no wound in hand", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not show in valid actions when no wound in hand", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeUndefined();
+    });
+  });
+
+  describe("combat restriction (S3)", () => {
+    it("should reject activation during combat", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not show in valid actions during combat", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+      });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeUndefined();
+    });
+  });
+
+  describe("mana requirement", () => {
+    it("should reject activation without mana source", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        // No manaSource provided
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not show in valid actions when no mana available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeUndefined();
+    });
+
+    it("should show in valid actions when mana token available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_BLUE, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeDefined();
+    });
+
+    it("should show in valid actions when crystal available", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [],
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeDefined();
+    });
+  });
+
+  describe("black mana at night (S2)", () => {
+    it("should accept black mana at night", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_BLACK, source: "card" as const }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_BLACK),
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_BRAEVALAR_REGENERATE,
+        })
+      );
+      // Wound removed
+      expect(result.state.players[0]?.hand).not.toContain(CARD_WOUND);
+    });
+
+    it("should show in valid actions with black mana at night", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_BLACK, source: "card" as const }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeDefined();
+    });
+
+    it("should not show in valid actions with only black mana during day", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_BLACK, source: "card" as const }],
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeUndefined();
+    });
+  });
+
+  describe("once per turn cooldown", () => {
+    it("should reject activation when already used this turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_BRAEVALAR_REGENERATE],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_RED),
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not show in valid actions when on cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_RED, source: "card" as const }],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_BRAEVALAR_REGENERATE],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+
+      const regenerateOption = skills?.activatable.find(
+        (s) => s.skillId === SKILL_BRAEVALAR_REGENERATE
+      );
+      expect(regenerateOption).toBeUndefined();
+    });
+  });
+
+  describe("tracks mana color used", () => {
+    it("should track the mana color in manaUsedThisTurn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Braevalar,
+        skills: [SKILL_BRAEVALAR_REGENERATE],
+        hand: [CARD_MARCH, CARD_WOUND],
+        pureMana: [{ color: MANA_GREEN, source: "card" as const }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_BRAEVALAR_REGENERATE,
+        manaSource: tokenMana(MANA_GREEN),
+      });
+
+      expect(result.state.players[0]?.manaUsedThisTurn).toContain(MANA_GREEN);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -59,3 +59,9 @@ export {
   removeShapeshiftEffect,
   canActivateShapeshift,
 } from "./shapeshiftEffect.js";
+
+export {
+  applyRegenerateEffect,
+  removeRegenerateEffect,
+  canActivateRegenerate,
+} from "./regenerateEffect.js";

--- a/packages/core/src/engine/commands/skills/regenerateEffect.ts
+++ b/packages/core/src/engine/commands/skills/regenerateEffect.ts
@@ -1,0 +1,205 @@
+/**
+ * Regenerate skill effect handler
+ *
+ * Braevalar's skill: Once per turn, except in combat (healing effect):
+ * Pay a mana of any color and throw away a Wound from hand.
+ * If green mana was used, or player has the least Fame (not tied), draw a card.
+ *
+ * FAQ rulings:
+ * S1: Must throw away a Wound - cannot just pay mana to draw.
+ * S2: Black mana is permitted at night.
+ * S3: Healing effect - cannot be used during combat.
+ *
+ * Implementation:
+ * - Consumes 1 mana from the specified source (UI handles color selection)
+ * - Removes one Wound from hand and returns it to wound pile
+ * - Conditionally draws one card (green mana OR strictly lowest fame)
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { Player } from "../../../types/player.js";
+import type { ManaSourceInfo } from "@mage-knight/shared";
+import { CARD_WOUND, MANA_GREEN, MANA_RED, MANA_BLUE, MANA_WHITE, MANA_BLACK } from "@mage-knight/shared";
+import { getPlayerIndexByIdOrThrow } from "../../helpers/playerHelpers.js";
+import { consumeMana } from "../helpers/manaConsumptionHelpers.js";
+
+/**
+ * Check if the player has the strictly lowest fame (not tied with anyone).
+ * In solo play, this never qualifies (no other player to compare against).
+ */
+function hasStrictlyLowestFame(state: GameState, playerId: string): boolean {
+  if (state.players.length <= 1) {
+    return false;
+  }
+
+  const player = state.players.find((p) => p.id === playerId);
+  if (!player) return false;
+
+  const otherPlayers = state.players.filter((p) => p.id !== playerId);
+  return otherPlayers.every((p) => p.fame > player.fame);
+}
+
+/**
+ * Check if the player can activate Regenerate.
+ * Requires:
+ * 1. Has at least one Wound in hand
+ * 2. Not in combat (healing effect, S3)
+ * 3. Has mana available (basic colors + black at night)
+ */
+export function canActivateRegenerate(
+  state: GameState,
+  player: Player
+): boolean {
+  // Must have a wound in hand
+  if (!player.hand.some((c) => c === CARD_WOUND)) {
+    return false;
+  }
+
+  // Cannot use during combat (healing effect, S3)
+  if (state.combat !== null) {
+    return false;
+  }
+
+  // Must have at least 1 mana available
+  const basicColors: readonly string[] = [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE];
+  const isNight = state.timeOfDay === "night";
+
+  // Check pure mana tokens
+  for (const token of player.pureMana) {
+    if (basicColors.includes(token.color)) {
+      return true;
+    }
+    if (isNight && token.color === MANA_BLACK) {
+      return true;
+    }
+  }
+
+  // Check crystals (basic colors only - no black crystals)
+  for (const color of [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE] as const) {
+    if (player.crystals[color] > 0) {
+      return true;
+    }
+  }
+
+  // Check source dice (if not blocked and available)
+  if (!player.usedManaFromSource) {
+    for (const die of state.source.dice) {
+      if (die.takenByPlayerId === null && !die.isDepleted) {
+        if (basicColors.includes(die.color)) {
+          return true;
+        }
+        if (isNight && die.color === MANA_BLACK) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Apply the Regenerate skill effect.
+ *
+ * 1. Consume mana from the specified source
+ * 2. Remove one Wound from hand, return to wound pile
+ * 3. If green mana was spent OR player has strictly lowest fame: draw a card
+ */
+export function applyRegenerateEffect(
+  state: GameState,
+  playerId: string,
+  manaSource?: ManaSourceInfo
+): GameState {
+  if (!manaSource) {
+    throw new Error("Regenerate requires a mana source");
+  }
+
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  // 1. Consume the mana
+  const manaResult = consumeMana(player, state.source, manaSource, playerId);
+  let updatedPlayer = manaResult.player;
+  state = { ...state, source: manaResult.source };
+
+  // 2. Remove one Wound from hand
+  const woundIndex = updatedPlayer.hand.indexOf(CARD_WOUND);
+  if (woundIndex === -1) {
+    throw new Error("No wound in hand to discard");
+  }
+
+  const newHand = [...updatedPlayer.hand];
+  newHand.splice(woundIndex, 1);
+  updatedPlayer = { ...updatedPlayer, hand: newHand };
+
+  // Return wound to wound pile
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : state.woundPileCount + 1;
+  state = { ...state, woundPileCount: newWoundPileCount };
+
+  // 3. Check if bonus card draw is triggered
+  const usedGreenMana = manaSource.color === MANA_GREEN;
+  const lowestFame = hasStrictlyLowestFame(state, playerId);
+
+  if (usedGreenMana || lowestFame) {
+    // Draw one card from deck
+    const cardToDraw = updatedPlayer.deck[0];
+    if (cardToDraw !== undefined) {
+      const newDeck = updatedPlayer.deck.slice(1);
+      updatedPlayer = {
+        ...updatedPlayer,
+        hand: [...updatedPlayer.hand, cardToDraw],
+        deck: newDeck,
+      };
+    }
+  }
+
+  // Update player in state
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return { ...state, players };
+}
+
+/**
+ * Remove the Regenerate skill effect for undo.
+ *
+ * Note: Regenerate is marked isReversible: false because it draws cards,
+ * so the checkpoint mechanism handles full state restoration.
+ * This is a best-effort undo that restores the wound to hand.
+ * Mana restoration is handled by useSkillCommand.
+ */
+export function removeRegenerateEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  // Add wound back to hand
+  const newHand = [...player.hand, CARD_WOUND];
+
+  // Decrement wound pile
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : Math.max(0, state.woundPileCount - 1);
+
+  const updatedPlayer: Player = {
+    ...player,
+    hand: newHand,
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return {
+    ...state,
+    players,
+    woundPileCount: newWoundPileCount,
+  };
+}

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -62,6 +62,7 @@ import {
   SKILL_BRAEVALAR_BEGUILE,
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
   SKILL_BRAEVALAR_SHAPESHIFT,
+  SKILL_BRAEVALAR_REGENERATE,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -73,6 +74,7 @@ import { CARD_WOUND } from "@mage-knight/shared";
 import { canActivatePolarization } from "../commands/skills/polarizationEffect.js";
 import { canActivateInvocation } from "../commands/skills/invocationEffect.js";
 import { canActivateShapeshift } from "../commands/skills/shapeshiftEffect.js";
+import { canActivateRegenerate } from "../commands/skills/regenerateEffect.js";
 import { canUseMeleeAttackSkill, isMeleeAttackSkill } from "../rules/skillPhasing.js";
 import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { hexKey } from "@mage-knight/shared";
@@ -128,6 +130,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_BRAEVALAR_BEGUILE,
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
   SKILL_BRAEVALAR_SHAPESHIFT,
+  SKILL_BRAEVALAR_REGENERATE,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING]);
@@ -184,6 +187,10 @@ function canActivateSkill(
     case SKILL_BRAEVALAR_SHAPESHIFT:
       // Must have at least one Basic Action card with a shapeshiftable effect in hand
       return canActivateShapeshift(state, player);
+
+    case SKILL_BRAEVALAR_REGENERATE:
+      // Must have wound in hand, not in combat, and mana available
+      return canActivateRegenerate(state, player);
 
     default:
       // No special requirements

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -46,6 +46,7 @@ import {
   SKILL_GOLDYX_UNIVERSAL_POWER,
   SKILL_GOLDYX_SOURCE_OPENING,
   SKILL_WOLFHAWK_REFRESHING_BATH,
+  SKILL_BRAEVALAR_REGENERATE,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT } from "../../types/cards.js";
 import {
@@ -354,6 +355,30 @@ export const validateSkillRequirements: Validator = (
       return invalid(
         SKILL_REQUIRES_INTERACTION,
         "Glittering Fortune can only be used during interaction"
+      );
+    }
+  }
+
+  // Regenerate: requires wound in hand, not in combat, and mana source
+  if (useSkillAction.skillId === SKILL_BRAEVALAR_REGENERATE) {
+    if (state.combat !== null) {
+      return invalid(
+        SKILL_REQUIRES_NOT_IN_COMBAT,
+        "Regenerate cannot be used during combat"
+      );
+    }
+
+    if (!player.hand.some((c) => c === CARD_WOUND)) {
+      return invalid(
+        SKILL_REQUIRES_WOUND_IN_HAND,
+        "Regenerate requires a Wound in hand"
+      );
+    }
+
+    if (!useSkillAction.manaSource) {
+      return invalid(
+        SKILL_REQUIRES_MANA,
+        "Regenerate requires a mana source to spend"
       );
     }
   }


### PR DESCRIPTION
## Summary
- Implement the Regenerate healing skill for Braevalar
- Pay any color mana and throw away a Wound from hand
- Green mana or strictly lowest fame (not tied) triggers bonus card draw
- Fix skill description: "Red mana" → "Green mana"

## Changes
- `regenerateEffect.ts` — Custom handler: mana consumption, wound removal, conditional draw
- `useSkillCommand.ts` — Register custom handler, mark as non-reversible (card draw)
- `skillValidators.ts` — Validate wound in hand, not in combat, mana source required
- `validActions/skills.ts` — Add to IMPLEMENTED_SKILLS, check mana + wound + combat
- `regenerate.ts` — Fix description typo (Red → Green)
- `skillRegenerate.test.ts` — 26 tests covering all acceptance criteria

## Test Plan
- [x] Skill requires wound in hand to activate
- [x] Pay any color mana as cost
- [x] Wound is discarded (thrown away) from hand
- [x] Green mana triggers card draw bonus
- [x] Lowest fame (not tied) triggers card draw bonus
- [x] Cannot be used during combat (S3)
- [x] Black mana only available at night (S2)
- [x] Once per turn usage tracked correctly
- [x] Description fixed: "Red mana" → "Green mana"
- [x] Tests verify wound requirement (S1)
- [x] Tests verify fame comparison logic
- [x] Tests verify combat restriction

Closes #368