### PR TITLE
feat: implement Shield Bash swiftness counter and armor reduction

### DIFF
--- a/packages/core/src/data/advancedActions/blue/shield-bash.ts
+++ b/packages/core/src/data/advancedActions/blue/shield-bash.ts
@@ -1,7 +1,15 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
+import {
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_APPLY_MODIFIER,
+} from "../../../types/effectTypes.js";
 import { MANA_BLUE, CARD_SHIELD_BASH } from "@mage-knight/shared";
-import { block } from "../helpers.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_SHIELD_BASH_ARMOR_REDUCTION,
+} from "../../../types/modifierConstants.js";
 
 export const SHIELD_BASH: DeedCard = {
   id: CARD_SHIELD_BASH,
@@ -10,9 +18,30 @@ export const SHIELD_BASH: DeedCard = {
   poweredBy: [MANA_BLUE],
   categories: [CATEGORY_COMBAT],
   // Basic: Block 3. Counts twice against an attack with Swiftness.
-  // Powered: Block 5. Counts twice against an attack with Swiftness. Blocked enemy gets Armor -1 for each point of block higher than needed (to a minimum of 1).
-  // TODO: Implement swiftness counter and armor reduction
-  basicEffect: block(3),
-  poweredEffect: block(5),
+  basicEffect: {
+    type: EFFECT_GAIN_BLOCK,
+    amount: 3,
+    countsTwiceAgainstSwift: true,
+  },
+  // Powered: Block 5. Counts twice against an attack with Swiftness.
+  // Blocked enemy gets Armor -1 for each point of block higher than needed (to a minimum of 1).
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      {
+        type: EFFECT_GAIN_BLOCK,
+        amount: 5,
+        countsTwiceAgainstSwift: true,
+      },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_SHIELD_BASH_ARMOR_REDUCTION,
+        },
+        duration: DURATION_COMBAT,
+        description: "On successful block: reduce enemy Armor by excess block",
+      },
+    ],
+  },
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/advancedActions/helpers.ts
+++ b/packages/core/src/data/advancedActions/helpers.ts
@@ -131,9 +131,16 @@ export function siegeAttack(amount: number): CardEffect {
  * Creates a block effect.
  *
  * @param amount - The block value
+ * @param options - Optional flags (countsTwiceAgainstSwift for Shield Bash)
  * @returns A GainBlockEffect
  */
-export function block(amount: number): CardEffect {
+export function block(
+  amount: number,
+  options?: { countsTwiceAgainstSwift?: boolean }
+): CardEffect {
+  if (options?.countsTwiceAgainstSwift) {
+    return { type: EFFECT_GAIN_BLOCK, amount, countsTwiceAgainstSwift: true };
+  }
   return { type: EFFECT_GAIN_BLOCK, amount };
 }
 

--- a/packages/core/src/engine/__tests__/cardShieldBash.test.ts
+++ b/packages/core/src/engine/__tests__/cardShieldBash.test.ts
@@ -1,0 +1,751 @@
+/**
+ * Shield Bash Card Tests
+ *
+ * Shield Bash (Blue Advanced Action):
+ * Basic: Block 3. Counts twice against an attack with Swiftness.
+ * Powered (Blue): Block 5. Counts twice against an attack with Swiftness.
+ *   Blocked enemy gets Armor -1 for each point of block higher than needed
+ *   (to a minimum of 1).
+ *
+ * Key mechanics:
+ * - Block counts twice vs Swiftness (via swiftBlockElements in accumulator)
+ * - Powered: excess undoubled block reduces enemy Armor
+ * - Ice Resistant enemies immune to armor reduction (blue card)
+ * - Cannot reduce Summoner armor via summoned monster
+ * - Armor reduction calculated per individual blocked attack
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestPlayer } from "./testHelpers.js";
+import { createTestGameState } from "./testHelpers.js";
+import {
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  PLAY_CARD_ACTION,
+  ASSIGN_BLOCK_ACTION,
+  DECLARE_BLOCK_ACTION,
+  CARD_SHIELD_BASH,
+  MANA_BLUE,
+  MANA_SOURCE_TOKEN,
+  ENEMY_WOLF_RIDERS,
+  ENEMY_GUARDSMEN,
+  ENEMY_DIGGERS,
+  ENEMY_ICE_GOLEMS,
+  getEnemy,
+} from "@mage-knight/shared";
+import {
+  COMBAT_PHASE_BLOCK,
+} from "../../types/combat.js";
+import { getEffectiveEnemyArmor } from "../modifiers/combat.js";
+
+describe("Shield Bash", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("basic effect", () => {
+    it("should grant Block 3", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Guardsmen
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_GUARDSMEN],
+      }).state;
+
+      // Skip to block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_BLOCK);
+
+      // Play Shield Bash basic
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: false,
+      });
+
+      // Should grant Block 3
+      expect(result.state.players[0].combatAccumulator.block).toBe(3);
+      expect(result.state.players[0].combatAccumulator.blockElements.physical).toBe(3);
+      expect(result.state.players[0].pendingChoice).toBeNull();
+    });
+
+    it("should track block in swiftBlockElements for Swiftness doubling", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_GUARDSMEN],
+      }).state;
+
+      // Skip to block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash basic
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: false,
+      }).state;
+
+      // Should be tracked in swiftBlockElements
+      expect(state.players[0].combatAccumulator.swiftBlockElements.physical).toBe(3);
+    });
+
+    it("should block Swift enemy with doubled block value", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Wolf Riders: Attack 3, Swift, Armor 4
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_WOLF_RIDERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+
+      // Skip to block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash basic (Block 3, counts twice = effective 6 vs Swift)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: false,
+      }).state;
+
+      // Assign all block to wolf riders
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+
+      // Declare block — Wolf Riders need 6 (3×2), Shield Bash provides 3×2 = 6
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      });
+
+      // Block should succeed
+      const enemy = result.state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(true);
+    });
+
+    it("should not grant armor reduction on basic effect", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Diggers: Attack 2, Armor 3, no resistances
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_DIGGERS).armor;
+
+      // Skip to block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash basic (Block 3)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: false,
+      }).state;
+
+      // Assign block and declare
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Armor should NOT be reduced (basic effect)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(baseArmor);
+    });
+  });
+
+  describe("powered effect", () => {
+    it("should grant Block 5 and track in swiftBlockElements", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_GUARDSMEN],
+      }).state;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Should grant Block 5 with swift tracking
+      expect(state.players[0].combatAccumulator.block).toBe(5);
+      expect(state.players[0].combatAccumulator.blockElements.physical).toBe(5);
+      expect(state.players[0].combatAccumulator.swiftBlockElements.physical).toBe(5);
+    });
+
+    it("should apply armor reduction for excess block on successful block", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Diggers: Attack 2, Armor 3
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_DIGGERS).armor;
+      expect(baseArmor).toBe(3);
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign 2 block (enough to block Diggers attack 2)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+
+      // Declare block — excess = 0 (assigned exactly 2, needed 2)
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // No excess block, no armor reduction
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(3);
+    });
+
+    it("should reduce armor by excess undoubled block points", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Diggers: Attack 2, Armor 3
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_DIGGERS).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign 5 block (3 excess over attack 2)
+      for (let i = 0; i < 5; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      // Declare block — excess = 5 - 2 = 3
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Armor should be reduced by 3: 3 - 3 = 0, clamped to minimum 1
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(1);
+    });
+
+    it("should calculate excess using undoubled block vs Swift enemy (Vlaada O3)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Wolf Riders: Attack 3, Swift, Armor 4
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_WOLF_RIDERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_WOLF_RIDERS).armor;
+      expect(baseArmor).toBe(4);
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5, counts twice vs Swift = effective 10)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign all 5 block to Wolf Riders
+      for (let i = 0; i < 5; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      // Declare block
+      // Wolf Riders need 6 doubled block (3×2), Shield Bash provides 5×2 = 10
+      // Block succeeds: 10 >= 6
+      // Undoubled excess: 5 (undoubled block) - 3 (undoubled attack) = 2
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Enemy should be blocked
+      const enemy = state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(true);
+
+      // Armor reduction: 2 (excess undoubled)
+      // Effective armor: 4 - 2 = 2
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(2);
+    });
+
+    it("should enforce minimum armor of 1", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Diggers: Attack 2, Armor 3
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_DIGGERS).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign all 5 block (excess = 5 - 2 = 3, armor 3 - 3 = 0 → clamped to 1)
+      for (let i = 0; i < 5; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Armor should be clamped to 1 (not 0)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(1);
+    });
+
+    it("should NOT apply armor reduction to Ice Resistant enemies (S7)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Ice Golems: Attack 2 (Ice), Armor 4, Ice + Physical Resistance
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_ICE_GOLEMS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_ICE_GOLEMS).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign block to Ice Golems
+      // Ice Golems attack is 2 (Ice element), physical block is inefficient
+      // Need 4 physical block (2 inefficient halved = 1 per 2)
+      // Actually, physical block vs ice attack is INefficient.
+      // 5 physical vs Ice: floor(5/2) = 2, which equals attack 2. Enough to block.
+      for (let i = 0; i < 5; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Block should succeed (5 physical vs Ice attack 2: floor(5/2) = 2 >= 2)
+      const enemy = state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(true);
+
+      // Armor should NOT be reduced (Ice Resistant = immune to Shield Bash armor reduction)
+      const resistanceCount = getEnemy(ENEMY_ICE_GOLEMS).resistances.length;
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        resistanceCount,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(baseArmor);
+    });
+
+    it("should block Swift enemy with Shield Bash powered and calculate correct Vlaada example", () => {
+      // Vlaada's Example: Shield Bash Block 5 × 2 = 10 vs Wolf Riders Attack 3 Swift
+      // Need 6 doubled block (3 × 2), use 6 of 10 doubled
+      // Excess: 4 doubled = 2 undoubled
+      // Armor reduction: 2
+      // This is tested by the O3 test above, but let's verify 3 block assigned also works
+
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Wolf Riders: Attack 3, Swift, Armor 4
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_WOLF_RIDERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_WOLF_RIDERS).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign only 3 block (just enough: 3×2 = 6 = 3×2 required)
+      for (let i = 0; i < 3; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Block succeeds (3×2 = 6 >= 6)
+      const enemy = state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(true);
+
+      // Excess: 3 (undoubled) - 3 (undoubled attack) = 0, no armor reduction
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(4); // No reduction
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should not apply armor reduction when block fails", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Guardsmen: Attack 3, Armor 7
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_GUARDSMEN],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_GUARDSMEN).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign only 2 block (not enough for Guardsmen attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_BLOCK_ACTION,
+        enemyInstanceId,
+        element: "physical",
+        amount: 1,
+      }).state;
+
+      // Declare block — should fail (2 < 3)
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Block should fail
+      const enemy = state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(false);
+
+      // No armor reduction on failed block
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(baseArmor);
+    });
+
+    it("should work with Guardsmen (non-Swift) - no doubling needed", () => {
+      const player = createTestPlayer({
+        hand: [CARD_SHIELD_BASH],
+        pureMana: [{ color: MANA_BLUE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Guardsmen: Attack 3, Armor 7
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_GUARDSMEN],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseArmor = getEnemy(ENEMY_GUARDSMEN).armor;
+
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Shield Bash powered (Block 5)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_SHIELD_BASH,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_BLUE }],
+      }).state;
+
+      // Assign 5 block
+      for (let i = 0; i < 5; i++) {
+        state = engine.processAction(state, "player1", {
+          type: ASSIGN_BLOCK_ACTION,
+          enemyInstanceId,
+          element: "physical",
+          amount: 1,
+        }).state;
+      }
+
+      // Declare block (5 >= 3, succeeds)
+      state = engine.processAction(state, "player1", {
+        type: DECLARE_BLOCK_ACTION,
+        targetEnemyInstanceId: enemyInstanceId,
+      }).state;
+
+      // Block succeeds
+      const enemy = state.combat?.enemies.find(
+        (e) => e.instanceId === enemyInstanceId
+      );
+      expect(enemy?.isBlocked).toBe(true);
+
+      // Excess = 5 - 3 = 2, armor 7 - 2 = 5
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        enemyInstanceId,
+        baseArmor,
+        0,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(5);
+    });
+  });
+});

--- a/packages/core/src/engine/combat/shieldBashHelpers.ts
+++ b/packages/core/src/engine/combat/shieldBashHelpers.ts
@@ -1,0 +1,143 @@
+/**
+ * Shield Bash armor reduction on-block-success handling.
+ *
+ * When a block succeeds while the Shield Bash armor reduction modifier is active:
+ * - Calculate excess undoubled block (undoubled effective block - undoubled required block)
+ * - Apply armor reduction equal to excess to the blocked enemy (minimum armor 1)
+ * - Ice Resistant enemies are immune to armor reduction (blue card = ice element)
+ * - Summoner enemies cannot have armor reduced via their summoned monster
+ *
+ * Per Vlaada's ruling (O3):
+ * 1. Calculate effective undoubled block (pending block only, not the swift-doubled portion)
+ * 2. Calculate undoubled required block (base attack, not Swift-doubled)
+ * 3. Excess = undoubled effective block - undoubled required block
+ * 4. Armor reduction = excess (cannot reduce below 1)
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { GameEvent, Element } from "@mage-knight/shared";
+import { RESIST_ICE } from "@mage-knight/shared";
+import type { CombatEnemy, PendingElementalDamage } from "../../types/combat.js";
+import {
+  EFFECT_SHIELD_BASH_ARMOR_REDUCTION,
+  EFFECT_ENEMY_STAT,
+  ENEMY_STAT_ARMOR,
+  DURATION_COMBAT,
+  SCOPE_ONE_ENEMY,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import { CARD_SHIELD_BASH } from "@mage-knight/shared";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+import { addModifier } from "../modifiers/lifecycle.js";
+import { getCumbersomeReducedAttack } from "./cumbersomeHelpers.js";
+import { getNaturesVengeanceAttackBonus } from "../modifiers/combat.js";
+import { getEnemyAttacks } from "./enemyAttackHelpers.js";
+import { getColdToughnessBlockBonus } from "./coldToughnessHelpers.js";
+import { getFinalBlockValue } from "./elementalCalc.js";
+
+/**
+ * Convert PendingElementalDamage to BlockSource[] format.
+ */
+function pendingToSources(pending: PendingElementalDamage): readonly { element: Element; value: number }[] {
+  const sources: { element: Element; value: number }[] = [];
+  if (pending.physical > 0) sources.push({ element: "physical", value: pending.physical });
+  if (pending.fire > 0) sources.push({ element: "fire", value: pending.fire });
+  if (pending.ice > 0) sources.push({ element: "ice", value: pending.ice });
+  if (pending.coldFire > 0) sources.push({ element: "cold_fire", value: pending.coldFire });
+  return sources;
+}
+
+/**
+ * Check for and apply Shield Bash armor reduction after a successful block.
+ *
+ * @param state - Current game state (BEFORE pending block is cleared)
+ * @param playerId - Player who blocked
+ * @param blockedEnemy - The enemy whose attack was blocked
+ * @param attackIndex - Which attack was blocked (for multi-attack enemies)
+ * @param pendingBlock - The pending block that was used for this block
+ * @returns Updated state and events, or null if no Shield Bash armor reduction active
+ */
+export function applyShieldBashArmorReduction(
+  state: GameState,
+  playerId: string,
+  blockedEnemy: CombatEnemy,
+  attackIndex: number,
+  pendingBlock: PendingElementalDamage
+): { state: GameState; events: GameEvent[] } | null {
+  // Find active Shield Bash armor reduction modifier
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const shieldBashMod = modifiers.find(
+    (m) => m.effect.type === EFFECT_SHIELD_BASH_ARMOR_REDUCTION
+  );
+
+  if (!shieldBashMod) {
+    return null;
+  }
+
+  // Ice Resistant enemies are immune to armor reduction (blue card = ice element per S7)
+  if (blockedEnemy.definition.resistances.includes(RESIST_ICE)) {
+    return null;
+  }
+
+  // Cannot reduce Summoner armor via summoned monster (Q6)
+  // If the blocked enemy is a summoned monster, skip armor reduction
+  if (blockedEnemy.summonedByInstanceId !== undefined) {
+    return null;
+  }
+
+  // Get the attack being blocked
+  const attacks = getEnemyAttacks(blockedEnemy);
+  const attack = attacks[attackIndex];
+  if (!attack) {
+    return null;
+  }
+
+  // Calculate undoubled block (pending block without the swift-doubled portion)
+  const baseSources = pendingToSources(pendingBlock);
+
+  // Add Cold Toughness bonus (same as in declareBlockCommand)
+  const coldToughnessBonus = getColdToughnessBlockBonus(state, playerId, blockedEnemy);
+  const sourcesWithBonus = coldToughnessBonus > 0
+    ? [...baseSources, { element: "ice" as Element, value: coldToughnessBonus }]
+    : baseSources;
+
+  // Calculate undoubled effective block (using elemental efficiency against attack element)
+  const undoubledEffectiveBlock = getFinalBlockValue(
+    sourcesWithBonus,
+    attack.element,
+    state,
+    playerId
+  );
+
+  // Calculate undoubled required block (base attack without Swift doubling)
+  let undoubledRequired = attack.damage;
+  undoubledRequired += getNaturesVengeanceAttackBonus(state, playerId);
+  undoubledRequired = getCumbersomeReducedAttack(state, playerId, blockedEnemy, undoubledRequired);
+
+  // Excess = undoubled block - undoubled required
+  const excess = undoubledEffectiveBlock - undoubledRequired;
+
+  if (excess <= 0) {
+    return null;
+  }
+
+  // Apply armor reduction modifier to the blocked enemy
+  const updatedState = addModifier(state, {
+    source: { type: SOURCE_CARD, cardId: CARD_SHIELD_BASH, playerId },
+    duration: DURATION_COMBAT,
+    scope: { type: SCOPE_ONE_ENEMY, enemyId: blockedEnemy.instanceId },
+    effect: {
+      type: EFFECT_ENEMY_STAT,
+      stat: ENEMY_STAT_ARMOR,
+      amount: -excess,
+      minimum: 1,
+    },
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  return {
+    state: updatedState,
+    events: [],
+  };
+}

--- a/packages/core/src/engine/commands/combat/declareBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareBlockCommand.ts
@@ -36,6 +36,7 @@ import { isSwiftActive } from "../../combat/swiftHelpers.js";
 import { getNaturesVengeanceAttackBonus } from "../../modifiers/combat.js";
 import { getColdToughnessBlockBonus } from "../../combat/coldToughnessHelpers.js";
 import { applyBurningShieldOnBlock } from "../../combat/burningShieldHelpers.js";
+import { applyShieldBashArmorReduction } from "../../combat/shieldBashHelpers.js";
 
 export const DECLARE_BLOCK_COMMAND = "DECLARE_BLOCK" as const;
 
@@ -335,6 +336,23 @@ export function createDeclareBlockCommand(
         if (shieldResult) {
           resultState = shieldResult.state;
           resultEvents.push(...shieldResult.events);
+        }
+      }
+
+      // Check for Shield Bash armor reduction on successful block
+      // Uses the original pendingBlock (before clearing)
+      // to calculate excess undoubled block for armor reduction
+      if (updatedEnemy) {
+        const shieldBashResult = applyShieldBashArmorReduction(
+          resultState,
+          params.playerId,
+          updatedEnemy,
+          attackIndex,
+          pendingBlock
+        );
+        if (shieldBashResult) {
+          resultState = shieldBashResult.state;
+          resultEvents.push(...shieldBashResult.events);
         }
       }
 

--- a/packages/core/src/engine/effects/atomicCombatEffects.ts
+++ b/packages/core/src/engine/effects/atomicCombatEffects.ts
@@ -298,7 +298,7 @@ export function applyGainBlock(
   player: Player,
   effect: GainBlockEffect
 ): EffectResolutionResult {
-  const { amount, element } = effect;
+  const { amount, element, countsTwiceAgainstSwift } = effect;
   const effectiveElement = element ?? ELEMENT_PHYSICAL;
 
   // Create a block source for tracking (for elemental efficiency calculations)
@@ -321,6 +321,14 @@ export function applyGainBlock(
         effectiveElement,
         amount
       ),
+      // Shield Bash: also track in swiftBlockElements so it doubles vs Swift enemies
+      swiftBlockElements: countsTwiceAgainstSwift
+        ? updateElementalValue(
+            player.combatAccumulator.swiftBlockElements,
+            effectiveElement,
+            amount
+          )
+        : player.combatAccumulator.swiftBlockElements,
       blockSources: [...player.combatAccumulator.blockSources, blockSource],
     },
   };

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -238,6 +238,7 @@ export interface GainBlockEffect {
   readonly type: typeof EFFECT_GAIN_BLOCK;
   readonly amount: number;
   readonly element?: Element; // undefined = physical
+  readonly countsTwiceAgainstSwift?: boolean; // Shield Bash: block counts twice vs Swiftness
 }
 
 export interface GainHealingEffect {

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -388,3 +388,11 @@ export const EFFECT_NATURES_VENGEANCE_ATTACK_BONUS = "natures_vengeance_attack_b
 //   Fire Resistance → Red, Ice Resistance → Blue, Physical Resistance → Green, always White.
 export const EFFECT_SOUL_HARVESTER_CRYSTAL_TRACKING = "soul_harvester_crystal_tracking" as const;
 
+// === ShieldBashArmorReductionModifier ===
+// When active, a successful block applies armor reduction to the blocked enemy.
+// Armor reduction = excess undoubled block points (block used minus block needed).
+// Ice Resistant enemies are immune to the armor reduction (blue card = ice element).
+// Summoner enemies cannot have their armor reduced via their summoned monster.
+// Duration: combat. Applied by Shield Bash powered effect.
+export const EFFECT_SHIELD_BASH_ARMOR_REDUCTION = "shield_bash_armor_reduction" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -71,6 +71,7 @@ import {
   EFFECT_BOW_PHASE_FAME_TRACKING,
   EFFECT_BOW_ATTACK_TRANSFORMATION,
   EFFECT_SOUL_HARVESTER_CRYSTAL_TRACKING,
+  EFFECT_SHIELD_BASH_ARMOR_REDUCTION,
   SHAPESHIFT_TARGET_MOVE,
   SHAPESHIFT_TARGET_ATTACK,
   SHAPESHIFT_TARGET_BLOCK,
@@ -645,6 +646,16 @@ export interface SoulHarvesterCrystalTrackingModifier {
   readonly trackByAttack: boolean;
 }
 
+// Shield Bash armor reduction modifier (Shield Bash powered effect)
+// When a block succeeds, reduces the blocked enemy's armor by the excess block points.
+// Excess = total undoubled block - block needed to fully block.
+// Ice Resistant enemies are immune (blue card = ice element).
+// Cannot reduce Summoner armor via summoned monster.
+// Not consumed — applies to every successful block while active.
+export interface ShieldBashArmorReductionModifier {
+  readonly type: typeof EFFECT_SHIELD_BASH_ARMOR_REDUCTION;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -696,7 +707,8 @@ export type ModifierEffect =
   | NaturesVengeanceAttackBonusModifier
   | BowPhaseFameTrackingModifier
   | BowAttackTransformationModifier
-  | SoulHarvesterCrystalTrackingModifier;
+  | SoulHarvesterCrystalTrackingModifier
+  | ShieldBashArmorReductionModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- Shield Bash block now counts twice against Swift enemies (basic and powered)
- Powered effect applies armor reduction equal to excess undoubled block points
- Ice Resistant enemies are immune to armor reduction (blue card = ice element)
- Summoner enemies cannot have armor reduced via their summoned monster
- Minimum armor enforced at 1

## Changes
- Extended `GainBlockEffect` with `countsTwiceAgainstSwift` flag
- Updated `applyGainBlock` to populate `swiftBlockElements` when flag is set
- Updated `block()` helper to accept options for swift doubling
- Added `ShieldBashArmorReductionModifier` to modifier system
- Created `shieldBashHelpers.ts` to calculate excess undoubled block and apply armor reduction on successful block
- Integrated armor reduction into `declareBlockCommand` after successful block
- Updated Shield Bash card to use new effects (basic: block with swift, powered: compound of block + armor reduction modifier)
- 13 comprehensive tests covering Swiftness doubling, armor reduction, Ice Resistance immunity, min armor, failed blocks, and Vlaada's ruling examples

## Test plan
- [x] Basic: Block 3 granted, tracked in swiftBlockElements
- [x] Basic: Successfully blocks Swift enemy with doubled value
- [x] Basic: No armor reduction on basic effect
- [x] Powered: Block 5 granted with swift tracking
- [x] Powered: Armor reduction = excess undoubled block
- [x] Powered: Excess calculated using undoubled values vs Swift (Vlaada O3)
- [x] Powered: Minimum armor enforced at 1
- [x] Powered: Ice Resistant enemies immune to armor reduction (S7)
- [x] No armor reduction on failed block
- [x] Works with non-Swift enemies (no doubling needed)

Closes #173