### PR TITLE
feat: implement Mountain Lore terrain-based hand limit and mountain movement

### DIFF
--- a/packages/core/src/data/advancedActions/green/mountain-lore.ts
+++ b/packages/core/src/data/advancedActions/green/mountain-lore.ts
@@ -1,7 +1,18 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_MOVEMENT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
 import { MANA_GREEN, CARD_MOUNTAIN_LORE } from "@mage-knight/shared";
-import { move } from "../helpers.js";
+import { TERRAIN_MOUNTAIN } from "@mage-knight/shared";
+import {
+  EFFECT_APPLY_MODIFIER,
+  EFFECT_COMPOUND,
+  EFFECT_GAIN_MOVE,
+} from "../../../types/effectTypes.js";
+import {
+  DURATION_TURN,
+  EFFECT_MOUNTAIN_LORE_HAND_LIMIT,
+  EFFECT_TERRAIN_COST,
+  EFFECT_TERRAIN_SAFE,
+} from "../../../types/modifierConstants.js";
 
 export const MOUNTAIN_LORE: DeedCard = {
   id: CARD_MOUNTAIN_LORE,
@@ -11,8 +22,58 @@ export const MOUNTAIN_LORE: DeedCard = {
   categories: [CATEGORY_MOVEMENT],
   // Basic: Move 3. If you end your turn in hills, your Hand limit is higher by 1 the next time you draw cards.
   // Powered: Move 5. You can enter mountains at a Move cost of 5 and they are considered a safe space for you at the end of this turn. If you end your turn in mountains/hills, your Hand limit is higher by 2/1 the next time you draw cards.
-  // TODO: Implement terrain-based hand limit modifier
-  basicEffect: move(3),
-  poweredEffect: move(5),
+  basicEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      { type: EFFECT_GAIN_MOVE, amount: 3 },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_MOUNTAIN_LORE_HAND_LIMIT,
+          hillsBonus: 1,
+          mountainBonus: 0,
+        },
+        duration: DURATION_TURN,
+        description: "If ending turn in hills, hand limit +1 on next draw",
+      },
+    ],
+  },
+  poweredEffect: {
+    type: EFFECT_COMPOUND,
+    effects: [
+      { type: EFFECT_GAIN_MOVE, amount: 5 },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_TERRAIN_COST,
+          terrain: TERRAIN_MOUNTAIN,
+          amount: 0,
+          minimum: 0,
+          replaceCost: 5,
+        },
+        duration: DURATION_TURN,
+        description: "Mountains cost 5 this turn",
+      },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_TERRAIN_SAFE,
+          terrain: TERRAIN_MOUNTAIN,
+        },
+        duration: DURATION_TURN,
+        description: "Mountains are safe spaces this turn",
+      },
+      {
+        type: EFFECT_APPLY_MODIFIER,
+        modifier: {
+          type: EFFECT_MOUNTAIN_LORE_HAND_LIMIT,
+          hillsBonus: 1,
+          mountainBonus: 2,
+        },
+        duration: DURATION_TURN,
+        description: "If ending turn in mountains/hills, hand limit +2/+1 on next draw",
+      },
+    ],
+  },
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/mountainLore.test.ts
+++ b/packages/core/src/engine/__tests__/mountainLore.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import type { CardId, Terrain } from "@mage-knight/shared";
+import {
+  CARD_MOUNTAIN_LORE,
+  CARD_MARCH,
+  MANA_GREEN,
+  MANA_SOURCE_CRYSTAL,
+  TERRAIN_HILLS,
+  TERRAIN_MOUNTAIN,
+  TERRAIN_PLAINS,
+  hexKey,
+} from "@mage-knight/shared";
+import { getCard } from "../validActions/cards/index.js";
+import { createPlayCardCommand } from "../commands/playCardCommand.js";
+import { createEndTurnCommand } from "../commands/endTurn/index.js";
+import { createTestGameState, createTestHex, createTestPlayer } from "./testHelpers.js";
+import { getEffectiveTerrainCost, isTerrainSafe } from "../modifiers/terrain.js";
+import { EFFECT_COMPOUND } from "../../types/effectTypes.js";
+
+function createMountainLoreState(terrain: Terrain) {
+  const player = createTestPlayer({
+    hand: [CARD_MOUNTAIN_LORE],
+    deck: Array.from({ length: 10 }, () => CARD_MARCH as CardId),
+    position: { q: 0, r: 0 },
+    crystals: { red: 0, blue: 0, green: 1, white: 0 },
+  });
+
+  const base = createTestGameState({ players: [player] });
+  return {
+    ...base,
+    map: {
+      ...base.map,
+      hexes: {
+        ...base.map.hexes,
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, terrain),
+      },
+    },
+  };
+}
+
+describe("Mountain Lore card definition", () => {
+  it("defines basic and powered effects", () => {
+    const card = getCard(CARD_MOUNTAIN_LORE);
+    expect(card).toBeDefined();
+    expect(card?.name).toBe("Mountain Lore");
+    expect(card?.poweredBy).toEqual([MANA_GREEN]);
+    expect(card?.basicEffect.type).toBe(EFFECT_COMPOUND);
+    expect(card?.poweredEffect.type).toBe(EFFECT_COMPOUND);
+  });
+});
+
+describe("Mountain Lore behavior", () => {
+  it("powered effect makes mountains cost 5 and safe this turn", () => {
+    const state = createMountainLoreState(TERRAIN_PLAINS);
+    const playResult = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MOUNTAIN_LORE,
+      handIndex: 0,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_CRYSTAL, color: MANA_GREEN }],
+      previousPlayedCardFromHand: false,
+    }).execute(state);
+
+    expect(getEffectiveTerrainCost(playResult.state, TERRAIN_MOUNTAIN, "player1")).toBe(5);
+    expect(isTerrainSafe(playResult.state, "player1", TERRAIN_MOUNTAIN)).toBe(true);
+  });
+
+  it("basic effect grants +1 draw-up hand limit when ending turn in hills", () => {
+    const state = createMountainLoreState(TERRAIN_HILLS);
+    const afterPlay = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MOUNTAIN_LORE,
+      handIndex: 0,
+      powered: false,
+      previousPlayedCardFromHand: false,
+    }).execute(state).state;
+
+    const afterEndTurn = createEndTurnCommand({ playerId: "player1" }).execute(afterPlay).state;
+    expect(afterEndTurn.players[0]?.hand.length).toBe(6);
+  });
+
+  it("powered effect grants +2 draw-up hand limit when ending turn in mountains", () => {
+    const state = createMountainLoreState(TERRAIN_MOUNTAIN);
+    const afterPlay = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MOUNTAIN_LORE,
+      handIndex: 0,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_CRYSTAL, color: MANA_GREEN }],
+      previousPlayedCardFromHand: false,
+    }).execute(state).state;
+
+    const afterEndTurn = createEndTurnCommand({ playerId: "player1" }).execute(afterPlay).state;
+    expect(afterEndTurn.players[0]?.hand.length).toBe(7);
+  });
+
+  it("powered effect grants +1 draw-up hand limit when ending turn in hills", () => {
+    const state = createMountainLoreState(TERRAIN_HILLS);
+    const afterPlay = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_MOUNTAIN_LORE,
+      handIndex: 0,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_CRYSTAL, color: MANA_GREEN }],
+      previousPlayedCardFromHand: false,
+    }).execute(state).state;
+
+    const afterEndTurn = createEndTurnCommand({ playerId: "player1" }).execute(afterPlay).state;
+    expect(afterEndTurn.players[0]?.hand.length).toBe(6);
+  });
+});

