### PR TITLE
feat: implement Blood of Ancients advanced action card (#172)

### DIFF
--- a/packages/core/src/data/advancedActions/red/blood-of-ancients.ts
+++ b/packages/core/src/data/advancedActions/red/blood-of-ancients.ts
@@ -1,7 +1,10 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_RED, CARD_BLOOD_OF_ANCIENTS } from "@mage-knight/shared";
-import { influence } from "../helpers.js";
+import {
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+} from "../../../types/effectTypes.js";
 
 export const BLOOD_OF_ANCIENTS: DeedCard = {
   id: CARD_BLOOD_OF_ANCIENTS,
@@ -10,9 +13,8 @@ export const BLOOD_OF_ANCIENTS: DeedCard = {
   poweredBy: [MANA_RED],
   categories: [CATEGORY_SPECIAL],
   // Basic: Gain a Wound. Pay one mana of any color. Gain a card of that color from the Advanced Actions offer and put it into your hand.
+  basicEffect: { type: EFFECT_BLOOD_OF_ANCIENTS_BASIC },
   // Powered: Gain a Wound to your hand or discard pile. Use the stronger effect of any card from the Advanced Actions offer without paying its mana cost. The card remains in the offer.
-  // TODO: Implement wound-taking, mana payment, and advanced action acquisition
-  basicEffect: influence(3),
-  poweredEffect: influence(6),
+  poweredEffect: { type: EFFECT_BLOOD_OF_ANCIENTS_POWERED },
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/bloodOfAncients.test.ts
+++ b/packages/core/src/engine/__tests__/bloodOfAncients.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Tests for Blood of Ancients advanced action card (#172)
+ *
+ * Basic: Gain a Wound. Pay one mana of any color. Gain a card of that color
+ * from the Advanced Actions Offer and put it into your hand.
+ *
+ * Powered: Gain a Wound to your hand or discard pile. Use the stronger effect
+ * of any card from the Advanced Actions Offer without paying its mana cost.
+ * The card remains in the offer.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type {
+  BloodOfAncientsBasicEffect,
+  BloodOfAncientsPoweredEffect,
+  ResolveBloodBasicSelectAAEffect,
+  ResolveBloodBasicGainAAEffect,
+  ResolveBloodPoweredWoundEffect,
+  ResolveBloodPoweredUseAAEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ADVANCED_ACTION,
+} from "../../types/cards.js";
+import {
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+  EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+  EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+  EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+} from "../../types/effectTypes.js";
+import {
+  CARD_BLOOD_OF_ANCIENTS,
+  CARD_FIRE_BOLT,
+  CARD_ICE_BOLT,
+  CARD_AGILITY,
+  CARD_WOUND,
+  CARD_MARCH,
+  CARD_CHILLING_STARE,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_TOKEN_SOURCE_SKILL,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { BLOOD_OF_ANCIENTS } from "../../data/advancedActions/red/blood-of-ancients.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createBloodState(
+  aaOffer: CardId[] = [],
+  aaDeck: CardId[] = [],
+  playerOverrides: Partial<Player> = {}
+): GameState {
+  const player = createTestPlayer({
+    id: "player1",
+    hand: [CARD_BLOOD_OF_ANCIENTS, CARD_MARCH],
+    ...playerOverrides,
+  });
+
+  return createTestGameState({
+    players: [player],
+    offers: {
+      units: [],
+      advancedActions: { cards: aaOffer },
+      spells: { cards: [] },
+      commonSkills: [],
+      monasteryAdvancedActions: [],
+      bondsOfLoyaltyBonusUnits: [],
+    },
+    decks: {
+      advancedActions: aaDeck,
+      spells: [],
+      artifacts: [],
+      units: { silver: [], gold: [] },
+    },
+  });
+}
+
+function getPlayer(state: GameState): Player {
+  return state.players[0]!;
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Blood of Ancients card definition", () => {
+  it("should have correct metadata", () => {
+    expect(BLOOD_OF_ANCIENTS.id).toBe(CARD_BLOOD_OF_ANCIENTS);
+    expect(BLOOD_OF_ANCIENTS.name).toBe("Blood of Ancients");
+    expect(BLOOD_OF_ANCIENTS.cardType).toBe(DEED_CARD_TYPE_ADVANCED_ACTION);
+    expect(BLOOD_OF_ANCIENTS.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by red mana", () => {
+    expect(BLOOD_OF_ANCIENTS.poweredBy).toEqual([MANA_RED]);
+  });
+
+  it("should have special category", () => {
+    expect(BLOOD_OF_ANCIENTS.categories).toEqual([CATEGORY_SPECIAL]);
+  });
+
+  it("should have Blood of Ancients basic effect", () => {
+    expect(BLOOD_OF_ANCIENTS.basicEffect.type).toBe(EFFECT_BLOOD_OF_ANCIENTS_BASIC);
+  });
+
+  it("should have Blood of Ancients powered effect", () => {
+    expect(BLOOD_OF_ANCIENTS.poweredEffect.type).toBe(EFFECT_BLOOD_OF_ANCIENTS_POWERED);
+  });
+});
+
+// ============================================================================
+// RESOLVABILITY TESTS - BASIC
+// ============================================================================
+
+describe("EFFECT_BLOOD_OF_ANCIENTS_BASIC resolvability", () => {
+  const effect: BloodOfAncientsBasicEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_BASIC };
+
+  it("should be resolvable when there are AAs in the offer", () => {
+    const state = createBloodState([CARD_FIRE_BOLT]);
+    expect(isEffectResolvable(state, "player1", effect)).toBe(true);
+  });
+
+  it("should not be resolvable when AA offer is empty", () => {
+    const state = createBloodState([]);
+    expect(isEffectResolvable(state, "player1", effect)).toBe(false);
+  });
+});
+
+// ============================================================================
+// RESOLVABILITY TESTS - POWERED
+// ============================================================================
+
+describe("EFFECT_BLOOD_OF_ANCIENTS_POWERED resolvability", () => {
+  const effect: BloodOfAncientsPoweredEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_POWERED };
+
+  it("should be resolvable when there are AAs in the offer", () => {
+    const state = createBloodState([CARD_FIRE_BOLT]);
+    expect(isEffectResolvable(state, "player1", effect)).toBe(true);
+  });
+
+  it("should not be resolvable when AA offer is empty", () => {
+    const state = createBloodState([]);
+    expect(isEffectResolvable(state, "player1", effect)).toBe(false);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT RESOLUTION TESTS
+// ============================================================================
+
+describe("Blood of Ancients basic effect", () => {
+  const effect: BloodOfAncientsBasicEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_BASIC };
+
+  it("should take wound to hand and present mana color choices", () => {
+    const state = createBloodState([CARD_FIRE_BOLT], [], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Wound should have been added to hand
+    const player = getPlayer(result.state);
+    expect(player.hand).toContain(CARD_WOUND);
+
+    // Should require a choice (mana color selection)
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toBeDefined();
+    expect(result.dynamicChoiceOptions!.length).toBeGreaterThan(0);
+
+    // Options should be RESOLVE_BLOOD_BASIC_SELECT_AA effects
+    const firstOption = result.dynamicChoiceOptions![0] as ResolveBloodBasicSelectAAEffect;
+    expect(firstOption.type).toBe(EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA);
+    expect(firstOption.paidColor).toBe(MANA_RED);
+  });
+
+  it("should only offer colors that have both mana to pay and matching AAs", () => {
+    // Player has red mana, but only blue AA in offer — no valid options for red
+    const state = createBloodState([CARD_ICE_BOLT], [], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Wound is taken regardless
+    const player = getPlayer(result.state);
+    expect(player.hand).toContain(CARD_WOUND);
+
+    // No valid mana/AA combination — should not require choice
+    expect(result.requiresChoice).toBeFalsy();
+  });
+
+  it("should gracefully handle no mana available", () => {
+    const state = createBloodState([CARD_FIRE_BOLT], [], {
+      pureMana: [],
+    });
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Wound taken, but no mana to pay
+    const player = getPlayer(result.state);
+    expect(player.hand).toContain(CARD_WOUND);
+    expect(result.requiresChoice).toBeFalsy();
+  });
+
+  it("should resolve mana payment and present matching AAs", () => {
+    const state = createBloodState([CARD_FIRE_BOLT, CARD_ICE_BOLT], [], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    // Step 1: Entry effect - takes wound, presents mana options
+    const result1 = resolveEffect(state, "player1", effect);
+    expect(result1.requiresChoice).toBe(true);
+
+    // Step 2: Select red mana → should present red AAs
+    const selectAAEffect = result1.dynamicChoiceOptions![0] as ResolveBloodBasicSelectAAEffect;
+    expect(selectAAEffect.paidColor).toBe(MANA_RED);
+
+    const result2 = resolveEffect(result1.state, "player1", selectAAEffect);
+
+    // Mana should be consumed
+    const player2 = getPlayer(result2.state);
+    expect(player2.pureMana.length).toBe(0);
+
+    // Fire Bolt is red, should be auto-selected (only 1 red AA)
+    // Card should be in hand
+    expect(player2.hand).toContain(CARD_FIRE_BOLT);
+
+    // Card should be removed from offer
+    expect(result2.state.offers.advancedActions.cards).not.toContain(CARD_FIRE_BOLT);
+  });
+
+  it("should replenish offer from deck after gaining AA", () => {
+    const state = createBloodState([CARD_FIRE_BOLT], [CARD_AGILITY], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    // Step 1: Entry effect
+    const result1 = resolveEffect(state, "player1", effect);
+
+    // Step 2: Select mana and auto-gain the AA
+    const selectAAEffect = result1.dynamicChoiceOptions![0] as ResolveBloodBasicSelectAAEffect;
+    const result2 = resolveEffect(result1.state, "player1", selectAAEffect);
+
+    // Offer should be replenished from deck
+    expect(result2.state.offers.advancedActions.cards).toContain(CARD_AGILITY);
+    expect(result2.state.decks.advancedActions).toHaveLength(0);
+  });
+
+  it("should present choice when multiple AAs of same color exist", () => {
+    // Two red AAs in offer
+    const state = createBloodState([CARD_FIRE_BOLT, CARD_BLOOD_OF_ANCIENTS], [], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    // Step 1: Entry effect
+    const result1 = resolveEffect(state, "player1", effect);
+
+    // Step 2: Select mana
+    const selectAAEffect = result1.dynamicChoiceOptions![0] as ResolveBloodBasicSelectAAEffect;
+    const result2 = resolveEffect(result1.state, "player1", selectAAEffect);
+
+    // Should require choice between the two red AAs
+    expect(result2.requiresChoice).toBe(true);
+    expect(result2.dynamicChoiceOptions!.length).toBe(2);
+
+    const option1 = result2.dynamicChoiceOptions![0] as ResolveBloodBasicGainAAEffect;
+    const option2 = result2.dynamicChoiceOptions![1] as ResolveBloodBasicGainAAEffect;
+    expect(option1.type).toBe(EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA);
+    expect(option2.type).toBe(EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA);
+
+    // Step 3: Select specific AA
+    const result3 = resolveEffect(result2.state, "player1", option1);
+    const player3 = getPlayer(result3.state);
+    expect(player3.hand).toContain(option1.cardId);
+  });
+
+  it("should match dual-color AAs by paid mana color", () => {
+    // Chilling Stare is powered by blue OR white
+    const state = createBloodState([CARD_CHILLING_STARE], [], {
+      pureMana: [{ color: MANA_BLUE, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    // Step 1: Entry effect
+    const result1 = resolveEffect(state, "player1", effect);
+    expect(result1.requiresChoice).toBe(true);
+
+    // Should offer blue mana payment for Chilling Stare
+    const options = result1.dynamicChoiceOptions as ResolveBloodBasicSelectAAEffect[];
+    const blueOption = options.find((o) => o.paidColor === MANA_BLUE);
+    expect(blueOption).toBeDefined();
+
+    // Step 2: Pay blue mana → auto-select Chilling Stare
+    const result2 = resolveEffect(result1.state, "player1", blueOption!);
+    const player2 = getPlayer(result2.state);
+    expect(player2.hand).toContain(CARD_CHILLING_STARE);
+  });
+
+  it("should track wound in woundsReceivedThisTurn.hand", () => {
+    const state = createBloodState([CARD_FIRE_BOLT], [], {
+      pureMana: [{ color: MANA_RED, source: MANA_TOKEN_SOURCE_SKILL }],
+    });
+
+    const result = resolveEffect(state, "player1", effect);
+    const player = getPlayer(result.state);
+    expect(player.woundsReceivedThisTurn.hand).toBe(1);
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT RESOLUTION TESTS
+// ============================================================================
+
+describe("Blood of Ancients powered effect", () => {
+  const effect: BloodOfAncientsPoweredEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_POWERED };
+
+  it("should present wound destination choice", () => {
+    const state = createBloodState([CARD_FIRE_BOLT]);
+
+    const result = resolveEffect(state, "player1", effect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toBeDefined();
+    expect(result.dynamicChoiceOptions!.length).toBe(2);
+
+    const options = result.dynamicChoiceOptions as ResolveBloodPoweredWoundEffect[];
+    expect(options[0]!.type).toBe(EFFECT_RESOLVE_BLOOD_POWERED_WOUND);
+    expect(options[0]!.destination).toBe("hand");
+    expect(options[1]!.destination).toBe("discard");
+  });
+
+  it("should not be available when AA offer is empty", () => {
+    const state = createBloodState([]);
+
+    const result = resolveEffect(state, "player1", effect);
+    expect(result.requiresChoice).toBeFalsy();
+  });
+
+  it("should take wound to hand and present AA choices", () => {
+    const state = createBloodState([CARD_FIRE_BOLT, CARD_ICE_BOLT]);
+
+    // Step 1: Entry effect - wound destination choice
+    const result1 = resolveEffect(state, "player1", effect);
+
+    // Step 2: Choose wound to hand
+    const woundToHand = (result1.dynamicChoiceOptions as ResolveBloodPoweredWoundEffect[])
+      .find((o) => o.destination === "hand")!;
+    const result2 = resolveEffect(result1.state, "player1", woundToHand);
+
+    // Wound should be in hand
+    const player2 = getPlayer(result2.state);
+    expect(player2.hand).toContain(CARD_WOUND);
+    expect(player2.woundsReceivedThisTurn.hand).toBe(1);
+
+    // Should present all AAs in offer as choices
+    expect(result2.requiresChoice).toBe(true);
+    const aaOptions = result2.dynamicChoiceOptions as ResolveBloodPoweredUseAAEffect[];
+    expect(aaOptions.length).toBe(2);
+    expect(aaOptions[0]!.type).toBe(EFFECT_RESOLVE_BLOOD_POWERED_USE_AA);
+  });
+
+  it("should take wound to discard and present AA choices", () => {
+    const state = createBloodState([CARD_FIRE_BOLT]);
+
+    // Step 1: Entry effect
+    const result1 = resolveEffect(state, "player1", effect);
+
+    // Step 2: Choose wound to discard
+    const woundToDiscard = (result1.dynamicChoiceOptions as ResolveBloodPoweredWoundEffect[])
+      .find((o) => o.destination === "discard")!;
+    const result2 = resolveEffect(result1.state, "player1", woundToDiscard);
+
+    // Wound should be in discard pile
+    const player2 = getPlayer(result2.state);
+    expect(player2.discard).toContain(CARD_WOUND);
+    expect(player2.hand).not.toContain(CARD_WOUND);
+    expect(player2.woundsReceivedThisTurn.discard).toBe(1);
+    expect(player2.woundsReceivedThisTurn.hand).toBe(0);
+  });
+
+  it("should resolve AA's powered effect and keep card in offer", () => {
+    // Fire Bolt powered: Ranged Fire Attack 4
+    const state = createBloodState([CARD_FIRE_BOLT]);
+
+    // Step 1: Entry effect
+    const result1 = resolveEffect(state, "player1", effect);
+
+    // Step 2: Wound to hand
+    const woundToHand = (result1.dynamicChoiceOptions as ResolveBloodPoweredWoundEffect[])
+      .find((o) => o.destination === "hand")!;
+    const result2 = resolveEffect(result1.state, "player1", woundToHand);
+
+    // Step 3: Select Fire Bolt to use
+    const useAA = (result2.dynamicChoiceOptions as ResolveBloodPoweredUseAAEffect[])[0]!;
+    expect(useAA.cardId).toBe(CARD_FIRE_BOLT);
+
+    const result3 = resolveEffect(result2.state, "player1", useAA);
+
+    // Fire Bolt should STILL be in the offer
+    expect(result3.state.offers.advancedActions.cards).toContain(CARD_FIRE_BOLT);
+  });
+
+  it("should let player choose any AA regardless of color", () => {
+    // Mix of colors: red Fire Bolt, blue Ice Bolt, white Agility
+    const state = createBloodState([CARD_FIRE_BOLT, CARD_ICE_BOLT, CARD_AGILITY]);
+
+    // Step 1 + 2: wound to hand
+    const result1 = resolveEffect(state, "player1", effect);
+    const woundToHand = (result1.dynamicChoiceOptions as ResolveBloodPoweredWoundEffect[])
+      .find((o) => o.destination === "hand")!;
+    const result2 = resolveEffect(result1.state, "player1", woundToHand);
+
+    // All 3 AAs should be available regardless of color
+    const aaOptions = result2.dynamicChoiceOptions as ResolveBloodPoweredUseAAEffect[];
+    expect(aaOptions.length).toBe(3);
+
+    const cardIds = aaOptions.map((o) => o.cardId);
+    expect(cardIds).toContain(CARD_FIRE_BOLT);
+    expect(cardIds).toContain(CARD_ICE_BOLT);
+    expect(cardIds).toContain(CARD_AGILITY);
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("Blood of Ancients describeEffect", () => {
+  it("should describe basic effect", () => {
+    const effect: BloodOfAncientsBasicEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_BASIC };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Wound");
+    expect(desc).toContain("AA");
+  });
+
+  it("should describe powered effect", () => {
+    const effect: BloodOfAncientsPoweredEffect = { type: EFFECT_BLOOD_OF_ANCIENTS_POWERED };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Wound");
+  });
+
+  it("should describe wound destination choice", () => {
+    const effect: ResolveBloodPoweredWoundEffect = {
+      type: EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+      destination: "discard",
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("discard");
+  });
+
+  it("should describe AA selection for powered", () => {
+    const effect: ResolveBloodPoweredUseAAEffect = {
+      type: EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+      cardId: CARD_FIRE_BOLT,
+      cardName: "Fire Bolt",
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Fire Bolt");
+  });
+
+  it("should describe mana payment for basic", () => {
+    const effect: ResolveBloodBasicSelectAAEffect = {
+      type: EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+      paidColor: MANA_RED,
+      manaSource: { type: "token" as const, color: MANA_RED },
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("red");
+  });
+
+  it("should describe AA gain for basic", () => {
+    const effect: ResolveBloodBasicGainAAEffect = {
+      type: EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+      cardId: CARD_FIRE_BOLT,
+      cardName: "Fire Bolt",
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Fire Bolt");
+  });
+});

--- a/packages/core/src/engine/effects/bloodOfAncientsEffects.ts
+++ b/packages/core/src/engine/effects/bloodOfAncientsEffects.ts
@@ -1,0 +1,508 @@
+/**
+ * Blood of Ancients Effect Handlers
+ *
+ * Handles the Blood of Ancients advanced action card:
+ *
+ * Basic: Gain a Wound. Pay one mana of any color. Gain a card of that color
+ * from the Advanced Actions Offer and put it into your hand.
+ *
+ * Powered: Gain a Wound to your hand or discard pile. Use the stronger effect
+ * of any card from the Advanced Actions Offer without paying its mana cost.
+ * The card remains in the offer.
+ *
+ * Flow (Basic):
+ * 1. EFFECT_BLOOD_OF_ANCIENTS_BASIC → take wound, present mana color choices
+ * 2. EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA → pay mana, present matching AAs
+ * 3. EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA → gain selected AA to hand
+ *
+ * Flow (Powered):
+ * 1. EFFECT_BLOOD_OF_ANCIENTS_POWERED → present wound destination choice
+ * 2. EFFECT_RESOLVE_BLOOD_POWERED_WOUND → take wound, present AA selection
+ * 3. EFFECT_RESOLVE_BLOOD_POWERED_USE_AA → resolve AA's powered effect (free)
+ *
+ * @module effects/bloodOfAncientsEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  ResolveBloodBasicSelectAAEffect,
+  ResolveBloodBasicGainAAEffect,
+  ResolveBloodPoweredWoundEffect,
+  ResolveBloodPoweredUseAAEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { EffectResolver } from "./compound.js";
+import type { CardId, BasicManaColor } from "@mage-knight/shared";
+import {
+  CARD_WOUND,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { updatePlayer } from "./atomicHelpers.js";
+import {
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+  EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+  EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+  EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+} from "../../types/effectTypes.js";
+import { getActionCardColor } from "../helpers/cardColor.js";
+import { getCard } from "../helpers/cardLookup.js";
+import { canPayForMana, getAvailableManaSourcesForColor } from "../validActions/mana.js";
+import { consumeMana } from "../commands/helpers/manaConsumptionHelpers.js";
+
+const ALL_BASIC_COLORS: readonly BasicManaColor[] = [
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+];
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Convert card color to mana color.
+ */
+function cardColorToManaColor(color: string): BasicManaColor {
+  switch (color) {
+    case "red": return MANA_RED;
+    case "blue": return MANA_BLUE;
+    case "green": return MANA_GREEN;
+    case "white": return MANA_WHITE;
+    default: throw new Error(`Unknown card color: ${color}`);
+  }
+}
+
+/**
+ * Get AAs from the offer matching a given mana color.
+ * Dual-color AAs match if any of their poweredBy colors match.
+ */
+function getMatchingAAsInOffer(
+  state: GameState,
+  color: BasicManaColor
+): { cardId: CardId; name: string }[] {
+  const results: { cardId: CardId; name: string }[] = [];
+  for (const cardId of state.offers.advancedActions.cards) {
+    const aaColor = getActionCardColor(cardId);
+    if (aaColor !== null && cardColorToManaColor(aaColor) === color) {
+      const card = getCard(cardId);
+      results.push({ cardId, name: card?.name ?? cardId });
+      continue;
+    }
+    // Check dual-color match via poweredBy
+    const card = getCard(cardId);
+    if (card && card.poweredBy.includes(color)) {
+      results.push({ cardId, name: card.name ?? cardId });
+    }
+  }
+  return results;
+}
+
+/**
+ * Remove an AA from the offer and replenish from deck.
+ */
+function removeFromOfferAndReplenish(
+  state: GameState,
+  cardId: CardId
+): GameState {
+  const aaOffer = state.offers.advancedActions.cards;
+  const offerIndex = aaOffer.indexOf(cardId);
+  if (offerIndex === -1) {
+    throw new Error(`Card ${cardId} not found in AA offer`);
+  }
+
+  const newOffer = [
+    ...aaOffer.slice(0, offerIndex),
+    ...aaOffer.slice(offerIndex + 1),
+  ];
+
+  let newDeck = state.decks.advancedActions;
+  let finalOffer = newOffer;
+  if (newDeck.length > 0) {
+    const newCard = newDeck[0];
+    if (newCard) {
+      finalOffer = [...newOffer, newCard];
+      newDeck = newDeck.slice(1);
+    }
+  }
+
+  return {
+    ...state,
+    offers: {
+      ...state.offers,
+      advancedActions: { cards: finalOffer },
+    },
+    decks: {
+      ...state.decks,
+      advancedActions: newDeck,
+    },
+  };
+}
+
+/**
+ * Take wound to the specified destination (hand or discard).
+ */
+function takeWoundTo(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  destination: "hand" | "discard"
+): GameState {
+  const woundsToAdd: CardId[] = [CARD_WOUND];
+
+  const updatedPlayer: Player = {
+    ...player,
+    hand: destination === "hand" ? [...player.hand, ...woundsToAdd] : player.hand,
+    discard: destination === "discard" ? [...player.discard, ...woundsToAdd] : player.discard,
+    woundsReceivedThisTurn: {
+      hand: player.woundsReceivedThisTurn.hand + (destination === "hand" ? 1 : 0),
+      discard: player.woundsReceivedThisTurn.discard + (destination === "discard" ? 1 : 0),
+    },
+  };
+
+  const newWoundPileCount =
+    state.woundPileCount === null ? null : Math.max(0, state.woundPileCount - 1);
+
+  return {
+    ...updatePlayer(state, playerIndex, updatedPlayer),
+    woundPileCount: newWoundPileCount,
+  };
+}
+
+// ============================================================================
+// BASIC EFFECT: Wound → Pay mana → Gain AA from offer to hand
+// ============================================================================
+
+/**
+ * Handle EFFECT_BLOOD_OF_ANCIENTS_BASIC entry point.
+ *
+ * 1. Take wound to hand (mandatory)
+ * 2. Present basic mana color choices (filtered by: can pay + has matching AA in offer)
+ */
+function handleBloodBasic(
+  state: GameState,
+  playerIndex: number,
+  player: Player
+): EffectResolutionResult {
+  // Take wound to hand immediately
+  const stateAfterWound = takeWoundTo(state, playerIndex, player, "hand");
+  const updatedPlayer = stateAfterWound.players[playerIndex]!;
+
+  // Build options: each payable mana color that has matching AAs in offer
+  const options: ResolveBloodBasicSelectAAEffect[] = [];
+
+  for (const color of ALL_BASIC_COLORS) {
+    if (!canPayForMana(stateAfterWound, updatedPlayer, color)) continue;
+
+    const matchingAAs = getMatchingAAsInOffer(stateAfterWound, color);
+    if (matchingAAs.length === 0) continue;
+
+    // Get available mana sources for this color
+    const manaSources = getAvailableManaSourcesForColor(stateAfterWound, updatedPlayer, color);
+    for (const manaSource of manaSources) {
+      options.push({
+        type: EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+        paidColor: color,
+        manaSource,
+      });
+    }
+  }
+
+  if (options.length === 0) {
+    return {
+      state: stateAfterWound,
+      description: "Blood of Ancients: took wound but no mana/AA combination available",
+    };
+  }
+
+  return {
+    state: stateAfterWound,
+    description: "Blood of Ancients: choose mana to pay for AA acquisition",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+/**
+ * Handle EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA.
+ * Pay the selected mana source, then present matching AAs.
+ */
+function resolveBloodBasicSelectAA(
+  state: GameState,
+  playerId: string,
+  effect: ResolveBloodBasicSelectAAEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  // Consume mana
+  const { player: updatedPlayer, source: updatedSource } = consumeMana(
+    player,
+    state.source,
+    effect.manaSource,
+    playerId
+  );
+
+  let updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+  updatedState = { ...updatedState, source: updatedSource };
+
+  // Find matching AAs in offer
+  const matchingAAs = getMatchingAAsInOffer(updatedState, effect.paidColor);
+
+  if (matchingAAs.length === 0) {
+    return {
+      state: updatedState,
+      description: `Blood of Ancients: paid ${effect.paidColor} mana but no matching AAs in offer`,
+    };
+  }
+
+  if (matchingAAs.length === 1) {
+    // Auto-select the only matching AA
+    const aa = matchingAAs[0]!;
+    return resolveBloodBasicGainAA(updatedState, playerId, {
+      type: EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+      cardId: aa.cardId,
+      cardName: aa.name,
+    });
+  }
+
+  // Multiple matches: present choice
+  const aaOptions: ResolveBloodBasicGainAAEffect[] = matchingAAs.map((aa) => ({
+    type: EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+    cardId: aa.cardId,
+    cardName: aa.name,
+  }));
+
+  return {
+    state: updatedState,
+    description: `Blood of Ancients: choose a ${effect.paidColor} AA from the offer`,
+    requiresChoice: true,
+    dynamicChoiceOptions: aaOptions,
+  };
+}
+
+/**
+ * Handle EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA.
+ * Gain the selected AA from the offer to hand.
+ */
+function resolveBloodBasicGainAA(
+  state: GameState,
+  playerId: string,
+  effect: ResolveBloodBasicGainAAEffect
+): EffectResolutionResult {
+  const { playerIndex } = getPlayerContext(state, playerId);
+
+  // Verify card is still in offer
+  if (!state.offers.advancedActions.cards.includes(effect.cardId)) {
+    return {
+      state,
+      description: `Blood of Ancients: ${effect.cardName} is no longer in the offer`,
+    };
+  }
+
+  // Remove from offer and replenish
+  let updatedState = removeFromOfferAndReplenish(state, effect.cardId);
+
+  // Add card to player's hand
+  const currentPlayer = updatedState.players[playerIndex]!;
+  const updatedPlayer: Player = {
+    ...currentPlayer,
+    hand: [...currentPlayer.hand, effect.cardId],
+  };
+  updatedState = updatePlayer(updatedState, playerIndex, updatedPlayer);
+
+  return {
+    state: updatedState,
+    description: `Blood of Ancients: gained ${effect.cardName} to hand`,
+  };
+}
+
+// ============================================================================
+// POWERED EFFECT: Wound choice → Select any AA → Use powered effect for free
+// ============================================================================
+
+/**
+ * Handle EFFECT_BLOOD_OF_ANCIENTS_POWERED entry point.
+ *
+ * Present wound destination choice (hand or discard).
+ */
+function handleBloodPowered(
+  state: GameState
+): EffectResolutionResult {
+  // Check if there are any AAs in the offer at all
+  if (state.offers.advancedActions.cards.length === 0) {
+    return {
+      state,
+      description: "Blood of Ancients: no AAs in the offer",
+    };
+  }
+
+  const woundOptions: ResolveBloodPoweredWoundEffect[] = [
+    { type: EFFECT_RESOLVE_BLOOD_POWERED_WOUND, destination: "hand" },
+    { type: EFFECT_RESOLVE_BLOOD_POWERED_WOUND, destination: "discard" },
+  ];
+
+  return {
+    state,
+    description: "Blood of Ancients: choose where to place the wound",
+    requiresChoice: true,
+    dynamicChoiceOptions: woundOptions,
+  };
+}
+
+/**
+ * Handle EFFECT_RESOLVE_BLOOD_POWERED_WOUND.
+ * Take wound to chosen destination, then present all AAs in offer.
+ */
+function resolveBloodPoweredWound(
+  state: GameState,
+  playerId: string,
+  effect: ResolveBloodPoweredWoundEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  // Take wound to chosen destination
+  const stateAfterWound = takeWoundTo(state, playerIndex, player, effect.destination);
+
+  // Present all AAs in the offer
+  const aaOptions: ResolveBloodPoweredUseAAEffect[] = [];
+  for (const cardId of stateAfterWound.offers.advancedActions.cards) {
+    const card = getCard(cardId);
+    aaOptions.push({
+      type: EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+      cardId,
+      cardName: card?.name ?? cardId,
+    });
+  }
+
+  if (aaOptions.length === 0) {
+    return {
+      state: stateAfterWound,
+      description: `Blood of Ancients: took wound to ${effect.destination} but no AAs in offer`,
+    };
+  }
+
+  return {
+    state: stateAfterWound,
+    description: `Blood of Ancients: took wound to ${effect.destination}, choose an AA to use`,
+    requiresChoice: true,
+    dynamicChoiceOptions: aaOptions,
+  };
+}
+
+/**
+ * Handle EFFECT_RESOLVE_BLOOD_POWERED_USE_AA.
+ * Resolve the selected AA's powered effect for free. Card stays in offer.
+ */
+function resolveBloodPoweredUseAA(
+  state: GameState,
+  playerId: string,
+  effect: ResolveBloodPoweredUseAAEffect,
+  resolveEffect: EffectResolver
+): EffectResolutionResult {
+  // Verify card is still in offer
+  if (!state.offers.advancedActions.cards.includes(effect.cardId)) {
+    return {
+      state,
+      description: `Blood of Ancients: ${effect.cardName} is no longer in the offer`,
+    };
+  }
+
+  // Get the card definition
+  const card = getCard(effect.cardId);
+  if (!card) {
+    return {
+      state,
+      description: `Blood of Ancients: ${effect.cardName} not found`,
+    };
+  }
+
+  // Resolve the AA's powered effect for free (card stays in offer)
+  const result = resolveEffect(
+    state,
+    playerId,
+    card.poweredEffect,
+    effect.cardId
+  );
+
+  return {
+    ...result,
+    description: `Blood of Ancients: used ${effect.cardName}'s powered effect (card stays in offer)`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Blood of Ancients effect handlers with the effect registry.
+ */
+export function registerBloodOfAncientsEffects(resolver: EffectResolver): void {
+  registerEffect(
+    EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+    (state, playerId) => {
+      const { playerIndex, player } = getPlayerContext(state, playerId);
+      return handleBloodBasic(state, playerIndex, player);
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+    (state, playerId, effect) => {
+      return resolveBloodBasicSelectAA(
+        state,
+        playerId,
+        effect as ResolveBloodBasicSelectAAEffect
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+    (state, playerId, effect) => {
+      return resolveBloodBasicGainAA(
+        state,
+        playerId,
+        effect as ResolveBloodBasicGainAAEffect
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+    (state) => {
+      return handleBloodPowered(state);
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+    (state, playerId, effect) => {
+      return resolveBloodPoweredWound(
+        state,
+        playerId,
+        effect as ResolveBloodPoweredWoundEffect
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+    (state, playerId, effect) => {
+      return resolveBloodPoweredUseAA(
+        state,
+        playerId,
+        effect as ResolveBloodPoweredUseAAEffect,
+        resolver
+      );
+    }
+  );
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -87,6 +87,12 @@ import {
   EFFECT_MAGIC_TALENT_POWERED,
   EFFECT_RESOLVE_MAGIC_TALENT_GAIN,
   EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA,
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+  EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+  EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+  EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
 } from "../../types/effectTypes.js";
 import type {
   GainAttackBowResolvedEffect,
@@ -571,6 +577,32 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA]: (effect) => {
     const e = effect as import("../../types/cards.js").ResolveMagicTalentSpellManaEffect;
     return `Pay ${e.manaSource.color} mana to cast ${e.spellName}`;
+  },
+
+  [EFFECT_BLOOD_OF_ANCIENTS_BASIC]: () =>
+    "Gain a Wound, pay mana, gain an AA of that color from the offer",
+
+  [EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveBloodBasicSelectAAEffect;
+    return `Pay ${e.paidColor} mana for AA acquisition`;
+  },
+
+  [EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveBloodBasicGainAAEffect;
+    return `Gain ${e.cardName} from the AA Offer`;
+  },
+
+  [EFFECT_BLOOD_OF_ANCIENTS_POWERED]: () =>
+    "Gain a Wound, use the powered effect of any AA in the offer for free",
+
+  [EFFECT_RESOLVE_BLOOD_POWERED_WOUND]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveBloodPoweredWoundEffect;
+    return `Wound to ${e.destination}`;
+  },
+
+  [EFFECT_RESOLVE_BLOOD_POWERED_USE_AA]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveBloodPoweredUseAAEffect;
+    return `Use ${e.cardName}'s powered effect`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -65,6 +65,7 @@ import { registerMagicTalentEffects } from "./magicTalentEffects.js";
 import { registerLearningEffects } from "./learningEffects.js";
 import { registerTrainingEffects } from "./trainingEffects.js";
 import { registerShapeshiftEffects } from "./shapeshiftEffects.js";
+import { registerBloodOfAncientsEffects } from "./bloodOfAncientsEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -242,4 +243,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Shapeshift effects (Braevalar's Shapeshift skill - effect type conversion)
   registerShapeshiftEffects();
+
+  // Blood of Ancients effects (wound cost + AA offer interaction)
+  registerBloodOfAncientsEffects(resolver);
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -352,6 +352,11 @@ export {
   registerMagicTalentEffects,
 } from "./magicTalentEffects.js";
 
+// Blood of Ancients effects (wound cost + AA offer interaction)
+export {
+  registerBloodOfAncientsEffects,
+} from "./bloodOfAncientsEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -118,6 +118,12 @@ import {
   EFFECT_RESOLVE_MAGIC_TALENT_GAIN,
   EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA,
   EFFECT_GAIN_ATTACK_BOW_RESOLVED,
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+  EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+  EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+  EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -629,6 +635,25 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Resolve spell mana payment is always resolvable (validated at resolution time)
   [EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA]: () => true,
+
+  // Blood of Ancients basic: resolvable if there are AAs in the offer
+  // (mana/wound checks happen at resolution time)
+  [EFFECT_BLOOD_OF_ANCIENTS_BASIC]: (state) => {
+    return state.offers.advancedActions.cards.length > 0;
+  },
+
+  // Internal Blood of Ancients effects are always resolvable (validated at resolution time)
+  [EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA]: () => true,
+  [EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA]: () => true,
+
+  // Blood of Ancients powered: resolvable if there are AAs in the offer
+  [EFFECT_BLOOD_OF_ANCIENTS_POWERED]: (state) => {
+    return state.offers.advancedActions.cards.length > 0;
+  },
+
+  // Internal Blood of Ancients powered effects are always resolvable
+  [EFFECT_RESOLVE_BLOOD_POWERED_WOUND]: () => true,
+  [EFFECT_RESOLVE_BLOOD_POWERED_USE_AA]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -136,6 +136,12 @@ import {
   EFFECT_RESOLVE_MAGIC_TALENT_SPELL_MANA,
   EFFECT_APPLY_LEARNING_DISCOUNT,
   EFFECT_SHAPESHIFT_RESOLVE,
+  EFFECT_BLOOD_OF_ANCIENTS_BASIC,
+  EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA,
+  EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA,
+  EFFECT_BLOOD_OF_ANCIENTS_POWERED,
+  EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
+  EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1574,6 +1580,70 @@ export interface ShapeshiftResolveEffect {
   readonly description: string;
 }
 
+/**
+ * Blood of Ancients basic effect entry point.
+ * Gain a wound to hand, pay mana of any basic color, gain an AA of that
+ * color from the offer to hand.
+ */
+export interface BloodOfAncientsBasicEffect {
+  readonly type: typeof EFFECT_BLOOD_OF_ANCIENTS_BASIC;
+}
+
+/**
+ * Internal: After paying mana, present matching AAs from offer.
+ * If only one match, auto-select. If multiple, present choice.
+ */
+export interface ResolveBloodBasicSelectAAEffect {
+  readonly type: typeof EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA;
+  /** The mana color that was paid — determines which AAs are available */
+  readonly paidColor: BasicManaColor;
+  /** The mana source used for payment */
+  readonly manaSource: ManaSourceInfo;
+}
+
+/**
+ * Internal: Gain a specific AA from the offer to hand.
+ * Removes from offer, replenishes from deck.
+ */
+export interface ResolveBloodBasicGainAAEffect {
+  readonly type: typeof EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA;
+  /** The AA card to gain from the offer */
+  readonly cardId: CardId;
+  /** Name of the card for display */
+  readonly cardName: string;
+}
+
+/**
+ * Blood of Ancients powered effect entry point.
+ * Gain a wound to hand or discard (choice), then select any AA from offer
+ * and use its powered effect for free. Card stays in offer.
+ */
+export interface BloodOfAncientsPoweredEffect {
+  readonly type: typeof EFFECT_BLOOD_OF_ANCIENTS_POWERED;
+}
+
+/**
+ * Internal: After wound destination choice for powered effect.
+ * Takes wound to the specified destination, then presents AA selection.
+ */
+export interface ResolveBloodPoweredWoundEffect {
+  readonly type: typeof EFFECT_RESOLVE_BLOOD_POWERED_WOUND;
+  /** Where the wound goes */
+  readonly destination: "hand" | "discard";
+}
+
+/**
+ * Internal: After selecting an AA from the offer for powered effect.
+ * Resolves the AA's powered effect for free. Card stays in offer.
+ */
+export interface ResolveBloodPoweredUseAAEffect {
+  readonly type: typeof EFFECT_RESOLVE_BLOOD_POWERED_USE_AA;
+  /** The AA card to use from the offer */
+  readonly cardId: CardId;
+  /** Name of the card for display */
+  readonly cardName: string;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1687,7 +1757,13 @@ export type CardEffect =
   | ResolveMagicTalentGainEffect
   | ResolveMagicTalentSpellManaEffect
   | ApplyLearningDiscountEffect
-  | ShapeshiftResolveEffect;
+  | ShapeshiftResolveEffect
+  | BloodOfAncientsBasicEffect
+  | ResolveBloodBasicSelectAAEffect
+  | ResolveBloodBasicGainAAEffect
+  | BloodOfAncientsPoweredEffect
+  | ResolveBloodPoweredWoundEffect
+  | ResolveBloodPoweredUseAAEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -400,6 +400,20 @@ export const EFFECT_SHAPESHIFT_RESOLVE = "shapeshift_resolve" as const;
 // transformation modifier. Skips re-triggering the transformation choice.
 export const EFFECT_GAIN_ATTACK_BOW_RESOLVED = "gain_attack_bow_resolved" as const;
 
+// === Blood of Ancients Effects ===
+// Basic: Gain wound to hand → pay mana of any color → gain AA of that color from offer to hand.
+export const EFFECT_BLOOD_OF_ANCIENTS_BASIC = "blood_of_ancients_basic" as const;
+// Internal: After paying mana, select an AA of matching color from the offer.
+export const EFFECT_RESOLVE_BLOOD_BASIC_SELECT_AA = "resolve_blood_basic_select_aa" as const;
+// Internal: After selecting an AA, gain it to hand.
+export const EFFECT_RESOLVE_BLOOD_BASIC_GAIN_AA = "resolve_blood_basic_gain_aa" as const;
+// Powered: Gain wound to hand or discard → select any AA in offer → use its powered effect for free.
+export const EFFECT_BLOOD_OF_ANCIENTS_POWERED = "blood_of_ancients_powered" as const;
+// Internal: After wound destination choice, present AA selection.
+export const EFFECT_RESOLVE_BLOOD_POWERED_WOUND = "resolve_blood_powered_wound" as const;
+// Internal: After AA selection, resolve the AA's powered effect (card stays in offer).
+export const EFFECT_RESOLVE_BLOOD_POWERED_USE_AA = "resolve_blood_powered_use_aa" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.


### PR DESCRIPTION
## Summary

Implements the Blood of Ancients advanced action card with proper multi-step effect resolution:

- **Basic:** Gain wound to hand → pay mana of any color → gain an Advanced Action of that color from the offer to hand
- **Powered:** Gain wound to hand or discard (player choice) → select any AA from the offer → use its powered effect for free (card stays in offer)

Key implementation details:
- 6 new effect types for the multi-step flows (3 basic, 3 powered)
- Dual-color AA matching (checks both primary color and `poweredBy` colors)
- Wound destination tracking for Banner of Protection compatibility
- AA offer replenishment after card removal (basic mode)
- Mana source selection with proper consumption
- Resolvability checks (requires AAs in offer)

## Test plan

- [x] 29 comprehensive tests covering:
  - Card definition verification
  - Resolvability checks for both basic and powered modes
  - Basic flow: wound → mana payment → AA color matching → gain to hand → offer replenishment
  - Powered flow: wound destination choice → AA selection → powered effect resolution → card stays in offer
  - Dual-color AA matching
  - Edge cases (empty offer, no payable mana)
  - describeEffect output for all 6 effect types
- [x] Build passes
- [x] Lint passes (0 warnings)
- [x] All 4578 core tests pass (0 failures)

Closes #172