### PR TITLE
feat: implement Force of Nature unit Physical Resistance grant

### DIFF
--- a/packages/core/src/data/advancedActions/green/force-of-nature.ts
+++ b/packages/core/src/data/advancedActions/green/force-of-nature.ts
@@ -1,7 +1,12 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
-import { MANA_GREEN, CARD_FORCE_OF_NATURE } from "@mage-knight/shared";
+import { MANA_GREEN, CARD_FORCE_OF_NATURE, RESIST_PHYSICAL } from "@mage-knight/shared";
 import { block, siegeAttack, choice } from "../helpers.js";
+import { EFFECT_SELECT_UNIT_FOR_MODIFIER } from "../../../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_GRANT_RESISTANCES,
+} from "../../../types/modifierConstants.js";
 
 export const FORCE_OF_NATURE: DeedCard = {
   id: CARD_FORCE_OF_NATURE,
@@ -11,8 +16,15 @@ export const FORCE_OF_NATURE: DeedCard = {
   categories: [CATEGORY_COMBAT],
   // Basic: Chosen Unit gains Physical resistance this combat.
   // Powered: Siege Attack 3 or Block 6
-  // TODO: Implement unit resistance modifier
-  basicEffect: block(2),
+  basicEffect: {
+    type: EFFECT_SELECT_UNIT_FOR_MODIFIER,
+    modifier: {
+      type: EFFECT_GRANT_RESISTANCES,
+      resistances: [RESIST_PHYSICAL],
+    },
+    duration: DURATION_COMBAT,
+    description: "Chosen unit gains Physical Resistance",
+  },
   poweredEffect: choice(siegeAttack(3), block(6)),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/forceOfNature.test.ts
+++ b/packages/core/src/engine/__tests__/forceOfNature.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Force of Nature Card Tests
+ *
+ * Tests for the Force of Nature advanced action card:
+ *
+ * Basic: Chosen Unit gains Physical Resistance this combat.
+ * Powered: Siege Attack 3 or Block 6.
+ */
+
+import { describe, it, expect } from "vitest";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { isEffectResolvable } from "../effects/resolvability.js";
+import { getEffectiveUnitResistances } from "../modifiers/units.js";
+import { addModifier } from "../modifiers/index.js";
+import { createPlayerUnit } from "../../types/unit.js";
+import {
+  EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+} from "../../types/effectTypes.js";
+import type {
+  SelectUnitForModifierEffect,
+  ResolveUnitModifierTargetEffect,
+} from "../../types/cards.js";
+import {
+  RESIST_PHYSICAL,
+  RESIST_FIRE,
+  RESIST_ICE,
+  UNIT_PEASANTS,
+  UNIT_GUARDIAN_GOLEMS,
+  CARD_FORCE_OF_NATURE,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import {
+  DURATION_COMBAT,
+  EFFECT_GRANT_RESISTANCES,
+  SOURCE_CARD,
+  SCOPE_ONE_UNIT,
+  SCOPE_ALL_UNITS,
+} from "../../types/modifierConstants.js";
+
+const basicEffect: SelectUnitForModifierEffect = {
+  type: EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  modifier: {
+    type: EFFECT_GRANT_RESISTANCES,
+    resistances: [RESIST_PHYSICAL],
+  },
+  duration: DURATION_COMBAT,
+  description: "Chosen unit gains Physical Resistance",
+};
+
+describe("Force of Nature", () => {
+  describe("Basic Effect: Select Unit for Modifier", () => {
+    it("should return no-op when player has no units", () => {
+      const player = createTestPlayer({ units: [] });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", basicEffect, CARD_FORCE_OF_NATURE);
+
+      expect(result.description).toBe("No units to target");
+      expect(result.requiresChoice).toBeUndefined();
+    });
+
+    it("should auto-resolve when player has exactly one unit", () => {
+      const unit = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const player = createTestPlayer({ units: [unit] });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", basicEffect, CARD_FORCE_OF_NATURE);
+
+      // Should auto-resolve (no choice needed)
+      expect(result.requiresChoice).toBeUndefined();
+      expect(result.description).toContain("Peasants");
+
+      // Verify modifier was applied
+      const resistances = getEffectiveUnitResistances(result.state, "player1", unit);
+      expect(resistances).toContain(RESIST_PHYSICAL);
+    });
+
+    it("should present choices when player has multiple units", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const unit2 = createPlayerUnit(UNIT_GUARDIAN_GOLEMS, "golem_1");
+      const player = createTestPlayer({ units: [unit1, unit2] });
+      const state = createTestGameState({ players: [player] });
+
+      const result = resolveEffect(state, "player1", basicEffect, CARD_FORCE_OF_NATURE);
+
+      expect(result.requiresChoice).toBe(true);
+      expect(result.dynamicChoiceOptions).toHaveLength(2);
+
+      // Verify choice options are ResolveUnitModifierTargetEffect
+      const options = result.dynamicChoiceOptions as ResolveUnitModifierTargetEffect[];
+      expect(options[0]?.type).toBe(EFFECT_RESOLVE_UNIT_MODIFIER_TARGET);
+      expect(options[1]?.type).toBe(EFFECT_RESOLVE_UNIT_MODIFIER_TARGET);
+    });
+
+    it("should apply modifier to selected unit when resolving choice", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const unit2 = createPlayerUnit(UNIT_PEASANTS, "peasant_2");
+      const player = createTestPlayer({ units: [unit1, unit2] });
+      const state = createTestGameState({ players: [player] });
+
+      // Resolve selecting the first unit
+      const resolveEffect1: ResolveUnitModifierTargetEffect = {
+        type: EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+        unitInstanceId: "peasant_1",
+        unitName: "Peasants",
+        modifier: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_PHYSICAL],
+        },
+        duration: DURATION_COMBAT,
+        description: "Chosen unit gains Physical Resistance",
+      };
+
+      const result = resolveEffect(state, "player1", resolveEffect1, CARD_FORCE_OF_NATURE);
+
+      // Unit 1 should have Physical Resistance
+      const resistances1 = getEffectiveUnitResistances(result.state, "player1", unit1);
+      expect(resistances1).toContain(RESIST_PHYSICAL);
+
+      // Unit 2 should NOT have Physical Resistance (Peasants have none by default)
+      const resistances2 = getEffectiveUnitResistances(result.state, "player1", unit2);
+      expect(resistances2).not.toContain(RESIST_PHYSICAL);
+    });
+  });
+
+  describe("SCOPE_ONE_UNIT modifier handling", () => {
+    it("should only grant resistance to the targeted unit via SCOPE_ONE_UNIT", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const unit2 = createPlayerUnit(UNIT_PEASANTS, "peasant_2");
+      const player = createTestPlayer({ units: [unit1, unit2] });
+      const baseState = createTestGameState({ players: [player] });
+
+      // Add SCOPE_ONE_UNIT modifier targeting unit at index 0
+      const state = addModifier(baseState, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: CARD_FORCE_OF_NATURE as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_UNIT, unitIndex: 0 },
+        effect: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_PHYSICAL],
+        },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Unit at index 0 should have Physical Resistance
+      const resistances1 = getEffectiveUnitResistances(state, "player1", unit1);
+      expect(resistances1).toContain(RESIST_PHYSICAL);
+
+      // Unit at index 1 should NOT have Physical Resistance
+      const resistances2 = getEffectiveUnitResistances(state, "player1", unit2);
+      expect(resistances2).not.toContain(RESIST_PHYSICAL);
+    });
+
+    it("should combine SCOPE_ONE_UNIT with SCOPE_ALL_UNITS resistances", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const unit2 = createPlayerUnit(UNIT_PEASANTS, "peasant_2");
+      const player = createTestPlayer({ units: [unit1, unit2] });
+      const baseState = createTestGameState({ players: [player] });
+
+      // Add SCOPE_ONE_UNIT modifier targeting unit at index 0 (Physical Resistance)
+      let state = addModifier(baseState, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: CARD_FORCE_OF_NATURE as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_UNIT, unitIndex: 0 },
+        effect: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_PHYSICAL],
+        },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Add SCOPE_ALL_UNITS modifier (Fire + Ice Resistance from Veil of Mist)
+      state = addModifier(state, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "mist_form" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ALL_UNITS },
+        effect: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_FIRE, RESIST_ICE],
+        },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Unit 1 should have all three resistances (Physical from ONE_UNIT + Fire/Ice from ALL_UNITS)
+      const resistances1 = getEffectiveUnitResistances(state, "player1", unit1);
+      expect(resistances1).toContain(RESIST_PHYSICAL);
+      expect(resistances1).toContain(RESIST_FIRE);
+      expect(resistances1).toContain(RESIST_ICE);
+
+      // Unit 2 should only have Fire + Ice (from ALL_UNITS), NOT Physical
+      const resistances2 = getEffectiveUnitResistances(state, "player1", unit2);
+      expect(resistances2).not.toContain(RESIST_PHYSICAL);
+      expect(resistances2).toContain(RESIST_FIRE);
+      expect(resistances2).toContain(RESIST_ICE);
+    });
+
+    it("should not grant resistance to units of other players", () => {
+      const unit1 = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const unit2 = createPlayerUnit(UNIT_PEASANTS, "peasant_2");
+      const player1 = createTestPlayer({ id: "player1", units: [unit1] });
+      const player2 = createTestPlayer({ id: "player2", position: { q: 1, r: 0 }, units: [unit2] });
+      const baseState = createTestGameState({
+        players: [player1, player2],
+        turnOrder: ["player1", "player2"],
+      });
+
+      // Apply modifier to player1's unit
+      const state = addModifier(baseState, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: CARD_FORCE_OF_NATURE as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_UNIT, unitIndex: 0 },
+        effect: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_PHYSICAL],
+        },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      // Player1's unit should have Physical Resistance
+      const resistances1 = getEffectiveUnitResistances(state, "player1", unit1);
+      expect(resistances1).toContain(RESIST_PHYSICAL);
+
+      // Player2's unit should NOT have Physical Resistance
+      const resistances2 = getEffectiveUnitResistances(state, "player2", unit2);
+      expect(resistances2).not.toContain(RESIST_PHYSICAL);
+    });
+
+    it("should combine with unit base resistances", () => {
+      // Guardian Golems have Physical Resistance by default
+      const unit = createPlayerUnit(UNIT_GUARDIAN_GOLEMS, "golem_1");
+      const player = createTestPlayer({ units: [unit] });
+      const baseState = createTestGameState({ players: [player] });
+
+      // Grant Fire Resistance via SCOPE_ONE_UNIT
+      const state = addModifier(baseState, {
+        source: {
+          type: SOURCE_CARD,
+          cardId: "test" as CardId,
+          playerId: "player1",
+        },
+        duration: DURATION_COMBAT,
+        scope: { type: SCOPE_ONE_UNIT, unitIndex: 0 },
+        effect: {
+          type: EFFECT_GRANT_RESISTANCES,
+          resistances: [RESIST_FIRE],
+        },
+        createdAtRound: 1,
+        createdByPlayerId: "player1",
+      });
+
+      const resistances = getEffectiveUnitResistances(state, "player1", unit);
+      // Should have base Physical + granted Fire
+      expect(resistances).toContain(RESIST_PHYSICAL);
+      expect(resistances).toContain(RESIST_FIRE);
+      // Should NOT have Ice (not granted or base)
+      expect(resistances).not.toContain(RESIST_ICE);
+    });
+  });
+
+  describe("Resolvability", () => {
+    it("should be resolvable when player has units", () => {
+      const unit = createPlayerUnit(UNIT_PEASANTS, "peasant_1");
+      const player = createTestPlayer({ units: [unit] });
+      const state = createTestGameState({ players: [player] });
+
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(true);
+    });
+
+    it("should not be resolvable when player has no units", () => {
+      const player = createTestPlayer({ units: [] });
+      const state = createTestGameState({ players: [player] });
+
+      expect(isEffectResolvable(state, "player1", basicEffect)).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -107,6 +107,8 @@ import {
   EFFECT_PEACEFUL_MOMENT_CONVERT,
   EFFECT_PEACEFUL_MOMENT_HEAL,
   EFFECT_PEACEFUL_MOMENT_REFRESH,
+  EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
 } from "../../types/effectTypes.js";
 import type {
   GainAttackBowResolvedEffect,
@@ -692,6 +694,17 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
   [EFFECT_PEACEFUL_MOMENT_REFRESH]: (effect) => {
     const e = effect as import("../../types/cards.js").PeacefulMomentRefreshEffect;
     return `Refresh ${e.unitName} (${e.influenceCost} Influence)`;
+  },
+
+  [EFFECT_SELECT_UNIT_FOR_MODIFIER]: (effect) => {
+    const e = effect as import("../../types/cards.js").SelectUnitForModifierEffect;
+    return e.description ?? "Select a unit to target";
+  },
+
+  [EFFECT_RESOLVE_UNIT_MODIFIER_TARGET]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveUnitModifierTargetEffect;
+    const desc = e.description ?? "Apply modifier";
+    return desc.replace("Chosen unit", e.unitName);
   },
 };
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -73,6 +73,7 @@ import { registerSpellForgeEffects } from "./spellForgeEffects.js";
 import { registerKnowYourPreyEffects } from "./knowYourPreyEffects.js";
 import { registerPeacefulMomentEffects } from "./peacefulMomentEffects.js";
 import { registerStoutResolveEffects } from "./stoutResolveEffects.js";
+import { registerUnitModifierEffects } from "./unitModifierEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -274,4 +275,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Stout Resolve effects (discard for bonus)
   registerStoutResolveEffects();
+
+  // Unit modifier effects (select unit + apply modifier, e.g., Force of Nature)
+  registerUnitModifierEffects();
 }

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -137,6 +137,8 @@ import {
   EFFECT_PEACEFUL_MOMENT_CONVERT,
   EFFECT_PEACEFUL_MOMENT_HEAL,
   EFFECT_PEACEFUL_MOMENT_REFRESH,
+  EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
 } from "../../types/effectTypes.js";
 import type {
   DrawCardsEffect,
@@ -712,6 +714,14 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
   [EFFECT_PEACEFUL_MOMENT_CONVERT]: () => true,
   [EFFECT_PEACEFUL_MOMENT_HEAL]: () => true,
   [EFFECT_PEACEFUL_MOMENT_REFRESH]: () => true,
+
+  // Unit modifier targeting is resolvable if player has at least one unit
+  [EFFECT_SELECT_UNIT_FOR_MODIFIER]: (_state, player) => {
+    return player.units.length > 0;
+  },
+
+  // Resolve unit modifier target is always resolvable (validated at resolution time)
+  [EFFECT_RESOLVE_UNIT_MODIFIER_TARGET]: () => true,
 };
 
 // ============================================================================

--- a/packages/core/src/engine/effects/unitModifierEffects.ts
+++ b/packages/core/src/engine/effects/unitModifierEffects.ts
@@ -1,0 +1,187 @@
+/**
+ * Unit Modifier Effect Handlers
+ *
+ * Handles effects that select a unit and apply modifiers to it:
+ * - EFFECT_SELECT_UNIT_FOR_MODIFIER: Entry point, finds eligible units
+ * - EFFECT_RESOLVE_UNIT_MODIFIER_TARGET: Applies modifier to selected unit
+ *
+ * Used by Force of Nature (grant Physical Resistance to a chosen unit).
+ *
+ * @module effects/unitModifierEffects
+ *
+ * @remarks Resolution Flow
+ * ```
+ * EFFECT_SELECT_UNIT_FOR_MODIFIER
+ *   └─► Find eligible units (player's units)
+ *       └─► Generate EFFECT_RESOLVE_UNIT_MODIFIER_TARGET options
+ *           └─► Player selects a unit
+ *               └─► EFFECT_RESOLVE_UNIT_MODIFIER_TARGET
+ *                   └─► Apply modifier with SCOPE_ONE_UNIT
+ * ```
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type {
+  SelectUnitForModifierEffect,
+  ResolveUnitModifierTargetEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { CardId } from "@mage-knight/shared";
+import { UNITS } from "@mage-knight/shared";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { addModifier } from "../modifiers/index.js";
+import {
+  SCOPE_ONE_UNIT,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+import {
+  EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+} from "../../types/effectTypes.js";
+
+// ============================================================================
+// SELECT UNIT FOR MODIFIER (Entry Point)
+// ============================================================================
+
+/**
+ * Handle the EFFECT_SELECT_UNIT_FOR_MODIFIER entry point.
+ * Finds eligible units and generates choice options.
+ */
+function handleSelectUnitForModifier(
+  state: GameState,
+  playerId: string,
+  effect: SelectUnitForModifierEffect
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+
+  // All units are eligible targets (wounded or not, spent or ready)
+  const eligibleUnits = player.units;
+
+  if (eligibleUnits.length === 0) {
+    return {
+      state,
+      description: "No units to target",
+    };
+  }
+
+  // If only one eligible unit, auto-resolve
+  if (eligibleUnits.length === 1) {
+    const targetUnit = eligibleUnits[0];
+    if (!targetUnit) {
+      throw new Error("Expected single eligible unit");
+    }
+    return resolveUnitModifierTarget(state, playerId, {
+      type: EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+      unitInstanceId: targetUnit.instanceId,
+      unitName: UNITS[targetUnit.unitId]?.name ?? targetUnit.unitId,
+      modifier: effect.modifier,
+      duration: effect.duration,
+      description: effect.description,
+    });
+  }
+
+  // Multiple eligible units — generate choice options
+  const choiceOptions: ResolveUnitModifierTargetEffect[] = eligibleUnits.map(
+    (unit) => {
+      const unitDef = UNITS[unit.unitId];
+      return {
+        type: EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+        unitInstanceId: unit.instanceId,
+        unitName: unitDef?.name ?? unit.unitId,
+        modifier: effect.modifier,
+        duration: effect.duration,
+        description: effect.description,
+      };
+    }
+  );
+
+  return {
+    state,
+    description: "Select a unit to target",
+    requiresChoice: true,
+    dynamicChoiceOptions: choiceOptions,
+  };
+}
+
+// ============================================================================
+// RESOLVE UNIT MODIFIER TARGET
+// ============================================================================
+
+/**
+ * Resolve the selected unit target — applies the modifier with SCOPE_ONE_UNIT.
+ */
+function resolveUnitModifierTarget(
+  state: GameState,
+  playerId: string,
+  effect: ResolveUnitModifierTargetEffect,
+  sourceCardId?: string
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+
+  const unitIndex = player.units.findIndex(
+    (u) => u.instanceId === effect.unitInstanceId
+  );
+
+  if (unitIndex === -1) {
+    return {
+      state,
+      description: `Unit not found: ${effect.unitInstanceId}`,
+    };
+  }
+
+  const newState = addModifier(state, {
+    source: {
+      type: SOURCE_CARD,
+      cardId: (sourceCardId ?? "unknown") as CardId,
+      playerId,
+    },
+    duration: effect.duration,
+    scope: { type: SCOPE_ONE_UNIT, unitIndex },
+    effect: effect.modifier,
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  const unitName = effect.unitName;
+  const description =
+    effect.description ?? `Applied modifier to ${unitName}`;
+
+  return {
+    state: newState,
+    description: description.replace("Chosen unit", unitName),
+  };
+}
+
+// ============================================================================
+// EFFECT REGISTRATION
+// ============================================================================
+
+/**
+ * Register unit modifier effect handlers with the effect registry.
+ * Called during effect system initialization.
+ */
+export function registerUnitModifierEffects(): void {
+  registerEffect(
+    EFFECT_SELECT_UNIT_FOR_MODIFIER,
+    (state, playerId, effect) => {
+      return handleSelectUnitForModifier(
+        state,
+        playerId,
+        effect as SelectUnitForModifierEffect
+      );
+    }
+  );
+
+  registerEffect(
+    EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
+    (state, playerId, effect, sourceCardId) => {
+      return resolveUnitModifierTarget(
+        state,
+        playerId,
+        effect as ResolveUnitModifierTargetEffect,
+        sourceCardId
+      );
+    }
+  );
+}

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -158,6 +158,8 @@ import {
   EFFECT_PEACEFUL_MOMENT_CONVERT,
   EFFECT_PEACEFUL_MOMENT_HEAL,
   EFFECT_PEACEFUL_MOMENT_REFRESH,
+  EFFECT_SELECT_UNIT_FOR_MODIFIER,
+  EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -355,6 +357,38 @@ export interface ResolveReadyUnitTargetEffect {
   readonly unitInstanceId: string;
   /** Stored for UI display without needing state lookup */
   readonly unitName: string;
+}
+
+/**
+ * Select a unit to apply modifiers to.
+ * Generates choices from eligible units, then applies modifiers to the selected unit.
+ * Used by Force of Nature (grant Physical Resistance to a chosen unit).
+ */
+export interface SelectUnitForModifierEffect {
+  readonly type: typeof EFFECT_SELECT_UNIT_FOR_MODIFIER;
+  /** Modifier to apply to the selected unit */
+  readonly modifier: import("./modifiers.js").ModifierEffect;
+  /** Duration for the modifier */
+  readonly duration: import("./modifiers.js").ModifierDuration;
+  /** Human-readable description for UI display */
+  readonly description?: string;
+}
+
+/**
+ * Internal effect generated as a choice option after unit selection.
+ * Applies the modifier to the specific unit.
+ */
+export interface ResolveUnitModifierTargetEffect {
+  readonly type: typeof EFFECT_RESOLVE_UNIT_MODIFIER_TARGET;
+  readonly unitInstanceId: string;
+  /** Stored for UI display without needing state lookup */
+  readonly unitName: string;
+  /** Modifier to apply to the selected unit */
+  readonly modifier: import("./modifiers.js").ModifierEffect;
+  /** Duration for the modifier */
+  readonly duration: import("./modifiers.js").ModifierDuration;
+  /** Human-readable description for UI display */
+  readonly description?: string;
 }
 
 /**
@@ -2001,7 +2035,9 @@ export type CardEffect =
   | PeacefulMomentActionEffect
   | PeacefulMomentConvertEffect
   | PeacefulMomentHealEffect
-  | PeacefulMomentRefreshEffect;
+  | PeacefulMomentRefreshEffect
+  | SelectUnitForModifierEffect
+  | ResolveUnitModifierTargetEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -463,6 +463,14 @@ export const EFFECT_PEACEFUL_MOMENT_HEAL = "peaceful_moment_heal" as const;
 // Internal: resolve a unit refresh (deduct influence, ready unit).
 export const EFFECT_PEACEFUL_MOMENT_REFRESH = "peaceful_moment_refresh" as const;
 
+// === Select Unit for Modifier Effect ===
+// Entry point for selecting a unit to apply modifiers to.
+// Generates choices from eligible units, then applies modifiers to the selected unit.
+// Used by Force of Nature (grant Physical Resistance to a chosen unit).
+export const EFFECT_SELECT_UNIT_FOR_MODIFIER = "select_unit_for_modifier" as const;
+// Internal: resolve effect after unit selection for modifier application.
+export const EFFECT_RESOLVE_UNIT_MODIFIER_TARGET = "resolve_unit_modifier_target" as const;
+
 // === Discard for Bonus Effect ===
 // Optionally discard cards from hand to increase a chosen effect.
 // Basic (Stout Resolve): discard 0-1 wound → +bonusPerCard per discard.


### PR DESCRIPTION
## Summary

- Fix Force of Nature basic effect from incorrect `block(2)` to proper unit selection with Physical Resistance grant for combat duration
- Add reusable `SELECT_UNIT_FOR_MODIFIER` / `RESOLVE_UNIT_MODIFIER_TARGET` effect pattern (follows existing ReadyUnit pattern)
- Fix `getEffectiveUnitResistances` to handle `SCOPE_ONE_UNIT` modifiers (previously only handled `SCOPE_ALL_UNITS`)

## Changes

- **Card definition**: Updated `force-of-nature.ts` basic effect to use `EFFECT_SELECT_UNIT_FOR_MODIFIER` with Physical Resistance
- **New effect types**: Added `EFFECT_SELECT_UNIT_FOR_MODIFIER` and `EFFECT_RESOLVE_UNIT_MODIFIER_TARGET` to `effectTypes.ts` and `cards.ts`
- **New resolver**: Created `unitModifierEffects.ts` — selects unit, applies modifier with `SCOPE_ONE_UNIT`
- **Bug fix**: `getEffectiveUnitResistances` now checks both `SCOPE_ALL_UNITS` and `SCOPE_ONE_UNIT` modifiers
- **Supporting**: Added description handlers, resolvability checks, and effect registration

## Test plan

- [x] No-op when player has no units
- [x] Auto-resolve when player has exactly one unit
- [x] Present choices when player has multiple units
- [x] Apply modifier to selected unit only (not other units)
- [x] SCOPE_ONE_UNIT isolation (only targeted unit gets resistance)
- [x] SCOPE_ONE_UNIT combines correctly with SCOPE_ALL_UNITS
- [x] Cross-player isolation (other players' units unaffected)
- [x] Combines with unit base resistances
- [x] Resolvability checks (resolvable with units, not without)

Closes #180