### PR TITLE
feat: implement mana system gaps — crystal overflow, standalone actions, combat UI

### DIFF
--- a/packages/client/src/components/Combat/CombatOverlay.css
+++ b/packages/client/src/components/Combat/CombatOverlay.css
@@ -412,6 +412,21 @@
   color: #3a3020;
 }
 
+/* Clickable crystals - convert to mana token */
+.combat-mana__crystal--clickable {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.combat-mana__crystal--clickable:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+}
+
+.combat-mana__crystal--clickable:active {
+  transform: scale(0.95);
+}
+
 /* Tokens - small colored circles */
 .combat-mana__token {
   width: 14px;

--- a/packages/client/src/components/Combat/CombatOverlay.tsx
+++ b/packages/client/src/components/Combat/CombatOverlay.tsx
@@ -25,7 +25,13 @@ import {
   UNASSIGN_ATTACK_ACTION,
   ASSIGN_BLOCK_ACTION,
   UNASSIGN_BLOCK_ACTION,
+  CONVERT_CRYSTAL_ACTION,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
 } from "@mage-knight/shared";
+import type { BasicManaColor } from "@mage-knight/shared";
 import type {
   AssignAttackOption,
   UnassignAttackOption,
@@ -83,6 +89,7 @@ interface ElementBreakdown {
  */
 function CombatManaDisplay() {
   const player = useMyPlayer();
+  const { state, sendAction } = useGame();
   if (!player) return null;
 
   const { crystals, pureMana } = player;
@@ -91,6 +98,25 @@ function CombatManaDisplay() {
 
   if (!hasCrystals && !hasTokens) return null;
 
+  // Check which crystals can be converted from validActions
+  const convertibleColors: readonly BasicManaColor[] =
+    state?.validActions && "mana" in state.validActions
+      ? state.validActions.mana.convertibleColors
+      : [];
+
+  const handleCrystalClick = (color: BasicManaColor) => {
+    if (convertibleColors.includes(color)) {
+      sendAction({ type: CONVERT_CRYSTAL_ACTION, color });
+    }
+  };
+
+  const crystalEntries: { color: BasicManaColor; label: string }[] = [
+    { color: MANA_RED, label: "Red Crystal" },
+    { color: MANA_BLUE, label: "Blue Crystal" },
+    { color: MANA_GREEN, label: "Green Crystal" },
+    { color: MANA_WHITE, label: "White Crystal" },
+  ];
+
   return (
     <div className="combat-mana">
       <div className="combat-mana__label">Mana</div>
@@ -98,26 +124,23 @@ function CombatManaDisplay() {
         {/* Crystals */}
         {hasCrystals && (
           <div className="combat-mana__group">
-            {crystals.red > 0 && (
-              <span className="combat-mana__crystal combat-mana__crystal--red" title="Red Crystal">
-                {crystals.red}
-              </span>
-            )}
-            {crystals.blue > 0 && (
-              <span className="combat-mana__crystal combat-mana__crystal--blue" title="Blue Crystal">
-                {crystals.blue}
-              </span>
-            )}
-            {crystals.green > 0 && (
-              <span className="combat-mana__crystal combat-mana__crystal--green" title="Green Crystal">
-                {crystals.green}
-              </span>
-            )}
-            {crystals.white > 0 && (
-              <span className="combat-mana__crystal combat-mana__crystal--white" title="White Crystal">
-                {crystals.white}
-              </span>
-            )}
+            {crystalEntries.map(({ color, label }) => {
+              if (crystals[color] <= 0) return null;
+              const isClickable = convertibleColors.includes(color);
+              return (
+                <span
+                  key={color}
+                  className={`combat-mana__crystal combat-mana__crystal--${color}${isClickable ? " combat-mana__crystal--clickable" : ""}`}
+                  title={isClickable ? `Convert ${label} to mana token` : label}
+                  onClick={() => handleCrystalClick(color)}
+                  role={isClickable ? "button" : undefined}
+                  tabIndex={isClickable ? 0 : undefined}
+                  onKeyDown={isClickable ? (e) => { if (e.key === "Enter" || e.key === " ") handleCrystalClick(color); } : undefined}
+                >
+                  {crystals[color]}
+                </span>
+              );
+            })}
           </div>
         )}
 

--- a/packages/client/src/components/GameBoard/ManaSourceOverlay.css
+++ b/packages/client/src/components/GameBoard/ManaSourceOverlay.css
@@ -121,6 +121,63 @@
   filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.3));
 }
 
+/* Clickable dice - available to use */
+.mana-source-overlay__die--clickable {
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  position: relative;
+}
+
+.mana-source-overlay__die--clickable:hover {
+  transform: scale(1.15);
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.4);
+}
+
+.mana-source-overlay__die--clickable:active {
+  transform: scale(0.95);
+}
+
+/* Color picker popup for gold/black dice */
+.mana-source-overlay__color-picker {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 4px;
+  padding: 4px;
+  background: rgba(30, 30, 40, 0.95);
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  z-index: 10;
+}
+
+.mana-source-overlay__color-option {
+  width: clamp(1.5rem, 2.5vw, 2.5rem);
+  height: clamp(1.5rem, 2.5vw, 2.5rem);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.1);
+  cursor: pointer;
+  padding: 2px;
+  transition: transform 0.1s ease, background 0.1s ease;
+}
+
+.mana-source-overlay__color-option img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.mana-source-overlay__color-option:hover {
+  transform: scale(1.15);
+  background: rgba(255, 255, 255, 0.25);
+}
+
+.mana-source-overlay__color-option:active {
+  transform: scale(0.95);
+}
+
 .mana-source-overlay__die--unavailable {
   opacity: 0.5;
   background: linear-gradient(145deg, #888, #666);

--- a/packages/core/src/engine/__tests__/convertCrystal.test.ts
+++ b/packages/core/src/engine/__tests__/convertCrystal.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for CONVERT_CRYSTAL action
+ *
+ * Covers validator and command for converting a crystal to a mana token.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { validateConvertCrystal } from "../validators/mana/standaloneManaValidators.js";
+import { createConvertCrystalCommand } from "../commands/convertCrystalCommand.js";
+import {
+  CONVERT_CRYSTAL_ACTION,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_TOKEN_SOURCE_CRYSTAL,
+  CRYSTAL_USED,
+} from "@mage-knight/shared";
+import { NO_CRYSTAL } from "../validators/validationCodes.js";
+import type { PlayerAction } from "@mage-knight/shared";
+
+function makeAction(color: string): PlayerAction {
+  return {
+    type: CONVERT_CRYSTAL_ACTION,
+    color,
+  } as PlayerAction;
+}
+
+describe("validateConvertCrystal", () => {
+  describe("happy path", () => {
+    it("should pass when player has red crystal", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateConvertCrystal(state, "player1", makeAction(MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should pass for each basic color", () => {
+      for (const color of [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE]) {
+        const player = createTestPlayer({
+          id: "player1",
+          crystals: { red: 1, blue: 1, green: 1, white: 1 },
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const result = validateConvertCrystal(state, "player1", makeAction(color));
+        expect(result.valid).toBe(true);
+      }
+    });
+
+    it("should pass when player has max crystals", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 3, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateConvertCrystal(state, "player1", makeAction(MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("no crystal available", () => {
+    it("should fail when player has no crystal of requested color", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateConvertCrystal(state, "player1", makeAction(MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(NO_CRYSTAL);
+      }
+    });
+
+    it("should fail when player has crystals of other colors but not requested", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 0, blue: 3, green: 2, white: 1 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateConvertCrystal(state, "player1", makeAction(MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(NO_CRYSTAL);
+      }
+    });
+  });
+
+  describe("non-matching action type", () => {
+    it("should pass for other action types", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateConvertCrystal(state, "player1", {
+        type: "END_TURN",
+      } as PlayerAction);
+      expect(result.valid).toBe(true);
+    });
+  });
+});
+
+describe("createConvertCrystalCommand", () => {
+  describe("execute", () => {
+    it("should decrement crystal and add mana token", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 2, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      expect(command.type).toBe("CONVERT_CRYSTAL");
+      expect(command.isReversible).toBe(true);
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players[0]!;
+
+      expect(updatedPlayer.crystals.red).toBe(1);
+      expect(updatedPlayer.pureMana).toHaveLength(1);
+      expect(updatedPlayer.pureMana[0]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      });
+    });
+
+    it("should emit CRYSTAL_USED event", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      const result = command.execute(state);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toEqual({
+        type: CRYSTAL_USED,
+        playerId: "player1",
+        color: MANA_RED,
+      });
+    });
+
+    it("should work for each basic color", () => {
+      for (const color of [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE]) {
+        const player = createTestPlayer({
+          id: "player1",
+          crystals: { red: 1, blue: 1, green: 1, white: 1 },
+        });
+        const state = createTestGameState({ players: [player] });
+
+        const command = createConvertCrystalCommand({
+          playerId: "player1",
+          color,
+        });
+
+        const result = command.execute(state);
+        const updatedPlayer = result.state.players[0]!;
+
+        expect(updatedPlayer.crystals[color]).toBe(0);
+        expect(updatedPlayer.pureMana).toHaveLength(1);
+        expect(updatedPlayer.pureMana[0]!.color).toBe(color);
+      }
+    });
+
+    it("should allow multiple conversions per turn", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 3, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const cmd1 = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+      const result1 = cmd1.execute(state);
+
+      const cmd2 = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+      const result2 = cmd2.execute(result1.state);
+      const updatedPlayer = result2.state.players[0]!;
+
+      expect(updatedPlayer.crystals.red).toBe(1);
+      expect(updatedPlayer.pureMana).toHaveLength(2);
+    });
+
+    it("should preserve existing mana tokens", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+        pureMana: [{ color: MANA_BLUE, source: MANA_TOKEN_SOURCE_CRYSTAL }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players[0]!;
+
+      expect(updatedPlayer.pureMana).toHaveLength(2);
+      expect(updatedPlayer.pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      });
+      expect(updatedPlayer.pureMana[1]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      });
+    });
+  });
+
+  describe("undo", () => {
+    it("should restore crystal and remove token", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 2, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      const executeResult = command.execute(state);
+      const undoResult = command.undo(executeResult.state);
+      const restoredPlayer = undoResult.state.players[0]!;
+
+      expect(restoredPlayer.crystals.red).toBe(2);
+      expect(restoredPlayer.pureMana).toHaveLength(0);
+    });
+
+    it("should only remove one token when undoing with multiple tokens present", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 2, blue: 1, green: 0, white: 0 },
+        pureMana: [{ color: MANA_BLUE, source: MANA_TOKEN_SOURCE_CRYSTAL }],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      const executeResult = command.execute(state);
+      // Now pureMana has [blue_crystal, red_crystal]
+
+      const undoResult = command.undo(executeResult.state);
+      const restoredPlayer = undoResult.state.players[0]!;
+
+      expect(restoredPlayer.crystals.red).toBe(2);
+      expect(restoredPlayer.pureMana).toHaveLength(1);
+      expect(restoredPlayer.pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      });
+    });
+
+    it("should produce no events on undo", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const command = createConvertCrystalCommand({
+        playerId: "player1",
+        color: MANA_RED,
+      });
+
+      const executeResult = command.execute(state);
+      const undoResult = command.undo(executeResult.state);
+
+      expect(undoResult.events).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/crystalOverflow.test.ts
+++ b/packages/core/src/engine/__tests__/crystalOverflow.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for crystal overflow logic
+ *
+ * When gaining a crystal at max (3 per color), the excess becomes
+ * a temporary mana token instead.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestPlayer } from "./testHelpers.js";
+import {
+  gainCrystalWithOverflow,
+  MAX_CRYSTALS_PER_COLOR,
+} from "../helpers/crystalHelpers.js";
+import {
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+  MANA_TOKEN_SOURCE_CARD,
+  MANA_TOKEN_SOURCE_CRYSTAL,
+  MANA_TOKEN_SOURCE_SITE,
+} from "@mage-knight/shared";
+
+describe("MAX_CRYSTALS_PER_COLOR", () => {
+  it("should be 3", () => {
+    expect(MAX_CRYSTALS_PER_COLOR).toBe(3);
+  });
+});
+
+describe("gainCrystalWithOverflow", () => {
+  describe("normal crystal gain (under max)", () => {
+    it("should gain 1 crystal when at 0", () => {
+      const player = createTestPlayer({
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 1, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(1);
+      expect(result.tokensGained).toBe(0);
+      expect(result.player.crystals.red).toBe(1);
+      expect(result.player.pureMana).toHaveLength(0);
+    });
+
+    it("should gain 1 crystal by default when count not specified", () => {
+      const player = createTestPlayer({
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      // Call with only 3 args to exercise the default count=1 parameter
+      const result = gainCrystalWithOverflow(player, MANA_BLUE, 1, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(1);
+      expect(result.player.crystals.blue).toBe(1);
+    });
+
+    it("should gain 2 crystals when at 1", () => {
+      const player = createTestPlayer({
+        crystals: { red: 1, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 2, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(2);
+      expect(result.tokensGained).toBe(0);
+      expect(result.player.crystals.red).toBe(3);
+      expect(result.player.pureMana).toHaveLength(0);
+    });
+
+    it("should work with each basic color", () => {
+      for (const color of [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE]) {
+        const player = createTestPlayer({
+          crystals: { red: 0, blue: 0, green: 0, white: 0 },
+        });
+
+        const result = gainCrystalWithOverflow(player, color, 1, MANA_TOKEN_SOURCE_CARD);
+
+        expect(result.crystalsGained).toBe(1);
+        expect(result.player.crystals[color]).toBe(1);
+      }
+    });
+
+    it("should not modify other crystal colors", () => {
+      const player = createTestPlayer({
+        crystals: { red: 1, blue: 2, green: 3, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 1, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.player.crystals.red).toBe(2);
+      expect(result.player.crystals.blue).toBe(2);
+      expect(result.player.crystals.green).toBe(3);
+      expect(result.player.crystals.white).toBe(0);
+    });
+  });
+
+  describe("overflow at max crystals", () => {
+    it("should create a mana token when at max (3)", () => {
+      const player = createTestPlayer({
+        crystals: { red: 3, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 1, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(0);
+      expect(result.tokensGained).toBe(1);
+      expect(result.player.crystals.red).toBe(3);
+      expect(result.player.pureMana).toHaveLength(1);
+      expect(result.player.pureMana[0]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should create multiple tokens when gaining multiple at max", () => {
+      const player = createTestPlayer({
+        crystals: { red: 3, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 2, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(0);
+      expect(result.tokensGained).toBe(2);
+      expect(result.player.crystals.red).toBe(3);
+      expect(result.player.pureMana).toHaveLength(2);
+    });
+
+    it("should use the correct token source for overflow tokens", () => {
+      const player = createTestPlayer({
+        crystals: { blue: 3, red: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_BLUE, 1, MANA_TOKEN_SOURCE_SITE);
+
+      expect(result.player.pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_SITE,
+      });
+    });
+  });
+
+  describe("partial overflow", () => {
+    it("should split between crystal and token when partially full", () => {
+      const player = createTestPlayer({
+        crystals: { red: 2, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 2, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(1);
+      expect(result.tokensGained).toBe(1);
+      expect(result.player.crystals.red).toBe(3);
+      expect(result.player.pureMana).toHaveLength(1);
+      expect(result.player.pureMana[0]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+    });
+
+    it("should handle count=3 with 1 slot available", () => {
+      const player = createTestPlayer({
+        crystals: { green: 2, red: 0, blue: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_GREEN, 3, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(1);
+      expect(result.tokensGained).toBe(2);
+      expect(result.player.crystals.green).toBe(3);
+      expect(result.player.pureMana).toHaveLength(2);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should preserve existing mana tokens on overflow", () => {
+      const player = createTestPlayer({
+        crystals: { red: 3, blue: 0, green: 0, white: 0 },
+        pureMana: [{ color: MANA_GREEN, source: MANA_TOKEN_SOURCE_CARD }],
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 1, MANA_TOKEN_SOURCE_CRYSTAL);
+
+      expect(result.player.pureMana).toHaveLength(2);
+      expect(result.player.pureMana[0]).toEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.player.pureMana[1]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      });
+    });
+
+    it("should return the same player reference when count is 0", () => {
+      const player = createTestPlayer({
+        crystals: { red: 0, blue: 0, green: 0, white: 0 },
+      });
+
+      const result = gainCrystalWithOverflow(player, MANA_RED, 0, MANA_TOKEN_SOURCE_CARD);
+
+      expect(result.crystalsGained).toBe(0);
+      expect(result.tokensGained).toBe(0);
+      expect(result.player).toBe(player);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/skillGreenCrystalCraft.test.ts
+++ b/packages/core/src/engine/__tests__/skillGreenCrystalCraft.test.ts
@@ -21,6 +21,7 @@ import {
   UNDO_ACTION,
   CARD_MARCH,
   MANA_GREEN,
+  MANA_BLUE,
   MANA_TOKEN_SOURCE_CARD,
   getSkillsFromValidActions,
 } from "@mage-knight/shared";
@@ -182,9 +183,13 @@ describe("Green Crystal Craft skill", () => {
       // Blue crystals should stay at 3 (capped)
       expect(result.state.players[0].crystals.blue).toBe(3);
 
-      // Green mana token should still be granted
-      expect(result.state.players[0].pureMana).toHaveLength(1);
+      // Blue crystal overflows to token + green mana token from skill
+      expect(result.state.players[0].pureMana).toHaveLength(2);
       expect(result.state.players[0].pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.state.players[0].pureMana[1]).toEqual({
         color: MANA_GREEN,
         source: MANA_TOKEN_SOURCE_CARD,
       });

--- a/packages/core/src/engine/__tests__/skillLeavesInTheWind.test.ts
+++ b/packages/core/src/engine/__tests__/skillLeavesInTheWind.test.ts
@@ -20,6 +20,7 @@ import {
   INVALID_ACTION,
   UNDO_ACTION,
   CARD_MARCH,
+  MANA_GREEN,
   MANA_WHITE,
   MANA_TOKEN_SOURCE_CARD,
   getSkillsFromValidActions,
@@ -182,9 +183,13 @@ describe("Leaves in the Wind skill", () => {
       // Green crystals should stay at 3 (capped)
       expect(result.state.players[0].crystals.green).toBe(3);
 
-      // White mana token should still be granted
-      expect(result.state.players[0].pureMana).toHaveLength(1);
+      // Green crystal overflows to token + white mana token from skill
+      expect(result.state.players[0].pureMana).toHaveLength(2);
       expect(result.state.players[0].pureMana[0]).toEqual({
+        color: MANA_GREEN,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.state.players[0].pureMana[1]).toEqual({
         color: MANA_WHITE,
         source: MANA_TOKEN_SOURCE_CARD,
       });

--- a/packages/core/src/engine/__tests__/skillRedCrystalCraft.test.ts
+++ b/packages/core/src/engine/__tests__/skillRedCrystalCraft.test.ts
@@ -18,6 +18,7 @@ import {
   USE_SKILL_ACTION,
   SKILL_USED,
   MANA_RED,
+  MANA_BLUE,
   MANA_TOKEN_SOURCE_CARD,
   CARD_MARCH,
   getSkillsFromValidActions,
@@ -99,8 +100,13 @@ describe("Red Crystal Craft skill", () => {
 
       expect(result.state.players[0].crystals.blue).toBe(3);
 
-      expect(result.state.players[0].pureMana).toHaveLength(1);
+      // Blue crystal overflows to token + red mana token from skill
+      expect(result.state.players[0].pureMana).toHaveLength(2);
       expect(result.state.players[0].pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.state.players[0].pureMana[1]).toEqual({
         color: MANA_RED,
         source: MANA_TOKEN_SOURCE_CARD,
       });

--- a/packages/core/src/engine/__tests__/skillWhispersInTheTreetops.test.ts
+++ b/packages/core/src/engine/__tests__/skillWhispersInTheTreetops.test.ts
@@ -21,6 +21,7 @@ import {
   UNDO_ACTION,
   CARD_MARCH,
   MANA_GREEN,
+  MANA_WHITE,
   MANA_TOKEN_SOURCE_CARD,
   getSkillsFromValidActions,
 } from "@mage-knight/shared";
@@ -182,9 +183,13 @@ describe("Whispers in the Treetops skill", () => {
       // White crystals should stay at 3 (capped)
       expect(result.state.players[0].crystals.white).toBe(3);
 
-      // Green mana token should still be granted
-      expect(result.state.players[0].pureMana).toHaveLength(1);
+      // White crystal overflows to token + green mana token from skill
+      expect(result.state.players[0].pureMana).toHaveLength(2);
       expect(result.state.players[0].pureMana[0]).toEqual({
+        color: MANA_WHITE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.state.players[0].pureMana[1]).toEqual({
         color: MANA_GREEN,
         source: MANA_TOKEN_SOURCE_CARD,
       });

--- a/packages/core/src/engine/__tests__/skillWhiteCrystalCraft.test.ts
+++ b/packages/core/src/engine/__tests__/skillWhiteCrystalCraft.test.ts
@@ -21,6 +21,7 @@ import {
   UNDO_ACTION,
   CARD_MARCH,
   MANA_WHITE,
+  MANA_BLUE,
   MANA_TOKEN_SOURCE_CARD,
   getSkillsFromValidActions,
 } from "@mage-knight/shared";
@@ -182,9 +183,13 @@ describe("White Crystal Craft skill", () => {
       // Blue crystals should stay at 3 (capped)
       expect(result.state.players[0].crystals.blue).toBe(3);
 
-      // White mana token should still be granted
-      expect(result.state.players[0].pureMana).toHaveLength(1);
+      // Blue crystal overflows to token + white mana token from skill
+      expect(result.state.players[0].pureMana).toHaveLength(2);
       expect(result.state.players[0].pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_CARD,
+      });
+      expect(result.state.players[0].pureMana[1]).toEqual({
         color: MANA_WHITE,
         source: MANA_TOKEN_SOURCE_CARD,
       });

--- a/packages/core/src/engine/__tests__/useManaDie.test.ts
+++ b/packages/core/src/engine/__tests__/useManaDie.test.ts
@@ -1,0 +1,538 @@
+/**
+ * Tests for USE_MANA_DIE action
+ *
+ * Covers validator and command for taking a die from the mana source.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { validateUseManaDie } from "../validators/mana/standaloneManaValidators.js";
+import { createUseManaDieCommand } from "../commands/useManaDieCommand.js";
+import type { SourceDie } from "../../types/mana.js";
+import { sourceDieId } from "../../types/mana.js";
+import {
+  USE_MANA_DIE_ACTION,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_GOLD,
+  MANA_BLACK,
+  MANA_TOKEN_SOURCE_DIE,
+  MANA_DIE_TAKEN,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+} from "@mage-knight/shared";
+import {
+  DIE_NOT_FOUND,
+  DIE_DEPLETED,
+  DIE_TAKEN,
+  DIE_COLOR_MISMATCH,
+  SOURCE_LIMIT_EXCEEDED,
+  SOURCE_BLOCKED,
+} from "../validators/validationCodes.js";
+import { addModifier } from "../modifiers/lifecycle.js";
+import {
+  RULE_BLACK_AS_ANY_COLOR,
+  RULE_SOURCE_BLOCKED,
+  RULE_EXTRA_SOURCE_DIE,
+  DURATION_TURN,
+  SCOPE_SELF,
+  SOURCE_CARD,
+  EFFECT_RULE_OVERRIDE,
+} from "../../types/modifierConstants.js";
+import type { PlayerAction } from "@mage-knight/shared";
+
+function createSourceDie(
+  id: string,
+  color: string,
+  overrides: Partial<SourceDie> = {}
+): SourceDie {
+  return {
+    id: sourceDieId(id),
+    color: color as SourceDie["color"],
+    isDepleted: false,
+    takenByPlayerId: null,
+    ...overrides,
+  };
+}
+
+function makeAction(dieId: string, color: string): PlayerAction {
+  return {
+    type: USE_MANA_DIE_ACTION,
+    dieId,
+    color: color as PlayerAction extends { color: infer C } ? C : never,
+  } as PlayerAction;
+}
+
+describe("validateUseManaDie", () => {
+  describe("happy path", () => {
+    it("should pass with a valid red die", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED)],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should pass for each basic color die", () => {
+      for (const color of [MANA_RED, MANA_BLUE, MANA_GREEN]) {
+        const player = createTestPlayer({ id: "player1" });
+        const state = createTestGameState({
+          players: [player],
+          source: {
+            dice: [createSourceDie("die_0", color)],
+          },
+        });
+
+        const result = validateUseManaDie(state, "player1", makeAction("die_0", color));
+        expect(result.valid).toBe(true);
+      }
+    });
+  });
+
+  describe("gold die (wild during day)", () => {
+    it("should allow gold die as basic color during day", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        source: {
+          dice: [createSourceDie("die_0", MANA_GOLD)],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should allow gold die as gold during day", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_DAY,
+        source: {
+          dice: [createSourceDie("die_0", MANA_GOLD)],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_GOLD));
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("black die", () => {
+    it("should allow black die as black at night", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        source: {
+          dice: [createSourceDie("die_0", MANA_BLACK)],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_BLACK));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should allow black die as any color with RULE_BLACK_AS_ANY_COLOR modifier", () => {
+      const player = createTestPlayer({ id: "player1" });
+      let state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        source: {
+          dice: [createSourceDie("die_0", MANA_BLACK)],
+        },
+      });
+
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: "mana_pull" as never, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_RULE_OVERRIDE, rule: RULE_BLACK_AS_ANY_COLOR },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject black die as basic color without modifier", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        timeOfDay: TIME_OF_DAY_NIGHT,
+        source: {
+          dice: [createSourceDie("die_0", MANA_BLACK)],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_COLOR_MISMATCH);
+      }
+    });
+  });
+
+  describe("die not found", () => {
+    it("should fail when die ID does not exist in source", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_99", MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_NOT_FOUND);
+      }
+    });
+  });
+
+  describe("die already taken", () => {
+    it("should fail when die is already taken by another player", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED, { takenByPlayerId: "player2" })],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_TAKEN);
+      }
+    });
+  });
+
+  describe("die depleted", () => {
+    it("should fail when die is depleted", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_BLACK, { isDepleted: true })],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_BLACK));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_DEPLETED);
+      }
+    });
+  });
+
+  describe("source limit", () => {
+    it("should fail when already used a die and no extra source die modifier", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        usedManaFromSource: true,
+        usedDieIds: [sourceDieId("die_0")],
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [
+            createSourceDie("die_0", MANA_RED, { takenByPlayerId: "player1" }),
+            createSourceDie("die_1", MANA_BLUE),
+          ],
+        },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_1", MANA_BLUE));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(SOURCE_LIMIT_EXCEEDED);
+      }
+    });
+
+    it("should allow second die with RULE_EXTRA_SOURCE_DIE modifier", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        usedManaFromSource: true,
+        usedDieIds: [sourceDieId("die_0")],
+      });
+      let state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [
+            createSourceDie("die_0", MANA_RED, { takenByPlayerId: "player1" }),
+            createSourceDie("die_1", MANA_BLUE),
+          ],
+        },
+      });
+
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: "mana_storm" as never, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_RULE_OVERRIDE, rule: RULE_EXTRA_SOURCE_DIE },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_1", MANA_BLUE));
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("source blocked", () => {
+    it("should fail when source is blocked", () => {
+      const player = createTestPlayer({ id: "player1" });
+      let state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED)],
+        },
+      });
+
+      state = addModifier(state, {
+        source: { type: SOURCE_CARD, cardId: "test" as never, playerId: "player1" },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        effect: { type: EFFECT_RULE_OVERRIDE, rule: RULE_SOURCE_BLOCKED },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("die_0", MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(SOURCE_BLOCKED);
+      }
+    });
+  });
+
+  describe("Mana Steal stored die", () => {
+    it("should allow using the stored Mana Steal die", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        tacticState: {
+          storedManaDie: { dieId: "stolen_die", color: MANA_RED },
+          manaStealUsedThisTurn: false,
+        },
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("stolen_die", MANA_RED));
+      expect(result.valid).toBe(true);
+    });
+
+    it("should reject Mana Steal die if already used this turn", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        tacticState: {
+          storedManaDie: { dieId: "stolen_die", color: MANA_RED },
+          manaStealUsedThisTurn: true,
+        },
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("stolen_die", MANA_RED));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_TAKEN);
+      }
+    });
+
+    it("should reject Mana Steal die with wrong color", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        tacticState: {
+          storedManaDie: { dieId: "stolen_die", color: MANA_RED },
+          manaStealUsedThisTurn: false,
+        },
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const result = validateUseManaDie(state, "player1", makeAction("stolen_die", MANA_BLUE));
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.error.code).toBe(DIE_COLOR_MISMATCH);
+      }
+    });
+  });
+
+  describe("non-matching action type", () => {
+    it("should pass for other action types", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({ players: [player] });
+
+      const result = validateUseManaDie(state, "player1", {
+        type: "END_TURN",
+      } as PlayerAction);
+      expect(result.valid).toBe(true);
+    });
+  });
+});
+
+describe("createUseManaDieCommand", () => {
+  describe("execute", () => {
+    it("should mark die as taken and add mana token", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED)],
+        },
+      });
+
+      const command = createUseManaDieCommand({
+        playerId: "player1",
+        dieId: "die_0",
+        color: MANA_RED,
+      });
+
+      expect(command.type).toBe("USE_MANA_DIE");
+      expect(command.isReversible).toBe(true);
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players[0]!;
+
+      expect(updatedPlayer.usedManaFromSource).toBe(true);
+      expect(updatedPlayer.usedDieIds).toContain("die_0");
+      expect(updatedPlayer.pureMana).toHaveLength(1);
+      expect(updatedPlayer.pureMana[0]).toEqual({
+        color: MANA_RED,
+        source: MANA_TOKEN_SOURCE_DIE,
+      });
+
+      const updatedDie = result.state.source.dice.find((d) => d.id === "die_0");
+      expect(updatedDie?.takenByPlayerId).toBe("player1");
+    });
+
+    it("should emit MANA_DIE_TAKEN event", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED)],
+        },
+      });
+
+      const command = createUseManaDieCommand({
+        playerId: "player1",
+        dieId: "die_0",
+        color: MANA_RED,
+      });
+
+      const result = command.execute(state);
+
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0]).toEqual({
+        type: MANA_DIE_TAKEN,
+        playerId: "player1",
+        dieId: "die_0",
+        color: MANA_RED,
+      });
+    });
+
+    it("should handle Mana Steal stored die", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        tacticState: {
+          storedManaDie: { dieId: "stolen_die", color: MANA_BLUE },
+          manaStealUsedThisTurn: false,
+        },
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const command = createUseManaDieCommand({
+        playerId: "player1",
+        dieId: "stolen_die",
+        color: MANA_BLUE,
+      });
+
+      const result = command.execute(state);
+      const updatedPlayer = result.state.players[0]!;
+
+      expect(updatedPlayer.tacticState.manaStealUsedThisTurn).toBe(true);
+      expect(updatedPlayer.pureMana).toHaveLength(1);
+      expect(updatedPlayer.pureMana[0]).toEqual({
+        color: MANA_BLUE,
+        source: MANA_TOKEN_SOURCE_DIE,
+      });
+      // Should NOT modify source dice
+      expect(result.state.source.dice).toHaveLength(0);
+    });
+  });
+
+  describe("undo", () => {
+    it("should reverse all changes from execute", () => {
+      const player = createTestPlayer({ id: "player1" });
+      const state = createTestGameState({
+        players: [player],
+        source: {
+          dice: [createSourceDie("die_0", MANA_RED)],
+        },
+      });
+
+      const command = createUseManaDieCommand({
+        playerId: "player1",
+        dieId: "die_0",
+        color: MANA_RED,
+      });
+
+      const executeResult = command.execute(state);
+      const undoResult = command.undo(executeResult.state);
+      const restoredPlayer = undoResult.state.players[0]!;
+
+      expect(restoredPlayer.usedManaFromSource).toBe(false);
+      expect(restoredPlayer.usedDieIds).toHaveLength(0);
+      expect(restoredPlayer.pureMana).toHaveLength(0);
+
+      const restoredDie = undoResult.state.source.dice.find((d) => d.id === "die_0");
+      expect(restoredDie?.takenByPlayerId).toBeNull();
+    });
+
+    it("should reverse Mana Steal stored die usage", () => {
+      const player = createTestPlayer({
+        id: "player1",
+        tacticState: {
+          storedManaDie: { dieId: "stolen_die", color: MANA_RED },
+          manaStealUsedThisTurn: false,
+        },
+      });
+      const state = createTestGameState({
+        players: [player],
+        source: { dice: [] },
+      });
+
+      const command = createUseManaDieCommand({
+        playerId: "player1",
+        dieId: "stolen_die",
+        color: MANA_RED,
+      });
+
+      const executeResult = command.execute(state);
+      const undoResult = command.undo(executeResult.state);
+      const restoredPlayer = undoResult.state.players[0]!;
+
+      expect(restoredPlayer.tacticState.manaStealUsedThisTurn).toBe(false);
+      expect(restoredPlayer.pureMana).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/convertCrystalCommand.ts
+++ b/packages/core/src/engine/commands/convertCrystalCommand.ts
@@ -1,0 +1,109 @@
+/**
+ * CONVERT_CRYSTAL command
+ *
+ * Converts a crystal to a mana token of the same color.
+ * The crystal is decremented and a token is added to pureMana.
+ *
+ * @module commands/convertCrystalCommand
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player, ManaToken } from "../../types/player.js";
+import type { BasicManaColor } from "@mage-knight/shared";
+import {
+  MANA_TOKEN_SOURCE_CRYSTAL,
+  CRYSTAL_USED,
+} from "@mage-knight/shared";
+import type { GameEvent } from "@mage-knight/shared";
+
+export const CONVERT_CRYSTAL_COMMAND = "CONVERT_CRYSTAL" as const;
+
+export interface ConvertCrystalCommandParams {
+  readonly playerId: string;
+  readonly color: BasicManaColor;
+}
+
+export function createConvertCrystalCommand(
+  params: ConvertCrystalCommandParams
+): Command {
+  return {
+    type: CONVERT_CRYSTAL_COMMAND,
+    playerId: params.playerId,
+    isReversible: true,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex]!;
+
+      const newToken: ManaToken = {
+        color: params.color,
+        source: MANA_TOKEN_SOURCE_CRYSTAL,
+      };
+
+      const updatedPlayer: Player = {
+        ...player,
+        crystals: {
+          ...player.crystals,
+          [params.color]: player.crystals[params.color] - 1,
+        },
+        pureMana: [...player.pureMana, newToken],
+      };
+
+      const players = [...state.players];
+      players[playerIndex] = updatedPlayer;
+
+      const events: GameEvent[] = [
+        {
+          type: CRYSTAL_USED,
+          playerId: params.playerId,
+          color: params.color,
+        },
+      ];
+
+      return { state: { ...state, players }, events };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex]!;
+
+      // Remove the token
+      const tokenIndex = player.pureMana.findIndex(
+        (t) =>
+          t.color === params.color && t.source === MANA_TOKEN_SOURCE_CRYSTAL
+      );
+      const newPureMana = [...player.pureMana];
+      if (tokenIndex !== -1) {
+        newPureMana.splice(tokenIndex, 1);
+      }
+
+      // Restore the crystal
+      const updatedPlayer: Player = {
+        ...player,
+        crystals: {
+          ...player.crystals,
+          [params.color]: player.crystals[params.color] + 1,
+        },
+        pureMana: newPureMana,
+      };
+
+      const players = [...state.players];
+      players[playerIndex] = updatedPlayer;
+
+      return { state: { ...state, players }, events: [] };
+    },
+  };
+}

--- a/packages/core/src/engine/commands/endTurn/sourceOpeningCrystal.ts
+++ b/packages/core/src/engine/commands/endTurn/sourceOpeningCrystal.ts
@@ -13,13 +13,12 @@
  */
 
 import type { GameState } from "../../../state/GameState.js";
-import type { Player, Crystals } from "../../../types/player.js";
+import type { Player } from "../../../types/player.js";
 import type { BasicManaColor } from "@mage-knight/shared";
-import { BASIC_MANA_COLORS } from "@mage-knight/shared";
+import { BASIC_MANA_COLORS, MANA_TOKEN_SOURCE_SKILL } from "@mage-knight/shared";
 import type { ManaColor } from "@mage-knight/shared";
 import type { SourceDieId } from "../../../types/mana.js";
-
-const MAX_CRYSTALS_PER_COLOR = 3;
+import { gainCrystalWithOverflow } from "../../helpers/crystalHelpers.js";
 
 function isBasicColor(color: ManaColor): color is BasicManaColor {
   return (BASIC_MANA_COLORS as readonly ManaColor[]).includes(color);
@@ -84,24 +83,8 @@ export function processSourceOpeningCrystal(
   }
 
   const owner = state.players[ownerIndex]!;
-  const currentCrystals = owner.crystals[die.color];
-  if (currentCrystals >= MAX_CRYSTALS_PER_COLOR) {
-    // Already at max — no crystal granted, but still offer reroll choice
-    return {
-      state: { ...state, sourceOpeningCenter: null },
-      extraDieId: extraDieId as SourceDieId,
-    };
-  }
-
-  const updatedCrystals: Crystals = {
-    ...owner.crystals,
-    [die.color]: currentCrystals + 1,
-  };
-
-  const updatedOwner: Player = {
-    ...owner,
-    crystals: updatedCrystals,
-  };
+  const { player: updatedOwner } =
+    gainCrystalWithOverflow(owner, die.color, 1, MANA_TOKEN_SOURCE_SKILL);
 
   const players = [...state.players];
   players[ownerIndex] = updatedOwner;

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -86,6 +86,8 @@ import {
   RESOLVE_UNIT_MAINTENANCE_ACTION,
   RESOLVE_MEDITATION_ACTION,
   ALTAR_TRIBUTE_ACTION,
+  USE_MANA_DIE_ACTION,
+  CONVERT_CRYSTAL_ACTION,
 } from "@mage-knight/shared";
 
 // Re-export the CommandFactory type
@@ -210,6 +212,12 @@ export {
   createUseBannerFearCommandFromAction,
 } from "./banners.js";
 
+// Mana factories
+export {
+  createUseManaDieCommandFromAction,
+  createConvertCrystalCommandFromAction,
+} from "./mana.js";
+
 // Import all factories for the registry
 import {
   createMoveCommandFromAction,
@@ -317,6 +325,11 @@ import {
   createUseBannerFearCommandFromAction,
 } from "./banners.js";
 
+import {
+  createUseManaDieCommandFromAction,
+  createConvertCrystalCommandFromAction,
+} from "./mana.js";
+
 import type { CommandFactory } from "./types.js";
 
 /**
@@ -405,4 +418,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [RESOLVE_UNIT_MAINTENANCE_ACTION]: createResolveUnitMaintenanceCommandFromAction,
   // Meditation resolve action
   [RESOLVE_MEDITATION_ACTION]: createResolveMeditationCommandFromAction,
+  // Standalone mana actions
+  [USE_MANA_DIE_ACTION]: createUseManaDieCommandFromAction,
+  [CONVERT_CRYSTAL_ACTION]: createConvertCrystalCommandFromAction,
 };

--- a/packages/core/src/engine/commands/factories/mana.ts
+++ b/packages/core/src/engine/commands/factories/mana.ts
@@ -1,0 +1,42 @@
+/**
+ * Mana Command Factories
+ *
+ * Factory functions for USE_MANA_DIE and CONVERT_CRYSTAL actions.
+ *
+ * @module commands/factories/mana
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import {
+  USE_MANA_DIE_ACTION,
+  CONVERT_CRYSTAL_ACTION,
+} from "@mage-knight/shared";
+import type { Command } from "../types.js";
+import { createUseManaDieCommand } from "../useManaDieCommand.js";
+import { createConvertCrystalCommand } from "../convertCrystalCommand.js";
+
+export function createUseManaDieCommandFromAction(
+  _state: GameState,
+  playerId: string,
+  action: PlayerAction
+): Command | null {
+  if (action.type !== USE_MANA_DIE_ACTION) return null;
+  return createUseManaDieCommand({
+    playerId,
+    dieId: action.dieId,
+    color: action.color,
+  });
+}
+
+export function createConvertCrystalCommandFromAction(
+  _state: GameState,
+  playerId: string,
+  action: PlayerAction
+): Command | null {
+  if (action.type !== CONVERT_CRYSTAL_ACTION) return null;
+  return createConvertCrystalCommand({
+    playerId,
+    color: action.color,
+  });
+}

--- a/packages/core/src/engine/commands/useManaDieCommand.ts
+++ b/packages/core/src/engine/commands/useManaDieCommand.ts
@@ -1,0 +1,195 @@
+/**
+ * USE_MANA_DIE command
+ *
+ * Takes a die from the mana source and adds a mana token of the chosen color.
+ * The die is marked as taken by the player.
+ *
+ * @module commands/useManaDieCommand
+ */
+
+import type { Command, CommandResult } from "./types.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player, ManaToken } from "../../types/player.js";
+import type { ManaColor } from "@mage-knight/shared";
+import type { SourceDieId } from "../../types/mana.js";
+import {
+  MANA_TOKEN_SOURCE_DIE,
+  MANA_DIE_TAKEN,
+} from "@mage-knight/shared";
+import type { GameEvent } from "@mage-knight/shared";
+
+export const USE_MANA_DIE_COMMAND = "USE_MANA_DIE" as const;
+
+export interface UseManaDieCommandParams {
+  readonly playerId: string;
+  readonly dieId: string;
+  readonly color: ManaColor;
+}
+
+export function createUseManaDieCommand(
+  params: UseManaDieCommandParams
+): Command {
+  return {
+    type: USE_MANA_DIE_COMMAND,
+    playerId: params.playerId,
+    isReversible: true,
+
+    execute(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex]!;
+      const newToken: ManaToken = {
+        color: params.color,
+        source: MANA_TOKEN_SOURCE_DIE,
+      };
+
+      // Check if this is a Mana Steal stored die
+      const storedDie = player.tacticState.storedManaDie;
+      if (storedDie && storedDie.dieId === params.dieId) {
+        // Using the stored die from Mana Steal
+        const updatedPlayer: Player = {
+          ...player,
+          pureMana: [...player.pureMana, newToken],
+          tacticState: {
+            ...player.tacticState,
+            manaStealUsedThisTurn: true,
+          },
+        };
+
+        const players = [...state.players];
+        players[playerIndex] = updatedPlayer;
+
+        const events: GameEvent[] = [
+          {
+            type: MANA_DIE_TAKEN,
+            playerId: params.playerId,
+            dieId: params.dieId,
+            color: params.color,
+          },
+        ];
+
+        return { state: { ...state, players }, events };
+      }
+
+      // Normal source die
+      const updatedDice = state.source.dice.map((d) =>
+        d.id === params.dieId
+          ? { ...d, takenByPlayerId: params.playerId }
+          : d
+      );
+
+      const updatedPlayer: Player = {
+        ...player,
+        usedManaFromSource: true,
+        usedDieIds: [...player.usedDieIds, params.dieId as SourceDieId],
+        pureMana: [...player.pureMana, newToken],
+      };
+
+      const players = [...state.players];
+      players[playerIndex] = updatedPlayer;
+
+      const events: GameEvent[] = [
+        {
+          type: MANA_DIE_TAKEN,
+          playerId: params.playerId,
+          dieId: params.dieId,
+          color: params.color,
+        },
+      ];
+
+      return {
+        state: {
+          ...state,
+          players,
+          source: { ...state.source, dice: updatedDice },
+        },
+        events,
+      };
+    },
+
+    undo(state: GameState): CommandResult {
+      const playerIndex = state.players.findIndex(
+        (p) => p.id === params.playerId
+      );
+      if (playerIndex === -1) {
+        throw new Error(`Player not found: ${params.playerId}`);
+      }
+
+      const player = state.players[playerIndex]!;
+
+      // Check if this was a Mana Steal stored die
+      const storedDie = player.tacticState.storedManaDie;
+      if (storedDie && storedDie.dieId === params.dieId) {
+        // Remove the token and un-mark the stored die
+        const tokenIndex = player.pureMana.findIndex(
+          (t) => t.color === params.color && t.source === MANA_TOKEN_SOURCE_DIE
+        );
+        const newPureMana = [...player.pureMana];
+        if (tokenIndex !== -1) {
+          newPureMana.splice(tokenIndex, 1);
+        }
+
+        const updatedPlayer: Player = {
+          ...player,
+          pureMana: newPureMana,
+          tacticState: {
+            ...player.tacticState,
+            manaStealUsedThisTurn: false,
+          },
+        };
+
+        const players = [...state.players];
+        players[playerIndex] = updatedPlayer;
+
+        return { state: { ...state, players }, events: [] };
+      }
+
+      // Normal die: un-take it from source
+      const updatedDice = state.source.dice.map((d) =>
+        d.id === params.dieId
+          ? { ...d, takenByPlayerId: null }
+          : d
+      );
+
+      // Remove the token
+      const tokenIndex = player.pureMana.findIndex(
+        (t) => t.color === params.color && t.source === MANA_TOKEN_SOURCE_DIE
+      );
+      const newPureMana = [...player.pureMana];
+      if (tokenIndex !== -1) {
+        newPureMana.splice(tokenIndex, 1);
+      }
+
+      // Remove die from usedDieIds
+      const newUsedDieIds = [...player.usedDieIds];
+      const dieIndex = newUsedDieIds.indexOf(params.dieId as SourceDieId);
+      if (dieIndex !== -1) {
+        newUsedDieIds.splice(dieIndex, 1);
+      }
+
+      const updatedPlayer: Player = {
+        ...player,
+        usedManaFromSource: newUsedDieIds.length > 0,
+        usedDieIds: newUsedDieIds,
+        pureMana: newPureMana,
+      };
+
+      const players = [...state.players];
+      players[playerIndex] = updatedPlayer;
+
+      return {
+        state: {
+          ...state,
+          players,
+          source: { ...state.source, dice: updatedDice },
+        },
+        events: [],
+      };
+    },
+  };
+}

--- a/packages/core/src/engine/effects/atomicResourceEffects.ts
+++ b/packages/core/src/engine/effects/atomicResourceEffects.ts
@@ -14,6 +14,7 @@ import type { ManaColor, BasicManaColor } from "@mage-knight/shared";
 import type { EffectResolutionResult } from "./types.js";
 import { MANA_TOKEN_SOURCE_CARD } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicHelpers.js";
+import { gainCrystalWithOverflow } from "../helpers/crystalHelpers.js";
 
 // ============================================================================
 // EFFECT HANDLERS
@@ -99,27 +100,22 @@ export function applyGainCrystal(
   player: Player,
   color: BasicManaColor
 ): EffectResolutionResult {
-  const MAX_CRYSTALS_PER_COLOR = 3;
-  const current = player.crystals[color];
-  if (current >= MAX_CRYSTALS_PER_COLOR) {
+  const { player: updatedPlayer, crystalsGained, tokensGained } =
+    gainCrystalWithOverflow(player, color, 1, MANA_TOKEN_SOURCE_CARD);
+
+  if (crystalsGained === 0 && tokensGained === 0) {
     return {
       state,
       description: `Already at max ${color} crystals`,
     };
   }
 
-  const updatedCrystals = {
-    ...player.crystals,
-    [color]: current + 1,
-  };
-
-  const updatedPlayer: Player = {
-    ...player,
-    crystals: updatedCrystals,
-  };
+  const description = tokensGained > 0
+    ? `${color} crystal full — gained ${color} mana token instead`
+    : `Gained ${color} crystal`;
 
   return {
     state: updatePlayer(state, playerIndex, updatedPlayer),
-    description: `Gained ${color} crystal`,
+    description,
   };
 }

--- a/packages/core/src/engine/effects/crystallize.ts
+++ b/packages/core/src/engine/effects/crystallize.ts
@@ -34,6 +34,7 @@ import { EFFECT_CRYSTALLIZE_COLOR, EFFECT_CONVERT_MANA_TO_CRYSTAL } from "../../
 import { updatePlayer } from "./atomicEffects.js";
 import { registerEffect } from "./effectRegistry.js";
 import { getPlayerContext } from "./effectHelpers.js";
+import { MAX_CRYSTALS_PER_COLOR } from "../helpers/crystalHelpers.js";
 
 // ============================================================================
 // CONVERT MANA TO CRYSTAL (Entry Point)
@@ -157,6 +158,15 @@ export function resolveCrystallizeColor(
   // Remove the mana token
   const newPureMana = [...player.pureMana];
   newPureMana.splice(tokenIndex, 1);
+
+  // If already at max crystals, the token is consumed but no crystal is gained
+  // (crystallize is a conversion, not a gain — the token is the cost)
+  if (player.crystals[effect.color] >= MAX_CRYSTALS_PER_COLOR) {
+    return {
+      state,
+      description: `Already at max ${effect.color} crystals — mana token wasted`,
+    };
+  }
 
   // Gain the crystal
   const updatedPlayer: Player = {

--- a/packages/core/src/engine/effects/mindReadEffects.ts
+++ b/packages/core/src/engine/effects/mindReadEffects.ts
@@ -57,6 +57,8 @@ import { BASIC_MANA_COLORS, CARD_WOUND } from "@mage-knight/shared";
 import { updatePlayer } from "./atomicEffects.js";
 import { registerEffect } from "./effectRegistry.js";
 import { getPlayerContext } from "./effectHelpers.js";
+import { gainCrystalWithOverflow } from "../helpers/crystalHelpers.js";
+import { MANA_TOKEN_SOURCE_CARD } from "@mage-knight/shared";
 import {
   EFFECT_MIND_READ,
   EFFECT_RESOLVE_MIND_READ_COLOR,
@@ -235,15 +237,14 @@ export function resolveMindReadColor(
   const cardColor = manaColorToCardColor(chosenColor);
   const descriptions: string[] = [];
 
-  // Gain crystal of chosen color
-  const updatedCaster: Player = {
-    ...caster,
-    crystals: {
-      ...caster.crystals,
-      [chosenColor]: caster.crystals[chosenColor] + 1,
-    },
-  };
-  descriptions.push(`Gained ${chosenColor} crystal`);
+  // Gain crystal of chosen color (with overflow to token)
+  const { player: updatedCaster, tokensGained } =
+    gainCrystalWithOverflow(caster, chosenColor, 1, MANA_TOKEN_SOURCE_CARD);
+  descriptions.push(
+    tokensGained > 0
+      ? `${chosenColor} crystal full — gained ${chosenColor} mana token instead`
+      : `Gained ${chosenColor} crystal`
+  );
 
   let currentState = updatePlayer(state, casterIndex, updatedCaster);
 
@@ -328,15 +329,14 @@ export function resolveMindStealColor(
   const cardColor = manaColorToCardColor(chosenColor);
   const descriptions: string[] = [];
 
-  // Gain crystal of chosen color
-  const updatedCaster: Player = {
-    ...caster,
-    crystals: {
-      ...caster.crystals,
-      [chosenColor]: caster.crystals[chosenColor] + 1,
-    },
-  };
-  descriptions.push(`Gained ${chosenColor} crystal`);
+  // Gain crystal of chosen color (with overflow to token)
+  const { player: updatedCaster, tokensGained: mindStealTokensGained } =
+    gainCrystalWithOverflow(caster, chosenColor, 1, MANA_TOKEN_SOURCE_CARD);
+  descriptions.push(
+    mindStealTokensGained > 0
+      ? `${chosenColor} crystal full — gained ${chosenColor} mana token instead`
+      : `Gained ${chosenColor} crystal`
+  );
 
   let currentState = updatePlayer(state, casterIndex, updatedCaster);
 

--- a/packages/core/src/engine/helpers/crystalHelpers.ts
+++ b/packages/core/src/engine/helpers/crystalHelpers.ts
@@ -1,0 +1,75 @@
+/**
+ * Crystal Helper Functions
+ *
+ * Shared logic for gaining crystals with overflow handling.
+ * When a player gains a crystal but is already at the max (3 per color),
+ * the excess becomes a temporary mana token instead.
+ *
+ * @module helpers/crystalHelpers
+ */
+
+import type { Player, ManaToken } from "../../types/player.js";
+import type { BasicManaColor, ManaTokenSource } from "@mage-knight/shared";
+
+export const MAX_CRYSTALS_PER_COLOR = 3;
+
+export interface GainCrystalResult {
+  readonly player: Player;
+  readonly crystalsGained: number;
+  readonly tokensGained: number;
+}
+
+/**
+ * Gain crystals with overflow handling.
+ *
+ * If the player has room, increment the crystal count.
+ * If at max (3), the excess becomes a temporary mana token instead.
+ * Handles partial overflow (e.g., count=2 with 1 slot = 1 crystal + 1 token).
+ *
+ * @param player - The player gaining the crystal(s)
+ * @param color - The basic mana color of crystal to gain
+ * @param count - Number of crystals to gain (default: 1)
+ * @param tokenSource - Source tag for overflow tokens
+ * @returns Updated player and counts of crystals/tokens gained
+ */
+export function gainCrystalWithOverflow(
+  player: Player,
+  color: BasicManaColor,
+  count: number = 1,
+  tokenSource: ManaTokenSource
+): GainCrystalResult {
+  const current = player.crystals[color];
+  const slotsAvailable = MAX_CRYSTALS_PER_COLOR - current;
+
+  const crystalsToGain = Math.min(count, Math.max(0, slotsAvailable));
+  const tokensToGain = count - crystalsToGain;
+
+  let updatedPlayer = player;
+
+  if (crystalsToGain > 0) {
+    updatedPlayer = {
+      ...updatedPlayer,
+      crystals: {
+        ...updatedPlayer.crystals,
+        [color]: current + crystalsToGain,
+      },
+    };
+  }
+
+  if (tokensToGain > 0) {
+    const overflowTokens: ManaToken[] = Array.from(
+      { length: tokensToGain },
+      () => ({ color, source: tokenSource })
+    );
+    updatedPlayer = {
+      ...updatedPlayer,
+      pureMana: [...updatedPlayer.pureMana, ...overflowTokens],
+    };
+  }
+
+  return {
+    player: updatedPlayer,
+    crystalsGained: crystalsToGain,
+    tokensGained: tokensToGain,
+  };
+}

--- a/packages/core/src/engine/helpers/index.ts
+++ b/packages/core/src/engine/helpers/index.ts
@@ -88,3 +88,10 @@ export {
   isEnemyAssignedToPlayer,
 } from "./cooperativeAssaultHelpers.js";
 export type { DistributeEnemiesResult } from "./cooperativeAssaultHelpers.js";
+
+// Crystal helpers
+export {
+  MAX_CRYSTALS_PER_COLOR,
+  gainCrystalWithOverflow,
+} from "./crystalHelpers.js";
+export type { GainCrystalResult } from "./crystalHelpers.js";

--- a/packages/core/src/engine/validators/mana/standaloneManaValidators.ts
+++ b/packages/core/src/engine/validators/mana/standaloneManaValidators.ts
@@ -1,0 +1,176 @@
+/**
+ * Standalone Mana Action Validators
+ *
+ * Validates USE_MANA_DIE and CONVERT_CRYSTAL actions.
+ * These are standalone mana actions (not embedded in card play).
+ *
+ * @module validators/mana/standaloneManaValidators
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { PlayerAction } from "@mage-knight/shared";
+import {
+  USE_MANA_DIE_ACTION,
+  CONVERT_CRYSTAL_ACTION,
+  MANA_GOLD,
+  MANA_BLACK,
+  BASIC_MANA_COLORS,
+} from "@mage-knight/shared";
+import type { ValidationResult } from "../types.js";
+import { valid, invalid } from "../types.js";
+import {
+  PLAYER_NOT_FOUND,
+  DIE_NOT_FOUND,
+  DIE_DEPLETED,
+  DIE_TAKEN,
+  DIE_COLOR_MISMATCH,
+  NO_CRYSTAL,
+  SOURCE_LIMIT_EXCEEDED,
+  SOURCE_BLOCKED,
+  MANA_COLOR_NOT_ALLOWED,
+} from "../validationCodes.js";
+import { getPlayerById } from "../../helpers/playerHelpers.js";
+import { isRuleActive, countRuleActive } from "../../modifiers/index.js";
+import { RULE_BLACK_AS_ANY_COLOR, RULE_GOLD_AS_ANY_COLOR, RULE_EXTRA_SOURCE_DIE, RULE_SOURCE_BLOCKED } from "../../../types/modifierConstants.js";
+import { isManaColorAllowed } from "../../rules/mana.js";
+
+/**
+ * Validate a USE_MANA_DIE action.
+ *
+ * Checks:
+ * - Die exists in source
+ * - Die is not already taken
+ * - Die is not depleted
+ * - Color matches die (including gold-as-wild, black-as-any modifiers)
+ * - Source not blocked
+ * - Die usage limit not exceeded
+ */
+export function validateUseManaDie(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== USE_MANA_DIE_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const { dieId, color: requestedColor } = action;
+
+  // Check Mana Steal stored die separately
+  const storedDie = player.tacticState.storedManaDie;
+  if (storedDie && storedDie.dieId === dieId) {
+    if (player.tacticState.manaStealUsedThisTurn) {
+      return invalid(DIE_TAKEN, "Mana Steal die already used this turn");
+    }
+    // Validate color match for stored die
+    if (!isColorMatchForDie(state, playerId, storedDie.color, requestedColor)) {
+      return invalid(DIE_COLOR_MISMATCH, `Die color ${storedDie.color} does not match requested ${requestedColor}`);
+    }
+    return valid();
+  }
+
+  // Check if source is blocked
+  if (isRuleActive(state, playerId, RULE_SOURCE_BLOCKED)) {
+    return invalid(SOURCE_BLOCKED, "Mana source is blocked");
+  }
+
+  // Find the die in the source
+  const die = state.source.dice.find((d) => d.id === dieId);
+  if (!die) {
+    return invalid(DIE_NOT_FOUND, `Die ${dieId} not found in source`);
+  }
+
+  if (die.takenByPlayerId !== null) {
+    return invalid(DIE_TAKEN, `Die ${dieId} already taken`);
+  }
+
+  if (die.isDepleted) {
+    return invalid(DIE_DEPLETED, `Die ${dieId} is depleted`);
+  }
+
+  // Check die usage limit
+  if (player.usedManaFromSource) {
+    const extraSourceDiceCount = countRuleActive(state, playerId, RULE_EXTRA_SOURCE_DIE);
+    const maxDiceUsage = 1 + extraSourceDiceCount;
+    if (Math.max(player.usedDieIds.length, 1) >= maxDiceUsage) {
+      return invalid(SOURCE_LIMIT_EXCEEDED, "Already used maximum dice from source this turn");
+    }
+  }
+
+  // Validate color match
+  if (!isColorMatchForDie(state, playerId, die.color, requestedColor)) {
+    return invalid(DIE_COLOR_MISMATCH, `Die color ${die.color} does not match requested ${requestedColor}`);
+  }
+
+  // Validate the requested color is allowed
+  const blackAsAny = isRuleActive(state, playerId, RULE_BLACK_AS_ANY_COLOR);
+  if (!isManaColorAllowed(state, requestedColor) && !(requestedColor === MANA_BLACK && blackAsAny)) {
+    return invalid(MANA_COLOR_NOT_ALLOWED, `Mana color ${requestedColor} is not allowed`);
+  }
+
+  return valid();
+}
+
+/**
+ * Check if a requested color matches a die color, considering modifiers.
+ */
+function isColorMatchForDie(
+  state: GameState,
+  playerId: string,
+  dieColor: string,
+  requestedColor: string
+): boolean {
+  // Exact match
+  if (dieColor === requestedColor) return true;
+
+  const blackAsAny = isRuleActive(state, playerId, RULE_BLACK_AS_ANY_COLOR);
+  const goldAsAny = isRuleActive(state, playerId, RULE_GOLD_AS_ANY_COLOR);
+
+  // Black die as any basic color (Mana Pull basic)
+  if (dieColor === MANA_BLACK && blackAsAny) {
+    return true;
+  }
+
+  // Gold die as any basic color (standard rule during day + Mana Storm)
+  if (dieColor === MANA_GOLD) {
+    const isBasic = (BASIC_MANA_COLORS as readonly string[]).includes(requestedColor);
+    if (isBasic && (isManaColorAllowed(state, MANA_GOLD) || goldAsAny)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Validate a CONVERT_CRYSTAL action.
+ *
+ * Checks:
+ * - Player has a crystal of the specified color
+ */
+export function validateConvertCrystal(
+  state: GameState,
+  playerId: string,
+  action: PlayerAction
+): ValidationResult {
+  if (action.type !== CONVERT_CRYSTAL_ACTION) {
+    return valid();
+  }
+
+  const player = getPlayerById(state, playerId);
+  if (!player) {
+    return invalid(PLAYER_NOT_FOUND, "Player not found");
+  }
+
+  const { color } = action;
+  if (player.crystals[color] <= 0) {
+    return invalid(NO_CRYSTAL, `No ${color} crystal to convert`);
+  }
+
+  return valid();
+}

--- a/packages/core/src/engine/validators/registry/index.ts
+++ b/packages/core/src/engine/validators/registry/index.ts
@@ -24,6 +24,7 @@ import { cooperativeRegistry } from "./cooperativeRegistry.js";
 import { skillRegistry } from "./skillRegistry.js";
 import { debugRegistry } from "./debugRegistry.js";
 import { bannerRegistry } from "./bannerRegistry.js";
+import { manaRegistry } from "./manaRegistry.js";
 
 /**
  * Combined validator registry - maps action types to their validator arrays.
@@ -81,4 +82,7 @@ export const validatorRegistry: Record<string, Validator[]> = {
 
   // Banner actions (ASSIGN_BANNER)
   ...bannerRegistry,
+
+  // Mana actions (USE_MANA_DIE, CONVERT_CRYSTAL)
+  ...manaRegistry,
 };

--- a/packages/core/src/engine/validators/registry/manaRegistry.ts
+++ b/packages/core/src/engine/validators/registry/manaRegistry.ts
@@ -1,0 +1,34 @@
+/**
+ * Mana action validator registry
+ * Handles USE_MANA_DIE and CONVERT_CRYSTAL standalone actions
+ */
+
+import type { Validator } from "../types.js";
+import { USE_MANA_DIE_ACTION, CONVERT_CRYSTAL_ACTION } from "@mage-knight/shared";
+
+// Turn validators
+import { validateIsPlayersTurn, validateRoundPhase } from "../turnValidators.js";
+
+// Choice validators
+import { validateNoChoicePending } from "../choiceValidators.js";
+
+// Mana validators
+import {
+  validateUseManaDie,
+  validateConvertCrystal,
+} from "../mana/standaloneManaValidators.js";
+
+export const manaRegistry: Record<string, Validator[]> = {
+  [USE_MANA_DIE_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateUseManaDie,
+  ],
+  [CONVERT_CRYSTAL_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateConvertCrystal,
+  ],
+};

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -85,6 +85,9 @@ export const POWERED_WITHOUT_MANA = "POWERED_WITHOUT_MANA" as const;
 export const SPELL_REQUIRES_TWO_MANA = "SPELL_REQUIRES_TWO_MANA" as const;
 export const SPELL_BASIC_REQUIRES_MANA = "SPELL_BASIC_REQUIRES_MANA" as const;
 export const MANA_CANNOT_POWER_SPELLS = "MANA_CANNOT_POWER_SPELLS" as const;
+export const SOURCE_LIMIT_EXCEEDED = "SOURCE_LIMIT_EXCEEDED" as const;
+export const SOURCE_BLOCKED = "SOURCE_BLOCKED" as const;
+export const MANA_COLOR_NOT_ALLOWED = "MANA_COLOR_NOT_ALLOWED" as const;
 
 // Unit recruitment mana payment codes
 export const RECRUIT_REQUIRES_MANA = "RECRUIT_REQUIRES_MANA" as const;
@@ -427,6 +430,9 @@ export type ValidationErrorCode =
   | typeof SPELL_REQUIRES_TWO_MANA
   | typeof SPELL_BASIC_REQUIRES_MANA
   | typeof MANA_CANNOT_POWER_SPELLS
+  | typeof SOURCE_LIMIT_EXCEEDED
+  | typeof SOURCE_BLOCKED
+  | typeof MANA_COLOR_NOT_ALLOWED
   // Combat validation
   | typeof ALREADY_IN_COMBAT
   | typeof NOT_IN_COMBAT

--- a/packages/shared/src/actions.ts
+++ b/packages/shared/src/actions.ts
@@ -198,10 +198,14 @@ export interface PlayCardSidewaysAction {
 
 // Mana usage actions
 export const USE_MANA_DIE_ACTION = "USE_MANA_DIE" as const;
-export interface UseManaDeieAction {
+export interface UseManaDieAction {
   readonly type: typeof USE_MANA_DIE_ACTION;
   readonly dieId: string;
+  readonly color: ManaColor;
 }
+
+/** @deprecated Use UseManaDieAction instead */
+export type UseManaDeieAction = UseManaDieAction;
 
 export const CONVERT_CRYSTAL_ACTION = "CONVERT_CRYSTAL" as const;
 export interface ConvertCrystalAction {
@@ -790,7 +794,7 @@ export type PlayerAction =
   | PlayCardAction
   | PlayCardSidewaysAction
   // Mana usage
-  | UseManaDeieAction
+  | UseManaDieAction
   | ConvertCrystalAction
   // Unit activation
   | ActivateUnitAction

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -103,7 +103,8 @@ export type {
   PlayCardSidewaysAction,
   ManaSourceInfo,
   // Mana usage
-  UseManaDeieAction,
+  UseManaDieAction,
+  UseManaDeieAction, // @deprecated alias
   ConvertCrystalAction,
   // Unit activation
   ActivateUnitAction,

--- a/packages/shared/src/valueConstants.ts
+++ b/packages/shared/src/valueConstants.ts
@@ -10,13 +10,15 @@ export const MANA_TOKEN_SOURCE_CARD = "card" as const;
 export const MANA_TOKEN_SOURCE_SKILL = "skill" as const;
 export const MANA_TOKEN_SOURCE_SITE = "site" as const;
 export const MANA_TOKEN_SOURCE_TACTIC = "tactic" as const;
+export const MANA_TOKEN_SOURCE_CRYSTAL = "crystal" as const;
 
 export type ManaTokenSource =
   | typeof MANA_TOKEN_SOURCE_DIE
   | typeof MANA_TOKEN_SOURCE_CARD
   | typeof MANA_TOKEN_SOURCE_SKILL
   | typeof MANA_TOKEN_SOURCE_SITE
-  | typeof MANA_TOKEN_SOURCE_TACTIC;
+  | typeof MANA_TOKEN_SOURCE_TACTIC
+  | typeof MANA_TOKEN_SOURCE_CRYSTAL;
 
 // === Action sub-unions ===
 export const MANA_SOURCE_DIE = "die" as const;


### PR DESCRIPTION
## Summary
- Crystal overflow: when gaining a crystal at 3/3 max, excess becomes a temporary mana token (via new `gainCrystalWithOverflow` helper applied across all 8 crystal gain paths)
- Standalone mana actions: wired `USE_MANA_DIE_ACTION` and `CONVERT_CRYSTAL_ACTION` through validators, commands, and factories
- Combat UI: crystals and source dice are now clickable during combat for mana conversion (with color picker for gold/black dice)

## Changes
- **New**: `crystalHelpers.ts` — shared `gainCrystalWithOverflow()` enforcing 3-per-color limit with overflow to mana token
- **New**: `useManaDieCommand.ts`, `convertCrystalCommand.ts` — reversible commands for standalone mana actions
- **New**: `standaloneManaValidators.ts`, `manaRegistry.ts` — validators for both action types
- **New**: `mana.ts` factory — command factories registered in factory index
- **Fixed**: 8 crystal gain paths now use overflow helper (atomicResourceEffects, crystallize, mindRead, manaMeltdown, rewards, sourceOpening)
- **Fixed**: `UseManaDeieAction` typo → `UseManaDieAction`, added `color` field
- **Added**: `MANA_TOKEN_SOURCE_CRYSTAL` constant for crystal conversion tracking
- **Updated**: Reverse handlers to properly undo crystal overflow
- **UI**: Clickable crystals in `CombatOverlay.tsx`, clickable dice in `ManaSourceOverlay.tsx`
- **Tests**: 3 new test files (crystalOverflow, useManaDie, convertCrystal) + updated 5 existing skill tests

## Test Plan
- All 4,532 tests pass (4,468 core + 52 server + 12 shared)
- Build and lint clean
- Manual: enter combat, click crystals/dice to convert mana; play cards that grant crystals at max to verify overflow token

Closes #50