### PR TITLE
feat: implement Dueling skill for Wolfhawk (#357)

### DIFF
--- a/packages/core/src/data/skills/wolfhawk/dueling.ts
+++ b/packages/core/src/data/skills/wolfhawk/dueling.ts
@@ -1,5 +1,18 @@
 /**
  * Dueling - Wolfhawk Skill
+ *
+ * Once per turn, during Block Phase:
+ * Block 1. Attack 1 versus the same enemy in the Attack phase.
+ * If you do not use any unit ability to block, attack or affect this enemy
+ * nor assign damage from it to any unit, you gain 1 more Fame for defeating it.
+ *
+ * Key rules:
+ * - Block Phase only - enemy must be alive and attacking (S1, S4)
+ * - Block 1 doesn't need to successfully block to qualify for Attack 1 or Fame (S1)
+ * - Unit resistance absorption still counts as unit involvement (S3)
+ * - Can't use if enemy prevented from attacking (Whirlwind/Chill) (S4)
+ * - CAN use if attack reduced to 0 by Swift Reflexes (S4)
+ *
  * @module data/skills/wolfhawk/dueling
  */
 
@@ -11,9 +24,9 @@ export const SKILL_WOLFHAWK_DUELING = "wolfhawk_dueling" as SkillId;
 
 export const dueling: SkillDefinition = {
   id: SKILL_WOLFHAWK_DUELING,
-    name: "Dueling",
-    heroId: "wolfhawk",
-    description: "Block 1 and Attack 1 vs same enemy. +1 Fame without Units",
-    usageType: SKILL_USAGE_ONCE_PER_TURN,
-    categories: [CATEGORY_COMBAT],
+  name: "Dueling",
+  heroId: "wolfhawk",
+  description: "Block 1 and Attack 1 vs same enemy. +1 Fame without Units",
+  usageType: SKILL_USAGE_ONCE_PER_TURN,
+  categories: [CATEGORY_COMBAT],
 };

--- a/packages/core/src/engine/__tests__/skillDueling.test.ts
+++ b/packages/core/src/engine/__tests__/skillDueling.test.ts
@@ -1,0 +1,851 @@
+/**
+ * Tests for Dueling skill (Wolfhawk)
+ *
+ * Once per turn, during Block Phase:
+ * Block 1. Attack 1 versus the same enemy in the Attack phase.
+ * If you do not use any unit ability to block, attack or affect this enemy
+ * nor assign damage from it to any unit, you gain 1 more Fame for defeating it.
+ *
+ * Key rules:
+ * - Block Phase only - enemy must be alive and attacking (S1, S4)
+ * - Block 1 doesn't need to successfully block to qualify for Attack 1 or Fame (S1)
+ * - Unit resistance absorption still counts as unit involvement (S3)
+ * - Can't use if enemy prevented from attacking (Whirlwind/Chill) (S4)
+ * - CAN use if attack reduced to 0 by Swift Reflexes (S4)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  ENEMY_PROWLERS,
+  ENEMY_GUARDSMEN,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_WOLFHAWK_DUELING } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+  createCombatState,
+} from "../../types/combat.js";
+import { addModifier } from "../modifiers/index.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_DUELING_TARGET,
+  EFFECT_ENEMY_SKIP_ATTACK,
+  SCOPE_ONE_ENEMY,
+  SOURCE_SKILL,
+} from "../../types/modifierConstants.js";
+import { applyDuelingAttackBonus, resolveDuelingFameBonus, markDuelingUnitInvolvement, markDuelingUnitInvolvementFromAbility } from "../combat/duelingHelpers.js";
+import type { DuelingTargetModifier } from "../../types/modifiers.js";
+
+function createWolfhawkPlayer() {
+  return createTestPlayer({
+    hero: Hero.Wolfhawk,
+    skills: [SKILL_WOLFHAWK_DUELING],
+    skillCooldowns: {
+      usedThisRound: [],
+      usedThisTurn: [],
+      usedThisCombat: [],
+      activeUntilNextTurn: [],
+    },
+  });
+}
+
+describe("Dueling skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  describe("activation", () => {
+    it("should activate during block phase", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_WOLFHAWK_DUELING,
+        })
+      );
+    });
+
+    it("should reject if not in block phase (ranged/siege)", () => {
+      const player = createWolfhawkPlayer();
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject if not in block phase (attack)", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK as typeof COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject when not in combat", () => {
+      const player = createWolfhawkPlayer();
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should only be usable once per turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_DUELING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_WOLFHAWK_DUELING],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+
+    it("should reject when enemy is prevented from attacking (skip attack)", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyId = state.combat!.enemies[0].instanceId;
+
+      // Apply skip-attack to the only enemy
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId },
+        effect: { type: EFFECT_ENEMY_SKIP_ATTACK },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+        })
+      );
+    });
+  });
+
+  describe("Block 1 effect", () => {
+    it("should add Block 1 to combatAccumulator on activation", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+      const blockBefore = state.players[0].combatAccumulator.block;
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      const blockAfter = result.state.players[0].combatAccumulator.block;
+      expect(blockAfter).toBe(blockBefore + 1);
+    });
+
+    it("should add physical block element", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+      const physicalBefore = state.players[0].combatAccumulator.blockElements.physical;
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      const physicalAfter = result.state.players[0].combatAccumulator.blockElements.physical;
+      expect(physicalAfter).toBe(physicalBefore + 1);
+    });
+  });
+
+  describe("enemy selection", () => {
+    it("should present a pending choice to select an enemy", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.state.players[0].pendingChoice).toBeDefined();
+      expect(result.state.players[0].pendingChoice!.skillId).toBe(SKILL_WOLFHAWK_DUELING);
+    });
+
+    it("should present options for each eligible enemy", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS, ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      expect(result.state.players[0].pendingChoice!.options).toHaveLength(2);
+    });
+
+    it("should create DuelingTarget modifier when enemy is selected", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      // Activate Dueling
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      // Select the enemy
+      const selectResult = engine.processAction(activateResult.state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      });
+
+      // Should have a DuelingTarget modifier
+      const duelingMod = selectResult.state.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_DUELING_TARGET
+      );
+      expect(duelingMod).toBeDefined();
+      const effect = duelingMod!.effect as DuelingTargetModifier;
+      expect(effect.enemyInstanceId).toBe(enemyInstanceId);
+      expect(effect.attackApplied).toBe(false);
+      expect(effect.unitInvolved).toBe(false);
+    });
+
+    it("should exclude enemies prevented from attacking", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS, ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const firstEnemyId = state.combat!.enemies[0].instanceId;
+
+      // Apply skip-attack to first enemy
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: firstEnemyId },
+        effect: { type: EFFECT_ENEMY_SKIP_ATTACK },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      // Should only have one option (second enemy)
+      expect(result.state.players[0].pendingChoice!.options).toHaveLength(1);
+    });
+  });
+
+  describe("deferred Attack 1", () => {
+    it("should apply Attack 1 to combatAccumulator when entering Attack phase", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      // Add a DuelingTarget modifier (simulating post-activation)
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const attackBefore = state.players[0].combatAccumulator.attack.normal;
+
+      // Apply deferred attack bonus
+      const updatedState = applyDuelingAttackBonus(state, "player1");
+
+      const attackAfter = updatedState.players[0].combatAccumulator.attack.normal;
+      expect(attackAfter).toBe(attackBefore + 1);
+    });
+
+    it("should add physical element to the attack", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const physicalBefore = state.players[0].combatAccumulator.attack.normalElements.physical;
+      const updatedState = applyDuelingAttackBonus(state, "player1");
+      const physicalAfter = updatedState.players[0].combatAccumulator.attack.normalElements.physical;
+
+      expect(physicalAfter).toBe(physicalBefore + 1);
+    });
+
+    it("should mark attackApplied on the modifier", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const updatedState = applyDuelingAttackBonus(state, "player1");
+      const duelingMod = updatedState.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_DUELING_TARGET
+      );
+      expect((duelingMod!.effect as DuelingTargetModifier).attackApplied).toBe(true);
+    });
+
+    it("should not apply attack bonus if enemy is already defeated", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Mark enemy as defeated
+      state = {
+        ...state,
+        combat: {
+          ...state.combat!,
+          enemies: state.combat!.enemies.map((e) => ({
+            ...e,
+            isDefeated: true,
+          })),
+        },
+      };
+
+      const attackBefore = state.players[0].combatAccumulator.attack.normal;
+      const updatedState = applyDuelingAttackBonus(state, "player1");
+      expect(updatedState.players[0].combatAccumulator.attack.normal).toBe(attackBefore);
+    });
+
+    it("should not apply attack bonus twice", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Apply once
+      const firstApply = applyDuelingAttackBonus(state, "player1");
+      const attackAfterFirst = firstApply.players[0].combatAccumulator.attack.normal;
+
+      // Apply again — should not change
+      const secondApply = applyDuelingAttackBonus(firstApply, "player1");
+      expect(secondApply.players[0].combatAccumulator.attack.normal).toBe(attackAfterFirst);
+    });
+  });
+
+  describe("fame bonus", () => {
+    it("should grant Fame +1 when target enemy is defeated without unit involvement", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK as typeof COMBAT_PHASE_ATTACK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      // Add DuelingTarget modifier
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: true,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Mark enemy as defeated
+      state = {
+        ...state,
+        combat: {
+          ...state.combat!,
+          enemies: state.combat!.enemies.map((e) => ({
+            ...e,
+            isDefeated: true,
+          })),
+        },
+      };
+
+      const fameBefore = state.players[0].fame;
+      const result = resolveDuelingFameBonus(state, "player1");
+
+      expect(result.fameGained).toBe(1);
+      expect(result.state.players[0].fame).toBe(fameBefore + 1);
+    });
+
+    it("should NOT grant fame if unit was involved", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK as typeof COMBAT_PHASE_ATTACK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      // Add DuelingTarget modifier with unitInvolved = true
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: true,
+          unitInvolved: true,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Mark enemy as defeated
+      state = {
+        ...state,
+        combat: {
+          ...state.combat!,
+          enemies: state.combat!.enemies.map((e) => ({
+            ...e,
+            isDefeated: true,
+          })),
+        },
+      };
+
+      const result = resolveDuelingFameBonus(state, "player1");
+      expect(result.fameGained).toBe(0);
+    });
+
+    it("should NOT grant fame if target enemy was not defeated", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK as typeof COMBAT_PHASE_ATTACK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      // Add DuelingTarget modifier (enemy NOT defeated)
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: true,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const result = resolveDuelingFameBonus(state, "player1");
+      expect(result.fameGained).toBe(0);
+    });
+  });
+
+  describe("unit involvement tracking", () => {
+    it("should mark unitInvolved when damage is assigned to unit from target enemy", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const updatedState = markDuelingUnitInvolvement(state, "player1", enemyInstanceId);
+      const mod = updatedState.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_DUELING_TARGET
+      );
+      expect((mod!.effect as DuelingTargetModifier).unitInvolved).toBe(true);
+    });
+
+    it("should NOT mark unitInvolved if damage is from a different enemy", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS, ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const targetEnemyId = state.combat!.enemies[0].instanceId;
+      const otherEnemyId = state.combat!.enemies[1].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: targetEnemyId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId: targetEnemyId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      // Mark involvement from a DIFFERENT enemy
+      const updatedState = markDuelingUnitInvolvement(state, "player1", otherEnemyId);
+      const mod = updatedState.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_DUELING_TARGET
+      );
+      expect((mod!.effect as DuelingTargetModifier).unitInvolved).toBe(false);
+    });
+
+    it("should mark unitInvolved when any unit combat ability is activated", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyInstanceId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId: enemyInstanceId },
+        effect: {
+          type: EFFECT_DUELING_TARGET,
+          enemyInstanceId,
+          attackApplied: false,
+          unitInvolved: false,
+        },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const updatedState = markDuelingUnitInvolvementFromAbility(state, "player1");
+      const mod = updatedState.activeModifiers.find(
+        (m) => m.effect.type === EFFECT_DUELING_TARGET
+      );
+      expect((mod!.effect as DuelingTargetModifier).unitInvolved).toBe(true);
+    });
+  });
+
+  describe("valid actions", () => {
+    it("should show skill during block phase with attacking enemies", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills).toBeDefined();
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_WOLFHAWK_DUELING,
+        })
+      );
+    });
+
+    it("should not show skill during ranged/siege phase", () => {
+      const player = createWolfhawkPlayer();
+      const combat = createCombatState([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        const dueling = skills.activatable.find(
+          (s) => s.skillId === SKILL_WOLFHAWK_DUELING
+        );
+        expect(dueling).toBeUndefined();
+      }
+    });
+
+    it("should not show skill when not in combat", () => {
+      const player = createWolfhawkPlayer();
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        const dueling = skills.activatable.find(
+          (s) => s.skillId === SKILL_WOLFHAWK_DUELING
+        );
+        expect(dueling).toBeUndefined();
+      }
+    });
+
+    it("should not show skill when already used this turn", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_DUELING],
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_WOLFHAWK_DUELING],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        const dueling = skills.activatable.find(
+          (s) => s.skillId === SKILL_WOLFHAWK_DUELING
+        );
+        expect(dueling).toBeUndefined();
+      }
+    });
+
+    it("should not show skill when all enemies are prevented from attacking", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      let state = createTestGameState({ players: [player], combat });
+      const enemyId = state.combat!.enemies[0].instanceId;
+
+      state = addModifier(state, {
+        source: { type: SOURCE_SKILL, skillId: SKILL_WOLFHAWK_DUELING, playerId: "player1" },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_ENEMY, enemyId },
+        effect: { type: EFFECT_ENEMY_SKIP_ATTACK },
+        createdAtRound: state.round,
+        createdByPlayerId: "player1",
+      });
+
+      const validActions = getValidActions(state, "player1");
+
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        const dueling = skills.activatable.find(
+          (s) => s.skillId === SKILL_WOLFHAWK_DUELING
+        );
+        expect(dueling).toBeUndefined();
+      }
+    });
+  });
+
+  describe("undo", () => {
+    it("should remove Block 1 and restore cooldown on undo", () => {
+      const player = createWolfhawkPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_BLOCK as typeof COMBAT_PHASE_BLOCK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate the skill
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_DUELING,
+      });
+
+      // Verify skill is on cooldown
+      expect(
+        result.state.players[0].skillCooldowns.usedThisTurn
+      ).toContain(SKILL_WOLFHAWK_DUELING);
+
+      // Verify Block 1 was added
+      expect(result.state.players[0].combatAccumulator.block).toBe(
+        state.players[0].combatAccumulator.block + 1
+      );
+
+      // Undo should be available (skill activation is reversible)
+      const validActions = getValidActions(result.state, "player1");
+      expect(validActions.turn.canUndo).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/engine/combat/duelingHelpers.ts
+++ b/packages/core/src/engine/combat/duelingHelpers.ts
@@ -1,0 +1,238 @@
+/**
+ * Dueling skill combat helpers.
+ *
+ * Handles the deferred Attack 1 when transitioning to Attack phase,
+ * and the Fame +1 bonus at combat end if no units were involved.
+ *
+ * Follows the same pattern as dodgeAndWeaveHelpers.ts for phase-transition
+ * automatic effects.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { DuelingTargetModifier } from "../../types/modifiers.js";
+import { EFFECT_DUELING_TARGET, SOURCE_SKILL } from "../../types/modifierConstants.js";
+import { ELEMENT_PHYSICAL } from "@mage-knight/shared";
+import { SKILL_WOLFHAWK_DUELING } from "../../data/skills/wolfhawk/dueling.js";
+import { getModifiersForPlayer } from "../modifiers/queries.js";
+
+/**
+ * Update a DuelingTargetModifier's effect in the activeModifiers array.
+ */
+function updateDuelingModifier(
+  state: GameState,
+  modifierId: string,
+  updatedEffect: DuelingTargetModifier
+): GameState {
+  return {
+    ...state,
+    activeModifiers: state.activeModifiers.map((m) =>
+      m.id === modifierId
+        ? { ...m, effect: updatedEffect }
+        : m
+    ),
+  };
+}
+
+/**
+ * Apply Dueling's deferred Attack 1 when entering Attack phase.
+ *
+ * Finds any active DuelingTargetModifier and grants physical melee Attack 1.
+ * The attack is added to the combatAccumulator.
+ * The modifier is updated to mark attackApplied = true but NOT removed
+ * (still needed for fame bonus tracking at combat end).
+ *
+ * @param state - Current game state (during phase transition to Attack)
+ * @param playerId - Player who used Dueling
+ * @returns Updated state with attack bonus applied
+ */
+export function applyDuelingAttackBonus(
+  state: GameState,
+  playerId: string
+): GameState {
+  if (!state.combat) return state;
+
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const duelingMod = modifiers.find(
+    (m) =>
+      m.effect.type === EFFECT_DUELING_TARGET &&
+      m.source.type === SOURCE_SKILL &&
+      m.source.skillId === SKILL_WOLFHAWK_DUELING
+  );
+
+  if (!duelingMod) return state;
+
+  const effect = duelingMod.effect as DuelingTargetModifier;
+  if (effect.attackApplied) return state;
+
+  // Check if the target enemy is still alive (can't attack a dead enemy)
+  const targetEnemy = state.combat.enemies.find(
+    (e) => e.instanceId === effect.enemyInstanceId
+  );
+  if (!targetEnemy || targetEnemy.isDefeated) {
+    // Enemy was defeated before Attack phase — no deferred attack
+    return state;
+  }
+
+  // Mark attack as applied
+  let currentState = updateDuelingModifier(state, duelingMod.id, {
+    ...effect,
+    attackApplied: true,
+  });
+
+  // Add Attack 1 (physical melee) to combatAccumulator
+  const playerIndex = currentState.players.findIndex((p) => p.id === playerId);
+  if (playerIndex === -1) return currentState;
+
+  const player = currentState.players[playerIndex]!;
+  const updatedPlayers = [...currentState.players];
+  updatedPlayers[playerIndex] = {
+    ...player,
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      attack: {
+        ...player.combatAccumulator.attack,
+        normal: player.combatAccumulator.attack.normal + 1,
+        normalElements: {
+          ...player.combatAccumulator.attack.normalElements,
+          [ELEMENT_PHYSICAL]:
+            player.combatAccumulator.attack.normalElements.physical + 1,
+        },
+      },
+    },
+  };
+
+  return { ...currentState, players: updatedPlayers };
+}
+
+/**
+ * Resolve Dueling fame bonus at combat end.
+ *
+ * Checks if the Dueling target enemy was defeated and no units were involved.
+ * If so, grants Fame +1 to the player.
+ * The modifier is cleaned up by normal combat-end modifier expiration.
+ *
+ * @param state - Current game state (at combat end, before combat = null)
+ * @param playerId - Player who used Dueling
+ * @returns Object with updated state and fame gained
+ */
+export function resolveDuelingFameBonus(
+  state: GameState,
+  playerId: string
+): { state: GameState; fameGained: number } {
+  if (!state.combat) return { state, fameGained: 0 };
+
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const duelingMod = modifiers.find(
+    (m) =>
+      m.effect.type === EFFECT_DUELING_TARGET &&
+      m.source.type === SOURCE_SKILL &&
+      m.source.skillId === SKILL_WOLFHAWK_DUELING
+  );
+
+  if (!duelingMod) return { state, fameGained: 0 };
+
+  const effect = duelingMod.effect as DuelingTargetModifier;
+
+  // Check if the target enemy was defeated
+  const targetEnemy = state.combat.enemies.find(
+    (e) => e.instanceId === effect.enemyInstanceId
+  );
+  if (!targetEnemy || !targetEnemy.isDefeated) {
+    return { state, fameGained: 0 };
+  }
+
+  // Check if any unit was involved
+  if (effect.unitInvolved) {
+    return { state, fameGained: 0 };
+  }
+
+  // Grant Fame +1
+  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  if (playerIndex === -1) return { state, fameGained: 0 };
+
+  const player = state.players[playerIndex]!;
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = {
+    ...player,
+    fame: player.fame + 1,
+  };
+
+  return {
+    state: { ...state, players: updatedPlayers },
+    fameGained: 1,
+  };
+}
+
+/**
+ * Mark unit involvement for the Dueling target enemy when a unit combat
+ * ability (block/attack/ranged/siege) is activated.
+ *
+ * Since unit abilities go to a generic accumulator (not targeting a specific enemy),
+ * any unit combat ability usage marks the Dueling target as unit-involved.
+ *
+ * @param state - Current game state
+ * @param playerId - Player who used Dueling
+ * @returns Updated state with unitInvolved flag set
+ */
+export function markDuelingUnitInvolvementFromAbility(
+  state: GameState,
+  playerId: string
+): GameState {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const duelingMod = modifiers.find(
+    (m) =>
+      m.effect.type === EFFECT_DUELING_TARGET &&
+      m.source.type === SOURCE_SKILL &&
+      m.source.skillId === SKILL_WOLFHAWK_DUELING
+  );
+
+  if (!duelingMod) return state;
+
+  const effect = duelingMod.effect as DuelingTargetModifier;
+  if (effect.unitInvolved) return state;
+
+  return updateDuelingModifier(state, duelingMod.id, {
+    ...effect,
+    unitInvolved: true,
+  });
+}
+
+/**
+ * Mark that a unit was involved with the Dueling target enemy.
+ *
+ * Called when:
+ * - Damage from this enemy is assigned to any unit (including resistant units - S3)
+ *
+ * @param state - Current game state
+ * @param playerId - Player who used Dueling
+ * @param enemyInstanceId - The enemy that had unit involvement
+ * @returns Updated state with unitInvolved flag set
+ */
+export function markDuelingUnitInvolvement(
+  state: GameState,
+  playerId: string,
+  enemyInstanceId: string
+): GameState {
+  const modifiers = getModifiersForPlayer(state, playerId);
+  const duelingMod = modifiers.find(
+    (m) =>
+      m.effect.type === EFFECT_DUELING_TARGET &&
+      m.source.type === SOURCE_SKILL &&
+      m.source.skillId === SKILL_WOLFHAWK_DUELING
+  );
+
+  if (!duelingMod) return state;
+
+  const effect = duelingMod.effect as DuelingTargetModifier;
+
+  // Only mark if this is the Dueling target enemy
+  if (effect.enemyInstanceId !== enemyInstanceId) return state;
+
+  // Already marked
+  if (effect.unitInvolved) return state;
+
+  return updateDuelingModifier(state, duelingMod.id, {
+    ...effect,
+    unitInvolved: true,
+  });
+}

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -49,6 +49,7 @@ import {
 import { getBannerForUnit, markBannerUsed } from "../../rules/banners.js";
 import { getHeroDamageReduction } from "../../modifiers/index.js";
 import { removeModifier } from "../../modifiers/index.js";
+import { markDuelingUnitInvolvement } from "../../combat/duelingHelpers.js";
 
 export const ASSIGN_DAMAGE_COMMAND = "ASSIGN_DAMAGE" as const;
 
@@ -157,8 +158,10 @@ export function createAssignDamageCommand(
       ];
 
       // Process each assignment
+      let unitDamageAssigned = false;
       for (const assignment of assignments) {
         if (assignment.target === DAMAGE_TARGET_UNIT) {
+          unitDamageAssigned = true;
           const result = processUnitAssignment(
             currentState,
             updatedPlayer,
@@ -175,6 +178,16 @@ export function createAssignDamageCommand(
           // Hero damage
           heroWounds += Math.ceil(assignment.amount / updatedPlayer.armor);
         }
+      }
+
+      // Mark Dueling unit involvement when damage from enemy is assigned to a unit
+      // (including resistant units that absorb damage - per FAQ S3)
+      if (unitDamageAssigned) {
+        currentState = markDuelingUnitInvolvement(
+          currentState,
+          params.playerId,
+          params.enemyInstanceId
+        );
       }
 
       // Apply hero wounds

--- a/packages/core/src/engine/commands/combat/combatEndHandlers.ts
+++ b/packages/core/src/engine/commands/combat/combatEndHandlers.ts
@@ -52,6 +52,7 @@ import { resolveAttackDefeatFameTrackers } from "../../combat/attackFameTracking
 import { resolveScoutFameBonus } from "../../combat/scoutFameTracking.js";
 import { resolveBowPhaseFameBonus } from "../../combat/bowPhaseFameTracking.js";
 import { resolveSoulHarvesterCrystals } from "../../combat/soulHarvesterTracking.js";
+import { resolveDuelingFameBonus } from "../../combat/duelingHelpers.js";
 
 // ============================================================================
 // Helper Functions
@@ -211,6 +212,12 @@ export function handleCombatEnd(
         stateAfterResolution = { ...stateAfterResolution, players: updatedPlayers };
       }
     }
+  }
+
+  // Resolve Dueling fame bonus (if target enemy defeated without unit involvement)
+  const duelingResult = resolveDuelingFameBonus(stateAfterResolution, playerId);
+  if (duelingResult.fameGained > 0) {
+    stateAfterResolution = duelingResult.state;
   }
 
   // Use resolved combat state for victory calculation

--- a/packages/core/src/engine/commands/combat/phaseTransitions.ts
+++ b/packages/core/src/engine/commands/combat/phaseTransitions.ts
@@ -35,6 +35,7 @@ import {
 import { applyDefeatedEnemyRewards } from "./combatEndHandlers.js";
 
 import { applyDodgeAndWeaveAttackBonus } from "../../combat/dodgeAndWeaveHelpers.js";
+import { applyDuelingAttackBonus } from "../../combat/duelingHelpers.js";
 
 // ============================================================================
 // Phase State Machine
@@ -119,6 +120,15 @@ export function handlePhaseTransition(
 
     // Apply Dodge and Weave attack bonus (if no wounds this combat)
     updatedState = applyDodgeAndWeaveAttackBonus(
+      { ...updatedState, combat: updatedCombat },
+      playerId
+    );
+    if (updatedState.combat) {
+      updatedCombat = updatedState.combat;
+    }
+
+    // Apply Dueling deferred Attack 1 (if target enemy is still alive)
+    updatedState = applyDuelingAttackBonus(
       { ...updatedState, combat: updatedCombat },
       playerId
     );

--- a/packages/core/src/engine/commands/skills/duelingEffect.ts
+++ b/packages/core/src/engine/commands/skills/duelingEffect.ts
@@ -1,0 +1,190 @@
+/**
+ * Dueling skill effect handler
+ *
+ * Wolfhawk's skill: Once per turn, during Block Phase, select an enemy:
+ * - Block 1 against selected enemy (added to combatAccumulator)
+ * - Attack 1 against same enemy in Attack phase (deferred via modifier)
+ * - Fame +1 if enemy defeated without any unit involvement
+ *
+ * Key rules:
+ * - Can only be used during Block Phase (S4)
+ * - Don't need to successfully block to qualify for Attack 1 or Fame (S1)
+ * - Can't use on already-dead enemies (S1)
+ * - Can't use if enemy prevented from attacking (no Block Phase for that enemy) (S4)
+ * - CAN use if attack reduced to 0 by Swift Reflexes (S4)
+ * - Unit resistance absorption still counts as unit involvement (S3)
+ *
+ * @module commands/skills/duelingEffect
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { Player } from "../../../types/player.js";
+import type { CardEffect } from "../../../types/cards.js";
+import { SKILL_WOLFHAWK_DUELING } from "../../../data/skills/wolfhawk/dueling.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_DUELING_TARGET,
+  SOURCE_SKILL,
+} from "../../../types/modifierConstants.js";
+import { EFFECT_RESOLVE_COMBAT_ENEMY_TARGET } from "../../../types/effectTypes.js";
+import { getPlayerIndexByIdOrThrow } from "../../helpers/playerHelpers.js";
+import { doesEnemyAttackThisCombat } from "../../modifiers/combat.js";
+import { ELEMENT_PHYSICAL } from "@mage-knight/shared";
+import type { ResolveCombatEnemyTargetEffect } from "../../../types/cards.js";
+
+/**
+ * Check if Dueling can be activated.
+ * Requires combat in Block phase with at least one eligible enemy
+ * that is alive and still attacks this combat.
+ */
+export function canActivateDueling(state: GameState): boolean {
+  if (!state.combat) return false;
+
+  return state.combat.enemies.some(
+    (e) => !e.isDefeated && doesEnemyAttackThisCombat(state, e.instanceId)
+  );
+}
+
+/**
+ * Apply the Dueling skill effect.
+ *
+ * Creates a pending choice with one option per eligible enemy.
+ * When the player selects an enemy, resolveChoiceCommand resolves the
+ * EFFECT_RESOLVE_COMBAT_ENEMY_TARGET which applies the block bonus
+ * and creates the DuelingTargetModifier.
+ *
+ * For Dueling, we use a bundledEffect that adds Block 1 to the accumulator,
+ * and the template adds the DuelingTargetModifier. But the template system
+ * only supports modifiers, not combatAccumulator updates. So we use a custom
+ * approach: present enemy choices, and when selected, we handle it via
+ * the dueling-specific resolution effect.
+ */
+export function applyDuelingEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  if (!state.combat) return state;
+
+  // Get eligible enemies: alive and still attacking this combat
+  const eligibleEnemies = state.combat.enemies.filter(
+    (e) => !e.isDefeated && doesEnemyAttackThisCombat(state, e.instanceId)
+  );
+
+  if (eligibleEnemies.length === 0) return state;
+
+  // Build choice options - one per eligible enemy
+  // Use EFFECT_RESOLVE_COMBAT_ENEMY_TARGET with a template that creates the modifier
+  const enemyOptions: CardEffect[] = eligibleEnemies.map(
+    (enemy) =>
+      ({
+        type: EFFECT_RESOLVE_COMBAT_ENEMY_TARGET,
+        enemyInstanceId: enemy.instanceId,
+        enemyName: enemy.definition.name,
+        template: {
+          // The modifier tracks the target for deferred attack and fame bonus
+          modifiers: [
+            {
+              modifier: {
+                type: EFFECT_DUELING_TARGET,
+                enemyInstanceId: enemy.instanceId,
+                attackApplied: false,
+                unitInvolved: false,
+              },
+              duration: DURATION_COMBAT,
+              description: "Dueling target",
+            },
+          ],
+        },
+      }) as ResolveCombatEnemyTargetEffect
+  );
+
+  // If only one enemy, still present choice (consistent with other skills)
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice: {
+      cardId: null,
+      skillId: SKILL_WOLFHAWK_DUELING,
+      unitInstanceId: null,
+      options: enemyOptions,
+    },
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  // Also add Block 1 to combatAccumulator immediately
+  // This is granted regardless of which enemy is selected
+  players[playerIndex] = {
+    ...updatedPlayer,
+    combatAccumulator: {
+      ...updatedPlayer.combatAccumulator,
+      block: updatedPlayer.combatAccumulator.block + 1,
+      blockElements: {
+        ...updatedPlayer.combatAccumulator.blockElements,
+        [ELEMENT_PHYSICAL]:
+          updatedPlayer.combatAccumulator.blockElements.physical + 1,
+      },
+    },
+  };
+
+  return { ...state, players };
+}
+
+/**
+ * Remove Dueling effects for undo.
+ * Clears pending choice and removes DuelingTarget modifier.
+ * Also removes Block 1 from combatAccumulator.
+ */
+export function removeDuelingEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) {
+    throw new Error(`Player not found at index: ${playerIndex}`);
+  }
+
+  // Clear pending choice if from Dueling
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice:
+      player.pendingChoice?.skillId === SKILL_WOLFHAWK_DUELING
+        ? null
+        : player.pendingChoice,
+    // Remove Block 1 from combatAccumulator
+    combatAccumulator: {
+      ...player.combatAccumulator,
+      block: Math.max(0, player.combatAccumulator.block - 1),
+      blockElements: {
+        ...player.combatAccumulator.blockElements,
+        [ELEMENT_PHYSICAL]: Math.max(
+          0,
+          player.combatAccumulator.blockElements.physical - 1
+        ),
+      },
+    },
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return {
+    ...state,
+    players,
+    activeModifiers: state.activeModifiers.filter(
+      (m) =>
+        !(
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_DUELING &&
+          m.source.playerId === playerId
+        )
+    ),
+  };
+}

