### PR TITLE
feat: implement Spirit Guides skill (Krang)

### DIFF
--- a/packages/core/src/data/skills/krang/spiritGuides.ts
+++ b/packages/core/src/data/skills/krang/spiritGuides.ts
@@ -1,19 +1,45 @@
 /**
  * Spirit Guides - Krang Skill
  * @module data/skills/krang/spiritGuides
+ *
+ * Once a turn: Move 1 and you may add +1 to a Block of any type in the Block phase.
+ *
+ * FAQ Rulings:
+ * - S1: +1 applies to any block source (cards, skills, units)
+ * - S2: Works with Diplomacy's Influence-to-Block conversion (including elemental)
+ * - S3: Move point is immediate; +1 Block persists throughout Block phase
  */
 
 import type { SkillId } from "@mage-knight/shared";
 import { CATEGORY_MOVEMENT, CATEGORY_COMBAT } from "../../../types/cards.js";
+import { EFFECT_COMPOUND, EFFECT_APPLY_MODIFIER, EFFECT_GAIN_MOVE } from "../../../types/effectTypes.js";
+import { EFFECT_COMBAT_VALUE, COMBAT_VALUE_BLOCK, DURATION_TURN, SCOPE_SELF } from "../../../types/modifierConstants.js";
 import { type SkillDefinition, SKILL_USAGE_ONCE_PER_TURN } from "../types.js";
 
 export const SKILL_KRANG_SPIRIT_GUIDES = "krang_spirit_guides" as SkillId;
 
 export const spiritGuides: SkillDefinition = {
   id: SKILL_KRANG_SPIRIT_GUIDES,
-    name: "Spirit Guides",
-    heroId: "krang",
-    description: "Move 1 and may add +1 to a Block",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_MOVEMENT, CATEGORY_COMBAT],
+  name: "Spirit Guides",
+  heroId: "krang",
+  description: "Move 1 and may add +1 to a Block",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  categories: [CATEGORY_MOVEMENT, CATEGORY_COMBAT],
+  effect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      { type: EFFECT_GAIN_MOVE, amount: 1 },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_COMBAT_VALUE,
+          valueType: COMBAT_VALUE_BLOCK,
+          amount: 1,
+        },
+        duration: DURATION_TURN,
+        scope: { type: SCOPE_SELF },
+        description: "Spirit Guides +1 Block",
+      },
+    ],
+  },
 };

