### PR TITLE
feat: implement Amulet of Darkness artifact

### DIFF
--- a/packages/core/src/data/artifacts/amuletOfDarkness.ts
+++ b/packages/core/src/data/artifacts/amuletOfDarkness.ts
@@ -3,12 +3,131 @@
  * Card #15 (128/377)
  *
  * Basic: Gain mana token of any color. At Day: deserts cost 3 to move,
- *        can use black mana as if Night.
- * Powered: Same as basic but gain three mana tokens of any colors.
+ *        can use black mana as if Night (including taking black dice from Source).
+ * Powered (any color, destroy): Same as basic but gain three mana tokens of any colors.
+ *
+ * FAQ S1:
+ * - Can gain black mana token(s) if desired
+ * - Can take black mana DICE from Source (normally black depleted during day)
+ * - Black mana usable day or night from ANY source
+ * - Can use black for spell powered effects
+ * - Gold mana: still usable during day, but NOT usable at night
+ * - "Night Rules" don't fully apply - just black mana access
+ * - Forest movement cost remains 3 at day (already 3)
+ * - Day/Night Skills still use DAY values
+ * - See Amulet of the Sun for counterpart
  */
 
-import type { DeedCard } from "../../types/cards.js";
+import type { DeedCard, CardEffect } from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_CHOICE,
+  EFFECT_GAIN_MANA,
+  EFFECT_APPLY_MODIFIER,
+} from "../../types/effectTypes.js";
+import { ifDay } from "../effectHelpers.js";
+import {
+  CARD_AMULET_OF_DARKNESS,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_BLACK,
+  MANA_GOLD,
+  TERRAIN_DESERT,
+} from "@mage-knight/shared";
 import type { CardId } from "@mage-knight/shared";
+import {
+  DURATION_TURN,
+  EFFECT_TERRAIN_COST,
+  EFFECT_RULE_OVERRIDE,
+  RULE_ALLOW_BLACK_AT_DAY,
+} from "../../types/modifierConstants.js";
 
