### PR TITLE
feat: implement Tome of All Spells artifact

### DIFF
--- a/packages/core/src/data/artifacts/tomeOfAllSpells.ts
+++ b/packages/core/src/data/artifacts/tomeOfAllSpells.ts
@@ -6,10 +6,33 @@
  *        of same color from offer without paying mana.
  * Powered: Discard card. Use stronger effect of Spell of same color
  *          from offer without mana cost. Works even during Day.
+ *          Artifact is destroyed after powered use.
  */
 
 import type { DeedCard } from "../../types/cards.js";
 import type { CardId } from "@mage-knight/shared";
+import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ARTIFACT } from "../../types/cards.js";
+import {
+  CARD_TOME_OF_ALL_SPELLS,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import { EFFECT_TOME_OF_ALL_SPELLS } from "../../types/effectTypes.js";
 
-// TODO: Implement Tome of All Spells
-export const TOME_OF_ALL_SPELLS_CARDS: Record<CardId, DeedCard> = {};
+export const TOME_OF_ALL_SPELLS: DeedCard = {
+  id: CARD_TOME_OF_ALL_SPELLS,
+  name: "Tome of All Spells",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  categories: [CATEGORY_SPECIAL],
+  basicEffect: { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" },
+  poweredEffect: { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "powered" },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const TOME_OF_ALL_SPELLS_CARDS: Record<CardId, DeedCard> = {
+  [CARD_TOME_OF_ALL_SPELLS]: TOME_OF_ALL_SPELLS,
+};

--- a/packages/core/src/engine/__tests__/tomeOfAllSpells.test.ts
+++ b/packages/core/src/engine/__tests__/tomeOfAllSpells.test.ts
@@ -1,0 +1,606 @@
+/**
+ * Tests for Tome of All Spells artifact (#235)
+ *
+ * Basic: Discard a card of any color. Use the basic effect of a Spell of the
+ * same color from the Spells Offer without paying its mana cost.
+ * Spell stays in the offer.
+ *
+ * Powered: Discard a card of any color. Use the stronger effect of a Spell of
+ * the same color from the Spells Offer without paying its mana cost.
+ * Works even during Day. Artifact is destroyed after powered use.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  resolveEffect,
+  isEffectResolvable,
+  describeEffect,
+} from "../effects/index.js";
+import type {
+  TomeOfAllSpellsEffect,
+  ResolveTomeSpellEffect,
+} from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_TOME_OF_ALL_SPELLS,
+  EFFECT_RESOLVE_TOME_SPELL,
+} from "../../types/effectTypes.js";
+import {
+  CARD_TOME_OF_ALL_SPELLS,
+  CARD_RAGE,
+  CARD_MARCH,
+  CARD_SWIFTNESS,
+  CARD_CRYSTALLIZE,
+  CARD_WOUND,
+  CARD_FIREBALL,
+  CARD_FLAME_WALL,
+  CARD_SNOWSTORM,
+  CARD_RESTORATION,
+  CARD_CURE,
+  MANA_BLUE,
+  MANA_RED,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { TOME_OF_ALL_SPELLS } from "../../data/artifacts/tomeOfAllSpells.js";
+import { createTestPlayer, createTestGameState } from "./testHelpers.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createTomeState(
+  spellOffer: CardId[] = [],
+  spellDeck: CardId[] = [],
+  playerOverrides: Partial<Player> = {}
+): GameState {
+  const player = createTestPlayer({
+    id: "player1",
+    hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE], // Artifact + Red basic action
+    ...playerOverrides,
+  });
+
+  return createTestGameState({
+    players: [player],
+    offers: {
+      units: [],
+      advancedActions: { cards: [] },
+      spells: { cards: spellOffer },
+      commonSkills: [],
+      monasteryAdvancedActions: [],
+      bondsOfLoyaltyBonusUnits: [],
+    },
+    decks: {
+      spells: spellDeck,
+      advancedActions: [],
+      artifacts: [],
+      units: { silver: [], gold: [] },
+    },
+  });
+}
+
+function getPlayer(state: GameState): Player {
+  return state.players[0]!;
+}
+
+// ============================================================================
+// CARD DEFINITION TESTS
+// ============================================================================
+
+describe("Tome of All Spells card definition", () => {
+  it("should have correct metadata", () => {
+    expect(TOME_OF_ALL_SPELLS.id).toBe(CARD_TOME_OF_ALL_SPELLS);
+    expect(TOME_OF_ALL_SPELLS.name).toBe("Tome of All Spells");
+    expect(TOME_OF_ALL_SPELLS.cardType).toBe(DEED_CARD_TYPE_ARTIFACT);
+    expect(TOME_OF_ALL_SPELLS.sidewaysValue).toBe(1);
+  });
+
+  it("should be powered by any basic mana color", () => {
+    expect(TOME_OF_ALL_SPELLS.poweredBy).toEqual([MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE]);
+  });
+
+  it("should have special category", () => {
+    expect(TOME_OF_ALL_SPELLS.categories).toEqual([CATEGORY_SPECIAL]);
+  });
+
+  it("should be destroyed after powered use", () => {
+    expect(TOME_OF_ALL_SPELLS.destroyOnPowered).toBe(true);
+  });
+
+  it("should have Tome of All Spells basic effect", () => {
+    expect(TOME_OF_ALL_SPELLS.basicEffect.type).toBe(EFFECT_TOME_OF_ALL_SPELLS);
+    expect((TOME_OF_ALL_SPELLS.basicEffect as TomeOfAllSpellsEffect).mode).toBe("basic");
+  });
+
+  it("should have Tome of All Spells powered effect", () => {
+    expect(TOME_OF_ALL_SPELLS.poweredEffect.type).toBe(EFFECT_TOME_OF_ALL_SPELLS);
+    expect((TOME_OF_ALL_SPELLS.poweredEffect as TomeOfAllSpellsEffect).mode).toBe("powered");
+  });
+});
+
+// ============================================================================
+// RESOLVABILITY TESTS
+// ============================================================================
+
+describe("EFFECT_TOME_OF_ALL_SPELLS resolvability", () => {
+  const basicEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+  const poweredEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "powered" };
+
+  it("should be resolvable when player has colored cards and matching spells in offer", () => {
+    const state = createTomeState([CARD_FIREBALL]); // Red spell, CARD_RAGE is red
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+  });
+
+  it("should not be resolvable when spell offer is empty", () => {
+    const state = createTomeState([]);
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+  });
+
+  it("should not be resolvable when player has only wounds in hand", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_WOUND, CARD_WOUND],
+    });
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+  });
+
+  it("should not be resolvable when player has only the Tome (no other cards)", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS],
+    });
+    // Tome is an artifact with no color, so it cannot be discarded
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+  });
+
+  it("should be resolvable for powered mode with same conditions as basic", () => {
+    const state = createTomeState([CARD_FIREBALL]);
+    expect(isEffectResolvable(state, "player1", poweredEffect)).toBe(true);
+  });
+
+  it("should be resolvable when discarding a spell card from hand", () => {
+    const state = createTomeState([CARD_SNOWSTORM], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_SNOWSTORM],
+    });
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+  });
+});
+
+// ============================================================================
+// BASIC EFFECT TESTS
+// ============================================================================
+
+describe("EFFECT_TOME_OF_ALL_SPELLS basic", () => {
+  const basicEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+
+  it("should return no-op when no colored cards in hand", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_WOUND],
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No colored cards");
+  });
+
+  it("should return no-op when no matching spells in offer", () => {
+    // Player has red cards but offer has only blue spells
+    const state = createTomeState([CARD_SNOWSTORM], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No spells in the offer match");
+  });
+
+  it("should set pendingDiscard when there are matching colored cards and spells", () => {
+    // Player has red card (Rage), offer has red spell (Fireball)
+    // No mana needed for Tome (unlike Magic Talent)
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+      pureMana: [], // No mana, but that's fine for Tome
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    expect(player.pendingDiscard).not.toBeNull();
+    expect(player.pendingDiscard?.colorMatters).toBe(true);
+  });
+
+  it("should NOT require mana (unlike Magic Talent)", () => {
+    // Player has red card (Rage), offer has red spell (Fireball), but NO mana
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+      pureMana: [],
+      crystals: { red: 0, blue: 0, green: 0, white: 0 },
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    // Should succeed even without mana (Tome casts for free)
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    expect(player.pendingDiscard).not.toBeNull();
+    expect(player.pendingDiscard?.thenEffectByColor?.[MANA_RED]).toBeDefined();
+  });
+
+  it("should not allow discarding the source card (Tome itself)", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS],
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    // Tome is an artifact (no color), so it can't be discarded for color match
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No colored cards");
+  });
+
+  it("should allow discarding different colored cards for different spells", () => {
+    const state = createTomeState(
+      [CARD_FIREBALL, CARD_RESTORATION],
+      [],
+      {
+        hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE, CARD_MARCH], // Red + Green
+      }
+    );
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    const byColor = player.pendingDiscard?.thenEffectByColor;
+    expect(byColor).toBeDefined();
+    expect(byColor?.[MANA_RED]).toBeDefined();
+    expect(byColor?.[MANA_GREEN]).toBeDefined();
+  });
+
+  it("should not allow discarding wounds", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_WOUND, CARD_RAGE],
+    });
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    expect(player.pendingDiscard?.filterWounds).toBe(true);
+  });
+
+  it("should work with all four spell colors", () => {
+    const state = createTomeState(
+      [CARD_FIREBALL, CARD_SNOWSTORM, CARD_RESTORATION, CARD_CURE],
+      [],
+      {
+        hand: [
+          CARD_TOME_OF_ALL_SPELLS,
+          CARD_RAGE,         // Red
+          CARD_CRYSTALLIZE,  // Blue
+          CARD_MARCH,        // Green
+          CARD_SWIFTNESS,    // White
+        ],
+      }
+    );
+
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    const byColor = player.pendingDiscard?.thenEffectByColor;
+    expect(byColor?.[MANA_RED]).toBeDefined();
+    expect(byColor?.[MANA_BLUE]).toBeDefined();
+    expect(byColor?.[MANA_GREEN]).toBeDefined();
+    expect(byColor?.[MANA_WHITE]).toBeDefined();
+  });
+});
+
+// ============================================================================
+// RESOLVE TOME SPELL BASIC TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_TOME_SPELL basic", () => {
+  it("should resolve the spell's basic effect without mana cost", () => {
+    // Fireball basic = Ranged Fire Attack 5
+    const state = createTomeState([CARD_FIREBALL], [], {
+      pureMana: [], // No mana needed
+    });
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Should gain ranged fire attack 5 without any mana consumed
+    const player = getPlayer(result.state);
+    expect(player.combatAccumulator.attack.rangedElements.fire).toBe(5);
+    expect(player.pureMana.length).toBe(0); // No mana was consumed
+    expect(result.description).toContain("Fireball");
+    expect(result.description).toContain("Spell Offer");
+    expect(result.description).toContain("no mana cost");
+  });
+
+  it("should keep the spell in the offer after resolving", () => {
+    const state = createTomeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Spell should still be in the offer (not removed)
+    expect(result.state.offers.spells.cards).toContain(CARD_FIREBALL);
+    expect(result.state.offers.spells.cards).toContain(CARD_SNOWSTORM);
+  });
+
+  it("should not consume any mana", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      pureMana: [{ color: MANA_RED, source: "skill" as const }],
+      crystals: { red: 1, blue: 0, green: 0, white: 0 },
+    });
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Mana and crystals should be untouched
+    const player = getPlayer(result.state);
+    expect(player.pureMana.length).toBe(1);
+    expect(player.crystals.red).toBe(1);
+  });
+
+  it("should handle spell no longer in offer gracefully", () => {
+    const state = createTomeState([]); // Empty offer
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    expect(result.description).toContain("no longer in the offer");
+  });
+});
+
+// ============================================================================
+// RESOLVE TOME SPELL POWERED TESTS
+// ============================================================================
+
+describe("EFFECT_RESOLVE_TOME_SPELL powered", () => {
+  it("should resolve the spell's powered effect without mana cost", () => {
+    // Fireball powered = Take Wound + Siege Fire Attack 8
+    const state = createTomeState([CARD_FIREBALL], [], {
+      pureMana: [],
+    });
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "powered",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Should gain siege fire attack 8 (Firestorm powered effect)
+    const player = getPlayer(result.state);
+    expect(player.combatAccumulator.attack.siegeElements.fire).toBe(8);
+    // Should have taken a wound (Fireball powered takes wound)
+    expect(player.hand).toContain(CARD_WOUND);
+    expect(result.description).toContain("Fireball");
+    expect(result.description).toContain("powered");
+  });
+
+  it("should keep the spell in the offer after powered use", () => {
+    const state = createTomeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "powered",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // Spell stays in offer
+    expect(result.state.offers.spells.cards).toContain(CARD_FIREBALL);
+    expect(result.state.offers.spells.cards).toContain(CARD_SNOWSTORM);
+  });
+
+  it("should not consume any mana for powered effect", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      pureMana: [{ color: MANA_RED, source: "skill" as const }],
+    });
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "powered",
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // No mana consumed (neither basic color nor black mana)
+    const player = getPlayer(result.state);
+    expect(player.pureMana.length).toBe(1);
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT MODE TESTS
+// ============================================================================
+
+describe("Tome powered mode entry point", () => {
+  const poweredEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "powered" };
+
+  it("should set up discard with powered mode in thenEffectByColor", () => {
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+    });
+
+    const result = resolveEffect(state, "player1", poweredEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    const byColor = player.pendingDiscard?.thenEffectByColor;
+    expect(byColor?.[MANA_RED]).toBeDefined();
+
+    // Verify the effect carries powered mode
+    const redEffect = byColor?.[MANA_RED];
+    if (redEffect && redEffect.type === EFFECT_RESOLVE_TOME_SPELL) {
+      expect(redEffect.mode).toBe("powered");
+    }
+  });
+
+  it("should present multiple spells of same color as choice for powered mode", () => {
+    const state = createTomeState(
+      [CARD_FIREBALL, CARD_FLAME_WALL], // Two red spells
+      [],
+      {
+        hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+      }
+    );
+
+    const result = resolveEffect(state, "player1", poweredEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    expect(result.requiresChoice).toBe(true);
+    const player = getPlayer(result.state);
+    const redEffect = player.pendingDiscard?.thenEffectByColor?.[MANA_RED];
+    // Should be a choice with multiple options
+    expect(redEffect?.type).toBe("choice");
+    if (redEffect?.type === "choice") {
+      expect(redEffect.options.length).toBe(2);
+    }
+  });
+});
+
+// ============================================================================
+// DESCRIBE EFFECT TESTS
+// ============================================================================
+
+describe("describeEffect for Tome of All Spells effects", () => {
+  it("should describe EFFECT_TOME_OF_ALL_SPELLS basic", () => {
+    const effect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Discard");
+    expect(desc).toContain("Spell");
+    expect(desc).toContain("basic");
+  });
+
+  it("should describe EFFECT_TOME_OF_ALL_SPELLS powered", () => {
+    const effect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "powered" };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Discard");
+    expect(desc).toContain("Spell");
+    expect(desc).toContain("powered");
+  });
+
+  it("should describe EFFECT_RESOLVE_TOME_SPELL", () => {
+    const effect: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+    const desc = describeEffect(effect);
+    expect(desc).toContain("Fireball");
+    expect(desc).toContain("Spell Offer");
+  });
+});
+
+// ============================================================================
+// EDGE CASE TESTS
+// ============================================================================
+
+describe("Tome of All Spells edge cases", () => {
+  it("artifacts (no color) cannot be discarded for Tome", () => {
+    // Player's only non-Tome card is another artifact (no color)
+    // Artifacts have no color, so they can't match any spell
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS], // Only the Tome itself
+    });
+
+    const basicEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    // Tome can't discard itself (it's the source) and has no color anyway
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No colored cards");
+  });
+
+  it("should allow discarding a spell from hand to match spell in offer", () => {
+    // Player has Snowstorm (blue spell) in hand, offer has blue spell
+    const state = createTomeState([CARD_SNOWSTORM], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_SNOWSTORM],
+    });
+
+    const basicEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    // Should allow since Snowstorm has a color (blue) matching blue spells in offer
+    expect(result.requiresChoice).toBe(true);
+  });
+
+  it("basic and powered should produce different effects for same spell", () => {
+    // Verify basic resolves spell's basic effect
+    const stateBasic = createTomeState([CARD_FIREBALL]);
+    const basicResolve: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "basic",
+    };
+    const resultBasic = resolveEffect(stateBasic, "player1", basicResolve);
+    const playerBasic = getPlayer(resultBasic.state);
+    // Fireball basic = Ranged Fire Attack 5
+    expect(playerBasic.combatAccumulator.attack.rangedElements.fire).toBe(5);
+    expect(playerBasic.combatAccumulator.attack.siegeElements.fire).toBe(0);
+
+    // Verify powered resolves spell's powered effect
+    const statePowered = createTomeState([CARD_FIREBALL]);
+    const poweredResolve: ResolveTomeSpellEffect = {
+      type: EFFECT_RESOLVE_TOME_SPELL,
+      spellCardId: CARD_FIREBALL,
+      spellName: "Fireball",
+      mode: "powered",
+    };
+    const resultPowered = resolveEffect(statePowered, "player1", poweredResolve);
+    const playerPowered = getPlayer(resultPowered.state);
+    // Fireball powered = Siege Fire Attack 8 (+ wound)
+    expect(playerPowered.combatAccumulator.attack.siegeElements.fire).toBe(8);
+  });
+
+  it("should work even without any mana at all", () => {
+    // Core mechanic: Tome doesn't require mana
+    const state = createTomeState([CARD_FIREBALL], [], {
+      hand: [CARD_TOME_OF_ALL_SPELLS, CARD_RAGE],
+      pureMana: [],
+      crystals: { red: 0, blue: 0, green: 0, white: 0 },
+    });
+
+    const basicEffect: TomeOfAllSpellsEffect = { type: EFFECT_TOME_OF_ALL_SPELLS, mode: "basic" };
+    const result = resolveEffect(state, "player1", basicEffect, CARD_TOME_OF_ALL_SPELLS);
+
+    // Should work with zero mana
+    expect(result.requiresChoice).toBe(true);
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -93,6 +93,8 @@ import {
   EFFECT_BLOOD_OF_ANCIENTS_POWERED,
   EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
   EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+  EFFECT_TOME_OF_ALL_SPELLS,
+  EFFECT_RESOLVE_TOME_SPELL,
 } from "../../types/effectTypes.js";
 import type {
   GainAttackBowResolvedEffect,
@@ -603,6 +605,18 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_RESOLVE_BLOOD_POWERED_USE_AA]: (effect) => {
     const e = effect as import("../../types/cards.js").ResolveBloodPoweredUseAAEffect;
     return `Use ${e.cardName}'s powered effect`;
+  },
+
+  [EFFECT_TOME_OF_ALL_SPELLS]: (effect) => {
+    const e = effect as import("../../types/cards.js").TomeOfAllSpellsEffect;
+    const modeStr = e.mode === "basic" ? "basic" : "powered";
+    return `Discard a colored card to use a Spell's ${modeStr} effect from the offer (no mana cost)`;
+  },
+
+  [EFFECT_RESOLVE_TOME_SPELL]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveTomeSpellEffect;
+    const modeStr = e.mode === "basic" ? "basic" : "powered";
+    return `Use ${e.spellName}'s ${modeStr} effect from the Spell Offer`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -66,6 +66,7 @@ import { registerLearningEffects } from "./learningEffects.js";
 import { registerTrainingEffects } from "./trainingEffects.js";
 import { registerShapeshiftEffects } from "./shapeshiftEffects.js";
 import { registerBloodOfAncientsEffects } from "./bloodOfAncientsEffects.js";
+import { registerTomeOfAllSpellsEffects } from "./tomeOfAllSpellsEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -246,4 +247,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Blood of Ancients effects (wound cost + AA offer interaction)
   registerBloodOfAncientsEffects(resolver);
+
+  // Tome of All Spells effects (discard card, cast spell from offer for free)
+  registerTomeOfAllSpellsEffects(resolver);
 }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -357,6 +357,11 @@ export {
   registerBloodOfAncientsEffects,
 } from "./bloodOfAncientsEffects.js";
 
+// Tome of All Spells effects (discard card, cast spell from offer for free)
+export {
+  registerTomeOfAllSpellsEffects,
+} from "./tomeOfAllSpellsEffects.js";
+
 // Effect helpers
 export { getPlayerContext } from "./effectHelpers.js";
 

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -124,6 +124,8 @@ import {
   EFFECT_BLOOD_OF_ANCIENTS_POWERED,
   EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
   EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+  EFFECT_TOME_OF_ALL_SPELLS,
+  EFFECT_RESOLVE_TOME_SPELL,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -654,6 +656,19 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   // Internal Blood of Ancients powered effects are always resolvable
   [EFFECT_RESOLVE_BLOOD_POWERED_WOUND]: () => true,
   [EFFECT_RESOLVE_BLOOD_POWERED_USE_AA]: () => true,
+
+  // Tome of All Spells is resolvable if player has colored cards to discard
+  // and there are spells in the offer
+  [EFFECT_TOME_OF_ALL_SPELLS]: (state, player) => {
+    const hasColoredCards = player.hand.some(
+      (c) => c !== CARD_WOUND && (getActionCardColor(c) !== null || getSpellColor(c) !== null)
+    );
+    if (!hasColoredCards) return false;
+    return state.offers.spells.cards.length > 0;
+  },
+
+  // Resolve Tome spell is always resolvable (validated at resolution time)
+  [EFFECT_RESOLVE_TOME_SPELL]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/tomeOfAllSpellsEffects.ts
+++ b/packages/core/src/engine/effects/tomeOfAllSpellsEffects.ts
@@ -1,0 +1,329 @@
+/**
+ * Tome of All Spells Effect Handlers
+ *
+ * Handles the Tome of All Spells artifact:
+ *
+ * Basic: Discard a card of any color from hand. Use the basic effect of a
+ * Spell of the same color from the Spells Offer without paying its mana cost.
+ * Spell stays in the offer.
+ *
+ * Powered: Discard a card of any color from hand. Use the stronger effect of
+ * a Spell of the same color from the Spells Offer without paying its mana cost.
+ * Works even during Day (bypasses black mana restriction). Spell stays in offer.
+ *
+ * Key differences from Magic Talent:
+ * - No mana cost required to cast the spell
+ * - Powered uses the spell's powered effect (not basic)
+ * - Powered works during Day (normal powered spells need black mana, day-restricted)
+ *
+ * Flow:
+ * 1. EFFECT_TOME_OF_ALL_SPELLS → discard a colored card from hand
+ * 2. Based on discarded card's color, present matching spells from offer
+ * 3. EFFECT_RESOLVE_TOME_SPELL → resolve the spell's basic/powered effect
+ *    (spell stays in offer, no mana cost)
+ *
+ * @module effects/tomeOfAllSpellsEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  TomeOfAllSpellsEffect,
+  ResolveTomeSpellEffect,
+  CardEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { EffectResolver } from "./compound.js";
+import type { CardId, BasicManaColor } from "@mage-knight/shared";
+import {
+  CARD_WOUND,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { updatePlayer } from "./atomicHelpers.js";
+import {
+  EFFECT_TOME_OF_ALL_SPELLS,
+  EFFECT_RESOLVE_TOME_SPELL,
+} from "../../types/effectTypes.js";
+import { getActionCardColor, getSpellColor } from "../helpers/cardColor.js";
+import { getCard } from "../helpers/cardLookup.js";
+import { DEED_CARD_TYPE_SPELL } from "../../types/cards.js";
+
+// All basic mana colors
+const ALL_BASIC_COLORS: readonly BasicManaColor[] = [
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+];
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/**
+ * Get cards eligible for Tome discard (any card with a color — action cards
+ * and spell cards, but not wounds or artifacts which have no color).
+ */
+function getCardsEligibleForTomeDiscard(
+  hand: readonly CardId[],
+  sourceCardId: CardId
+): CardId[] {
+  return hand.filter((cardId) => {
+    if (cardId === CARD_WOUND) return false;
+    if (cardId === sourceCardId) return false;
+    // Must have a color (action cards or spell cards)
+    const actionColor = getActionCardColor(cardId);
+    if (actionColor !== null) return true;
+    const spellColor = getSpellColor(cardId);
+    return spellColor !== null;
+  });
+}
+
+/**
+ * Get the mana color of any card (action or spell).
+ */
+function getCardManaColor(cardId: CardId): BasicManaColor | null {
+  const actionColor = getActionCardColor(cardId);
+  if (actionColor !== null) {
+    return cardColorToManaColor(actionColor);
+  }
+  const sc = getSpellColor(cardId);
+  if (sc !== null) {
+    return cardColorToManaColor(sc);
+  }
+  return null;
+}
+
+/**
+ * Get spells in the offer matching a given mana color.
+ */
+function getMatchingSpellsInOffer(
+  state: GameState,
+  color: BasicManaColor
+): { cardId: CardId; name: string }[] {
+  const results: { cardId: CardId; name: string }[] = [];
+  for (const cardId of state.offers.spells.cards) {
+    const sc = getSpellColor(cardId);
+    if (sc !== null && cardColorToManaColor(sc) === color) {
+      const card = getCard(cardId);
+      results.push({ cardId, name: card?.name ?? cardId });
+    }
+  }
+  return results;
+}
+
+/**
+ * Convert card color string to mana color.
+ */
+function cardColorToManaColor(color: string): BasicManaColor {
+  switch (color) {
+    case "red": return MANA_RED;
+    case "blue": return MANA_BLUE;
+    case "green": return MANA_GREEN;
+    case "white": return MANA_WHITE;
+    default: throw new Error(`Unknown card color: ${color}`);
+  }
+}
+
+// ============================================================================
+// ENTRY POINT EFFECT
+// ============================================================================
+
+/**
+ * Handle EFFECT_TOME_OF_ALL_SPELLS entry point.
+ *
+ * Sets pendingDiscard with colorMatters so the discarded card's color
+ * determines which spells from the offer are presented as choices.
+ * Unlike Magic Talent, no mana payment is required to cast.
+ */
+function handleTomeOfAllSpells(
+  state: GameState,
+  playerIndex: number,
+  player: Player,
+  effect: TomeOfAllSpellsEffect,
+  sourceCardId: CardId | null
+): EffectResolutionResult {
+  if (!sourceCardId) {
+    throw new Error("TomeOfAllSpellsEffect requires sourceCardId");
+  }
+
+  const eligibleCards = getCardsEligibleForTomeDiscard(
+    player.hand,
+    sourceCardId
+  );
+
+  if (eligibleCards.length === 0) {
+    return {
+      state,
+      description: "No colored cards in hand to discard for Tome of All Spells",
+    };
+  }
+
+  // Check which cards actually have matching spells in the offer
+  const cardsWithMatchingSpells = eligibleCards.filter((cardId) => {
+    const color = getCardManaColor(cardId);
+    if (!color) return false;
+    return getMatchingSpellsInOffer(state, color).length > 0;
+  });
+
+  if (cardsWithMatchingSpells.length === 0) {
+    return {
+      state,
+      description: "No spells in the offer match any discardable card color",
+    };
+  }
+
+  // Build thenEffectByColor: maps each discarded color to spell selection
+  // No mana check needed — Tome casts for free
+  const thenEffectByColor: Partial<Record<BasicManaColor, CardEffect>> = {};
+
+  for (const color of ALL_BASIC_COLORS) {
+    const matchingSpells = getMatchingSpellsInOffer(state, color);
+    if (matchingSpells.length === 0) continue;
+
+    if (matchingSpells.length === 1) {
+      // Single match: resolve directly
+      const spell = matchingSpells[0]!;
+      thenEffectByColor[color] = {
+        type: EFFECT_RESOLVE_TOME_SPELL,
+        spellCardId: spell.cardId,
+        spellName: spell.name,
+        mode: effect.mode,
+      } as ResolveTomeSpellEffect;
+    } else {
+      // Multiple matches: present as choice
+      const options: ResolveTomeSpellEffect[] = matchingSpells.map(
+        (spell) => ({
+          type: EFFECT_RESOLVE_TOME_SPELL,
+          spellCardId: spell.cardId,
+          spellName: spell.name,
+          mode: effect.mode,
+        })
+      );
+      thenEffectByColor[color] = {
+        type: "choice" as const,
+        options,
+      };
+    }
+  }
+
+  if (Object.keys(thenEffectByColor).length === 0) {
+    return {
+      state,
+      description: "No spells in the offer match any discardable card color",
+    };
+  }
+
+  // Create pendingDiscard state
+  const updatedPlayer: Player = {
+    ...player,
+    pendingDiscard: {
+      sourceCardId,
+      count: 1,
+      optional: false,
+      thenEffect: { type: "noop" as const }, // Unused when colorMatters is true
+      colorMatters: true,
+      thenEffectByColor,
+      filterWounds: true,
+    },
+  };
+
+  const updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+
+  return {
+    state: updatedState,
+    description: `Tome of All Spells (${effect.mode}): discard a colored card to use a spell from the offer`,
+    requiresChoice: true,
+  };
+}
+
+// ============================================================================
+// RESOLVE SPELL EFFECT
+// ============================================================================
+
+/**
+ * Resolve the selected spell from the offer.
+ * No mana payment needed. Resolves the spell's basic or powered effect.
+ * Spell stays in the offer.
+ */
+function resolveTomeSpell(
+  state: GameState,
+  playerId: string,
+  effect: ResolveTomeSpellEffect,
+  resolveEffect: EffectResolver
+): EffectResolutionResult {
+  // Verify spell is still in the offer
+  if (!state.offers.spells.cards.includes(effect.spellCardId)) {
+    return {
+      state,
+      description: `Spell ${effect.spellName} is no longer in the offer`,
+    };
+  }
+
+  // Get the spell card definition
+  const spellCard = getCard(effect.spellCardId);
+  if (!spellCard || spellCard.cardType !== DEED_CARD_TYPE_SPELL) {
+    return {
+      state,
+      description: `${effect.spellCardId} is not a valid spell`,
+    };
+  }
+
+  // Resolve the spell's effect (no mana cost required)
+  const spellEffect = effect.mode === "basic"
+    ? spellCard.basicEffect
+    : spellCard.poweredEffect;
+
+  const result = resolveEffect(
+    state,
+    playerId,
+    spellEffect,
+    effect.spellCardId
+  );
+
+  const modeLabel = effect.mode === "basic" ? "basic" : "powered";
+  return {
+    ...result,
+    description: `Tome of All Spells: used ${modeLabel} effect of ${effect.spellName} from the Spell Offer (no mana cost)`,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register Tome of All Spells effect handlers with the effect registry.
+ */
+export function registerTomeOfAllSpellsEffects(resolver: EffectResolver): void {
+  registerEffect(
+    EFFECT_TOME_OF_ALL_SPELLS,
+    (state, playerId, effect, sourceCardId) => {
+      const { playerIndex, player } = getPlayerContext(state, playerId);
+      return handleTomeOfAllSpells(
+        state,
+        playerIndex,
+        player,
+        effect as TomeOfAllSpellsEffect,
+        (sourceCardId as CardId | undefined) ?? null
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_TOME_SPELL,
+    (state, playerId, effect) => {
+      return resolveTomeSpell(
+        state,
+        playerId,
+        effect as ResolveTomeSpellEffect,
+        resolver
+      );
+    }
+  );
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -142,6 +142,8 @@ import {
   EFFECT_BLOOD_OF_ANCIENTS_POWERED,
   EFFECT_RESOLVE_BLOOD_POWERED_WOUND,
   EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
+  EFFECT_TOME_OF_ALL_SPELLS,
+  EFFECT_RESOLVE_TOME_SPELL,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1644,6 +1646,33 @@ export interface ResolveBloodPoweredUseAAEffect {
   readonly cardName: string;
 }
 
+/**
+ * Tome of All Spells effect entry point.
+ * Discard a card of any color from hand. Use the basic or powered effect
+ * of a Spell of the same color from the Spells Offer without paying mana.
+ * Spell stays in the offer. No mana cost required.
+ */
+export interface TomeOfAllSpellsEffect {
+  readonly type: typeof EFFECT_TOME_OF_ALL_SPELLS;
+  /** "basic" uses spell's basic effect; "powered" uses spell's powered effect */
+  readonly mode: "basic" | "powered";
+}
+
+/**
+ * Internal: After discarding a card for Tome of All Spells, resolve the
+ * selected spell from the offer. The spell's effect is resolved without
+ * mana cost and the spell stays in the offer.
+ */
+export interface ResolveTomeSpellEffect {
+  readonly type: typeof EFFECT_RESOLVE_TOME_SPELL;
+  /** The spell card selected from the offer */
+  readonly spellCardId: CardId;
+  /** Name of the spell for display */
+  readonly spellName: string;
+  /** "basic" uses spell's basic effect; "powered" uses spell's powered effect */
+  readonly mode: "basic" | "powered";
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1763,7 +1792,9 @@ export type CardEffect =
   | ResolveBloodBasicGainAAEffect
   | BloodOfAncientsPoweredEffect
   | ResolveBloodPoweredWoundEffect
-  | ResolveBloodPoweredUseAAEffect;
+  | ResolveBloodPoweredUseAAEffect
+  | TomeOfAllSpellsEffect
+  | ResolveTomeSpellEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -414,6 +414,14 @@ export const EFFECT_RESOLVE_BLOOD_POWERED_WOUND = "resolve_blood_powered_wound" 
 // Internal: After AA selection, resolve the AA's powered effect (card stays in offer).
 export const EFFECT_RESOLVE_BLOOD_POWERED_USE_AA = "resolve_blood_powered_use_aa" as const;
 
+// === Tome of All Spells Effects ===
+// Basic: Discard a card of any color. Use the basic effect of a Spell of the
+// same color from the Spells Offer without paying its mana cost.
+export const EFFECT_TOME_OF_ALL_SPELLS = "tome_of_all_spells" as const;
+// Internal: After discarding a card, player selects a spell from the offer
+// of matching color, then resolves that spell's basic or powered effect (no mana cost).
+export const EFFECT_RESOLVE_TOME_SPELL = "resolve_tome_spell" as const;
+
 // === Wings of Night Multi-Target Skip Attack Effect ===
 // Entry point for multi-target enemy skip-attack with scaling move cost.
 // First enemy free, second costs 1 move, third costs 2 move, etc.


### PR DESCRIPTION
## Summary
- Implement the Tome of All Spells artifact card with basic and powered effects
- Basic: Discard a colored card, use a matching spell's basic effect from the offer (no mana cost)
- Powered: Discard a colored card, use a matching spell's powered effect from the offer (no mana cost, works during day)
- Reuses the existing discard-cost system (`pendingDiscard` with `colorMatters`) for card selection
- Spell stays in the offer after use (not removed)

## Changes
- `packages/core/src/data/artifacts/tomeOfAllSpells.ts` — Card definition with `EFFECT_TOME_OF_ALL_SPELLS`
- `packages/core/src/types/effectTypes.ts` — New effect type constants
- `packages/core/src/types/cards.ts` — New effect interfaces and union members
- `packages/core/src/engine/effects/tomeOfAllSpellsEffects.ts` — Effect handler (discard → color match → spell selection → resolve effect)
- `packages/core/src/engine/effects/effectRegistrations.ts` — Register new effects
- `packages/core/src/engine/effects/describeEffect.ts` — Human-readable descriptions
- `packages/core/src/engine/effects/resolvability.ts` — Resolvability checks
- `packages/core/src/engine/effects/index.ts` — Module exports
- `packages/core/src/engine/__tests__/tomeOfAllSpells.test.ts` — 36 tests covering all acceptance criteria

Closes #235