--- a/packages/core/src/engine/commands/endTurn/mountainLoreBonus.ts
+++ b/packages/core/src/engine/commands/endTurn/mountainLoreBonus.ts
@@ -1,0 +1,79 @@
+import type { GameState } from "../../../state/GameState.js";
+import type { Player } from "../../../types/player.js";
+import type { MountainLoreHandLimitModifier } from "../../../types/modifiers.js";
+import { getModifiersForPlayer } from "../../modifiers/index.js";
+import {
+  EFFECT_MOUNTAIN_LORE_HAND_LIMIT,
+} from "../../../types/modifierConstants.js";
+import {
+  TERRAIN_HILLS,
+  TERRAIN_MOUNTAIN,
+  hexKey,
+} from "@mage-knight/shared";
+
+export interface MountainLoreBonusResult {
+  readonly state: GameState;
+  readonly player: Player;
+  readonly appliedBonus: number;
+}
+
+/**
+ * Apply Mountain Lore end-of-turn hand limit bonus before draw-up.
+ * Reads turn-scoped Mountain Lore modifiers and grants the terrain-appropriate
+ * bonus to meditationHandLimitBonus so existing draw logic can consume it.
+ */
+export function applyMountainLoreEndTurnBonus(
+  state: GameState,
+  player: Player
+): MountainLoreBonusResult {
+  const position = player.position;
+  if (!position) {
+    return { state, player, appliedBonus: 0 };
+  }
+
+  const terrain = state.map.hexes[hexKey(position)]?.terrain;
+  if (!terrain) {
+    return { state, player, appliedBonus: 0 };
+  }
+
+  const loreModifiers = getModifiersForPlayer(state, player.id)
+    .filter((modifier) => modifier.effect.type === EFFECT_MOUNTAIN_LORE_HAND_LIMIT)
+    .map((modifier) => modifier.effect as MountainLoreHandLimitModifier);
+
+  if (loreModifiers.length === 0) {
+    return { state, player, appliedBonus: 0 };
+  }
+
+  const bonus = loreModifiers.reduce((total, modifier) => {
+    if (terrain === TERRAIN_MOUNTAIN) {
+      return total + modifier.mountainBonus;
+    }
+    if (terrain === TERRAIN_HILLS) {
+      return total + modifier.hillsBonus;
+    }
+    return total;
+  }, 0);
+
+  if (bonus <= 0) {
+    return { state, player, appliedBonus: 0 };
+  }
+
+  const playerIndex = state.players.findIndex((p) => p.id === player.id);
+  if (playerIndex === -1) {
+    return { state, player, appliedBonus: 0 };
+  }
+
+  const updatedPlayer: Player = {
+    ...player,
+    meditationHandLimitBonus: player.meditationHandLimitBonus + bonus,
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+
+  return {
+    state: { ...state, players },
+    player: updatedPlayer,
+    appliedBonus: bonus,
+  };
+}

--- a/packages/core/src/types/modifierConstants.ts
+++ b/packages/core/src/types/modifierConstants.ts
@@ -319,6 +319,11 @@ export const RULE_GARRISON_REVEAL_DISTANCE_2 = "garrison_reveal_distance_2" as c
 // Used by Braevalar's Elemental Resistance, Krang's Battle Hardened.
 export const EFFECT_HERO_DAMAGE_REDUCTION = "hero_damage_reduction" as const;
 
+// === Mountain Lore Hand Limit Modifier ===
+// Marks that end-of-turn terrain should grant a next-draw hand limit bonus.
+// Basic: hills +1. Powered: mountains +2, hills +1.
+export const EFFECT_MOUNTAIN_LORE_HAND_LIMIT = "mountain_lore_hand_limit" as const;
+
 // === ExploreCostReductionModifier ===
 // Reduces the move point cost of exploring (revealing a new tile).
 // Base exploration cost is 2; this modifier reduces it by the specified amount.
@@ -419,4 +424,3 @@ export const EFFECT_CONVERT_ATTACK_ELEMENT = "convert_attack_element" as const;
 // Also tracks whether any unit was involved with this enemy (for Fame +1 bonus).
 // Duration: combat. Applied by Dueling skill activation.
 export const EFFECT_DUELING_TARGET = "dueling_target" as const;
-

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -61,6 +61,7 @@ import {
   EFFECT_LEADERSHIP_BONUS,
   EFFECT_POSSESS_ATTACK_RESTRICTION,
   EFFECT_HERO_DAMAGE_REDUCTION,
+  EFFECT_MOUNTAIN_LORE_HAND_LIMIT,
   EFFECT_EXPLORE_COST_REDUCTION,
   EFFECT_GOLDEN_GRAIL_FAME_TRACKING,
   EFFECT_GOLDEN_GRAIL_DRAW_ON_HEAL,
@@ -706,6 +707,16 @@ export interface DuelingTargetModifier {
   readonly unitInvolved: boolean;
 }
 
+// Mountain Lore end-turn hand limit modifier
+// Stores terrain-dependent bonuses to apply at end of turn:
+// - hillsBonus when ending turn in hills
+// - mountainBonus when ending turn in mountains
+export interface MountainLoreHandLimitModifier {
+  readonly type: typeof EFFECT_MOUNTAIN_LORE_HAND_LIMIT;
+  readonly hillsBonus: number;
+  readonly mountainBonus: number;
+}
+
 // Union of all modifier effects
 export type ModifierEffect =
   | TerrainCostModifier
@@ -762,7 +773,8 @@ export type ModifierEffect =
   | RemoveIceResistanceModifier
   | ConvertAttackElementModifier
   | DodgeAndWeaveAttackBonusModifier
-  | DuelingTargetModifier;
+  | DuelingTargetModifier
+  | MountainLoreHandLimitModifier;
 
 // === Active Modifier (live in game state) ===
 


### PR DESCRIPTION
## Summary
- implement full Mountain Lore basic and powered effects
- add powered mountain movement support (mountains cost 5 this turn and are safe spaces)
- add end-turn terrain evaluation for Mountain Lore to grant next-draw hand limit bonuses (+1 hills, +2 mountains powered)
- add integration tests for Mountain Lore card behavior and end-turn draw outcomes

## Validation
- bun run build
- bun run lint
- bun run test

Closes #181