### PR TITLE
Implement end-of-round announce/forfeit flow

### DIFF
--- a/packages/client/src/components/TurnActions/TurnActions.css
+++ b/packages/client/src/components/TurnActions/TurnActions.css
@@ -173,6 +173,16 @@
   transform: translateX(-2px);
 }
 
+.turn-actions__btn--announce {
+  background: linear-gradient(135deg, #8e3b2f, #b04b3b);
+  color: #fff;
+}
+
+.turn-actions__btn--announce:hover {
+  background: linear-gradient(135deg, #b04b3b, #c85a47);
+  transform: translateX(-2px);
+}
+
 .turn-actions__status {
   padding: 0.5rem 1rem;
   border-radius: 8px;

--- a/packages/core/src/engine/__tests__/endTurn.test.ts
+++ b/packages/core/src/engine/__tests__/endTurn.test.ts
@@ -578,8 +578,8 @@ describe("END_TURN with empty deck and hand", () => {
       })
     );
 
-    // State should reflect announcement
-    expect(result.state.endOfRoundAnnouncedBy).toBe("player1");
+    // In solo mode, announcement immediately forfeits and ends the round
+    expect(result.state.endOfRoundAnnouncedBy).toBeNull();
   });
 
   it("should allow normal end turn if end of round already announced", () => {

--- a/packages/core/src/engine/__tests__/mustAnnounceValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/mustAnnounceValidActions.test.ts
@@ -18,6 +18,7 @@ import {
   TERRAIN_PLAINS,
   hexKey,
   UNIT_PEASANTS,
+  CARD_MARCH,
 } from "@mage-knight/shared";
 import { createEnemyTokenId } from "../helpers/enemy/index.js";
 import {
@@ -50,11 +51,17 @@ describe("Must announce end of round", () => {
 
     const afterAnnounceState = {
       ...state,
+      players: state.players.map((p) =>
+        p.id === player.id ? { ...p, hand: [CARD_MARCH] } : p
+      ),
       endOfRoundAnnouncedBy: "player2",
     };
 
-    expect(getValidMoveTargets(afterAnnounceState, player)).toBeDefined();
-    expect(getFullUnitOptions(afterAnnounceState, player)).toBeDefined();
+    const announcedPlayer = afterAnnounceState.players[0];
+    if (!announcedPlayer) throw new Error("Missing player");
+
+    expect(getValidMoveTargets(afterAnnounceState, announcedPlayer)).toBeDefined();
+    expect(getFullUnitOptions(afterAnnounceState, announcedPlayer)).toBeDefined();
   });
 
   it("blocks challenge options until announced", () => {

--- a/packages/core/src/engine/commands/endTurn/index.ts
+++ b/packages/core/src/engine/commands/endTurn/index.ts
@@ -22,9 +22,9 @@ import { expireModifiers } from "../../modifiers/index.js";
 import { EXPIRATION_TURN_END } from "../../../types/modifierConstants.js";
 import { END_TURN_COMMAND } from "../commandTypes.js";
 import { createEndRoundCommand } from "../endRound/index.js";
-import { createAnnounceEndOfRoundCommand } from "../announceEndOfRoundCommand.js";
 import { isDummyPlayer } from "../../../types/dummyPlayer.js";
 import { executeDummyPlayerTurn } from "../dummyTurnCommand.js";
+import { applyRoundAnnouncement } from "../roundAnnouncement.js";
 
 import type { EndTurnCommandParams } from "./types.js";
 import { checkMagicalGladeWound, processMineRewards, checkCrystalJoyReclaim, checkSteadyTempoDeckPlacement, checkBannerProtectionWoundRemoval } from "./siteChecks.js";
@@ -83,11 +83,20 @@ export function createEndTurnCommand(params: EndTurnCommandParams): Command {
 
       // Auto-announce end of round if deck and hand are both empty
       if (
+        !(params.skipAutoAnnounce ?? false) &&
         currentPlayer.deck.length === 0 &&
         currentPlayer.hand.length === 0 &&
         state.endOfRoundAnnouncedBy === null
       ) {
-        return createAnnounceEndOfRoundCommand({ playerId: params.playerId }).execute(state);
+        const announcement = applyRoundAnnouncement(state, params.playerId);
+        const forfeitedTurnResult = createEndTurnCommand({
+          ...params,
+          skipAutoAnnounce: true,
+        }).execute(announcement.state);
+        return {
+          state: forfeitedTurnResult.state,
+          events: [announcement.event, ...forfeitedTurnResult.events],
+        };
       }
 
       // Check for mine crystal rewards

--- a/packages/core/src/engine/commands/endTurn/types.ts
+++ b/packages/core/src/engine/commands/endTurn/types.ts
@@ -25,6 +25,8 @@ export interface EndTurnCommandParams {
   readonly skipSourceOpeningReroll?: boolean;
   /** Die ID to exclude from automatic reroll (Source Opening extra die, already handled) */
   readonly sourceOpeningDieHandled?: string;
+  /** If true, skip automatic deck+hand empty announcement handling */
+  readonly skipAutoAnnounce?: boolean;
 }
 
 /**

--- a/packages/core/src/engine/commands/roundAnnouncement.ts
+++ b/packages/core/src/engine/commands/roundAnnouncement.ts
@@ -1,0 +1,47 @@
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { END_OF_ROUND_ANNOUNCED, type EndOfRoundAnnouncedEvent } from "@mage-knight/shared";
+
+export interface RoundAnnouncementResult {
+  readonly state: GameState;
+  readonly event: EndOfRoundAnnouncedEvent;
+}
+
+/**
+ * Apply round-end announcement state updates.
+ *
+ * - Stores the announcing player
+ * - Grants one final turn to all other players
+ * - Marks announcer as having taken an action this turn
+ */
+export function applyRoundAnnouncement(
+  state: GameState,
+  playerId: string
+): RoundAnnouncementResult {
+  const otherPlayerIds = state.players
+    .filter((p) => p.id !== playerId)
+    .map((p) => p.id);
+
+  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  const updatedPlayers: Player[] = [...state.players];
+  const currentPlayer = updatedPlayers[playerIndex];
+  if (currentPlayer) {
+    updatedPlayers[playerIndex] = {
+      ...currentPlayer,
+      hasTakenActionThisTurn: true,
+    };
+  }
+
+  return {
+    state: {
+      ...state,
+      players: updatedPlayers,
+      endOfRoundAnnouncedBy: playerId,
+      playersWithFinalTurn: otherPlayerIds,
+    },
+    event: {
+      type: END_OF_ROUND_ANNOUNCED,
+      playerId,
+    },
+  };
+}

--- a/packages/core/src/engine/rules/turnStructure.ts
+++ b/packages/core/src/engine/rules/turnStructure.ts
@@ -188,3 +188,36 @@ export function hasMetMinimumTurnRequirement(player: Player): boolean {
   // Player has cards in hand but hasn't played or discarded
   return false;
 }
+
+/**
+ * Check if player must announce end of round.
+ *
+ * Triggered when deck and hand are both empty and round end is not announced.
+ */
+export function mustAnnounceEndOfRoundAtTurnStart(
+  state: GameState,
+  player: Player
+): boolean {
+  return (
+    state.endOfRoundAnnouncedBy === null &&
+    player.deck.length === 0 &&
+    player.hand.length === 0
+  );
+}
+
+/**
+ * Check if player must forfeit turn because round end was announced by another player.
+ *
+ * Triggered when the current player has no cards in deck or hand and cannot take actions.
+ */
+export function mustForfeitTurnAfterRoundAnnouncement(
+  state: GameState,
+  player: Player
+): boolean {
+  return (
+    state.endOfRoundAnnouncedBy !== null &&
+    state.endOfRoundAnnouncedBy !== player.id &&
+    player.deck.length === 0 &&
+    player.hand.length === 0
+  );
+}

--- a/packages/core/src/engine/validActions/helpers.ts
+++ b/packages/core/src/engine/validActions/helpers.ts
@@ -17,6 +17,10 @@ import {
   PLAYER_NOT_FOUND,
 } from "../validators/validationCodes.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
+import {
+  mustAnnounceEndOfRoundAtTurnStart,
+  mustForfeitTurnAfterRoundAnnouncement,
+} from "../rules/turnStructure.js";
 
 /**
  * Check if a player can act in the current game state.
@@ -109,16 +113,18 @@ export function isPlayerTurnsPhase(state: GameState): boolean {
 }
 
 /**
- * Check if the player must announce end of round (deck + hand empty, not announced).
+ * Check if turn-start rules force the player to pass instead of taking normal actions.
+ *
+ * - Must announce when deck+hand are empty and no announcement exists.
+ * - Must forfeit when another player already announced and deck+hand are empty.
  */
 export function mustAnnounceEndOfRound(
   state: GameState,
   player: Player
 ): boolean {
   return (
-    state.endOfRoundAnnouncedBy === null &&
-    player.deck.length === 0 &&
-    player.hand.length === 0
+    mustAnnounceEndOfRoundAtTurnStart(state, player) ||
+    mustForfeitTurnAfterRoundAnnouncement(state, player)
   );
 }
 

--- a/packages/core/src/engine/validators/validationCodes.ts
+++ b/packages/core/src/engine/validators/validationCodes.ts
@@ -200,6 +200,7 @@ export const GOLD_MANA_NOT_ALLOWED = "GOLD_MANA_NOT_ALLOWED" as const;
 export const DECK_NOT_EMPTY = "DECK_NOT_EMPTY" as const;
 export const ALREADY_ANNOUNCED = "ALREADY_ANNOUNCED" as const;
 export const MUST_ANNOUNCE_END_OF_ROUND = "MUST_ANNOUNCE_END_OF_ROUND" as const;
+export const MUST_FORFEIT_TURN = "MUST_FORFEIT_TURN" as const;
 
 // Minimum turn validation codes
 export const MUST_PLAY_OR_DISCARD_CARD = "MUST_PLAY_OR_DISCARD_CARD" as const;
@@ -526,6 +527,7 @@ export type ValidationErrorCode =
   | typeof DECK_NOT_EMPTY
   | typeof ALREADY_ANNOUNCED
   | typeof MUST_ANNOUNCE_END_OF_ROUND
+  | typeof MUST_FORFEIT_TURN
   // Minimum turn validation
   | typeof MUST_PLAY_OR_DISCARD_CARD
   // Rampaging enemy validation


### PR DESCRIPTION
## Summary
- wire `ANNOUNCE_END_OF_ROUND` to immediately forfeit the announcing player's turn
- enforce mandatory forfeit when end-of-round is already announced and the current player has no cards in deck+hand
- add shared round-announcement helper used by explicit announce and auto-announce paths
- surface announce action in turn UI and relabel end-turn seal to `Forfeit` in forced-forfeit state
- update round-cycle and related tests for immediate-forfeit behavior

## Ticket
Closes #44

## Testing
- Could not run full build/test in this worktree due missing local tooling/deps (`bunup` missing and `@mage-knight/shared` unresolved in direct test invocation).
