### PR TITLE
Implement full Power of Crystals card behavior

### DIFF
--- a/packages/core/src/data/advancedActions/green/power-of-crystals.ts
+++ b/packages/core/src/data/advancedActions/green/power-of-crystals.ts
@@ -6,7 +6,10 @@ import {
   DEED_CARD_TYPE_ADVANCED_ACTION,
 } from "../../../types/cards.js";
 import { MANA_GREEN, MANA_BLUE, CARD_POWER_OF_CRYSTALS } from "@mage-knight/shared";
-import { move, heal, choice, gainCrystal } from "../helpers.js";
+import {
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
+} from "../../../types/effectTypes.js";
 
 export const POWER_OF_CRYSTALS: DeedCard = {
   id: CARD_POWER_OF_CRYSTALS,
@@ -16,8 +19,7 @@ export const POWER_OF_CRYSTALS: DeedCard = {
   categories: [CATEGORY_MOVEMENT, CATEGORY_HEALING, CATEGORY_SPECIAL],
   // Basic: Gain a crystal to your Inventory of a basic color you do not already own.
   // Powered: Move 4, or Heal 2, or draw two cards. For each set of four different color crystals in your Inventory: Move 2, or Heal 1, or draw a card.
-  // TODO: Implement crystal-set scaling and card draw
-  basicEffect: gainCrystal(MANA_GREEN),
-  poweredEffect: choice(move(4), heal(2)),
+  basicEffect: { type: EFFECT_POWER_OF_CRYSTALS_BASIC },
+  poweredEffect: { type: EFFECT_POWER_OF_CRYSTALS_POWERED },
   sidewaysValue: 1,
 };

--- a/packages/core/src/data/effectHelpers.ts
+++ b/packages/core/src/data/effectHelpers.ts
@@ -13,6 +13,7 @@ import type {
   GainAttackEffect,
   GainBlockEffect,
   GainHealingEffect,
+  DrawCardsEffect,
   GainFameEffect,
   CompoundEffect,
   ChoiceEffect,
@@ -46,6 +47,7 @@ import {
   EFFECT_GAIN_ATTACK,
   EFFECT_GAIN_BLOCK,
   EFFECT_GAIN_HEALING,
+  EFFECT_DRAW_CARDS,
   EFFECT_GAIN_FAME,
   EFFECT_COMPOUND,
   EFFECT_CHOICE,
@@ -92,6 +94,10 @@ export function block(amount: number): GainBlockEffect {
 
 export function heal(amount: number): GainHealingEffect {
   return { type: EFFECT_GAIN_HEALING, amount };
+}
+
+export function drawCards(amount: number): DrawCardsEffect {
+  return { type: EFFECT_DRAW_CARDS, amount };
 }
 
 export function fame(amount: number): GainFameEffect {
@@ -489,6 +495,32 @@ export function scalingInfluence(
   options?: { minimum?: number; maximum?: number }
 ): ScalingEffect {
   const baseEffect: GainInfluenceEffect = { type: EFFECT_GAIN_INFLUENCE, amount: baseAmount };
+  return scaling(baseEffect, scalingFactor, amountPerUnit, options);
+}
+
+/**
+ * Create a scaling healing effect
+ */
+export function scalingHealing(
+  baseAmount: number,
+  scalingFactor: ScalingFactor,
+  amountPerUnit: number,
+  options?: { minimum?: number; maximum?: number }
+): ScalingEffect {
+  const baseEffect: GainHealingEffect = { type: EFFECT_GAIN_HEALING, amount: baseAmount };
+  return scaling(baseEffect, scalingFactor, amountPerUnit, options);
+}
+
+/**
+ * Create a scaling draw cards effect
+ */
+export function scalingDrawCards(
+  baseAmount: number,
+  scalingFactor: ScalingFactor,
+  amountPerUnit: number,
+  options?: { minimum?: number; maximum?: number }
+): ScalingEffect {
+  const baseEffect: DrawCardsEffect = { type: EFFECT_DRAW_CARDS, amount: baseAmount };
   return scaling(baseEffect, scalingFactor, amountPerUnit, options);
 }
 

--- a/packages/core/src/engine/__tests__/powerOfCrystals.test.ts
+++ b/packages/core/src/engine/__tests__/powerOfCrystals.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  CARD_POWER_OF_CRYSTALS,
+  CARD_RAGE,
+  CARD_SWIFTNESS,
+  CARD_MARCH,
+  CARD_STAMINA,
+  CARD_WOUND,
+  CHOICE_REQUIRED,
+  ENEMIES,
+  ENEMY_FIRE_CATAPULT,
+  MANA_GREEN,
+  MANA_SOURCE_TOKEN,
+} from "@mage-knight/shared";
+import type { CombatState } from "../../types/combat.js";
+import {
+  COMBAT_CONTEXT_STANDARD,
+  COMBAT_PHASE_BLOCK,
+} from "../../types/combat.js";
+import type { GainCrystalEffect, PowerOfCrystalsBasicEffect } from "../../types/cards.js";
+import {
+  EFFECT_DRAW_CARDS,
+  EFFECT_GAIN_HEALING,
+  EFFECT_GAIN_MOVE,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+} from "../../types/effectTypes.js";
+import { resolveEffect, isEffectResolvable } from "../effects/index.js";
+import { handlePowerOfCrystalsBasic } from "../effects/powerOfCrystalsEffects.js";
+import { createPlayCardCommand } from "../commands/playCardCommand.js";
+import { createResolveChoiceCommand } from "../commands/resolveChoiceCommand.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+
+const basicEffect: PowerOfCrystalsBasicEffect = { type: EFFECT_POWER_OF_CRYSTALS_BASIC };
+
+function createCumbersomeCombatState(): CombatState {
+  const def = ENEMIES[ENEMY_FIRE_CATAPULT];
+  return {
+    enemies: [
+      {
+        instanceId: "enemy_1",
+        enemyId: ENEMY_FIRE_CATAPULT,
+        definition: def,
+        isBlocked: false,
+        isDefeated: false,
+        damageAssigned: false,
+        isRequiredForConquest: true,
+      },
+    ],
+    phase: COMBAT_PHASE_BLOCK,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+  };
+}
+
+describe("Power of Crystals basic effect", () => {
+  it("offers only missing crystal colors", () => {
+    const player = createTestPlayer({
+      crystals: { red: 1, blue: 0, green: 0, white: 2 },
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const result = handlePowerOfCrystalsBasic(state, player.id, basicEffect, resolveEffect);
+    expect(result.requiresChoice).toBe(true);
+
+    const options = result.dynamicChoiceOptions as GainCrystalEffect[];
+    expect(options).toHaveLength(2);
+    expect(options.map((o) => o.color)).toEqual(["blue", "green"]);
+  });
+
+  it("auto-resolves when only one crystal color is missing", () => {
+    const player = createTestPlayer({
+      crystals: { red: 1, blue: 1, green: 1, white: 0 },
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const result = handlePowerOfCrystalsBasic(state, player.id, basicEffect, resolveEffect);
+    expect(result.requiresChoice).toBeUndefined();
+    expect(result.state.players[0]?.crystals.white).toBe(1);
+  });
+
+  it("is not resolvable when all basic colors are already owned", () => {
+    const player = createTestPlayer({
+      crystals: { red: 1, blue: 1, green: 1, white: 1 },
+    });
+    const state = createTestGameState({ players: [player] });
+
+    expect(isEffectResolvable(state, player.id, basicEffect)).toBe(false);
+  });
+});
+
+describe("Power of Crystals powered effect", () => {
+  it("offers move/heal/draw with complete crystal set scaling outside combat", () => {
+    const player = createTestPlayer({
+      hand: [CARD_POWER_OF_CRYSTALS, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+      deck: [CARD_RAGE, CARD_SWIFTNESS, CARD_MARCH, CARD_STAMINA],
+      pureMana: [{ color: MANA_GREEN, source: MANA_SOURCE_TOKEN }],
+      crystals: { red: 2, blue: 1, green: 1, white: 1 }, // 1 complete set
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const playCommand = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_POWER_OF_CRYSTALS,
+      handIndex: 0,
+      powered: true,
+      manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      previousPlayedCardFromHand: false,
+    });
+    const playResult = playCommand.execute(state);
+
+    expect(playResult.events.some((e) => e.type === CHOICE_REQUIRED)).toBe(true);
+    const pendingChoice = playResult.state.players[0]?.pendingChoice;
+    expect(pendingChoice?.options).toHaveLength(3);
+
+    const options = pendingChoice?.options ?? [];
+    expect(options[0]).toMatchObject({
+      type: EFFECT_GAIN_MOVE,
+      amount: 6,
+    });
+    expect(options[1]).toMatchObject({
+      type: EFFECT_GAIN_HEALING,
+      amount: 3,
+    });
+    expect(options[2]).toMatchObject({
+      type: EFFECT_DRAW_CARDS,
+      amount: 3,
+    });
+
+    const resolveChoice = createResolveChoiceCommand({
+      playerId: "player1",
+      choiceIndex: 2,
+      previousPendingChoice: pendingChoice!,
+    });
+    const resolveResult = resolveChoice.execute(playResult.state);
+
+    // Draw 2 + 1 per complete set = draw 3 cards
+    expect(resolveResult.state.players[0]?.hand.length).toBe(6);
+  });
+
+  it("becomes move-only in combat and auto-resolves with crystal-set scaling", () => {
+    const player = createTestPlayer({
+      hand: [CARD_POWER_OF_CRYSTALS],
+      pureMana: [{ color: MANA_GREEN, source: MANA_SOURCE_TOKEN }],
+      crystals: { red: 2, blue: 2, green: 2, white: 2 }, // 2 complete sets
+      movePoints: 0,
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createCumbersomeCombatState(),
+    });
+
+    const playCommand = createPlayCardCommand({
+      playerId: "player1",
+      cardId: CARD_POWER_OF_CRYSTALS,
+      handIndex: 0,
+      powered: true,
+      manaSource: { type: MANA_SOURCE_TOKEN, color: MANA_GREEN },
+      previousPlayedCardFromHand: false,
+    });
+    const playResult = playCommand.execute(state);
+
+    expect(playResult.events.some((e) => e.type === CHOICE_REQUIRED)).toBe(false);
+    expect(playResult.state.players[0]?.pendingChoice).toBeNull();
+    expect(playResult.state.players[0]?.movePoints).toBe(8); // 4 + (2 sets * 2)
+  });
+});

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -43,6 +43,8 @@ import {
   EFFECT_TRAINING,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
   EFFECT_APPLY_RECRUIT_DISCOUNT,
   EFFECT_READY_UNITS_FOR_INFLUENCE,
   EFFECT_RESOLVE_READY_UNIT_FOR_INFLUENCE,
@@ -410,6 +412,14 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
 
   [EFFECT_CRYSTAL_MASTERY_POWERED]: () => {
     return "Crystals spent this turn are returned at end of turn";
+  },
+
+  [EFFECT_POWER_OF_CRYSTALS_BASIC]: () => {
+    return "Gain a crystal of a basic color you do not already own";
+  },
+
+  [EFFECT_POWER_OF_CRYSTALS_POWERED]: () => {
+    return "Move/Heal/Draw with bonus per complete crystal set";
   },
 
   [EFFECT_APPLY_RECRUIT_DISCOUNT]: (effect) => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -55,6 +55,7 @@ import { registerHealAllUnitsEffects } from "./healAllUnitsEffects.js";
 import { registerWingsOfNightEffects } from "./wingsOfNightEffects.js";
 import { registerDecomposeEffects } from "./decomposeEffects.js";
 import { registerCrystalMasteryEffects } from "./crystalMasteryEffects.js";
+import { registerPowerOfCrystalsEffects } from "./powerOfCrystalsEffects.js";
 import { registerPossessEffects } from "./possessEffects.js";
 import { registerManaStormEffects } from "./manaStormEffects.js";
 import { registerSourceOpeningEffects } from "./sourceOpeningEffects.js";
@@ -221,6 +222,9 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Crystal Mastery effects (crystal duplication + spent crystal return)
   registerCrystalMasteryEffects();
+
+  // Power of Crystals effects (gain missing-color crystal)
+  registerPowerOfCrystalsEffects(resolver);
 
   // Possess enemy effects (Charm/Possess spell powered effect)
   registerPossessEffects(resolver);

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -330,6 +330,13 @@ export {
   registerCrystalMasteryEffects,
 } from "./crystalMasteryEffects.js";
 
+// Power of Crystals effects
+export {
+  handlePowerOfCrystalsBasic,
+  handlePowerOfCrystalsPowered,
+  registerPowerOfCrystalsEffects,
+} from "./powerOfCrystalsEffects.js";
+
 // Possess enemy effects (Charm/Possess spell powered effect)
 export {
   registerPossessEffects,

--- a/packages/core/src/engine/effects/powerOfCrystalsEffects.ts
+++ b/packages/core/src/engine/effects/powerOfCrystalsEffects.ts
@@ -1,0 +1,130 @@
+import type { BasicManaColor } from "@mage-knight/shared";
+import {
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import type { GameState } from "../../state/GameState.js";
+import type {
+  CardEffect,
+  DrawCardsEffect,
+  GainCrystalEffect,
+  GainHealingEffect,
+  GainMoveEffect,
+  PowerOfCrystalsBasicEffect,
+  PowerOfCrystalsPoweredEffect,
+} from "../../types/cards.js";
+import {
+  EFFECT_DRAW_CARDS,
+  EFFECT_GAIN_CRYSTAL,
+  EFFECT_GAIN_HEALING,
+  EFFECT_GAIN_MOVE,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
+} from "../../types/effectTypes.js";
+import type { EffectResolutionResult } from "./types.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { registerEffect } from "./effectRegistry.js";
+import type { EffectResolver } from "./compound.js";
+
+const BASIC_COLORS: readonly BasicManaColor[] = [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE];
+
+export function handlePowerOfCrystalsBasic(
+  state: GameState,
+  playerId: string,
+  _effect: PowerOfCrystalsBasicEffect,
+  resolveEffect: EffectResolver
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+  const missingColors = BASIC_COLORS.filter((color) => player.crystals[color] === 0);
+
+  if (missingColors.length === 0) {
+    return {
+      state,
+      description: "No missing crystal color available",
+    };
+  }
+
+  if (missingColors.length === 1) {
+    const color = missingColors[0]!;
+    const gainEffect: GainCrystalEffect = {
+      type: EFFECT_GAIN_CRYSTAL,
+      color,
+    };
+    return resolveEffect(state, playerId, gainEffect);
+  }
+
+  const options: GainCrystalEffect[] = missingColors.map((color) => ({
+    type: EFFECT_GAIN_CRYSTAL,
+    color,
+  }));
+
+  return {
+    state,
+    description: "Choose a crystal color you do not already own",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+export function registerPowerOfCrystalsEffects(resolver: EffectResolver): void {
+  registerEffect(EFFECT_POWER_OF_CRYSTALS_BASIC, (state, playerId, effect) => {
+    return handlePowerOfCrystalsBasic(
+      state,
+      playerId,
+      effect as PowerOfCrystalsBasicEffect,
+      resolver
+    );
+  });
+
+  registerEffect(EFFECT_POWER_OF_CRYSTALS_POWERED, (state, playerId, effect) => {
+    return handlePowerOfCrystalsPowered(
+      state,
+      playerId,
+      effect as PowerOfCrystalsPoweredEffect,
+      resolver
+    );
+  });
+}
+
+export function handlePowerOfCrystalsPowered(
+  state: GameState,
+  playerId: string,
+  _effect: PowerOfCrystalsPoweredEffect,
+  resolveEffect: EffectResolver
+): EffectResolutionResult {
+  const { player } = getPlayerContext(state, playerId);
+  const completeCrystalSets = Math.min(
+    player.crystals.red,
+    player.crystals.blue,
+    player.crystals.green,
+    player.crystals.white
+  );
+
+  const moveEffect: GainMoveEffect = {
+    type: EFFECT_GAIN_MOVE,
+    amount: 4 + completeCrystalSets * 2,
+  };
+
+  if (state.combat) {
+    return resolveEffect(state, playerId, moveEffect);
+  }
+
+  const healEffect: GainHealingEffect = {
+    type: EFFECT_GAIN_HEALING,
+    amount: 2 + completeCrystalSets,
+  };
+  const drawEffect: DrawCardsEffect = {
+    type: EFFECT_DRAW_CARDS,
+    amount: 2 + completeCrystalSets,
+  };
+  const options: CardEffect[] = [moveEffect, healEffect, drawEffect];
+
+  return {
+    state,
+    description: "Choose one: Move, Heal, or Draw",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}

--- a/packages/core/src/engine/effects/resolvability.ts
+++ b/packages/core/src/engine/effects/resolvability.ts
@@ -111,6 +111,8 @@ import {
   EFFECT_TRAINING,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
   EFFECT_POSSESS_ENEMY,
   EFFECT_RESOLVE_POSSESS_ENEMY,
   EFFECT_MAGIC_TALENT_BASIC,
@@ -610,6 +612,25 @@ const resolvabilityHandlers: Partial<Record<EffectType, ResolvabilityHandler>> =
 
   // Crystal Mastery powered is always resolvable (sets a flag)
   [EFFECT_CRYSTAL_MASTERY_POWERED]: () => true,
+
+  // Power of Crystals basic is resolvable when player is missing at least one crystal color
+  [EFFECT_POWER_OF_CRYSTALS_BASIC]: (_state, player) => {
+    const { red, blue, green, white } = player.crystals;
+    return red === 0 || blue === 0 || green === 0 || white === 0;
+  },
+
+  // Power of Crystals powered:
+  // - In combat: move-only, so resolvable only when move would matter
+  // - Out of combat: move option always available
+  [EFFECT_POWER_OF_CRYSTALS_POWERED]: (state, player) => {
+    if (state.combat) {
+      return isEffectResolvable(state, player.id, {
+        type: EFFECT_GAIN_MOVE,
+        amount: 4,
+      });
+    }
+    return true;
+  },
 
   // Possess is resolvable if in combat with at least one non-defeated, non-Arcane-Immune enemy
   [EFFECT_POSSESS_ENEMY]: (state) => {

--- a/packages/core/src/engine/effects/reverse.ts
+++ b/packages/core/src/engine/effects/reverse.ts
@@ -68,6 +68,8 @@ import {
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
   COMBAT_TYPE_RANGED,
   COMBAT_TYPE_SIEGE,
   EFFECT_GAIN_ATTACK_BOW_RESOLVED,
@@ -408,6 +410,13 @@ const reverseHandlers: Partial<Record<EffectType, ReverseHandler>> = {
   // Crystal Mastery basic presents choices — no direct player state change.
   // Actual state change is via GainCrystal (already handled above).
   [EFFECT_CRYSTAL_MASTERY_BASIC]: (player) => player,
+
+  // Power of Crystals basic presents choices — no direct player state change.
+  // Actual state change is via GainCrystal (already handled above).
+  [EFFECT_POWER_OF_CRYSTALS_BASIC]: (player) => player,
+
+  // Power of Crystals powered presents dynamic choices or auto-resolves to base effects.
+  [EFFECT_POWER_OF_CRYSTALS_POWERED]: (player) => player,
 
   // Crystal Mastery powered sets a flag — reverse by clearing it.
   [EFFECT_CRYSTAL_MASTERY_POWERED]: (player) => ({

--- a/packages/core/src/engine/effects/scalingEvaluator.ts
+++ b/packages/core/src/engine/effects/scalingEvaluator.ts
@@ -10,6 +10,7 @@ import {
   SCALING_PER_WOUND_THIS_COMBAT,
   SCALING_PER_UNIT,
   SCALING_PER_CRYSTAL_COLOR,
+  SCALING_PER_COMPLETE_CRYSTAL_SET,
   SCALING_PER_EMPTY_COMMAND_TOKEN,
   SCALING_PER_WOUND_TOTAL,
   SCALING_PER_ENEMY_BLOCKED,
@@ -71,6 +72,16 @@ export function evaluateScalingFactor(
       if (player.crystals.green > 0) count++;
       if (player.crystals.white > 0) count++;
       return count;
+    }
+
+    case SCALING_PER_COMPLETE_CRYSTAL_SET: {
+      // Count complete red/blue/green/white crystal sets
+      return Math.min(
+        player.crystals.red,
+        player.crystals.blue,
+        player.crystals.green,
+        player.crystals.white
+      );
     }
 
     case SCALING_PER_EMPTY_COMMAND_TOKEN: {

--- a/packages/core/src/engine/rules/effectDetection/movementEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/movementEffects.ts
@@ -15,6 +15,7 @@ import {
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
   EFFECT_PURE_MAGIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
 } from "../../../types/effectTypes.js";
 
 /**
@@ -24,6 +25,7 @@ export function effectHasMove(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_MOVE:
     case EFFECT_PURE_MAGIC: // Pure Magic can provide Move (via green mana)
+    case EFFECT_POWER_OF_CRYSTALS_POWERED:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/engine/rules/effectDetection/specialEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/specialEffects.ts
@@ -10,6 +10,7 @@ import {
   EFFECT_MANA_DRAW_POWERED,
   EFFECT_GAIN_CRYSTAL,
   EFFECT_CONVERT_MANA_TO_CRYSTAL,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
   EFFECT_CARD_BOOST,
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_WINGS_OF_NIGHT,
@@ -60,6 +61,7 @@ export function effectHasCrystal(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_CRYSTAL:
     case EFFECT_CONVERT_MANA_TO_CRYSTAL:
+    case EFFECT_POWER_OF_CRYSTALS_BASIC:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/engine/validActions/cards/effectDetection/movementEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/movementEffects.ts
@@ -13,6 +13,7 @@ import {
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
 } from "../../../../types/effectTypes.js";
 
 /**
@@ -21,6 +22,7 @@ import {
 export function effectHasMove(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_MOVE:
+    case EFFECT_POWER_OF_CRYSTALS_POWERED:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/engine/validActions/cards/effectDetection/specialEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/specialEffects.ts
@@ -10,6 +10,7 @@ import {
   EFFECT_MANA_DRAW_POWERED,
   EFFECT_GAIN_CRYSTAL,
   EFFECT_CONVERT_MANA_TO_CRYSTAL,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
   EFFECT_CARD_BOOST,
   EFFECT_SELECT_COMBAT_ENEMY,
   EFFECT_CHOICE,
@@ -59,6 +60,7 @@ export function effectHasCrystal(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_CRYSTAL:
     case EFFECT_CONVERT_MANA_TO_CRYSTAL:
+    case EFFECT_POWER_OF_CRYSTALS_BASIC:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -123,6 +123,8 @@ import {
   EFFECT_RESOLVE_WINGS_OF_NIGHT_TARGET,
   EFFECT_CRYSTAL_MASTERY_BASIC,
   EFFECT_CRYSTAL_MASTERY_POWERED,
+  EFFECT_POWER_OF_CRYSTALS_BASIC,
+  EFFECT_POWER_OF_CRYSTALS_POWERED,
   EFFECT_POSSESS_ENEMY,
   EFFECT_RESOLVE_POSSESS_ENEMY,
   EFFECT_ROLL_DIE_FOR_WOUND,
@@ -481,7 +483,9 @@ export type ScalableBaseEffect =
   | GainAttackEffect
   | GainBlockEffect
   | GainMoveEffect
-  | GainInfluenceEffect;
+  | GainInfluenceEffect
+  | GainHealingEffect
+  | DrawCardsEffect;
 
 export interface ScalingEffect {
   readonly type: typeof EFFECT_SCALING;
@@ -1427,6 +1431,22 @@ export interface CrystalMasteryPoweredEffect {
 }
 
 /**
+ * Power of Crystals basic effect.
+ * Gain a crystal of a basic color you do not currently own.
+ */
+export interface PowerOfCrystalsBasicEffect {
+  readonly type: typeof EFFECT_POWER_OF_CRYSTALS_BASIC;
+}
+
+/**
+ * Power of Crystals powered effect.
+ * Move/Heal/Draw with bonus per complete crystal set.
+ */
+export interface PowerOfCrystalsPoweredEffect {
+  readonly type: typeof EFFECT_POWER_OF_CRYSTALS_POWERED;
+}
+
+/**
  * Wings of Night multi-target skip-attack effect entry point.
  * First enemy targeted for free. Additional enemies cost 1, 2, 3... move points.
  * All targeted enemies get SKIP_ATTACK modifier. Arcane Immune enemies excluded.
@@ -1996,6 +2016,8 @@ export type CardEffect =
   | ResolveWingsOfNightTargetEffect
   | CrystalMasteryBasicEffect
   | CrystalMasteryPoweredEffect
+  | PowerOfCrystalsBasicEffect
+  | PowerOfCrystalsPoweredEffect
   | ManaStormBasicEffect
   | ManaStormSelectDieEffect
   | ManaStormPoweredEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -309,6 +309,12 @@ export const EFFECT_CRYSTAL_MASTERY_BASIC = "crystal_mastery_basic" as const;
 // Powered: At end of turn, spent crystals this turn are returned to inventory.
 export const EFFECT_CRYSTAL_MASTERY_POWERED = "crystal_mastery_powered" as const;
 
+// === Power of Crystals Effects ===
+// Basic: Gain a crystal of a basic color you do not currently own.
+export const EFFECT_POWER_OF_CRYSTALS_BASIC = "power_of_crystals_basic" as const;
+// Powered: Move/Heal/Draw with scaling based on complete crystal sets.
+export const EFFECT_POWER_OF_CRYSTALS_POWERED = "power_of_crystals_powered" as const;
+
 // === Heal All Units Effect ===
 // Heal all units completely (remove wounds from all wounded units).
 // Used by Banner of Fortitude powered effect.

--- a/packages/core/src/types/scaling.ts
+++ b/packages/core/src/types/scaling.ts
@@ -10,6 +10,7 @@ export const SCALING_PER_WOUND_IN_HAND = "per_wound_in_hand" as const;
 export const SCALING_PER_WOUND_THIS_COMBAT = "per_wound_this_combat" as const;
 export const SCALING_PER_UNIT = "per_unit" as const;
 export const SCALING_PER_CRYSTAL_COLOR = "per_crystal_color" as const;
+export const SCALING_PER_COMPLETE_CRYSTAL_SET = "per_complete_crystal_set" as const;
 export const SCALING_PER_EMPTY_COMMAND_TOKEN = "per_empty_command_token" as const;
 export const SCALING_PER_WOUND_TOTAL = "per_wound_total" as const;
 export const SCALING_PER_ENEMY_BLOCKED = "per_enemy_blocked" as const;
@@ -43,6 +44,15 @@ export interface ScalingPerUnitFactor {
  */
 export interface ScalingPerCrystalColorFactor {
   readonly type: typeof SCALING_PER_CRYSTAL_COLOR;
+}
+
+/**
+ * Scales by number of complete crystal sets in inventory.
+ * A complete set is one red + one blue + one green + one white crystal.
+ * Count is min(red, blue, green, white).
+ */
+export interface ScalingPerCompleteCrystalSetFactor {
+  readonly type: typeof SCALING_PER_COMPLETE_CRYSTAL_SET;
 }
 
 /**
@@ -90,6 +100,7 @@ export type ScalingFactor =
   | ScalingPerWoundThisCombatFactor
   | ScalingPerUnitFactor
   | ScalingPerCrystalColorFactor
+  | ScalingPerCompleteCrystalSetFactor
   | ScalingPerEmptyCommandTokenFactor
   | ScalingPerWoundTotalFactor
   | ScalingPerEnemyBlockedFactor;


### PR DESCRIPTION
## Summary\n- implement missing basic behavior: gain a crystal of a basic color the player does not currently own\n- implement powered behavior with complete crystal-set scaling for Move/Heal/Draw and combat move-only handling\n- register new Power of Crystals effect handlers and wire effect detection/resolvability/description/reverse support\n- add focused engine tests for missing-color basic choices and powered scaling/combat behavior\n\n## Testing\n- bun run build\n- bun run lint\n- bun run test\n\nCloses #182