### PR TITLE
feat: implement Spell Forge spell offer crystal gain

### DIFF
--- a/packages/core/src/data/advancedActions/blue/spell-forge.ts
+++ b/packages/core/src/data/advancedActions/blue/spell-forge.ts
@@ -1,7 +1,10 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_SPECIAL, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_BLUE, CARD_SPELL_FORGE } from "@mage-knight/shared";
-import { gainCrystal } from "../helpers.js";
+import {
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+} from "../../../types/effectTypes.js";
 
 export const SPELL_FORGE: DeedCard = {
   id: CARD_SPELL_FORGE,
@@ -10,9 +13,8 @@ export const SPELL_FORGE: DeedCard = {
   poweredBy: [MANA_BLUE],
   categories: [CATEGORY_SPECIAL],
   // Basic: Gain one crystal to your Inventory of the same color as one of the Spell cards in the Spells offer.
+  basicEffect: { type: EFFECT_SPELL_FORGE_BASIC },
   // Powered: Gain two crystals to your Inventory of the same colors as two different Spell cards in the Spells offer.
-  // TODO: Implement spell offer interaction for crystal gain
-  basicEffect: gainCrystal(MANA_BLUE),
-  poweredEffect: gainCrystal(MANA_BLUE),
+  poweredEffect: { type: EFFECT_SPELL_FORGE_POWERED },
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/spellForge.test.ts
+++ b/packages/core/src/engine/__tests__/spellForge.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Spell Forge Card Tests
+ *
+ * Tests for the Spell Forge advanced action card:
+ *
+ * Basic: Choose one spell card from the Spells Offer, gain a crystal of that spell's color.
+ * Powered: Choose two different spell cards from the Spells Offer, gain a crystal for each.
+ *
+ * "Two different Spell cards" means distinct cards, not necessarily different colors.
+ * If there are two blue spells, both can be picked.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { isEffectResolvable } from "../effects/resolvability.js";
+import {
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+} from "../../types/effectTypes.js";
+import type {
+  SpellForgeBasicEffect,
+  SpellForgePoweredEffect,
+  ResolveSpellForgeCrystalEffect,
+} from "../../types/cards.js";
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { resolveEffect } from "../effects/index.js";
+import {
+  CARD_SPELL_FORGE,
+  CARD_FIREBALL,
+  CARD_SNOWSTORM,
+  CARD_RESTORATION,
+  CARD_CHILL,
+  CARD_CURE,
+} from "@mage-knight/shared";
+
+const basicEffect: SpellForgeBasicEffect = { type: EFFECT_SPELL_FORGE_BASIC };
+const poweredEffect: SpellForgePoweredEffect = { type: EFFECT_SPELL_FORGE_POWERED };
+
+function createSpellForgeState(
+  spellOffer: string[],
+  playerOverrides: Partial<Player> = {}
+): GameState {
+  const player = createTestPlayer({
+    hand: [CARD_SPELL_FORGE],
+    crystals: { red: 0, blue: 0, green: 0, white: 0 },
+    ...playerOverrides,
+  });
+
+  return createTestGameState({
+    players: [player],
+    offers: {
+      units: [],
+      advancedActions: { cards: [] },
+      spells: { cards: spellOffer },
+      commonSkills: [],
+      monasteryAdvancedActions: [],
+      bondsOfLoyaltyBonusUnits: [],
+    },
+  });
+}
+
+// ============================================================================
+// BASIC EFFECT: CHOOSE ONE SPELL, GAIN CRYSTAL
+// ============================================================================
+
+describe("Spell Forge Basic Effect", () => {
+  it("should present choice of spells from offer", () => {
+    // Red (Fireball) and Blue (Snowstorm) spells in offer
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+    const options = result.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+    const colors = options.map((o) => o.color);
+    expect(colors).toContain("red");
+    expect(colors).toContain("blue");
+  });
+
+  it("should auto-resolve when only one spell in offer", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    expect(result.requiresChoice).toBeUndefined();
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+    expect(result.resolvedEffect).toBeDefined();
+  });
+
+  it("should gain crystal of chosen spell's color", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+    expect(updatedPlayer.crystals.blue).toBe(0);
+    expect(updatedPlayer.crystals.green).toBe(0);
+    expect(updatedPlayer.crystals.white).toBe(0);
+  });
+
+  it("should handle green spells", () => {
+    const state = createSpellForgeState([CARD_RESTORATION]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.green).toBe(1);
+  });
+
+  it("should handle white spells", () => {
+    const state = createSpellForgeState([CARD_CURE]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.white).toBe(1);
+  });
+
+  it("should handle blue spells", () => {
+    const state = createSpellForgeState([CARD_CHILL]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.blue).toBe(1);
+  });
+
+  it("should handle three spells in offer", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM, CARD_CURE]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(3);
+
+    const options = result.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+    const colors = options.map((o) => o.color);
+    expect(colors).toContain("red");
+    expect(colors).toContain("blue");
+    expect(colors).toContain("white");
+  });
+
+  it("should return no-op when spell offer is empty", () => {
+    const state = createSpellForgeState([]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No spells");
+  });
+
+  it("should include spell names in options", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    // Auto-resolved since single option — check description mentions spell
+    expect(result.description).toContain("red");
+  });
+
+  it("should handle duplicate color spells as separate options", () => {
+    // Two blue spells — should show as two distinct options
+    const state = createSpellForgeState([CARD_SNOWSTORM, CARD_CHILL]);
+
+    const result = resolveEffect(state, "player1", basicEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+    const options = result.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+    // Both are blue
+    expect(options[0]!.color).toBe("blue");
+    expect(options[1]!.color).toBe("blue");
+    // But different offer indices
+    expect(options[0]!.offerIndex).toBe(0);
+    expect(options[1]!.offerIndex).toBe(1);
+  });
+});
+
+// ============================================================================
+// POWERED EFFECT: CHOOSE TWO DIFFERENT SPELLS, GAIN CRYSTALS
+// ============================================================================
+
+describe("Spell Forge Powered Effect", () => {
+  it("should present choice for first spell", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM, CARD_CURE]);
+
+    const result = resolveEffect(state, "player1", poweredEffect);
+
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(3);
+  });
+
+  it("should chain to second choice after first crystal is gained", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM, CARD_CURE]);
+
+    // Simulate choosing the first spell (red Fireball at index 0)
+    const firstChoice: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "red",
+      spellName: "Fireball",
+      offerIndex: 0,
+      chainSecondChoice: true,
+    };
+
+    const result = resolveEffect(state, "player1", firstChoice);
+
+    // Should have gained red crystal
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+
+    // Should present second choice (excluding Fireball at index 0)
+    expect(result.requiresChoice).toBe(true);
+    expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+    const options = result.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+    const indices = options.map((o) => o.offerIndex);
+    expect(indices).not.toContain(0); // Fireball excluded
+    expect(indices).toContain(1); // Snowstorm
+    expect(indices).toContain(2); // Cure
+  });
+
+  it("should gain two crystals of different colors", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+
+    // First choice: red (Fireball at index 0, chaining)
+    const firstChoice: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "red",
+      spellName: "Fireball",
+      offerIndex: 0,
+      chainSecondChoice: true,
+    };
+
+    const afterFirst = resolveEffect(state, "player1", firstChoice);
+
+    // After first: red crystal gained, second choice auto-resolved (only Snowstorm left)
+    const updatedPlayer = afterFirst.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+    expect(updatedPlayer.crystals.blue).toBe(1);
+  });
+
+  it("should allow two crystals of same color from different spell cards", () => {
+    // Two blue spells — "different cards" not "different colors"
+    const state = createSpellForgeState([CARD_SNOWSTORM, CARD_CHILL]);
+
+    // First choice: blue (Snowstorm at index 0, chaining)
+    const firstChoice: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "blue",
+      spellName: "Snowstorm",
+      offerIndex: 0,
+      chainSecondChoice: true,
+    };
+
+    const afterFirst = resolveEffect(state, "player1", firstChoice);
+
+    // After first: one blue crystal, second auto-resolved (only Chill left) → two blue crystals
+    const updatedPlayer = afterFirst.state.players[0]!;
+    expect(updatedPlayer.crystals.blue).toBe(2);
+  });
+
+  it("should only gain one crystal when offer has single spell", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    const result = resolveEffect(state, "player1", poweredEffect);
+
+    // Auto-resolved since only one spell
+    expect(result.requiresChoice).toBeUndefined();
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+  });
+
+  it("should handle empty offer gracefully", () => {
+    const state = createSpellForgeState([]);
+
+    const result = resolveEffect(state, "player1", poweredEffect);
+
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.description).toContain("No spells");
+  });
+
+  it("should not repeat same spell in second choice", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+
+    const firstChoice: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "red",
+      spellName: "Fireball",
+      offerIndex: 0,
+      chainSecondChoice: true,
+    };
+
+    const afterFirst = resolveEffect(state, "player1", firstChoice);
+
+    // With 2 spells and 1 picked, second should auto-resolve (only 1 option left)
+    // If it returned a choice, verify the first spell is excluded
+    if (afterFirst.requiresChoice && afterFirst.dynamicChoiceOptions) {
+      const options = afterFirst.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+      expect(options.every((o) => o.offerIndex !== 0)).toBe(true);
+    }
+
+    // Either way, player should have both crystals
+    const updatedPlayer = afterFirst.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(1);
+    expect(updatedPlayer.crystals.blue).toBe(1);
+  });
+
+  it("should present second choice when three spells in offer", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM, CARD_CURE]);
+
+    // Pick Snowstorm (index 1)
+    const firstChoice: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "blue",
+      spellName: "Snowstorm",
+      offerIndex: 1,
+      chainSecondChoice: true,
+    };
+
+    const afterFirst = resolveEffect(state, "player1", firstChoice);
+
+    // Blue crystal gained
+    expect(afterFirst.state.players[0]!.crystals.blue).toBe(1);
+
+    // Should present choice of remaining spells
+    expect(afterFirst.requiresChoice).toBe(true);
+    expect(afterFirst.dynamicChoiceOptions).toHaveLength(2);
+
+    const options = afterFirst.dynamicChoiceOptions as ResolveSpellForgeCrystalEffect[];
+    const colors = options.map((o) => o.color);
+    expect(colors).toContain("red"); // Fireball
+    expect(colors).toContain("white"); // Cure
+
+    // None should chain further
+    expect(options.every((o) => o.chainSecondChoice === false)).toBe(true);
+  });
+});
+
+// ============================================================================
+// RESOLVE CRYSTAL EFFECT
+// ============================================================================
+
+describe("Resolve Spell Forge Crystal Effect", () => {
+  it("should gain crystal of specified color", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    const effect: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "green",
+      spellName: "Whirlwind",
+      offerIndex: 0,
+      chainSecondChoice: false,
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    expect(result.state.players[0]!.crystals.green).toBe(1);
+  });
+
+  it("should handle crystal overflow (max 3 per color)", () => {
+    const state = createSpellForgeState([CARD_FIREBALL], {
+      crystals: { red: 3, blue: 0, green: 0, white: 0 },
+    });
+
+    const effect: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "red",
+      spellName: "Fireball",
+      offerIndex: 0,
+      chainSecondChoice: false,
+    };
+
+    const result = resolveEffect(state, "player1", effect);
+
+    // At max — should overflow to mana token
+    const updatedPlayer = result.state.players[0]!;
+    expect(updatedPlayer.crystals.red).toBe(3);
+    expect(updatedPlayer.pureMana.some((t) => t.color === "red")).toBe(true);
+  });
+});
+
+// ============================================================================
+// RESOLVABILITY
+// ============================================================================
+
+describe("Spell Forge Resolvability", () => {
+  it("basic should be resolvable when spells are in offer", () => {
+    const state = createSpellForgeState([CARD_FIREBALL]);
+
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+  });
+
+  it("basic should not be resolvable when offer is empty", () => {
+    const state = createSpellForgeState([]);
+
+    expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+  });
+
+  it("powered should be resolvable when spells are in offer", () => {
+    const state = createSpellForgeState([CARD_FIREBALL, CARD_SNOWSTORM]);
+
+    expect(isEffectResolvable(state, "player1", poweredEffect)).toBe(true);
+  });
+
+  it("powered should not be resolvable when offer is empty", () => {
+    const state = createSpellForgeState([]);
+
+    expect(isEffectResolvable(state, "player1", poweredEffect)).toBe(false);
+  });
+
+  it("resolve crystal should always be resolvable", () => {
+    const state = createSpellForgeState([]);
+
+    const effect: ResolveSpellForgeCrystalEffect = {
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: "red",
+      spellName: "Fireball",
+      offerIndex: 0,
+      chainSecondChoice: false,
+    };
+
+    expect(isEffectResolvable(state, "player1", effect)).toBe(true);
+  });
+});