--- a/packages/core/src/engine/__tests__/skillSpiritGuides.test.ts
+++ b/packages/core/src/engine/__tests__/skillSpiritGuides.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for Spirit Guides skill (Krang)
+ *
+ * Once a turn: Move 1 and you may add +1 to a Block of any type in the Block phase.
+ *
+ * FAQ Rulings:
+ * - S1: +1 applies to any block source (cards, skills, units)
+ * - S2: Works with Diplomacy's Influence-to-Block (including elemental)
+ * - S3: Move is immediate; +1 Block persists throughout Block phase
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  UNDO_ACTION,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_KRANG_SPIRIT_GUIDES } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import type { CombatState } from "../../types/combat.js";
+import type { EnemyTokenId } from "../../types/enemy.js";
+import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
+import { EFFECT_COMBAT_VALUE, COMBAT_VALUE_BLOCK, SCOPE_SELF } from "../../types/modifierConstants.js";
+
+function buildSkillCooldowns() {
+  return {
+    usedThisRound: [] as string[],
+    usedThisTurn: [] as string[],
+    usedThisCombat: [] as string[],
+    activeUntilNextTurn: [] as string[],
+  };
+}
+
+function createTestCombat(phase: CombatState["phase"] = COMBAT_PHASE_BLOCK): CombatState {
+  return {
+    phase,
+    enemies: [{
+      instanceId: "enemy_0",
+      definition: {
+        id: "orc" as EnemyTokenId,
+        name: "Orc",
+        attack: 4,
+        armor: 3,
+        fame: 2,
+        abilities: [],
+        resistances: [],
+      },
+      isDefeated: false,
+      isBlocked: false,
+      damageAssigned: 0,
+      modifiers: [],
+    }],
+    isAtFortifiedSite: false,
+    woundsThisCombat: 0,
+    fameGained: 0,
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    pendingDamage: {},
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    combatContext: "standard",
+  };
+}
+
+describe("Spirit Guides skill (Krang)", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ============================================================================
+  // ACTIVATION: Move 1 + Block modifier
+  // ============================================================================
+
+  describe("activation", () => {
+    it("should grant Move 1 immediately on activation", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_KRANG_SPIRIT_GUIDES,
+        })
+      );
+
+      expect(result.state.players[0].movePoints).toBe(1);
+    });
+
+    it("should apply +1 Block modifier on activation", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      // Check that a CombatValue block modifier was applied
+      const blockModifiers = result.state.activeModifiers.filter(
+        (m) =>
+          m.effect.type === EFFECT_COMBAT_VALUE &&
+          m.effect.valueType === COMBAT_VALUE_BLOCK &&
+          m.effect.amount === 1
+      );
+      expect(blockModifiers).toHaveLength(1);
+      expect(blockModifiers[0].scope.type).toBe(SCOPE_SELF);
+    });
+
+    it("should activate both outside and inside combat", () => {
+      // Outside combat - move point is useful
+      const playerOutside = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+        movePoints: 0,
+      });
+      const stateOutside = createTestGameState({ players: [playerOutside] });
+
+      const resultOutside = engine.processAction(stateOutside, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(resultOutside.events).toContainEqual(
+        expect.objectContaining({ type: SKILL_USED })
+      );
+
+      // Inside combat - block bonus is useful
+      const playerInside = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+        movePoints: 0,
+      });
+      const stateInside = createTestGameState({
+        players: [playerInside],
+        combat: createTestCombat(),
+      });
+
+      const resultInside = engine.processAction(stateInside, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(resultInside.events).toContainEqual(
+        expect.objectContaining({ type: SKILL_USED })
+      );
+    });
+  });
+
+  // ============================================================================
+  // ONCE PER TURN USAGE
+  // ============================================================================
+
+  describe("once per turn", () => {
+    it("should add skill to usedThisTurn cooldown", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(
+        result.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_KRANG_SPIRIT_GUIDES);
+    });
+
+    it("should reject if skill already used this turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: {
+          ...buildSkillCooldowns(),
+          usedThisTurn: [SKILL_KRANG_SPIRIT_GUIDES],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should reject if skill not learned", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+  });
+
+  // ============================================================================
+  // UNDO
+  // ============================================================================
+
+  describe("undo", () => {
+    it("should be undoable after activation", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+        movePoints: 0,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      // Activate skill
+      const afterSkill = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      expect(afterSkill.state.players[0].movePoints).toBe(1);
+      expect(
+        afterSkill.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_KRANG_SPIRIT_GUIDES);
+
+      // Undo
+      const afterUndo = engine.processAction(afterSkill.state, "player1", {
+        type: UNDO_ACTION,
+      });
+
+      expect(afterUndo.state.players[0].movePoints).toBe(0);
+      expect(
+        afterUndo.state.players[0].skillCooldowns.usedThisTurn
+      ).not.toContain(SKILL_KRANG_SPIRIT_GUIDES);
+
+      // Block modifier should be removed
+      const blockModifiers = afterUndo.state.activeModifiers.filter(
+        (m) =>
+          m.effect.type === EFFECT_COMBAT_VALUE &&
+          m.effect.valueType === COMBAT_VALUE_BLOCK
+      );
+      expect(blockModifiers).toHaveLength(0);
+    });
+  });
+
+  // ============================================================================
+  // VALID ACTIONS
+  // ============================================================================
+
+  describe("valid actions", () => {
+    it("should show skill in valid actions when available outside combat", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_KRANG_SPIRIT_GUIDES,
+        })
+      );
+    });
+
+    it("should show skill in valid actions when in combat block phase", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({
+        players: [player],
+        combat: createTestCombat(COMBAT_PHASE_BLOCK),
+      });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_KRANG_SPIRIT_GUIDES,
+        })
+      );
+    });
+
+    it("should not show skill when already used this turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: {
+          ...buildSkillCooldowns(),
+          usedThisTurn: [SKILL_KRANG_SPIRIT_GUIDES],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_KRANG_SPIRIT_GUIDES,
+          })
+        );
+      }
+    });
+
+    it("should not show skill if player has not learned it", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      expect(getSkillsFromValidActions(validActions)).toBeUndefined();
+    });
+  });
+
+  // ============================================================================
+  // BLOCK BONUS APPLICATION (S1 - Any block source)
+  // ============================================================================
+
+  describe("block bonus modifier", () => {
+    it("should create a turn-duration modifier", () => {
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      const blockModifier = result.state.activeModifiers.find(
+        (m) =>
+          m.effect.type === EFFECT_COMBAT_VALUE &&
+          m.effect.valueType === COMBAT_VALUE_BLOCK
+      );
+
+      expect(blockModifier).toBeDefined();
+      expect(blockModifier!.duration).toBe("turn");
+      expect(blockModifier!.effect.type).toBe(EFFECT_COMBAT_VALUE);
+    });
+
+    it("should apply +1 to block regardless of element (S1)", () => {
+      // The CombatValueModifier with no element field applies to all elements
+      const player = createTestPlayer({
+        hero: Hero.Krang,
+        skills: [SKILL_KRANG_SPIRIT_GUIDES],
+        skillCooldowns: buildSkillCooldowns(),
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_SPIRIT_GUIDES,
+      });
+
+      const blockModifier = result.state.activeModifiers.find(
+        (m) =>
+          m.effect.type === EFFECT_COMBAT_VALUE &&
+          m.effect.valueType === COMBAT_VALUE_BLOCK
+      );
+
+      // No element restriction means it applies to physical, fire, ice, cold fire
+      expect(blockModifier!.effect).not.toHaveProperty("element");
+    });
+  });
+});

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -414,6 +414,10 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
   // Store the effect that was applied so we can reverse it on undo
   let appliedEffect: CardEffect | null = null;
 
