### PR TITLE
feat: add expansion heroes to pre-game hero selection

### DIFF
--- a/packages/client/src/components/Setup/SetupScreen.tsx
+++ b/packages/client/src/components/Setup/SetupScreen.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useCallback } from "react";
 import type { GameConfig, HeroId } from "@mage-knight/shared";
-import { BASE_HEROES, SCENARIO_FIRST_RECONNAISSANCE } from "@mage-knight/shared";
+import { ALL_HEROES, SCENARIO_FIRST_RECONNAISSANCE } from "@mage-knight/shared";
 import { PlayerCountSelector } from "./PlayerCountSelector";
 import { HeroSelectionGrid } from "./HeroSelectionGrid";
 import "./SetupScreen.css";
@@ -91,7 +91,7 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
         />
 
         <HeroSelectionGrid
-          availableHeroes={BASE_HEROES}
+          availableHeroes={ALL_HEROES}
           selectedHeroes={selectedHeroes}
           onSelectHero={handleSelectHero}
           currentPlayerIndex={


### PR DESCRIPTION
## Summary
Show all 7 heroes (including expansion heroes Wolfhawk, Krang, Braevalar) in the pre-game hero selection UI instead of only the 4 base-game heroes.

## Changes
- Changed `SetupScreen` to use `ALL_HEROES` instead of `BASE_HEROES` for the hero selection grid
- Expansion heroes were already fully defined in `@mage-knight/shared` and supported by game initialization — this simply surfaces them in the UI

Closes #93