--- a/packages/core/src/engine/commands/choice/choiceResolution.ts
+++ b/packages/core/src/engine/commands/choice/choiceResolution.ts
@@ -26,6 +26,9 @@ import {
   EFFECT_READY_UNIT,
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_SOURCE_OPENING_REROLL,
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
 } from "../../../types/effectTypes.js";
 import { describeEffect, isEffectResolvable } from "../../effects/index.js";
 import type { EffectResolutionResult } from "../../effects/index.js";
@@ -71,6 +74,9 @@ const DYNAMIC_CHOICE_EFFECTS = new Set<string>([
   EFFECT_READY_UNIT,
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_SOURCE_OPENING_REROLL,
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
 ]);
 
 function buildPendingChoice(

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -96,6 +96,9 @@ import {
   EFFECT_HAND_LIMIT_BONUS,
   EFFECT_TOME_OF_ALL_SPELLS,
   EFFECT_RESOLVE_TOME_SPELL,
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
 } from "../../types/effectTypes.js";
 import type {
   GainAttackBowResolvedEffect,
@@ -623,6 +626,19 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     const e = effect as import("../../types/cards.js").ResolveTomeSpellEffect;
     const modeStr = e.mode === "basic" ? "basic" : "powered";
     return `Use ${e.spellName}'s ${modeStr} effect from the Spell Offer`;
+  },
+
+  [EFFECT_SPELL_FORGE_BASIC]: () => {
+    return "Gain crystal matching a spell in the Spells Offer";
+  },
+
+  [EFFECT_SPELL_FORGE_POWERED]: () => {
+    return "Gain 2 crystals matching different spells in the Spells Offer";
+  },
+
+  [EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveSpellForgeCrystalEffect;
+    return `Gain ${e.color} crystal (${e.spellName})`;
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -68,6 +68,7 @@ import { registerShapeshiftEffects } from "./shapeshiftEffects.js";
 import { registerBloodOfAncientsEffects } from "./bloodOfAncientsEffects.js";
 import { registerHandLimitBonusEffects } from "./handLimitBonusEffects.js";
 import { registerTomeOfAllSpellsEffects } from "./tomeOfAllSpellsEffects.js";
+import { registerSpellForgeEffects } from "./spellForgeEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -254,4 +255,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Tome of All Spells effects (discard card, cast spell from offer for free)
   registerTomeOfAllSpellsEffects(resolver);
+
+  // Spell Forge effects (gain crystals from spell offer colors)
+  registerSpellForgeEffects();
 }

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -126,6 +126,9 @@ import {
   EFFECT_RESOLVE_BLOOD_POWERED_USE_AA,
   EFFECT_TOME_OF_ALL_SPELLS,
   EFFECT_RESOLVE_TOME_SPELL,
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -669,6 +672,18 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Resolve Tome spell is always resolvable (validated at resolution time)
   [EFFECT_RESOLVE_TOME_SPELL]: () => true,
+
+  // Spell Forge basic/powered: resolvable if there are spells in the offer
+  [EFFECT_SPELL_FORGE_BASIC]: (state) => {
+    return state.offers.spells.cards.length > 0;
+  },
+
+  [EFFECT_SPELL_FORGE_POWERED]: (state) => {
+    return state.offers.spells.cards.length > 0;
+  },
+
+  // Resolve Spell Forge crystal is always resolvable (validated at resolution time)
+  [EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/spellForgeEffects.ts
+++ b/packages/core/src/engine/effects/spellForgeEffects.ts
@@ -1,0 +1,228 @@
+/**
+ * Spell Forge Effect Handlers
+ *
+ * Implements the Spell Forge advanced action card:
+ *
+ * Basic: Choose one spell card from the Spells Offer, gain a crystal of that spell's color.
+ * Powered: Choose two different spell cards from the Spells Offer, gain a crystal for each.
+ *
+ * "Two different Spell cards" means distinct cards from the offer, not necessarily
+ * different colors. If there are two blue spells, both can be picked.
+ *
+ * @module effects/spellForgeEffects
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type {
+  SpellForgeBasicEffect,
+  SpellForgePoweredEffect,
+  ResolveSpellForgeCrystalEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { BasicManaColor } from "@mage-knight/shared";
+import {
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+} from "../../types/effectTypes.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { updatePlayer } from "./atomicHelpers.js";
+import { gainCrystalWithOverflow } from "../helpers/crystalHelpers.js";
+import { getSpellColor } from "../helpers/cardColor.js";
+import { getCard } from "../helpers/cardLookup.js";
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function cardColorToManaColor(color: string): BasicManaColor {
+  const map: Record<string, BasicManaColor> = {
+    red: "red",
+    blue: "blue",
+    green: "green",
+    white: "white",
+  };
+  const result = map[color];
+  if (!result) {
+    throw new Error(`Unknown card color: ${color}`);
+  }
+  return result;
+}
+
+/**
+ * Build choice options from the spell offer, optionally excluding a specific index.
+ */
+function buildSpellOfferOptions(
+  state: GameState,
+  excludeIndex: number | null,
+  chainSecondChoice: boolean
+): ResolveSpellForgeCrystalEffect[] {
+  const options: ResolveSpellForgeCrystalEffect[] = [];
+
+  for (let i = 0; i < state.offers.spells.cards.length; i++) {
+    if (i === excludeIndex) continue;
+
+    const cardId = state.offers.spells.cards[i];
+    if (!cardId) continue;
+
+    const spellColor = getSpellColor(cardId);
+    if (spellColor === null) continue;
+
+    const card = getCard(cardId);
+    const spellName = card?.name ?? cardId;
+    const manaColor = cardColorToManaColor(spellColor);
+
+    options.push({
+      type: EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
+      color: manaColor,
+      spellName,
+      offerIndex: i,
+      chainSecondChoice,
+    });
+  }
+
+  return options;
+}
+
+// ============================================================================
+// BASIC EFFECT: CHOOSE ONE SPELL, GAIN CRYSTAL
+// ============================================================================
+
+function handleSpellForgeBasic(
+  state: GameState,
+  playerId: string,
+  _effect: SpellForgeBasicEffect
+): EffectResolutionResult {
+  const options = buildSpellOfferOptions(state, null, false);
+
+  if (options.length === 0) {
+    return {
+      state,
+      description: "No spells in offer to choose from",
+    };
+  }
+
+  if (options.length === 1) {
+    const singleOption = options[0]!;
+    const result = resolveSpellForgeCrystal(state, playerId, singleOption);
+    return {
+      ...result,
+      resolvedEffect: singleOption,
+    };
+  }
+
+  return {
+    state,
+    description: "Choose a spell card from the Spells Offer to gain a crystal of its color",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+// ============================================================================
+// POWERED EFFECT: CHOOSE TWO DIFFERENT SPELLS, GAIN CRYSTALS
+// ============================================================================
+
+function handleSpellForgePowered(
+  state: GameState,
+  playerId: string,
+  _effect: SpellForgePoweredEffect
+): EffectResolutionResult {
+  const options = buildSpellOfferOptions(state, null, true);
+
+  if (options.length === 0) {
+    return {
+      state,
+      description: "No spells in offer to choose from",
+    };
+  }
+
+  // If only one spell in offer, can only gain one crystal (no second choice possible)
+  if (options.length === 1) {
+    const singleOption: ResolveSpellForgeCrystalEffect = {
+      ...options[0]!,
+      chainSecondChoice: false,
+    };
+    const result = resolveSpellForgeCrystal(state, playerId, singleOption);
+    return {
+      ...result,
+      resolvedEffect: singleOption,
+    };
+  }
+
+  return {
+    state,
+    description: "Choose first spell card from the Spells Offer (gain crystal of its color)",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+// ============================================================================
+// RESOLVE: GAIN CRYSTAL + OPTIONAL CHAIN
+// ============================================================================
+
+function resolveSpellForgeCrystal(
+  state: GameState,
+  playerId: string,
+  effect: ResolveSpellForgeCrystalEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+
+  // Gain crystal of the spell's color
+  const { player: updatedPlayer } = gainCrystalWithOverflow(player, effect.color);
+  const updatedState = updatePlayer(state, playerIndex, updatedPlayer);
+
+  if (!effect.chainSecondChoice) {
+    return {
+      state: updatedState,
+      description: `Gained ${effect.color} crystal (${effect.spellName})`,
+    };
+  }
+
+  // Chain to second choice — exclude the spell we just picked
+  const secondOptions = buildSpellOfferOptions(updatedState, effect.offerIndex, false);
+
+  if (secondOptions.length === 0) {
+    return {
+      state: updatedState,
+      description: `Gained ${effect.color} crystal (${effect.spellName}), no other spells to choose`,
+    };
+  }
+
+  if (secondOptions.length === 1) {
+    const singleOption = secondOptions[0]!;
+    const secondResult = resolveSpellForgeCrystal(updatedState, playerId, singleOption);
+    return {
+      ...secondResult,
+      description: `Gained ${effect.color} crystal (${effect.spellName}), then ${secondResult.description}`,
+      resolvedEffect: singleOption,
+    };
+  }
+
+  return {
+    state: updatedState,
+    description: "Choose second spell card (different from first) to gain another crystal",
+    requiresChoice: true,
+    dynamicChoiceOptions: secondOptions,
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+export function registerSpellForgeEffects(): void {
+  registerEffect(EFFECT_SPELL_FORGE_BASIC, (state, playerId, effect) => {
+    return handleSpellForgeBasic(state, playerId, effect as SpellForgeBasicEffect);
+  });
+
+  registerEffect(EFFECT_SPELL_FORGE_POWERED, (state, playerId, effect) => {
+    return handleSpellForgePowered(state, playerId, effect as SpellForgePoweredEffect);
+  });
+
+  registerEffect(EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL, (state, playerId, effect) => {
+    return resolveSpellForgeCrystal(state, playerId, effect as ResolveSpellForgeCrystalEffect);
+  });
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -145,6 +145,9 @@ import {
   EFFECT_HAND_LIMIT_BONUS,
   EFFECT_TOME_OF_ALL_SPELLS,
   EFFECT_RESOLVE_TOME_SPELL,
+  EFFECT_SPELL_FORGE_BASIC,
+  EFFECT_SPELL_FORGE_POWERED,
+  EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1686,6 +1689,39 @@ export interface ResolveTomeSpellEffect {
   readonly mode: "basic" | "powered";
 }
 
+/**
+ * Spell Forge basic effect entry point.
+ * Choose one spell card from the Spells Offer, gain a crystal of that spell's color.
+ */
+export interface SpellForgeBasicEffect {
+  readonly type: typeof EFFECT_SPELL_FORGE_BASIC;
+}
+
+/**
+ * Spell Forge powered effect entry point.
+ * Choose two different spell cards from the Spells Offer, gain a crystal for each.
+ */
+export interface SpellForgePoweredEffect {
+  readonly type: typeof EFFECT_SPELL_FORGE_POWERED;
+}
+
+/**
+ * Internal: Resolve gaining a crystal from a specific spell in the offer.
+ * For powered mode, after the first crystal is gained, chains to a second choice
+ * (excluding the already-chosen spell by offer index).
+ */
+export interface ResolveSpellForgeCrystalEffect {
+  readonly type: typeof EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL;
+  /** The color of crystal to gain (derived from the spell's color) */
+  readonly color: BasicManaColor;
+  /** Name of the chosen spell for display */
+  readonly spellName: string;
+  /** Index of the chosen spell in the offer (for powered mode exclusion) */
+  readonly offerIndex: number;
+  /** Whether this is part of powered mode and should chain to a second choice */
+  readonly chainSecondChoice: boolean;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -1808,7 +1844,10 @@ export type CardEffect =
   | ResolveBloodPoweredUseAAEffect
   | HandLimitBonusEffect
   | TomeOfAllSpellsEffect
-  | ResolveTomeSpellEffect;
+  | ResolveTomeSpellEffect
+  | SpellForgeBasicEffect
+  | SpellForgePoweredEffect
+  | ResolveSpellForgeCrystalEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -435,3 +435,12 @@ export const EFFECT_WINGS_OF_NIGHT = "wings_of_night" as const;
 // Internal: resolve after selecting an enemy target for Wings of Night.
 // Applies skip-attack modifier, deducts move cost, chains for more targets.
 export const EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET = "resolve_wings_of_night_target" as const;
+
+// === Spell Forge Effects ===
+// Basic: Choose a spell card from the Spells Offer, gain a crystal of that spell's color.
+export const EFFECT_SPELL_FORGE_BASIC = "spell_forge_basic" as const;
+// Powered: Choose two different spell cards from the Spells Offer, gain a crystal for each.
+export const EFFECT_SPELL_FORGE_POWERED = "spell_forge_powered" as const;
+// Internal: Resolve gaining a crystal from a specific spell in the offer.
+// For powered, after first crystal gain, chains to second choice (excluding already-chosen spell).
+export const EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL = "resolve_spell_forge_crystal" as const;


### PR DESCRIPTION
## Summary
- Implement Spell Forge advanced action card basic and powered effects
- Basic: Choose one spell card from the Spells Offer, gain a crystal of that spell's color
- Powered: Choose two different spell cards from the Spells Offer, gain a crystal for each

## Changes
- New effect types: `EFFECT_SPELL_FORGE_BASIC`, `EFFECT_SPELL_FORGE_POWERED`, `EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL`
- New effect handler `spellForgeEffects.ts` with dynamic choice generation from spell offer
- Updated card definition to use new effects instead of placeholder `gainCrystal(MANA_BLUE)`
- Added effect descriptions, resolvability checks, and dynamic choice registration
- 25 tests covering basic/powered effects, color selection, chaining, edge cases

## Key Design Decisions
- "Different spell cards" means distinct offer positions, not different colors (per rulebook)
- Powered effect chains: first choice resolves crystal + generates second choice excluding picked spell
- Single-spell offers auto-resolve; empty offers gracefully no-op
- Crystal overflow handled via existing `gainCrystalWithOverflow` helper

Closes #175