--- a/packages/core/src/engine/commands/skills/duelingEffect.ts
+++ b/packages/core/src/engine/commands/skills/duelingEffect.ts
@@ -178,12 +178,19 @@ export function removeDuelingEffect(
   return {
     ...state,
     players,
+    // Remove modifiers from Dueling:
+    // - SOURCE_SKILL modifiers created by useSkillCommand
+    // - DuelingTarget modifiers created by the template system (which uses SOURCE_CARD)
     activeModifiers: state.activeModifiers.filter(
       (m) =>
         !(
           m.source.type === SOURCE_SKILL &&
           m.source.skillId === SKILL_WOLFHAWK_DUELING &&
           m.source.playerId === playerId
+        ) &&
+        !(
+          m.effect.type === EFFECT_DUELING_TARGET &&
+          m.createdByPlayerId === playerId
         )
     ),
   };

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -80,3 +80,8 @@ export {
   applyKnowYourPreyEffect,
   removeKnowYourPreyEffect,
 } from "./knowYourPreyEffect.js";
+
+export {
+  applyDuelingEffect,
+  removeDuelingEffect,
+} from "./duelingEffect.js";

--- a/packages/core/src/engine/commands/units/activateUnitCommand.ts
+++ b/packages/core/src/engine/commands/units/activateUnitCommand.ts
@@ -61,6 +61,7 @@ import {
   getChoiceOptionsFromEffect,
   type PendingChoiceSource,
 } from "../choice/choiceResolution.js";
+import { markDuelingUnitInvolvementFromAbility } from "../../combat/duelingHelpers.js";
 
 export const ACTIVATE_UNIT_COMMAND = "ACTIVATE_UNIT" as const;
 
@@ -564,6 +565,11 @@ export function createActivateUnitCommand(
             ),
           };
         }
