### PR TITLE
feat: implement Wolf's Howl skill for Wolfhawk

### DIFF
--- a/packages/core/src/engine/__tests__/skillWolfsHowl.test.ts
+++ b/packages/core/src/engine/__tests__/skillWolfsHowl.test.ts
@@ -1,0 +1,695 @@
+/**
+ * Tests for Wolf's Howl skill (Wolfhawk)
+ *
+ * Part 1 — Sideways Bonus (owner activation):
+ * Once per round, except during interaction/combat: One sideways card gives +4
+ * instead of +1. For each command token without assigned unit, gives another +1.
+ * Place skill token in center.
+ *
+ * Part 2 — Return Mechanic (interactive):
+ * First player who encounters combat returns the skill face-down to Wolfhawk and:
+ * Step 1: Reduce armor of chosen enemy by 1 (min 1) — excludes Arcane Immune (S5)
+ * Step 2: Reduce attack of same or another enemy by 1 — NO Arcane Immune exclusion (S5)
+ * Can split between summoner and summoned monster (S2).
+ *
+ * Key rules:
+ * - Part of sideways bonus exclusion group (S2)
+ * - No competitive penalty while in center (unlike Nature's Vengeance)
+ * - Arcane Immune: cannot reduce armor (S5), CAN reduce attack (S5)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import type { GameState } from "../../state/GameState.js";
+import type { CombatEnemy, CombatState } from "../../types/combat.js";
+import {
+  USE_SKILL_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  ENTER_COMBAT_ACTION,
+  RETURN_INTERACTIVE_SKILL_ACTION,
+  INVALID_ACTION,
+  ENEMY_DIGGERS,
+  ENEMY_SORCERERS,
+  ENEMIES,
+} from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import {
+  SKILL_WOLFHAWK_WOLFS_HOWL,
+  SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
+} from "../../data/skills/index.js";
+import { getEffectiveEnemyAttack, getEffectiveEnemyArmor } from "../modifiers/combat.js";
+import { getEffectiveSidewaysValue } from "../modifiers/index.js";
+import {
+  SOURCE_SKILL,
+  EFFECT_SIDEWAYS_VALUE,
+  EFFECT_TERRAIN_COST,
+} from "../../types/modifierConstants.js";
+import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
+import { getValidActions } from "../validActions/index.js";
+
+const defaultCooldowns = {
+  usedThisRound: [] as string[],
+  usedThisTurn: [] as string[],
+  usedThisCombat: [] as string[],
+  activeUntilNextTurn: [] as string[],
+};
+
+/**
+ * Create a CombatEnemy from a known enemy definition.
+ */
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string,
+  overrides: Partial<CombatEnemy> = {}
+): CombatEnemy {
+  const definition = ENEMIES[enemyId as keyof typeof ENEMIES];
+  if (!definition) {
+    throw new Error(`Unknown enemy: ${enemyId}`);
+  }
+  return {
+    instanceId,
+    enemyId: enemyId as CombatEnemy["enemyId"],
+    definition,
+    isBlocked: false,
+    isDefeated: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a combat state with specific enemies.
+ */
+function createCombatWithEnemies(enemies: CombatEnemy[]): CombatState {
+  return {
+    enemies,
+    phase: COMBAT_PHASE_BLOCK,
+    woundsThisCombat: 0,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+  };
+}
+
+describe("Wolf's Howl skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ============================================================================
+  // PART 1: SIDEWAYS BONUS (OWNER ACTIVATION)
+  // ============================================================================
+
+  describe("sideways bonus (Part 1)", () => {
+    it("should create sideways value modifier with +4 base + empty command tokens", () => {
+      // Default player has commandTokens: 1, units: [] → 1 empty → +5
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const sidewaysModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_SIDEWAYS_VALUE
+      );
+      expect(sidewaysModifier).toBeDefined();
+      if (sidewaysModifier && sidewaysModifier.effect.type === EFFECT_SIDEWAYS_VALUE) {
+        expect(sidewaysModifier.effect.newValue).toBe(5);
+      }
+    });
+
+    it("should give +4 with no empty command tokens", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+        commandTokens: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const sidewaysModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_SIDEWAYS_VALUE
+      );
+      expect(sidewaysModifier).toBeDefined();
+      if (sidewaysModifier && sidewaysModifier.effect.type === EFFECT_SIDEWAYS_VALUE) {
+        expect(sidewaysModifier.effect.newValue).toBe(4);
+      }
+    });
+
+    it("should scale with multiple empty command tokens", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+        commandTokens: 3,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const sidewaysModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_SIDEWAYS_VALUE
+      );
+      expect(sidewaysModifier).toBeDefined();
+      if (sidewaysModifier && sidewaysModifier.effect.type === EFFECT_SIDEWAYS_VALUE) {
+        expect(sidewaysModifier.effect.newValue).toBe(7); // 4 + 3
+      }
+    });
+
+    it("should place skill token in center after activation", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const centerModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_TERRAIN_COST
+      );
+      expect(centerModifier).toBeDefined();
+    });
+
+    it("should be usable once per round", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: {
+          ...defaultCooldowns,
+          usedThisRound: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        },
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not be usable during combat", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_DIGGERS],
+      }).state;
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should not be usable when conflicting sideways skill is active", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL, SKILL_TOVAK_I_DONT_GIVE_A_DAMN],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      let state = createTestGameState({ players: [player] });
+
+      // Activate I Don't Give a Damn first
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
+      }).state;
+
+      // Wolf's Howl should not appear in valid actions
+      const validActions = getValidActions(state, "player1");
+      if (validActions.mode === "normal_turn" && validActions.skills) {
+        const wolfsHowl = validActions.skills.activatable.find(
+          (s) => s.skillId === SKILL_WOLFHAWK_WOLFS_HOWL
+        );
+        expect(wolfsHowl).toBeUndefined();
+      }
+    });
+
+    it("should affect effective sideways value", () => {
+      const player = createTestPlayer({
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+        commandTokens: 0,
+      });
+      let state = createTestGameState({ players: [player] });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const value = getEffectiveSidewaysValue(state, "player1", false, false);
+      expect(value).toBe(4);
+    });
+  });
+
+  // ============================================================================
+  // PART 2: RETURN MECHANIC
+  // ============================================================================
+
+  describe("return mechanic", () => {
+    function createMultiplayerState(): GameState {
+      const owner = createTestPlayer({
+        id: "player1",
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      const otherPlayer = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+
+      return createTestGameState({
+        players: [owner, otherPlayer],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 0,
+      });
+    }
+
+    function activateAndSwitchToPlayer2(state: GameState, combat: CombatState): GameState {
+      // Owner activates Wolf's Howl
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Switch to player2's turn in combat
+      return {
+        ...state,
+        currentPlayerIndex: 1,
+        combat,
+      };
+    }
+
+    it("should show returnable skill for non-owner player", () => {
+      let state = createMultiplayerState();
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const player2State: GameState = {
+        ...state,
+        currentPlayerIndex: 1,
+        combat: undefined,
+      };
+
+      const validActions = getValidActions(player2State, "player2");
+      if (validActions.mode === "normal_turn") {
+        expect(validActions.returnableSkills).toBeDefined();
+        expect(validActions.returnableSkills?.returnable).toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+          })
+        );
+      }
+    });
+
+    it("should flip owner's skill face-down when returned", () => {
+      let state = createMultiplayerState();
+      const combat = createUnitCombatState(COMBAT_PHASE_BLOCK);
+      state = activateAndSwitchToPlayer2(state, combat);
+
+      // Player2 returns the skill
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Resolve all pending choices
+      while (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      expect(
+        state.players[0]?.skillFlipState.flippedSkills
+      ).toContain(SKILL_WOLFHAWK_WOLFS_HOWL);
+    });
+
+    it("should remove center modifier when returned", () => {
+      let state = createMultiplayerState();
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Verify center modifier exists
+      let centerModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_TERRAIN_COST
+      );
+      expect(centerModifier).toBeDefined();
+
+      const combat = createUnitCombatState(COMBAT_PHASE_BLOCK);
+      state = {
+        ...state,
+        currentPlayerIndex: 1,
+        combat,
+      };
+
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      while (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      centerModifier = state.activeModifiers.find(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.effect.type === EFFECT_TERRAIN_COST
+      );
+      expect(centerModifier).toBeUndefined();
+    });
+
+    it("return benefit should reduce enemy armor by 1 and attack by 1 (single enemy)", () => {
+      let state = createMultiplayerState();
+      const combat = createUnitCombatState(COMBAT_PHASE_BLOCK);
+      state = activateAndSwitchToPlayer2(state, combat);
+
+      const enemyInstanceId = state.combat!.enemies[0]!.instanceId;
+      const baseArmor = state.combat!.enemies[0]!.definition.armor; // 3
+      const baseAttack = state.combat!.enemies[0]!.definition.attack; // 3
+
+      // Player2 returns the skill — single enemy auto-resolves both steps
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      while (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Armor reduced by 1 (3 → 2)
+      expect(getEffectiveEnemyArmor(state, enemyInstanceId, baseArmor, 0, "player2")).toBe(2);
+
+      // Attack reduced by 1 (3 → 2)
+      expect(getEffectiveEnemyAttack(state, enemyInstanceId, baseAttack)).toBe(2);
+    });
+
+    it("should present enemy choices with two enemies", () => {
+      let state = createMultiplayerState();
+      const combat = createCombatWithEnemies([
+        createCombatEnemy("enemy_1", ENEMY_DIGGERS),
+        createCombatEnemy("enemy_2", ENEMY_DIGGERS),
+      ]);
+      state = activateAndSwitchToPlayer2(state, combat);
+
+      // Player2 returns the skill
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Should have pending choice for armor target (2 enemies)
+      const pendingChoice = state.players[1]?.pendingChoice;
+      expect(pendingChoice).not.toBeNull();
+      expect(pendingChoice?.options).toHaveLength(2);
+    });
+
+    it("should allow splitting armor and attack reductions between different enemies (S2)", () => {
+      let state = createMultiplayerState();
+      const combat = createCombatWithEnemies([
+        createCombatEnemy("enemy_1", ENEMY_DIGGERS),
+        createCombatEnemy("enemy_2", ENEMY_DIGGERS),
+      ]);
+      state = activateAndSwitchToPlayer2(state, combat);
+
+      const baseArmor = 3;
+      const baseAttack = 3;
+
+      // Player2 returns the skill
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Step 1: Choose enemy_1 for armor reduction
+      expect(state.players[1]?.pendingChoice).not.toBeNull();
+      state = engine.processAction(state, "player2", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // Step 2: Choose enemy_2 for attack reduction
+      if (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 1, // Second enemy
+        }).state;
+      }
+
+      // Enemy 1: armor reduced, attack unchanged
+      expect(getEffectiveEnemyArmor(state, "enemy_1", baseArmor, 0, "player2")).toBe(2);
+      expect(getEffectiveEnemyAttack(state, "enemy_1", baseAttack)).toBe(3);
+
+      // Enemy 2: armor unchanged, attack reduced
+      expect(getEffectiveEnemyArmor(state, "enemy_2", baseArmor, 0, "player2")).toBe(3);
+      expect(getEffectiveEnemyAttack(state, "enemy_2", baseAttack)).toBe(2);
+    });
+  });
+
+  // ============================================================================
+  // ARCANE IMMUNITY (S5)
+  // ============================================================================
+
+  describe("Arcane Immunity interaction (S5)", () => {
+    function createMultiplayerState(): GameState {
+      const owner = createTestPlayer({
+        id: "player1",
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      const otherPlayer = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+
+      return createTestGameState({
+        players: [owner, otherPlayer],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 0,
+      });
+    }
+
+    it("should exclude Arcane Immune enemies from armor selection", () => {
+      let state = createMultiplayerState();
+
+      // Owner activates Wolf's Howl
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Combat with Sorcerers (Arcane Immune) + Diggers
+      const combat = createCombatWithEnemies([
+        createCombatEnemy("enemy_sorcerers", ENEMY_SORCERERS),
+        createCombatEnemy("enemy_diggers", ENEMY_DIGGERS),
+      ]);
+      state = {
+        ...state,
+        currentPlayerIndex: 1,
+        combat,
+      };
+
+      // Player2 returns the skill
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // The first pending choice is for armor selection.
+      // Only Diggers should be eligible (Sorcerers are Arcane Immune → excluded).
+      const armorChoice = state.players[1]?.pendingChoice;
+      expect(armorChoice).not.toBeNull();
+      expect(armorChoice?.options).toHaveLength(1); // Only Diggers
+
+      // Resolve armor selection (Diggers)
+      state = engine.processAction(state, "player2", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+
+      // After armor, the attack step should present BOTH enemies
+      // (Arcane Immune NOT excluded from attack reduction)
+      const attackChoice = state.players[1]?.pendingChoice;
+      if (attackChoice) {
+        expect(attackChoice.options).toHaveLength(2);
+      }
+
+      // Resolve any remaining choices
+      while (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Verify Diggers got armor reduced
+      expect(getEffectiveEnemyArmor(state, "enemy_diggers", 3, 0, "player2")).toBe(2);
+    });
+
+    it("should allow attack reduction on Arcane Immune enemies", () => {
+      let state = createMultiplayerState();
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Combat with only Sorcerers (Arcane Immune)
+      const combat = createCombatWithEnemies([
+        createCombatEnemy("enemy_sorcerers", ENEMY_SORCERERS),
+      ]);
+      state = {
+        ...state,
+        currentPlayerIndex: 1,
+        combat,
+      };
+
+      const baseAttack = 6; // Sorcerers attack
+
+      // Player2 returns the skill
+      state = engine.processAction(state, "player2", {
+        type: RETURN_INTERACTIVE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      // Resolve remaining choices
+      while (state.players[1]?.pendingChoice) {
+        state = engine.processAction(state, "player2", {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: 0,
+        }).state;
+      }
+
+      // Armor should NOT be reduced (no valid targets — Arcane Immune excluded)
+      // Sorcerers armor stays at 6
+      expect(getEffectiveEnemyArmor(state, "enemy_sorcerers", 6, 0, "player2")).toBe(6);
+
+      // Attack SHOULD be reduced by 1 (Arcane Immunity does NOT block attack reduction)
+      expect(getEffectiveEnemyAttack(state, "enemy_sorcerers", baseAttack)).toBe(5);
+    });
+  });
+
+  // ============================================================================
+  // NO COMPETITIVE PENALTY
+  // ============================================================================
+
+  describe("no competitive penalty", () => {
+    it("should not have attack bonus modifier for other players while in center", () => {
+      const owner = createTestPlayer({
+        id: "player1",
+        hero: Hero.Wolfhawk,
+        skills: [SKILL_WOLFHAWK_WOLFS_HOWL],
+        skillCooldowns: { ...defaultCooldowns },
+      });
+      const otherPlayer = createTestPlayer({
+        id: "player2",
+        hero: Hero.Arythea,
+        position: { q: 1, r: 0 },
+      });
+      let state = createTestGameState({
+        players: [owner, otherPlayer],
+        turnOrder: ["player1", "player2"],
+        currentPlayerIndex: 0,
+      });
+
+      state = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      }).state;
+
+      const wolfsHowlModifiers = state.activeModifiers.filter(
+        (m) =>
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL
+      );
+
+      // Should have sideways value modifier and center marker only (no attack bonus penalty)
+      const effectTypes = wolfsHowlModifiers.map((m) => m.effect.type);
+      expect(effectTypes).toContain(EFFECT_SIDEWAYS_VALUE);
+      expect(effectTypes).toContain(EFFECT_TERRAIN_COST);
+      expect(effectTypes.length).toBe(2);
+    });
+  });
+});

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -85,3 +85,9 @@ export {
   applyDuelingEffect,
   removeDuelingEffect,
 } from "./duelingEffect.js";
+
+export {
+  applyWolfsHowlEffect,
+  removeWolfsHowlEffect,
+  canActivateWolfsHowl,
+} from "./wolfsHowlEffect.js";

--- a/packages/core/src/engine/commands/skills/universalPowerEffect.ts
+++ b/packages/core/src/engine/commands/skills/universalPowerEffect.ts
@@ -23,6 +23,7 @@ import {
   SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
   SKILL_TOVAK_WHO_NEEDS_MAGIC,
   SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 } from "../../../data/skills/index.js";
 import {
   DURATION_TURN,
@@ -150,7 +151,7 @@ const CONFLICTING_SKILLS = [
   SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
   SKILL_TOVAK_WHO_NEEDS_MAGIC,
   SKILL_ARYTHEA_POWER_OF_PAIN,
-  // Wolf's Howl would be added here when implemented
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 ];
 
 /**

--- a/packages/core/src/engine/commands/skills/wolfsHowlEffect.ts
+++ b/packages/core/src/engine/commands/skills/wolfsHowlEffect.ts
@@ -1,0 +1,143 @@
+/**
+ * Wolf's Howl skill effect handler
+ *
+ * Wolfhawk's interactive skill (once per round, except during interaction):
+ * - One sideways card gives +4 instead of +1
+ * - For each command token without assigned unit, gives another +1
+ * - Place skill token in center
+ *
+ * The sideways bonus is implemented as a base +4, plus a scaling bonus
+ * based on empty command tokens. The empty command token bonus is calculated
+ * at activation time and baked into the modifier's newValue.
+ *
+ * Part of the sideways bonus exclusion group: cannot stack with
+ * Universal Power, I Don't Give a Damn, Who Needs Magic, or Power of Pain.
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { Player } from "../../../types/player.js";
+import { addModifier, getModifiersForPlayer } from "../../modifiers/index.js";
+import { SKILL_WOLFHAWK_WOLFS_HOWL } from "../../../data/skills/wolfhawk/wolfsHowl.js";
+import {
+  SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
+  SKILL_TOVAK_WHO_NEEDS_MAGIC,
+  SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_GOLDYX_UNIVERSAL_POWER,
+} from "../../../data/skills/index.js";
+import {
+  DURATION_TURN,
+  EFFECT_SIDEWAYS_VALUE,
+  SCOPE_SELF,
+  SOURCE_SKILL,
+} from "../../../types/modifierConstants.js";
+import { EFFECT_PLACE_SKILL_IN_CENTER } from "../../../types/effectTypes.js";
+import { handlePlaceSkillInCenter } from "../../effects/ritualOfPainEffects.js";
+
+/**
+ * Conflicting sideways-boosting skills that cannot be active simultaneously.
+ * Wolf's Howl cannot stack with these skills (S2 ruling on Universal Power).
+ */
+const CONFLICTING_SKILLS = [
+  SKILL_TOVAK_I_DONT_GIVE_A_DAMN,
+  SKILL_TOVAK_WHO_NEEDS_MAGIC,
+  SKILL_ARYTHEA_POWER_OF_PAIN,
+  SKILL_GOLDYX_UNIVERSAL_POWER,
+];
+
+/**
+ * Check if Wolf's Howl can be activated.
+ * Requires:
+ * 1. Not during interaction (handled by validator — same as "not in combat" since
+ *    interaction blocks skill activation)
+ * 2. No conflicting sideways-boosting skills are active
+ */
+export function canActivateWolfsHowl(
+  state: GameState,
+  player: Player
+): boolean {
+  // Cannot use during combat
+  if (state.combat !== null) {
+    return false;
+  }
+
+  // Check for conflicting active modifiers from other sideways skills
+  const activeModifiers = getModifiersForPlayer(state, player.id);
+  const hasConflict = activeModifiers.some(
+    (m) =>
+      m.source.type === SOURCE_SKILL &&
+      CONFLICTING_SKILLS.includes(m.source.skillId)
+  );
+  return !hasConflict;
+}
+
+/**
+ * Apply the Wolf's Howl skill effect.
+ *
+ * 1. Calculate sideways bonus: +4 base + 1 per empty command token
+ * 2. Create SidewaysValueModifier with the calculated value
+ * 3. Place skill token in center for other players
+ */
+export function applyWolfsHowlEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = state.players.findIndex((p) => p.id === playerId);
+  if (playerIndex === -1) {
+    throw new Error(`Player not found: ${playerId}`);
+  }
+
+  const player = state.players[playerIndex]!;
+
+  // Calculate bonus from empty command tokens
+  const emptyCommandTokens = Math.max(0, player.commandTokens - player.units.length);
+  const sidewaysValue = 4 + emptyCommandTokens;
+
+  // Place skill token in center first (this clears existing modifiers for the skill)
+  const centerResult = handlePlaceSkillInCenter(state, playerId, {
+    type: EFFECT_PLACE_SKILL_IN_CENTER,
+    skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+  });
+  state = centerResult.state;
+
+  // Add sideways value modifier AFTER center placement, since handlePlaceSkillInCenter
+  // removes all existing modifiers for the skill before adding center markers
+  state = addModifier(state, {
+    source: {
+      type: SOURCE_SKILL,
+      skillId: SKILL_WOLFHAWK_WOLFS_HOWL,
+      playerId,
+    },
+    duration: DURATION_TURN,
+    scope: { type: SCOPE_SELF },
+    effect: {
+      type: EFFECT_SIDEWAYS_VALUE,
+      newValue: sidewaysValue,
+      forWounds: false,
+    },
+    createdAtRound: state.round,
+    createdByPlayerId: playerId,
+  });
+
+  return state;
+}
+
+/**
+ * Remove all modifiers created by Wolf's Howl skill for a player.
+ * Used for undo functionality.
+ */
+export function removeWolfsHowlEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  return {
+    ...state,
+    activeModifiers: state.activeModifiers.filter(
+      (m) =>
+        !(
+          m.source.type === SOURCE_SKILL &&
+          m.source.skillId === SKILL_WOLFHAWK_WOLFS_HOWL &&
+          m.source.playerId === playerId
+        )
+    ),
+  };
+}

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -40,6 +40,7 @@ import {
   SKILL_WOLFHAWK_DEADLY_AIM,
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_DUELING,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 } from "../../data/skills/index.js";
 import {
   applyWhoNeedsMagicEffect,
@@ -72,6 +73,8 @@ import {
   removeKnowYourPreyEffect,
   applyDuelingEffect,
   removeDuelingEffect,
+  applyWolfsHowlEffect,
+  removeWolfsHowlEffect,
 } from "./skills/index.js";
 import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
 import { restoreMana } from "./helpers/manaConsumptionHelpers.js";
@@ -97,7 +100,7 @@ import { isMotivationSkill, ALL_MOTIVATION_SKILLS } from "../rules/motivation.js
 
 import { SKILL_GOLDYX_SOURCE_OPENING } from "../../data/skills/index.js";
 
-const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING]);
+const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_WOLFHAWK_WOLFS_HOWL]);
 
 /**
  * Check if an effect (or any sub-effect in a compound) contains non-reversible
@@ -182,6 +185,9 @@ function applyCustomSkillEffect(
     case SKILL_WOLFHAWK_DUELING:
       return applyDuelingEffect(state, playerId);
 
+    case SKILL_WOLFHAWK_WOLFS_HOWL:
+      return applyWolfsHowlEffect(state, playerId);
+
     default:
       // Skill has no custom handler - will use generic effect resolution
       return state;
@@ -245,6 +251,9 @@ function removeCustomSkillEffect(
     case SKILL_WOLFHAWK_DUELING:
       return removeDuelingEffect(state, playerId);
 
+    case SKILL_WOLFHAWK_WOLFS_HOWL:
+      return removeWolfsHowlEffect(state, playerId);
+
     default:
       return state;
   }
@@ -270,6 +279,7 @@ function hasCustomHandler(skillId: SkillId): boolean {
     SKILL_WOLFHAWK_DEADLY_AIM,
     SKILL_WOLFHAWK_KNOW_YOUR_PREY,
     SKILL_WOLFHAWK_DUELING,
+    SKILL_WOLFHAWK_WOLFS_HOWL,
   ].includes(skillId);
 }
 

--- a/packages/core/src/engine/effects/ritualOfPainEffects.ts
+++ b/packages/core/src/engine/effects/ritualOfPainEffects.ts
@@ -36,6 +36,7 @@ import {
 import { SKILL_NOROWAS_PRAYER_OF_WEATHER } from "../../data/skills/norowas/prayerOfWeather.js";
 import { SKILL_GOLDYX_SOURCE_OPENING } from "../../data/skills/goldyx/sourceFreeze.js";
 import { SKILL_BRAEVALAR_NATURES_VENGEANCE } from "../../data/skills/braevalar/naturesVengeance.js";
+import { SKILL_WOLFHAWK_WOLFS_HOWL } from "../../data/skills/wolfhawk/wolfsHowl.js";
 
 // ============================================================================
 // DISCARD WOUNDS EFFECT
@@ -170,6 +171,18 @@ export function handlePlaceSkillInCenter(
         usedDieCountAtReturn: 0,
       },
     };
+  } else if (skillId === SKILL_WOLFHAWK_WOLFS_HOWL) {
+    // Wolf's Howl: add marker modifier so the system knows the skill is in center.
+    // First player entering combat can return it to reduce enemy armor -1 and attack -1.
+    // No competitive penalty (unlike Nature's Vengeance).
+    updatedState = addModifier(updatedState, {
+      source: { type: SOURCE_SKILL, skillId, playerId },
+      duration: DURATION_ROUND,
+      scope: { type: SCOPE_OTHER_PLAYERS },
+      effect: { type: EFFECT_TERRAIN_COST, terrain: TERRAIN_ALL, amount: 0, minimum: 0 },
+      createdAtRound: state.round,
+      createdByPlayerId: playerId,
+    });
   } else {
     // Ritual of Pain: other players can return it to play a Wound sideways for +3
     updatedState = addModifier(updatedState, {

--- a/packages/core/src/engine/validActions/returnableSkills.ts
+++ b/packages/core/src/engine/validActions/returnableSkills.ts
@@ -9,7 +9,7 @@ import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
 import type { ReturnableSkillOptions } from "@mage-knight/shared";
 import { SOURCE_SKILL } from "../../types/modifierConstants.js";
-import { SKILLS, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_BRAEVALAR_NATURES_VENGEANCE } from "../../data/skills/index.js";
+import { SKILLS, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_BRAEVALAR_NATURES_VENGEANCE, SKILL_WOLFHAWK_WOLFS_HOWL } from "../../data/skills/index.js";
 import type { SkillId } from "@mage-knight/shared";
 
 /** Skills that support the return mechanic */
