### PR TITLE
feat: implement Dodge and Weave attack reduction and conditional bonus

### DIFF
--- a/packages/core/src/data/advancedActions/white/dodge-and-weave.ts
+++ b/packages/core/src/data/advancedActions/white/dodge-and-weave.ts
@@ -1,7 +1,31 @@
+/**
+ * Dodge and Weave (White Advanced Action)
+ *
+ * Basic: Reduce one enemy attack by 2.
+ *   Gain Attack 1 in Attack phase if no wounds added to hand this combat.
+ *
+ * Powered (White): Reduce one enemy attack by 4 OR two attacks by 2 each.
+ *   Gain Attack 2 in Attack phase if no wounds added to hand this combat.
+ *
+ * This is NOT a block effect — it reduces the enemy's attack value itself,
+ * which affects Swiftness (doubled block needed) and Brutal (doubled damage).
+ * The attack bonus is physical (non-elemental).
+ */
+
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
+import { EFFECT_SELECT_COMBAT_ENEMY } from "../../../types/effectTypes.js";
 import { MANA_WHITE, CARD_DODGE_AND_WEAVE } from "@mage-knight/shared";
-import { block } from "../helpers.js";
+import { compound, choice } from "../helpers.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_ENEMY_STAT,
+  ENEMY_STAT_ATTACK,
+  EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS,
+  SCOPE_SELF,
+} from "../../../types/modifierConstants.js";
+import { COMBAT_PHASE_BLOCK } from "../../../types/combat.js";
+import { EFFECT_APPLY_MODIFIER } from "../../../types/effectTypes.js";
 
 export const DODGE_AND_WEAVE: DeedCard = {
   id: CARD_DODGE_AND_WEAVE,
@@ -9,10 +33,94 @@ export const DODGE_AND_WEAVE: DeedCard = {
   cardType: DEED_CARD_TYPE_ADVANCED_ACTION,
   poweredBy: [MANA_WHITE],
   categories: [CATEGORY_COMBAT],
-  // Basic: Reduce one enemy attack by 2. Gain Attack 1 in the Attack phase if you did not add any Wounds to your hand in the previous combat phases.
-  // Powered: Reduce one enemy attack by 4 or two attacks of one or two enemies by 2. Gain Attack 2 in the Attack phase if you did not add any Wounds to your hand in the previous combat phases.
-  // TODO: Implement damage reduction and conditional attack bonus
-  basicEffect: block(2),
-  poweredEffect: block(4),
+  basicEffect: compound(
+    // Conditional Attack 1 (evaluated at phase transition to Attack)
+    // Must be first: compound stops at choice-requiring effects
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS,
+        amount: 1,
+      },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_SELF },
+      description: "Attack 1 if no wounds this combat",
+    },
+    // Reduce one enemy attack by 2
+    {
+      type: EFFECT_SELECT_COMBAT_ENEMY,
+      template: {
+        modifiers: [
+          {
+            modifier: {
+              type: EFFECT_ENEMY_STAT,
+              stat: ENEMY_STAT_ATTACK,
+              amount: -2,
+              minimum: 0,
+            },
+            duration: DURATION_COMBAT,
+            description: "Reduce enemy attack by 2",
+          },
+        ],
+      },
+      requiredPhase: COMBAT_PHASE_BLOCK,
+    }
+  ),
+  poweredEffect: compound(
+    // Conditional Attack 2 (evaluated at phase transition to Attack)
+    // Must be first: compound stops at choice-requiring effects
+    {
+      type: EFFECT_APPLY_MODIFIER,
+      modifier: {
+        type: EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS,
+        amount: 2,
+      },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_SELF },
+      description: "Attack 2 if no wounds this combat",
+    },
+    // Choice: Reduce one attack by 4 OR two attacks by 2 each
+    choice(
+      // Option 1: Reduce one enemy attack by 4
+      {
+        type: EFFECT_SELECT_COMBAT_ENEMY,
+        template: {
+          modifiers: [
+            {
+              modifier: {
+                type: EFFECT_ENEMY_STAT,
+                stat: ENEMY_STAT_ATTACK,
+                amount: -4,
+                minimum: 0,
+              },
+              duration: DURATION_COMBAT,
+              description: "Reduce enemy attack by 4",
+            },
+          ],
+        },
+        requiredPhase: COMBAT_PHASE_BLOCK,
+      },
+      // Option 2: Reduce two attacks by 2 each (can target same or different enemies)
+      {
+        type: EFFECT_SELECT_COMBAT_ENEMY,
+        template: {
+          modifiers: [
+            {
+              modifier: {
+                type: EFFECT_ENEMY_STAT,
+                stat: ENEMY_STAT_ATTACK,
+                amount: -2,
+                minimum: 0,
+              },
+              duration: DURATION_COMBAT,
+              description: "Reduce enemy attack by 2",
+            },
+          ],
+        },
+        maxTargets: 2,
+        requiredPhase: COMBAT_PHASE_BLOCK,
+      }
+    )
+  ),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/cardDodgeAndWeave.test.ts
+++ b/packages/core/src/engine/__tests__/cardDodgeAndWeave.test.ts
@@ -1,0 +1,658 @@
+/**
+ * Dodge and Weave Card Tests
+ *
+ * Dodge and Weave is a white Advanced Action.
+ * Basic: Reduce one enemy attack by 2. Gain Attack 1 in Attack phase if no wounds to hand this combat.
+ * Powered (White): Reduce one attack by 4 OR two attacks by 2 each. Gain Attack 2 if no wounds.
+ *
+ * Key mechanics:
+ * - Attack reduction (NOT block) - affects Swiftness/Brutal calculations
+ * - Conditional attack bonus evaluated at phase transition to Attack
+ * - Block phase only (attack reduction)
+ * - Physical attack bonus (non-elemental)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  ENTER_COMBAT_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  PLAY_CARD_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  ASSIGN_DAMAGE_ACTION,
+  CARD_DODGE_AND_WEAVE,
+  MANA_WHITE,
+  MANA_SOURCE_TOKEN,
+  ENEMY_DIGGERS,
+  ENEMY_PROWLERS,
+  DAMAGE_TARGET_HERO,
+} from "@mage-knight/shared";
+import {
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ASSIGN_DAMAGE,
+  COMBAT_PHASE_ATTACK,
+} from "../../types/combat.js";
+import { getEffectiveEnemyAttack } from "../modifiers/combat.js";
+
+describe("Dodge and Weave", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("basic effect - attack reduction", () => {
+    it("should reduce enemy attack by 2 in Block phase", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3, Armor 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      expect(baseAttack).toBe(3);
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_BLOCK);
+
+      // Play Dodge and Weave basic - compound effect with attack reduction + modifier
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      // Select enemy target for attack reduction
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Verify attack was reduced by 2
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(1);
+    });
+
+    it("should only be playable during Block phase", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat (starts in Ranged/Siege phase)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Try to play in Ranged/Siege phase - the attack reduction has requiredPhase: BLOCK
+      // The compound effect should still resolve but the attack reduction won't have valid targets
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      });
+
+      // The attack reduction part should resolve as "no valid targets" since we're not in Block phase
+      // The modifier part should still apply
+      expect(result.state.combat?.enemies[0].definition.attack).toBe(3);
+    });
+  });
+
+  describe("basic effect - conditional attack bonus", () => {
+    it("should grant Attack 1 in Attack phase when no wounds taken this combat", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_BLOCK);
+
+      // Play Dodge and Weave basic
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      // Select enemy for attack reduction
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Attack is now 1 (3 - 2). Skip block phase.
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ASSIGN_DAMAGE);
+
+      // Assign 1 damage to hero (reduced from 3 to 1)
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_DAMAGE_ACTION,
+        enemyInstanceId,
+        assignments: [{ target: DAMAGE_TARGET_HERO, amount: 1 }],
+      }).state;
+
+      // Hero takes 1 wound (1 damage / 2 armor rounds up to 1)
+      // woundsAddedToHandThisCombat should be true
+      expect(state.combat?.woundsAddedToHandThisCombat).toBe(true);
+
+      // Skip to Attack phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ATTACK);
+
+      // Should NOT have conditional attack bonus since wounds were taken
+      expect(state.players[0].combatAccumulator.attack.normal).toBe(0);
+    });
+
+    it("should grant Attack 1 when enemy attack reduced to 0 (no damage taken)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE, CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_BLOCK);
+
+      // Play first Dodge and Weave basic - reduces attack by 2 (3 -> 1)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Play second Dodge and Weave basic - reduces attack by 2 (1 -> 0)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+
+      // Verify attack is 0
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(0);
+
+      // No wounds taken
+      expect(state.combat?.woundsAddedToHandThisCombat).toBe(false);
+
+      // Skip Block → Assign Damage (enemy has 0 attack, auto-skips assignment)
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Skip Assign Damage → Attack
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ATTACK);
+
+      // Should have conditional attack bonus: 1 + 1 = 2 (two cards played)
+      expect(state.players[0].combatAccumulator.attack.normal).toBe(2);
+    });
+  });
+
+  describe("powered effect", () => {
+    it("should offer choice between reduce by 4 or reduce two by 2", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+        pureMana: [{ color: MANA_WHITE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play powered
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+      }).state;
+
+      // Should have pending choice with 2 options
+      expect(state.players[0].pendingChoice).not.toBeNull();
+      expect(state.players[0].pendingChoice?.options).toHaveLength(2);
+    });
+
+    it("should reduce one enemy attack by 4 when first option chosen", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+        pureMana: [{ color: MANA_WHITE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const baseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      expect(baseAttack).toBe(3);
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play powered
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+      }).state;
+
+      // Choose option 1: reduce one attack by 4
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // Select enemy
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Verify attack was reduced by 4 (clamped to 0)
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(0);
+    });
+
+    it("should reduce two enemies by 2 each when second option chosen", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+        pureMana: [{ color: MANA_WHITE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with two enemies
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_PROWLERS],
+      }).state;
+
+      const enemy1InstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const enemy2InstanceId = state.combat?.enemies[1].instanceId ?? "";
+      const enemy1BaseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      const enemy2BaseAttack = state.combat?.enemies[1].definition.attack ?? 0;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play powered
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+      }).state;
+
+      // Choose option 2: reduce two attacks by 2 each
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 1,
+      }).state;
+
+      // Select first enemy
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Select second enemy
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Both enemies should have attack reduced by 2
+      expect(getEffectiveEnemyAttack(state, enemy1InstanceId, enemy1BaseAttack)).toBe(
+        enemy1BaseAttack - 2
+      );
+      expect(getEffectiveEnemyAttack(state, enemy2InstanceId, enemy2BaseAttack)).toBe(
+        enemy2BaseAttack - 2
+      );
+    });
+
+    it("should grant Attack 2 in Attack phase when no wounds taken (powered)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+        pureMana: [{ color: MANA_WHITE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play powered - reduces attack by 4 (3 -> 0)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+      }).state;
+
+      // Choose reduce by 4
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // Select enemy
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // No wounds - attack reduced to 0
+      expect(state.combat?.woundsAddedToHandThisCombat).toBe(false);
+
+      // Skip through to Attack phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ATTACK);
+
+      // Should have Attack 2 from powered conditional bonus
+      expect(state.players[0].combatAccumulator.attack.normal).toBe(2);
+    });
+  });
+
+  describe("wound tracking", () => {
+    it("should track woundsAddedToHandThisCombat correctly", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Initially false
+      expect(state.combat?.woundsAddedToHandThisCombat).toBe(false);
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Dodge and Weave
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      // Select enemy for reduction
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Skip to Assign Damage
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ASSIGN_DAMAGE);
+
+      // Assign damage to hero (attack reduced from 3 to 1)
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_DAMAGE_ACTION,
+        enemyInstanceId,
+        assignments: [{ target: DAMAGE_TARGET_HERO, amount: 1 }],
+      }).state;
+
+      // Should be true after hero takes wounds
+      expect(state.combat?.woundsAddedToHandThisCombat).toBe(true);
+    });
+
+    it("should NOT grant attack bonus when wounds were taken", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Dodge and Weave - reduces attack by 2 (3 -> 1)
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Skip to Assign Damage
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Assign damage (1 damage remaining)
+      const enemyInstanceId = state.combat?.enemies[0].instanceId ?? "";
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_DAMAGE_ACTION,
+        enemyInstanceId,
+        assignments: [{ target: DAMAGE_TARGET_HERO, amount: 1 }],
+      }).state;
+
+      // Skip to Attack phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ATTACK);
+
+      // Should NOT have attack bonus (wounds were taken)
+      expect(state.players[0].combatAccumulator.attack.normal).toBe(0);
+    });
+  });
+
+  describe("attack bonus is physical", () => {
+    it("should grant physical (non-elemental) attack", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+        pureMana: [{ color: MANA_WHITE, source: "die" }],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with Diggers (Attack 3)
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      // Skip to Block
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play powered - reduce by 4
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: true,
+        manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+      }).state;
+
+      // Choose reduce by 4
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      if (state.players[0].pendingChoice) {
+        state = engine.processAction(state, "player1", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Skip through to Attack phase (no damage since attack reduced to 0)
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+      expect(state.combat?.phase).toBe(COMBAT_PHASE_ATTACK);
+
+      // Attack bonus should be physical
+      expect(state.players[0].combatAccumulator.attack.normalElements.physical).toBe(2);
+      expect(state.players[0].combatAccumulator.attack.normalElements.fire).toBe(0);
+      expect(state.players[0].combatAccumulator.attack.normalElements.ice).toBe(0);
+    });
+  });
+
+  describe("multi-enemy interaction", () => {
+    it("should only reduce attack of targeted enemy (basic)", () => {
+      const player = createTestPlayer({
+        hand: [CARD_DODGE_AND_WEAVE],
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Enter combat with two enemies
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS, ENEMY_PROWLERS],
+      }).state;
+
+      const enemy1InstanceId = state.combat?.enemies[0].instanceId ?? "";
+      const enemy2InstanceId = state.combat?.enemies[1].instanceId ?? "";
+      const enemy1BaseAttack = state.combat?.enemies[0].definition.attack ?? 0;
+      const enemy2BaseAttack = state.combat?.enemies[1].definition.attack ?? 0;
+
+      // Skip to Block phase
+      state = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      }).state;
+
+      // Play Dodge and Weave and target first enemy
+      state = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_DODGE_AND_WEAVE,
+        powered: false,
+      }).state;
+
+      // Should have enemy selection choice
+      expect(state.players[0].pendingChoice).not.toBeNull();
+
+      // Select first enemy
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // First enemy reduced, second unchanged
+      expect(getEffectiveEnemyAttack(state, enemy1InstanceId, enemy1BaseAttack)).toBe(
+        enemy1BaseAttack - 2
+      );
+      expect(getEffectiveEnemyAttack(state, enemy2InstanceId, enemy2BaseAttack)).toBe(
+        enemy2BaseAttack
+      );
+    });
+  });
+});

--- a/packages/core/src/engine/combat/dodgeAndWeaveHelpers.ts
+++ b/packages/core/src/engine/combat/dodgeAndWeaveHelpers.ts
@@ -1,0 +1,78 @@
+/**
+ * Dodge and Weave conditional attack bonus handling.
+ *
+ * When transitioning to Attack phase, checks for active Dodge and Weave
+ * modifiers and grants physical attack bonus if no wounds were added
+ * to the hero's hand during this combat.
+ *
+ * The modifier is consumed (removed) after evaluation regardless of
+ * whether the bonus was granted.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { DodgeAndWeaveAttackBonusModifier } from "../../types/modifiers.js";
+import { EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS, ELEMENT_PHYSICAL } from "../../types/modifierConstants.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+import { removeModifier } from "../modifiers/lifecycle.js";
+
+/**
+ * Apply Dodge and Weave conditional attack bonuses when entering Attack phase.
+ *
+ * For each active Dodge and Weave modifier:
+ * - If no wounds were added to hand this combat: grant physical attack
+ * - Remove the modifier (consumed regardless)
+ *
+ * @param state - Current game state (during phase transition to Attack)
+ * @param playerId - Player who played Dodge and Weave
+ * @returns Updated state with attack bonus applied (if applicable)
+ */
+export function applyDodgeAndWeaveAttackBonus(
+  state: GameState,
+  playerId: string
+): GameState {
+  if (!state.combat) return state;
+
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const dodgeAndWeaveMods = modifiers.filter(
+    (m) => m.effect.type === EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS
+  );
+
+  if (dodgeAndWeaveMods.length === 0) return state;
+
+  let currentState = state;
+
+  for (const mod of dodgeAndWeaveMods) {
+    const effect = mod.effect as DodgeAndWeaveAttackBonusModifier;
+
+    // Remove the modifier (consumed after evaluation)
+    currentState = removeModifier(currentState, mod.id);
+
+    // Only grant bonus if no wounds were added to hand this combat
+    if (currentState.combat && !currentState.combat.woundsAddedToHandThisCombat) {
+      const playerIndex = currentState.players.findIndex((p) => p.id === playerId);
+      if (playerIndex === -1) continue;
+
+      const player = currentState.players[playerIndex]!;
+      const updatedPlayers = [...currentState.players];
+      updatedPlayers[playerIndex] = {
+        ...player,
+        combatAccumulator: {
+          ...player.combatAccumulator,
+          attack: {
+            ...player.combatAccumulator.attack,
+            normal: player.combatAccumulator.attack.normal + effect.amount,
+            normalElements: {
+              ...player.combatAccumulator.attack.normalElements,
+              [ELEMENT_PHYSICAL]:
+                player.combatAccumulator.attack.normalElements.physical + effect.amount,
+            },
+          },
+        },
+      };
+
+      currentState = { ...currentState, players: updatedPlayers };
+    }
+  }
+
+  return currentState;
+}

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -242,6 +242,8 @@ export function createAssignDamageCommand(
         ...currentState.combat,
         enemies: updatedEnemies,
         woundsThisCombat: combatWoundsThisCombat,
+        woundsAddedToHandThisCombat:
+          currentState.combat.woundsAddedToHandThisCombat || heroWounds > 0,
         vampiricArmorBonus: updatedVampiricArmorBonus,
       };
 