+      }
+
+      // Mark Dueling unit involvement when a unit combat ability is used
+      if (isAttackAbility || isBlockAbility) {
+        updatedState = markDuelingUnitInvolvementFromAbility(updatedState, params.playerId);
       }
 
       const events: GameEvent[] = [

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -39,6 +39,7 @@ import {
   SKILL_WOLFHAWK_HAWK_EYES,
   SKILL_WOLFHAWK_DEADLY_AIM,
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
+  SKILL_WOLFHAWK_DUELING,
 } from "../../data/skills/index.js";
 import {
   applyWhoNeedsMagicEffect,
@@ -69,6 +70,8 @@ import {
   removeDeadlyAimEffect,
   applyKnowYourPreyEffect,
   removeKnowYourPreyEffect,
+  applyDuelingEffect,
+  removeDuelingEffect,
 } from "./skills/index.js";
 import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
 import { restoreMana } from "./helpers/manaConsumptionHelpers.js";
@@ -176,6 +179,9 @@ function applyCustomSkillEffect(
     case SKILL_WOLFHAWK_KNOW_YOUR_PREY:
       return applyKnowYourPreyEffect(state, playerId);
 
+    case SKILL_WOLFHAWK_DUELING:
+      return applyDuelingEffect(state, playerId);
+
     default:
       // Skill has no custom handler - will use generic effect resolution
       return state;
@@ -236,6 +242,9 @@ function removeCustomSkillEffect(
     case SKILL_WOLFHAWK_KNOW_YOUR_PREY:
       return removeKnowYourPreyEffect(state, playerId);
 
+    case SKILL_WOLFHAWK_DUELING:
+      return removeDuelingEffect(state, playerId);
+
     default:
       return state;
   }
@@ -260,6 +269,7 @@ function hasCustomHandler(skillId: SkillId): boolean {
     SKILL_WOLFHAWK_HAWK_EYES,
     SKILL_WOLFHAWK_DEADLY_AIM,
     SKILL_WOLFHAWK_KNOW_YOUR_PREY,
+    SKILL_WOLFHAWK_DUELING,
   ].includes(skillId);
 }
 

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -64,6 +64,7 @@ import {
   SKILL_WOLFHAWK_DEADLY_AIM,
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_TAUNT,
+  SKILL_WOLFHAWK_DUELING,
   SKILL_BRAEVALAR_ELEMENTAL_RESISTANCE,
   SKILL_BRAEVALAR_BEGUILE,
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
@@ -85,6 +86,7 @@ import { canActivateInvocation } from "../commands/skills/invocationEffect.js";
 import { canActivateShapeshift } from "../commands/skills/shapeshiftEffect.js";
 import { canActivateRegenerate } from "../commands/skills/regenerateEffect.js";
 import { canActivateKnowYourPrey } from "../commands/skills/knowYourPreyEffect.js";
+import { canActivateDueling } from "../commands/skills/duelingEffect.js";
 import { canUseMeleeAttackSkill, isMeleeAttackSkill, isSkillFaceUp } from "../rules/skillPhasing.js";
 import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { hexKey } from "@mage-knight/shared";
@@ -142,6 +144,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_WOLFHAWK_DEADLY_AIM,
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_TAUNT,
+  SKILL_WOLFHAWK_DUELING,
   SKILL_BRAEVALAR_ELEMENTAL_RESISTANCE,
   SKILL_BRAEVALAR_BEGUILE,
   SKILL_BRAEVALAR_FORKED_LIGHTNING,
@@ -216,6 +219,10 @@ function canActivateSkill(
       // Must be in combat with targetable enemies
       return canActivateKnowYourPrey(state);
 
+    case SKILL_WOLFHAWK_DUELING:
+      // Must be in combat with eligible enemies that are alive and still attacking
+      return canActivateDueling(state);
+
     default:
       // No special requirements
       return true;
@@ -254,7 +261,7 @@ export function getSkillOptions(
     }
 
     // Block skills are only available during block phase
-    const blockSkills = [SKILL_TOVAK_SHIELD_MASTERY, SKILL_WOLFHAWK_TAUNT];
+    const blockSkills = [SKILL_TOVAK_SHIELD_MASTERY, SKILL_WOLFHAWK_TAUNT, SKILL_WOLFHAWK_DUELING];
     if (blockSkills.includes(skillId)) {
       if (!state.combat || state.combat.phase !== COMBAT_PHASE_BLOCK) {
         continue;

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -52,6 +52,7 @@ import {
   SKILL_WOLFHAWK_DEADLY_AIM,
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_TAUNT,
+  SKILL_WOLFHAWK_DUELING,
   SKILL_BRAEVALAR_REGENERATE,
   SKILL_BRAEVALAR_NATURES_VENGEANCE,
 } from "../../data/skills/index.js";
@@ -67,6 +68,7 @@ import { canUseMeleeAttackSkill, isMeleeAttackSkill, isSkillFaceUp } from "../ru
 import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { canActivateUniversalPower } from "../commands/skills/universalPowerEffect.js";
 import { canActivateKnowYourPrey } from "../commands/skills/knowYourPreyEffect.js";
+import { canActivateDueling } from "../commands/skills/duelingEffect.js";
 import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_BRAEVALAR_NATURES_VENGEANCE]);
@@ -222,7 +224,7 @@ export const validateBlockSkillInBlockPhase: Validator = (state, _playerId, acti
   const useSkillAction = action as UseSkillAction;
 
   // Skills that provide block can only be used during block phase
-  const blockSkills = [SKILL_TOVAK_SHIELD_MASTERY, SKILL_WOLFHAWK_TAUNT];
+  const blockSkills = [SKILL_TOVAK_SHIELD_MASTERY, SKILL_WOLFHAWK_TAUNT, SKILL_WOLFHAWK_DUELING];
 
   if (blockSkills.includes(useSkillAction.skillId)) {
     if (!state.combat || state.combat.phase !== COMBAT_PHASE_BLOCK) {
@@ -436,6 +438,16 @@ export const validateSkillRequirements: Validator = (
       return invalid(
         SKILL_CONFLICTS_WITH_ACTIVE,
         "Universal Power cannot be activated while a conflicting sideways skill is active"
+      );
+    }
+  }
+
+  // Dueling: requires eligible enemies that are alive and still attacking
+  if (useSkillAction.skillId === SKILL_WOLFHAWK_DUELING) {
+    if (!canActivateDueling(state)) {
+      return invalid(
+        SKILL_NO_VALID_TARGET,
+        "Dueling requires an eligible enemy that is alive and still attacking"
       );
     }
   }

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -413,3 +413,10 @@ export const EFFECT_REMOVE_ICE_RESISTANCE = "remove_ice_resistance" as const;
 // Applied per-enemy by Know Your Prey skill.
 export const EFFECT_CONVERT_ATTACK_ELEMENT = "convert_attack_element" as const;
 
+// === DuelingTargetModifier ===
+// Tracks which enemy was targeted by Wolfhawk's Dueling skill in Block phase.
+// Used to grant Attack 1 vs the same enemy in Attack phase.
+// Also tracks whether any unit was involved with this enemy (for Fame +1 bonus).
+// Duration: combat. Applied by Dueling skill activation.
+export const EFFECT_DUELING_TARGET = "dueling_target" as const;
+

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -75,6 +75,7 @@ import {
   EFFECT_REMOVE_ICE_RESISTANCE,
   EFFECT_CONVERT_ATTACK_ELEMENT,
   EFFECT_DODGE_AND_WEAVE_ATTACK_BONUS,
+  EFFECT_DUELING_TARGET,
   SHAPESHIFT_TARGET_MOVE,
   SHAPESHIFT_TARGET_ATTACK,
   SHAPESHIFT_TARGET_BLOCK,
@@ -691,6 +692,20 @@ export interface ConvertAttackElementModifier {
   readonly toElement: Element;
 }
 
+// Dueling target modifier (Wolfhawk Dueling skill)
+// Tracks the enemy targeted in Block phase for the deferred Attack 1 in Attack phase.
+// Also tracks whether any unit was involved with this enemy for the Fame +1 bonus.
+// Scoped to SCOPE_SELF with playerId. Duration: combat.
+export interface DuelingTargetModifier {
+  readonly type: typeof EFFECT_DUELING_TARGET;
+  /** The enemy instance ID targeted by Dueling */
+  readonly enemyInstanceId: string;
+  /** Whether Attack 1 has been granted in Attack phase */
+  readonly attackApplied: boolean;
+  /** Whether any unit was involved with this enemy (disqualifies Fame +1) */
+  readonly unitInvolved: boolean;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -746,7 +761,8 @@ export type ModifierEffect =
   | ShieldBashArmorReductionModifier
   | RemoveIceResistanceModifier
   | ConvertAttackElementModifier
-  | DodgeAndWeaveAttackBonusModifier;
+  | DodgeAndWeaveAttackBonusModifier
+  | DuelingTargetModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary

Implements the Dueling skill for Wolfhawk (issue #357).

- **Block Phase activation**: Block 1 + enemy selection via pending choice with DuelingTarget modifier
- **Deferred Attack 1**: Applied automatically at ASSIGN_DAMAGE → ATTACK phase transition (same pattern as Dodge and Weave)
- **Fame +1 bonus**: Resolved at combat end if target enemy defeated without any unit involvement
- **Unit involvement tracking**: Marked when damage from target enemy is assigned to a unit, or when any unit combat ability (block/attack/ranged/siege) is activated
- **Validation**: Block phase only, requires eligible enemies (alive + still attacking), once per turn cooldown

### Files changed

| Area | Files |
|------|-------|
| Skill data | `dueling.ts` - updated documentation |
| Effect handler | `duelingEffect.ts` (new) - custom apply/remove/canActivate |
| Combat helpers | `duelingHelpers.ts` (new) - deferred attack, fame bonus, unit tracking |
| Integration | `phaseTransitions.ts`, `combatEndHandlers.ts`, `assignDamageCommand.ts`, `activateUnitCommand.ts` |
| Skill system | `useSkillCommand.ts`, `skills/index.ts` |
| Validators | `skillValidators.ts`, `validActions/skills.ts` |
| Types | `modifierConstants.ts`, `modifiers.ts` (DuelingTargetModifier) |
| Tests | `skillDueling.test.ts` (new) - 29 tests |

## Test plan

- [x] Activation during block phase succeeds
- [x] Rejection outside block phase (ranged/siege, attack, no combat)
- [x] Once per turn cooldown enforcement
- [x] Rejection when all enemies have skip-attack
- [x] Block 1 added to combatAccumulator with physical element
- [x] Enemy selection creates pending choice with correct options
- [x] DuelingTarget modifier created on enemy selection
- [x] Enemies with skip-attack excluded from options
- [x] Deferred Attack 1 applied at phase transition
- [x] Attack not applied if enemy defeated before Attack phase
- [x] Attack not applied twice (idempotent)
- [x] Fame +1 when target defeated without unit involvement
- [x] No fame if unit was involved
- [x] No fame if target not defeated
- [x] Unit involvement tracked from damage assignment and ability activation
- [x] Valid actions show/hide correctly per phase and cooldown
- [x] Undo removes Block 1 and restores cooldown

Closes #357