-// TODO: Implement Amulet of Darkness
-export const AMULET_OF_DARKNESS_CARDS: Record<CardId, DeedCard> = {};
+/**
+ * Choice effect for gaining one mana token of any color.
+ * Player can choose from all 6 colors (red, blue, green, white, black, gold).
+ */
+const anyColorManaChoice: CardEffect = {
+  type: EFFECT_CHOICE,
+  options: [
+    { type: EFFECT_GAIN_MANA, color: MANA_RED },
+    { type: EFFECT_GAIN_MANA, color: MANA_BLUE },
+    { type: EFFECT_GAIN_MANA, color: MANA_GREEN },
+    { type: EFFECT_GAIN_MANA, color: MANA_WHITE },
+    { type: EFFECT_GAIN_MANA, color: MANA_BLACK },
+    { type: EFFECT_GAIN_MANA, color: MANA_GOLD },
+  ],
+};
+
+/**
+ * Day modifiers applied by the Amulet of Darkness:
+ * 1. Desert movement cost reduced to 3 (night cost)
+ * 2. Black mana can be used (including black dice from Source)
+ */
+const dayModifiers: CardEffect = {
+  type: EFFECT_COMPOUND,
+  effects: [
+    // Desert movement cost reduced to 3 (replaces day cost of 5)
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_TERRAIN_COST,
+        terrain: TERRAIN_DESERT,
+        amount: 0,
+        minimum: 0,
+        replaceCost: 3,
+      },
+      duration: DURATION_TURN,
+      description: "Deserts cost 3 movement",
+    },
+    // Allow black mana usage at day + black dice from Source
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_RULE_OVERRIDE,
+        rule: RULE_ALLOW_BLACK_AT_DAY,
+      },
+      duration: DURATION_TURN,
+      description: "Black mana can be used during the day",
+    },
+  ],
+};
+
+/**
+ * Create the full effect: gain any-color mana + conditional day modifiers
+ */
+function createAmuletEffect(manaCount: number): CardEffect {
+  const manaEffects: CardEffect[] = [];
+  for (let i = 0; i < manaCount; i++) {
+    manaEffects.push(anyColorManaChoice);
+  }
+
+  return {
+    type: EFFECT_COMPOUND,
+    effects: [
+      ...manaEffects,
+      ifDay(dayModifiers),
+    ],
+  };
+}
+
+const AMULET_OF_DARKNESS: DeedCard = {
+  id: CARD_AMULET_OF_DARKNESS,
+  name: "Amulet of Darkness",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  categories: [CATEGORY_SPECIAL],
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  basicEffect: createAmuletEffect(1),
+  poweredEffect: createAmuletEffect(3),
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const AMULET_OF_DARKNESS_CARDS: Record<CardId, DeedCard> = {
+  [CARD_AMULET_OF_DARKNESS]: AMULET_OF_DARKNESS,
+};

--- a/packages/core/src/engine/__tests__/amuletOfDarkness.test.ts
+++ b/packages/core/src/engine/__tests__/amuletOfDarkness.test.ts
@@ -1,0 +1,606 @@
+/**
+ * Tests for Amulet of Darkness artifact
+ *
+ * Basic: Gain 1 mana token of any color (choice). At day: deserts cost 3, black mana usable.
+ * Powered (any color, destroy): Same but gain 3 mana tokens of any colors.
+ *
+ * Edge cases:
+ * - Forest stays at cost 3 during day (no change)
+ * - Gold mana still usable during day
+ * - Gold mana still NOT usable at night
+ * - Day/Night skills still use day values
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createUnitCombatState,
+} from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { AMULET_OF_DARKNESS_CARDS } from "../../data/artifacts/amuletOfDarkness.js";
+import { getEffectiveTerrainCost } from "../modifiers/terrain.js";
+import { isRuleActive } from "../modifiers/index.js";
+import { isManaColorAllowed } from "../rules/mana.js";
+import { validateManaTimeOfDayWithDungeonOverride } from "../validators/mana/rulesValidators.js";
+import { canPayForMana, getManaOptions } from "../validActions/mana.js";
+import {
+  CARD_AMULET_OF_DARKNESS,
+  CARD_MARCH,
+  MANA_GOLD,
+  MANA_BLACK,
+  MANA_RED,
+  MANA_BLUE,
+  PLAY_CARD_ACTION,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+  TERRAIN_FOREST,
+  TERRAIN_DESERT,
+  TERRAIN_PLAINS,
+  TERRAIN_HILLS,
+} from "@mage-knight/shared";
+import { RULE_ALLOW_BLACK_AT_DAY } from "../../types/modifierConstants.js";
+import { COMBAT_PHASE_ATTACK } from "../../types/combat.js";
+
+describe("Amulet of Darkness", () => {
+  const card = AMULET_OF_DARKNESS_CARDS[CARD_AMULET_OF_DARKNESS]!;
+
+  // ============================================================================
+  // CARD DEFINITION
+  // ============================================================================
+
+  describe("card definition", () => {
+    it("should be defined with correct properties", () => {
+      expect(card).toBeDefined();
+      expect(card.name).toBe("Amulet of Darkness");
+      expect(card.destroyOnPowered).toBe(true);
+      expect(card.sidewaysValue).toBe(1);
+      expect(card.categories).toContain("special");
+    });
+
+    it("should be powered by any basic color", () => {
+      expect(card.poweredBy).toEqual(["red", "blue", "green", "white"]);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT - NIGHT
+  // ============================================================================
+
+  describe("basic effect during night", () => {
+    it("should present a mana color choice (requiresChoice)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Should require a choice for mana color
+      expect(result.requiresChoice).toBe(true);
+    });
+
+    it("should not apply day modifiers during night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // Resolve the mana choice manually (pick red)
+      const manaEffect = { type: "gain_mana" as const, color: MANA_RED };
+      const manaResult = resolveEffect(state, "player1", manaEffect);
+
+      // Then resolve the conditional (ifDay at night = no effect)
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const condResult = resolveEffect(manaResult.state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // No modifiers should be applied during night
+      expect(condResult.state.activeModifiers).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // BASIC EFFECT - DAY (simulated via resolving parts individually)
+  // ============================================================================
+
+  describe("basic effect during day", () => {
+    it("should present a mana color choice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.basicEffect);
+
+      // Should require a choice for mana color
+      expect(result.requiresChoice).toBe(true);
+    });
+
+    it("should apply day modifiers when resolving full compound after choice", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Simulate: resolve mana choice first (pick red), then resolve day conditional
+      const manaEffect = { type: "gain_mana" as const, color: MANA_RED };
+      const manaResult = resolveEffect(state, "player1", manaEffect);
+
+      // The second sub-effect is ifDay(dayModifiers)
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const condResult = resolveEffect(manaResult.state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Should have terrain cost and rule override modifiers
+      expect(condResult.state.activeModifiers.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it("should reduce desert movement cost to 3 during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Desert at day costs 5
+      const desertCostBefore = getEffectiveTerrainCost(
+        state,
+        TERRAIN_DESERT,
+        "player1"
+      );
+      expect(desertCostBefore).toBe(5);
+
+      // Resolve just the day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // After Amulet, desert should cost 3
+      const desertCostAfter = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_DESERT,
+        "player1"
+      );
+      expect(desertCostAfter).toBe(3);
+    });
+
+    it("should allow black mana usage during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Before: black mana not allowed during day
+      expect(isManaColorAllowed(state, MANA_BLACK, "player1")).toBe(false);
+
+      // Resolve the day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // After: black mana allowed for this player
+      expect(
+        isManaColorAllowed(result.state, MANA_BLACK, "player1")
+      ).toBe(true);
+      expect(
+        isRuleActive(result.state, "player1", RULE_ALLOW_BLACK_AT_DAY)
+      ).toBe(true);
+    });
+
+    it("should make black dice available from Source during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        source: {
+          dice: [
+            { id: "die1", color: MANA_BLACK, takenByPlayerId: null, isDepleted: true },
+            { id: "die2", color: MANA_RED, takenByPlayerId: null, isDepleted: false },
+          ],
+        },
+      });
+
+      // Before: black die is depleted, should not be available
+      const optionsBefore = getManaOptions(state, state.players[0]!);
+      const blackDiceBefore = optionsBefore.availableDice.filter(d => d.color === MANA_BLACK);
+      expect(blackDiceBefore).toHaveLength(0);
+
+      // Resolve the day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // After: black die should be available despite being depleted
+      const optionsAfter = getManaOptions(result.state, result.state.players[0]!);
+      const blackDiceAfter = optionsAfter.availableDice.filter(d => d.color === MANA_BLACK);
+      expect(blackDiceAfter).toHaveLength(1);
+    });
+  });
+
+  // ============================================================================
+  // POWERED EFFECT
+  // ============================================================================
+
+  describe("powered effect", () => {
+    it("should present a mana color choice (3 choices for powered)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      const result = resolveEffect(state, "player1", card.poweredEffect);
+
+      // Should require a choice for first mana color
+      expect(result.requiresChoice).toBe(true);
+    });
+
+    it("should apply day modifiers after all choices resolved", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Simulate resolving all 3 mana choices then the day conditional
+      let currentState = state;
+      for (let i = 0; i < 3; i++) {
+        const manaEffect = { type: "gain_mana" as const, color: MANA_RED };
+        const manaResult = resolveEffect(currentState, "player1", manaEffect);
+        currentState = manaResult.state;
+      }
+
+      // Now resolve the day conditional
+      const conditionalEffect = (card.poweredEffect as { effects: readonly unknown[] }).effects[3]!;
+      const condResult = resolveEffect(currentState, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Should have modifiers applied
+      expect(condResult.state.activeModifiers.length).toBeGreaterThanOrEqual(2);
+
+      // Desert should cost 3
+      const desertCost = getEffectiveTerrainCost(
+        condResult.state,
+        TERRAIN_DESERT,
+        "player1"
+      );
+      expect(desertCost).toBe(3);
+    });
+  });
+
+  // ============================================================================
+  // EDGE CASES
+  // ============================================================================
+
+  describe("edge cases", () => {
+    it("should not change forest movement cost during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Forest at day costs 3
+      const forestCostBefore = getEffectiveTerrainCost(
+        state,
+        TERRAIN_FOREST,
+        "player1"
+      );
+      expect(forestCostBefore).toBe(3);
+
+      // Resolve day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Forest should still cost 3 (Amulet only affects desert)
+      const forestCostAfter = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_FOREST,
+        "player1"
+      );
+      expect(forestCostAfter).toBe(3);
+    });
+
+    it("should not affect other terrain costs during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Resolve day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Hills at day = 3, should be unchanged
+      const hillsCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_HILLS,
+        "player1"
+      );
+      expect(hillsCost).toBe(3);
+
+      // Plains at day = 2, should be unchanged
+      const plainsCost = getEffectiveTerrainCost(
+        result.state,
+        TERRAIN_PLAINS,
+        "player1"
+      );
+      expect(plainsCost).toBe(2);
+    });
+
+    it("should still allow gold mana during day", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Resolve day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Gold mana should still be allowed during day
+      expect(isManaColorAllowed(result.state, MANA_GOLD)).toBe(true);
+    });
+
+    it("should not allow gold mana at night (amulet doesn't grant night gold)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // Resolve conditional at night (no modifiers applied)
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Gold mana should NOT be allowed at night
+      expect(isManaColorAllowed(result.state, MANA_GOLD, "player1")).toBe(false);
+    });
+
+    it("should not affect black mana for other players", () => {
+      const player1 = createTestPlayer({
+        id: "player1",
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const player2 = createTestPlayer({
+        id: "player2",
+        hand: [],
+      });
+      const state = createTestGameState({
+        players: [player1, player2],
+        timeOfDay: TIME_OF_DAY_DAY,
+        turnOrder: ["player1", "player2"],
+      });
+
+      // Resolve day modifiers for player1
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // Player 1 can use black mana
+      expect(
+        isManaColorAllowed(result.state, MANA_BLACK, "player1")
+      ).toBe(true);
+
+      // Player 2 cannot use black mana during day
+      expect(
+        isManaColorAllowed(result.state, MANA_BLACK, "player2")
+      ).toBe(false);
+    });
+
+    it("should have no effect on modifiers during night", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+      });
+
+      // Resolve conditional at night
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const result = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // No modifiers at night (conditional is false, no else branch)
+      expect(result.state.activeModifiers).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // VALIDATOR INTEGRATION - validateManaTimeOfDayWithDungeonOverride
+  // ============================================================================
+
+  describe("validator integration", () => {
+    it("should reject black mana during day without Amulet in non-dungeon combat", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_ATTACK);
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        combat,
+      });
+
+      const result = validateManaTimeOfDayWithDungeonOverride(
+        state,
+        "player1",
+        {
+          type: PLAY_CARD_ACTION,
+          cardId: CARD_AMULET_OF_DARKNESS,
+          powered: true,
+          manaSource: { type: "token", color: MANA_BLACK },
+        }
+      );
+
+      expect(result.valid).toBe(false);
+    });
+
+    it("should allow black mana during day with Amulet in non-dungeon combat", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_ATTACK);
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        combat,
+      });
+
+      // Apply Amulet day modifiers to get RULE_ALLOW_BLACK_AT_DAY
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const afterAmulet = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      const result = validateManaTimeOfDayWithDungeonOverride(
+        afterAmulet.state,
+        "player1",
+        {
+          type: PLAY_CARD_ACTION,
+          cardId: CARD_MARCH,
+          powered: true,
+          manaSource: { type: "token", color: MANA_BLACK },
+        }
+      );
+
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject gold mana at night in non-dungeon combat", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const combat = createUnitCombatState(COMBAT_PHASE_ATTACK);
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        combat,
+      });
+
+      const result = validateManaTimeOfDayWithDungeonOverride(
+        state,
+        "player1",
+        {
+          type: PLAY_CARD_ACTION,
+          cardId: CARD_AMULET_OF_DARKNESS,
+          powered: true,
+          manaSource: { type: "token", color: MANA_GOLD },
+        }
+      );
+
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  // ============================================================================
+  // VALID ACTIONS INTEGRATION - canPayForMana / getManaOptions
+  // ============================================================================
+
+  describe("validActions mana integration", () => {
+    it("should allow black token to pay for spells during day with Amulet", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+        pureMana: [{ color: MANA_BLACK }],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+      });
+
+      // Without Amulet: black cannot be used during day
+      expect(canPayForMana(state, state.players[0]!, MANA_BLACK)).toBe(false);
+
+      // Apply Amulet day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const afterAmulet = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // With Amulet: black token can be used during day
+      expect(
+        canPayForMana(afterAmulet.state, afterAmulet.state.players[0]!, MANA_BLACK)
+      ).toBe(true);
+    });
+
+    it("should show black source dice as available during day with Amulet", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        source: {
+          dice: [
+            { id: "die1", color: MANA_BLACK, takenByPlayerId: null, isDepleted: true },
+            { id: "die2", color: MANA_BLUE, takenByPlayerId: null, isDepleted: false },
+          ],
+        },
+      });
+
+      // Without Amulet: only blue die available
+      const optionsBefore = getManaOptions(state, state.players[0]!);
+      expect(optionsBefore.availableDice.map(d => d.color)).toEqual([MANA_BLUE]);
+
+      // Apply Amulet day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const afterAmulet = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // With Amulet: black die should now also be available
+      const optionsAfter = getManaOptions(afterAmulet.state, afterAmulet.state.players[0]!);
+      const colors = optionsAfter.availableDice.map(d => d.color);
+      expect(colors).toContain(MANA_BLACK);
+      expect(colors).toContain(MANA_BLUE);
+    });
+
+    it("should allow black source die to pay for mana during day with Amulet", () => {
+      const player = createTestPlayer({
+        hand: [CARD_AMULET_OF_DARKNESS],
+      });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        source: {
+          dice: [
+            { id: "die1", color: MANA_BLACK, takenByPlayerId: null, isDepleted: true },
+          ],
+        },
+      });
+
+      // Without Amulet: black die cannot pay
+      expect(canPayForMana(state, state.players[0]!, MANA_BLACK)).toBe(false);
+
+      // Apply Amulet day modifiers
+      const conditionalEffect = (card.basicEffect as { effects: readonly unknown[] }).effects[1]!;
+      const afterAmulet = resolveEffect(state, "player1", conditionalEffect as Parameters<typeof resolveEffect>[2]);
+
+      // With Amulet: black die can pay
+      expect(
+        canPayForMana(afterAmulet.state, afterAmulet.state.players[0]!, MANA_BLACK)
+      ).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/rules/mana.ts
+++ b/packages/core/src/engine/rules/mana.ts
@@ -13,7 +13,7 @@ import {
   TIME_OF_DAY_DAY,
 } from "@mage-knight/shared";
 import { isRuleActive } from "../modifiers/index.js";
-import { RULE_ALLOW_GOLD_AT_NIGHT } from "../../types/modifierConstants.js";
+import { RULE_ALLOW_GOLD_AT_NIGHT, RULE_ALLOW_BLACK_AT_DAY } from "../../types/modifierConstants.js";
 
 export interface ManaTimeRules {
   readonly blackAllowed: boolean;
@@ -36,7 +36,12 @@ export function getManaTimeRules(state: GameState): ManaTimeRules {
 export function isManaColorAllowed(state: GameState, color: ManaColor, playerId?: string): boolean {
   const rules = getManaTimeRules(state);
   if (color === MANA_BLACK) {
-    return rules.blackAllowed;
+    if (rules.blackAllowed) return true;
+    // Amulet of Darkness: allow black mana usage at day for this player
+    if (playerId && isRuleActive(state, playerId, RULE_ALLOW_BLACK_AT_DAY)) {
+      return true;
+    }
+    return false;
   }
   if (color === MANA_GOLD) {
     if (rules.goldAllowed) return true;

--- a/packages/core/src/engine/validActions/mana.ts
+++ b/packages/core/src/engine/validActions/mana.ts
@@ -17,7 +17,7 @@ import {
   MANA_SOURCE_ENDLESS,
 } from "@mage-knight/shared";
 import { isRuleActive, countRuleActive, hasEndlessMana } from "../modifiers/index.js";
-import { RULE_BLACK_AS_ANY_COLOR, RULE_GOLD_AS_ANY_COLOR, RULE_EXTRA_SOURCE_DIE, RULE_SOURCE_BLOCKED } from "../../types/modifierConstants.js";
+import { RULE_BLACK_AS_ANY_COLOR, RULE_GOLD_AS_ANY_COLOR, RULE_EXTRA_SOURCE_DIE, RULE_SOURCE_BLOCKED, RULE_ALLOW_BLACK_AT_DAY } from "../../types/modifierConstants.js";
 import { canUseGoldAsWild, isManaColorAllowed } from "../rules/mana.js";
 
 /**
@@ -71,10 +71,18 @@ export function getManaOptions(
     canUseSource = Math.max(player.usedDieIds.length, 1) < maxDiceUsage;
   }
 
+  // Amulet of Darkness: black dice available from Source during day
+  const allowBlackAtDay = isRuleActive(state, player.id, RULE_ALLOW_BLACK_AT_DAY);
+
   if (canUseSource) {
     for (const die of state.source.dice) {
-      // Die must not be taken and not depleted
-      if (die.takenByPlayerId === null && !die.isDepleted) {
+      if (die.takenByPlayerId !== null) continue;
+
+      // Override depletion for black dice during day when Amulet of Darkness is active
+      const effectivelyAvailable = !die.isDepleted ||
+        (die.color === MANA_BLACK && die.isDepleted && allowBlackAtDay);
+
+      if (effectivelyAvailable) {
         addAvailableDie(die.id, die.color);
 
         // Mana Pull basic: black dice can be used as any color this turn
@@ -197,8 +205,12 @@ export function canPayForMana(
   if (canUseSource2) {
     const blackAsAnyColor2 = isRuleActive(state, player.id, RULE_BLACK_AS_ANY_COLOR);
     const goldAsAnyColor2 = isRuleActive(state, player.id, RULE_GOLD_AS_ANY_COLOR);
+    const allowBlackAtDay2 = isRuleActive(state, player.id, RULE_ALLOW_BLACK_AT_DAY);
     for (const die of state.source.dice) {
-      if (die.takenByPlayerId === null && !die.isDepleted) {
+      if (die.takenByPlayerId !== null) continue;
+      const effectivelyAvailable2 = !die.isDepleted ||
+        (die.color === MANA_BLACK && die.isDepleted && allowBlackAtDay2);
+      if (effectivelyAvailable2) {
         if (die.color === requiredColor) {
           return true;
         }
@@ -373,10 +385,14 @@ function countManaSourcesForColor(
     canUseSource3 = Math.max(player.usedDieIds.length, 1) < maxDice3;
   }
   const goldAsAnyColor3 = isRuleActive(state, player.id, RULE_GOLD_AS_ANY_COLOR);
+  const allowBlackAtDay3 = isRuleActive(state, player.id, RULE_ALLOW_BLACK_AT_DAY);
 
   if (canUseSource3) {
     for (const die of state.source.dice) {
-      if (die.takenByPlayerId === null && !die.isDepleted) {
+      if (die.takenByPlayerId !== null) continue;
+      const effectivelyAvailable3 = !die.isDepleted ||
+        (die.color === MANA_BLACK && die.isDepleted && allowBlackAtDay3);
+      if (effectivelyAvailable3) {
         if (die.color === requiredColor) {
           count++;
         } else if (die.color === MANA_BLACK && requiredColor !== MANA_BLACK && blackAsAnyColor) {
@@ -484,10 +500,14 @@ export function getAvailableManaSourcesForColor(
     canUseSource4 = Math.max(player.usedDieIds.length, 1) < maxDice4;
   }
   const goldAsAnyColor4 = isRuleActive(state, player.id, RULE_GOLD_AS_ANY_COLOR);
+  const allowBlackAtDay4 = isRuleActive(state, player.id, RULE_ALLOW_BLACK_AT_DAY);
 
   if (canUseSource4) {
     for (const die of state.source.dice) {
-      if (die.takenByPlayerId === null && !die.isDepleted) {
+      if (die.takenByPlayerId !== null) continue;
+      const effectivelyAvailable4 = !die.isDepleted ||
+        (die.color === MANA_BLACK && die.isDepleted && allowBlackAtDay4);
+      if (effectivelyAvailable4) {
         const canUseBlackAsAny =
           blackAsAnyColor && die.color === MANA_BLACK && requiredColor !== MANA_BLACK;
         const canUseGoldAsAny =

--- a/packages/core/src/engine/validators/mana/rulesValidators.ts
+++ b/packages/core/src/engine/validators/mana/rulesValidators.ts
@@ -12,7 +12,6 @@ import {
   PLAY_CARD_ACTION,
   MANA_GOLD,
   MANA_BLACK,
-  TIME_OF_DAY_DAY,
 } from "@mage-knight/shared";
 import { isRuleActive } from "../../modifiers/index.js";
 import { RULE_BLACK_AS_ANY_COLOR } from "../../../types/modifierConstants.js";
@@ -108,8 +107,8 @@ export function validateManaTimeOfDay(
 
   for (const source of manaSources) {
     const manaColor = source.color;
-    // Black mana cannot be used during day
-    if (manaColor === MANA_BLACK && state.timeOfDay === TIME_OF_DAY_DAY) {
+    // Black mana cannot be used during day (unless Amulet of Darkness)
+    if (manaColor === MANA_BLACK && !isManaColorAllowed(state, MANA_BLACK, playerId)) {
       return invalid(BLACK_MANA_DAY, "Black mana cannot be used during the day");
     }
 
@@ -184,7 +183,7 @@ export function validateManaTimeOfDayWithDungeonOverride(
 
   const blackAsAnyColor = isRuleActive(state, playerId, RULE_BLACK_AS_ANY_COLOR);
   for (const source of manaSources) {
-    if (source.color === MANA_BLACK && !isManaColorAllowed(state, MANA_BLACK) && !blackAsAnyColor) {
+    if (source.color === MANA_BLACK && !isManaColorAllowed(state, MANA_BLACK, playerId) && !blackAsAnyColor) {
       return invalid(BLACK_MANA_DAY, "Black mana cannot be used during the day");
     }
     if (source.color === MANA_GOLD && !isManaColorAllowed(state, MANA_GOLD, playerId)) {

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -300,6 +300,12 @@ export const RULE_NO_EXPLORATION = "no_exploration" as const;
 // Does NOT change time of day for skills, does NOT allow gold→black conversion
 export const RULE_ALLOW_GOLD_AT_NIGHT = "allow_gold_at_night" as const;
 
+// === RuleOverrideModifier["rule"] - Amulet of Darkness ===
+// Allows using black mana during day (normally black is only available at night)
+// Also makes black dice available from Source during day (overrides depletion)
+// Does NOT change time of day for skills, does NOT allow black→gold conversion
+export const RULE_ALLOW_BLACK_AT_DAY = "allow_black_at_day" as const;
+
 // === HeroDamageReductionModifier ===
 // Reduces incoming damage to the hero from a single enemy attack.
 // Element-specific: different reduction amounts based on attack element.

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -92,6 +92,7 @@ import {
   RULE_INFLUENCE_CARDS_IN_COMBAT,
   RULE_NO_EXPLORATION,
   RULE_ALLOW_GOLD_AT_NIGHT,
+  RULE_ALLOW_BLACK_AT_DAY,
   RULE_SOURCE_BLOCKED,
   RULE_TERRAIN_DAY_NIGHT_SWAP,
   RULE_UNITS_CANNOT_ABSORB_DAMAGE,
@@ -236,7 +237,8 @@ export interface RuleOverrideModifier {
     | typeof RULE_SPACE_BENDING_ADJACENCY
     | typeof RULE_TIME_BENDING_ACTIVE
     | typeof RULE_NO_EXPLORATION
-    | typeof RULE_ALLOW_GOLD_AT_NIGHT;
+    | typeof RULE_ALLOW_GOLD_AT_NIGHT
+    | typeof RULE_ALLOW_BLACK_AT_DAY;
 }
 
 // Ability nullifier (e.g., "ignore Swift on one enemy")


### PR DESCRIPTION
## Summary
- Implemented the Amulet of Darkness artifact card (#15)
- Basic: Player chooses 1 mana token of any color. During day: deserts cost 3, black mana usable (including dice from Source)
- Powered (any color, destroy): Same as basic but 3 mana tokens of any colors

## Changes
- **Card definition** (`amuletOfDarkness.ts`): Full card with choice effects for any-color mana and `ifDay` conditional for day modifiers
- **New rule `RULE_ALLOW_BLACK_AT_DAY`** (`modifierConstants.ts`, `modifiers.ts`): Mirrors `RULE_ALLOW_GOLD_AT_NIGHT` from Amulet of the Sun
- **Mana rules** (`rules/mana.ts`): `isManaColorAllowed()` now checks `RULE_ALLOW_BLACK_AT_DAY` for black mana during day
- **ValidActions** (`validActions/mana.ts`): `getManaOptions()`, `canPayForMana()`, `countManaSourcesForColor()`, `getAvailableManaSourcesForColor()` all override black die depletion when rule is active
- **Validators** (`validators/mana/rulesValidators.ts`): Updated to use `isManaColorAllowed()` for black mana checks (consistent with gold mana pattern)
- **23 tests** covering card definition, day/night behavior, desert cost reduction, black mana usage, black dice availability, edge cases, validator and validActions integration

Closes #230