--- a/packages/core/src/engine/commands/combat/phaseTransitions.ts
+++ b/packages/core/src/engine/commands/combat/phaseTransitions.ts
@@ -34,6 +34,8 @@ import {
 
 import { applyDefeatedEnemyRewards } from "./combatEndHandlers.js";
 
+import { applyDodgeAndWeaveAttackBonus } from "../../combat/dodgeAndWeaveHelpers.js";
+
 // ============================================================================
 // Phase State Machine
 // ============================================================================
@@ -105,6 +107,7 @@ export function handlePhaseTransition(
   // When transitioning from ASSIGN_DAMAGE to ATTACK:
   // - Discard all summoned enemies (they grant no fame)
   // - Restore original summoners (unhide them)
+  // - Apply Dodge and Weave conditional attack bonus
   if (
     currentPhase === COMBAT_PHASE_ASSIGN_DAMAGE &&
     nextPhase === COMBAT_PHASE_ATTACK
@@ -113,6 +116,15 @@ export function handlePhaseTransition(
     updatedState = result.state;
     updatedCombat = result.combat;
     phaseEvents.push(...result.events);
+
+    // Apply Dodge and Weave attack bonus (if no wounds this combat)
+    updatedState = applyDodgeAndWeaveAttackBonus(
+      { ...updatedState, combat: updatedCombat },
+      playerId
+    );
+    if (updatedState.combat) {
+      updatedCombat = updatedState.combat;
+    }
   }
 
   return {

--- a/packages/core/src/types/combat.ts
+++ b/packages/core/src/types/combat.ts
@@ -131,6 +131,7 @@ export interface CombatState {
   readonly phase: CombatPhase;
   readonly enemies: readonly CombatEnemy[];
   readonly woundsThisCombat: number; // Track for knockout
+  readonly woundsAddedToHandThisCombat: boolean; // Track for Dodge and Weave conditional attack
   readonly attacksThisPhase: number; // Track attacks made
   readonly fameGained: number; // Accumulated fame from defeated enemies
   readonly isAtFortifiedSite: boolean; // Site fortification (Keeps, Mage Towers, Cities)
@@ -301,6 +302,7 @@ export function createCombatState(
     phase: COMBAT_PHASE_RANGED_SIEGE,
     enemies,
     woundsThisCombat: 0,
+    woundsAddedToHandThisCombat: false,
     attacksThisPhase: 0,
     fameGained: 0,
     isAtFortifiedSite,

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -388,6 +388,12 @@ export const EFFECT_NATURES_VENGEANCE_ATTACK_BONUS = "natures_vengeance_attack_b
 //   Fire Resistance → Red, Ice Resistance → Blue, Physical Resistance → Green, always White.
 export const EFFECT_SOUL_HARVESTER_CRYSTAL_TRACKING = "soul_harvester_crystal_tracking" as const;
 
+// === DodgeAndWeaveAttackBonusModifier ===
+// Grants physical attack in Attack phase if no wounds were added to hero's hand this combat.
+// The condition is evaluated when transitioning to Attack phase.
+// Duration: combat. Applied by Dodge and Weave card.
+export const EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS = "dodge_and_weave_attack_bonus" as const;
+
 // === ShieldBashArmorReductionModifier ===
 // When active, a successful block applies armor reduction to the blocked enemy.
 // Armor reduction = excess undoubled block points (block used minus block needed).

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -72,6 +72,7 @@ import {
   EFFECT_BOW_ATTACK_TRANSFORMATION,
   EFFECT_SOUL_HARVESTER_CRYSTAL_TRACKING,
   EFFECT_SHIELD_BASH_ARMOR_REDUCTION,
+  EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS,
   SHAPESHIFT_TARGET_MOVE,
   SHAPESHIFT_TARGET_ATTACK,
   SHAPESHIFT_TARGET_BLOCK,
@@ -649,6 +650,15 @@ export interface SoulHarvesterCrystalTrackingModifier {
   readonly trackByAttack: boolean;
 }
 
+// Dodge and Weave conditional attack bonus modifier
+// Applied when Dodge and Weave is played in Block phase.
+// When transitioning to Attack phase, grants physical attack if no wounds
+// were added to hero's hand this combat.
+export interface DodgeAndWeaveAttackBonusModifier {
+  readonly type: typeof EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS;
+  readonly amount: number; // Attack bonus (1 for basic, 2 for powered)
+}
+
 // Shield Bash armor reduction modifier (Shield Bash powered effect)
 // When a block succeeds, reduces the blocked enemy's armor by the excess block points.
 // Excess = total undoubled block - block needed to fully block.
@@ -711,7 +721,8 @@ export type ModifierEffect =
   | BowPhaseFameTrackingModifier
   | BowAttackTransformationModifier
   | SoulHarvesterCrystalTrackingModifier
-  | ShieldBashArmorReductionModifier;
+  | ShieldBashArmorReductionModifier
+  | DodgeAndWeaveAttackBonusModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- Replace placeholder block effects with proper attack reduction mechanics for Dodge and Weave
- Basic: Reduce one enemy attack by 2, plus conditional Attack 1 if no wounds this combat
- Powered (White): Choice of reduce by 4 or reduce two by 2, plus conditional Attack 2
- Track `woundsAddedToHandThisCombat` on CombatState for the conditional bonus
- Apply deferred attack bonus during ASSIGN_DAMAGE → ATTACK phase transition

Closes #178

## Test plan
- [x] Basic effect reduces enemy attack by 2 (not block)
- [x] Powered effect offers choice between reduce-by-4 and reduce-two-by-2
- [x] Multi-target reduction works on two different enemies
- [x] Conditional attack bonus granted when no wounds taken
- [x] Conditional attack bonus NOT granted when wounds taken
- [x] Attack bonus is physical (non-elemental)
- [x] Wound tracking via `woundsAddedToHandThisCombat` works correctly
- [x] All 12 new tests pass, full suite passes (4789 core tests)