+  // Snapshot of activeModifiers before effect resolution, restored on undo
+  // to remove any modifiers added by EFFECT_APPLY_MODIFIER sub-effects
+  let preEffectModifiers: GameState["activeModifiers"] | null = null;
+
   // Check if the skill's effect contains non-reversible sub-effects (e.g., draw cards).
   // If so, the command sets an undo checkpoint to prevent exploit via undo+reuse.
   // Custom handlers that draw cards must also be marked non-reversible.
@@ -484,6 +488,9 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
         } else {
           appliedEffect = skill.effect;
         }
+
+        // Snapshot modifiers before resolution so undo can restore them
+        preEffectModifiers = updatedState.activeModifiers;
 
         // Resolve the effect using the standard effect resolution system
         const effectResult = resolveEffect(updatedState, playerId, skill.effect);
@@ -576,8 +583,11 @@ export function createUseSkillCommand(params: UseSkillCommandParams): Command {
       const players = [...state.players];
       players[playerIndex] = updatedPlayer;
 
+      // Restore activeModifiers to pre-effect snapshot if modifiers were added
+      const activeModifiers = preEffectModifiers ?? state.activeModifiers;
+
       return {
-        state: { ...state, players },
+        state: { ...state, players, activeModifiers },
         events: [],
       };
     },

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -66,8 +66,9 @@ import {
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
   SKILL_BRAEVALAR_SHAPESHIFT,
   SKILL_BRAEVALAR_REGENERATE,
+  SKILL_KRANG_SPIRIT_GUIDES,
 } from "../../data/skills/index.js";
-import { CATEGORY_COMBAT } from "../../types/cards.js";
+import { CATEGORY_COMBAT, CATEGORY_MOVEMENT } from "../../types/cards.js";
 import {
   COMBAT_PHASE_ATTACK,
   COMBAT_PHASE_BLOCK,
@@ -137,6 +138,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
   SKILL_BRAEVALAR_SHAPESHIFT,
   SKILL_BRAEVALAR_REGENERATE,
+  SKILL_KRANG_SPIRIT_GUIDES,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING]);
@@ -224,9 +226,13 @@ export function getSkillOptions(
     // Only include skills that have been implemented
     if (!IMPLEMENTED_SKILLS.has(skillId)) continue;
 
-    // Combat skills (CATEGORY_COMBAT) are only available during combat
+    // Combat skills (CATEGORY_COMBAT) are only available during combat,
+    // unless they also have CATEGORY_MOVEMENT (e.g., Spirit Guides grants
+    // Move 1 outside combat and +1 Block modifier usable in Block phase)
     if (skill.categories.includes(CATEGORY_COMBAT) && !inCombat) {
-      continue;
+      if (!skill.categories.includes(CATEGORY_MOVEMENT)) {
+        continue;
+      }
     }
 
     // Block skills are only available during block phase

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -50,7 +50,7 @@ import {
   SKILL_BRAEVALAR_REGENERATE,
   SKILL_BRAEVALAR_NATURES_VENGEANCE,
 } from "../../data/skills/index.js";
-import { CATEGORY_COMBAT } from "../../types/cards.js";
+import { CATEGORY_COMBAT, CATEGORY_MOVEMENT } from "../../types/cards.js";
 import {
   COMBAT_PHASE_ATTACK,
   COMBAT_PHASE_BLOCK,
@@ -171,9 +171,10 @@ export const validateCombatSkillInCombat: Validator = (state, _playerId, action)
   }
 
   // Check if skill is combat-only
+  // Skills with both CATEGORY_MOVEMENT and CATEGORY_COMBAT (e.g., Spirit Guides)
+  // can be used outside combat for their movement effect
   if (skill.categories.includes(CATEGORY_COMBAT)) {
-    // Must be in combat to use combat skills
-    if (!state.combat) {
+    if (!skill.categories.includes(CATEGORY_MOVEMENT) && !state.combat) {
       return invalid(
         NOT_IN_COMBAT,
         `${skill.name} can only be used during combat`


### PR DESCRIPTION
## Summary
- Implements Spirit Guides skill for Krang: Move 1 and +1 Block modifier (once per turn)
- Uses compound effect (`EFFECT_GAIN_MOVE` + `EFFECT_APPLY_MODIFIER` with `CombatValueBlock`) so the block bonus automatically applies to all block sources via existing `getEffectiveCombatBonus` pipeline
- Allows dual-category (combat+movement) skills to be used outside combat in both validators and validActions
- Fixes generic skill undo to restore `activeModifiers` snapshot when effects add modifiers

## Test plan
- [x] 13 tests covering activation, cooldowns, undo, valid actions, and modifier properties
- [x] Full test suite passes (4734 tests)
- [x] Build and lint clean

Closes #340