@@ -17,6 +17,7 @@ const RETURNABLE_SKILL_IDS = new Set<SkillId>([
   SKILL_NOROWAS_PRAYER_OF_WEATHER,
   SKILL_GOLDYX_SOURCE_OPENING,
   SKILL_BRAEVALAR_NATURES_VENGEANCE,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 ]);
 
 /** Return benefit descriptions by skill */
@@ -24,6 +25,7 @@ const RETURN_BENEFITS: Record<string, string> = {
   [SKILL_NOROWAS_PRAYER_OF_WEATHER]: "All terrain costs -1 this turn (min 1)",
   [SKILL_GOLDYX_SOURCE_OPENING]: "Use an extra basic-color die from Source, give Goldyx a crystal",
   [SKILL_BRAEVALAR_NATURES_VENGEANCE]: "Reduce one enemy's attack by 1, gains Cumbersome",
+  [SKILL_WOLFHAWK_WOLFS_HOWL]: "Reduce one enemy's armor by 1 (min 1), and one enemy's attack by 1",
 };
 
 /**

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -74,6 +74,7 @@ import {
   SKILL_KRANG_SPIRIT_GUIDES,
   SKILL_KRANG_BATTLE_HARDENED,
   SKILL_KRANG_BATTLE_FRENZY,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT, CATEGORY_MOVEMENT } from "../../types/cards.js";
 import {
@@ -92,6 +93,7 @@ import { canUseMeleeAttackSkill, isMeleeAttackSkill, isSkillFaceUp } from "../ru
 import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { hexKey } from "@mage-knight/shared";
 import { canActivateUniversalPower } from "../commands/skills/universalPowerEffect.js";
+import { canActivateWolfsHowl } from "../commands/skills/wolfsHowlEffect.js";
 import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
 /**
@@ -155,9 +157,10 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_KRANG_SPIRIT_GUIDES,
   SKILL_KRANG_BATTLE_HARDENED,
   SKILL_KRANG_BATTLE_FRENZY,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 ]);
 
-const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING]);
+const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_WOLFHAWK_WOLFS_HOWL]);
 
 /**
  * Check skill-specific requirements beyond cooldowns.
@@ -208,6 +211,9 @@ function canActivateSkill(
 
     case SKILL_GOLDYX_UNIVERSAL_POWER:
       return canActivateUniversalPower(state, player);
+
+    case SKILL_WOLFHAWK_WOLFS_HOWL:
+      return canActivateWolfsHowl(state, player);
 
     case SKILL_BRAEVALAR_SHAPESHIFT:
       // Must have at least one Basic Action card with a shapeshiftable effect in hand

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -55,6 +55,7 @@ import {
   SKILL_WOLFHAWK_DUELING,
   SKILL_BRAEVALAR_REGENERATE,
   SKILL_BRAEVALAR_NATURES_VENGEANCE,
+  SKILL_WOLFHAWK_WOLFS_HOWL,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT, CATEGORY_MOVEMENT } from "../../types/cards.js";
 import {
@@ -71,7 +72,7 @@ import { canActivateKnowYourPrey } from "../commands/skills/knowYourPreyEffect.j
 import { canActivateDueling } from "../commands/skills/duelingEffect.js";
 import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
-const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_BRAEVALAR_NATURES_VENGEANCE]);
+const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_BRAEVALAR_NATURES_VENGEANCE, SKILL_WOLFHAWK_WOLFS_HOWL]);
 
 /**
  * Validates the turn requirement for skill usage.
@@ -382,6 +383,15 @@ export const validateSkillRequirements: Validator = (
       return invalid(
         SKILL_REQUIRES_NOT_IN_COMBAT,
         "Refreshing Breeze cannot be used during combat"
+      );
+    }
+  }
+
+  if (useSkillAction.skillId === SKILL_WOLFHAWK_WOLFS_HOWL) {
+    if (state.combat !== null) {
+      return invalid(
+        SKILL_REQUIRES_NOT_IN_COMBAT,
+        "Wolf's Howl cannot be used during combat"
       );
     }
   }


### PR DESCRIPTION
## Summary
- Implement Wolf's Howl (Howl of the Pack) interactive skill for Wolfhawk (#359)
- **Owner activation**: Once per round (not during interaction/combat), one sideways card gives +4 instead of +1, plus +1 per empty command token. Skill placed in center.
- **Return mechanic**: Two-step enemy selection — armor -1 (min 1, excludes Arcane Immune per S5), then attack -1 (includes Arcane Immune per S5). Can split between enemies.
- Part of sideways bonus exclusion group (cannot stack with Universal Power, I Don't Give a Damn, Who Needs Magic, Power of Pain)

## Test plan
- [x] 17 tests covering sideways bonus values, center placement, cooldowns, combat restriction, conflicting skills, return mechanic (flip, center removal, armor/attack reduction, enemy choices, splitting between enemies), Arcane Immunity exclusion, no competitive penalty
- [x] Full test suite passes (5060+ tests)
- [x] Build and lint clean

Closes #359