### PR TITLE
feat: implement Explosive Bolt missing wound cost, dual crystal gain, and armor reduction

### DIFF
--- a/packages/core/src/data/advancedActions/helpers.ts
+++ b/packages/core/src/data/advancedActions/helpers.ts
@@ -323,5 +323,32 @@ export function attackWithDefeatBonus(
   };
 }
 
+/**
+ * Creates a ranged attack effect with per-defeat armor reduction.
+ * Used by Explosive Bolt.
+ *
+ * For each enemy defeated by this attack, another surviving enemy
+ * gets Armor reduced by the specified amount (minimum 1).
+ * Fire Resistant enemies are immune to the armor reduction.
+ * Armor reduction lasts the entire combat.
+ *
+ * @param amount - The ranged attack value
+ * @param armorReduction - Armor reduction per enemy defeated (typically 1)
+ * @returns An AttackWithDefeatBonusEffect with ranged combat type and armor reduction
+ */
+export function rangedAttackWithArmorReduction(
+  amount: number,
+  armorReduction: number
+): CardEffect {
+  return {
+    type: EFFECT_ATTACK_WITH_DEFEAT_BONUS,
+    amount,
+    combatType: COMBAT_TYPE_RANGED,
+    reputationPerDefeat: 0,
+    famePerDefeat: 0,
+    armorReductionPerDefeat: armorReduction,
+  };
+}
+
 // Re-export element constants for convenience
 export { ELEMENT_FIRE, ELEMENT_ICE, ELEMENT_COLD_FIRE } from "../../types/modifierConstants.js";

--- a/packages/core/src/data/advancedActions/red/explosive-bolt.ts
+++ b/packages/core/src/data/advancedActions/red/explosive-bolt.ts
@@ -5,7 +5,12 @@ import {
   DEED_CARD_TYPE_ADVANCED_ACTION,
 } from "../../../types/cards.js";
 import { MANA_RED, MANA_WHITE, CARD_EXPLOSIVE_BOLT } from "@mage-knight/shared";
-import { gainCrystal, rangedAttack } from "../helpers.js";
+import {
+  compound,
+  takeWound,
+  gainCrystal,
+  rangedAttackWithArmorReduction,
+} from "../helpers.js";
 
 export const EXPLOSIVE_BOLT: DeedCard = {
   id: CARD_EXPLOSIVE_BOLT,
@@ -14,9 +19,12 @@ export const EXPLOSIVE_BOLT: DeedCard = {
   poweredBy: [MANA_RED, MANA_WHITE], // Dual-color: can be powered by red OR white
   categories: [CATEGORY_SPECIAL, CATEGORY_COMBAT],
   // Basic: Take a Wound. Gain a white and a red crystal to your Inventory.
-  // Powered: Ranged Attack 3. For each enemy defeated by this attack, another enemy gets Armor -1 (to a minimum of 1).
-  // TODO: Implement wound-taking, dual crystal gain, and armor reduction on defeat
-  basicEffect: gainCrystal(MANA_RED),
-  poweredEffect: rangedAttack(3),
+  basicEffect: compound(
+    takeWound(1),
+    gainCrystal(MANA_WHITE),
+    gainCrystal(MANA_RED),
+  ),
+  // Powered: Ranged Attack 3. For each enemy defeated by this attack, another enemy gets Armor -1 (min 1).
+  poweredEffect: rangedAttackWithArmorReduction(3, 1),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/explosiveBolt.test.ts
+++ b/packages/core/src/engine/__tests__/explosiveBolt.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Explosive Bolt card tests
+ *
+ * Tests for the Explosive Bolt advanced action card:
+ * - Basic: Take a Wound. Gain a white and a red crystal.
+ * - Powered: Ranged Attack 3. For each enemy defeated, another enemy gets Armor -1 (min 1).
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState } from "./testHelpers.js";
+import { resolveEffect } from "../effects/index.js";
+import { reverseEffect } from "../effects/reverse.js";
+import { describeEffect } from "../effects/describeEffect.js";
+import { EXPLOSIVE_BOLT } from "../../data/advancedActions/red/explosive-bolt.js";
+import type { AttackWithDefeatBonusEffect, CompoundEffect } from "../../types/cards.js";
+import {
+  EFFECT_ATTACK_WITH_DEFEAT_BONUS,
+  EFFECT_COMPOUND,
+  COMBAT_TYPE_RANGED,
+} from "../../types/effectTypes.js";
+import {
+  ENTER_COMBAT_ACTION,
+  ASSIGN_ATTACK_ACTION,
+  END_COMBAT_PHASE_ACTION,
+  ATTACK_TYPE_RANGED,
+  ATTACK_ELEMENT_PHYSICAL,
+  ENEMY_PROWLERS,
+  ENEMY_FIRE_MAGES,
+  getEnemy,
+  CARD_WOUND,
+  MANA_RED,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import { getEffectiveEnemyArmor } from "../modifiers/combat.js";
+
+describe("Explosive Bolt", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ==========================================================================
+  // BASIC EFFECT TESTS
+  // ==========================================================================
+
+  describe("basic effect", () => {
+    it("is a compound effect with wound, white crystal, and red crystal", () => {
+      const effect = EXPLOSIVE_BOLT.basicEffect;
+      expect(effect.type).toBe(EFFECT_COMPOUND);
+      const compound = effect as CompoundEffect;
+      expect(compound.effects).toHaveLength(3);
+      expect(compound.effects[0]).toEqual({ type: "take_wound", amount: 1 });
+      expect(compound.effects[1]).toEqual({ type: "gain_crystal", color: MANA_WHITE });
+      expect(compound.effects[2]).toEqual({ type: "gain_crystal", color: MANA_RED });
+    });
+
+    it("takes a wound and gains white + red crystals", () => {
+      let state = createTestGameState();
+      const player = state.players.find((p) => p.id === "player1")!;
+      const initialWounds = player.hand.filter((c) => c === CARD_WOUND).length;
+      const initialWhiteCrystals = player.crystals.white;
+      const initialRedCrystals = player.crystals.red;
+
+      const result = resolveEffect(state, "player1", EXPLOSIVE_BOLT.basicEffect, EXPLOSIVE_BOLT.id);
+      state = result.state;
+
+      const updatedPlayer = state.players.find((p) => p.id === "player1")!;
+      // Should have gained a wound in hand
+      const newWounds = updatedPlayer.hand.filter((c) => c === CARD_WOUND).length;
+      expect(newWounds).toBe(initialWounds + 1);
+      // Should have gained white and red crystals
+      expect(updatedPlayer.crystals.white).toBe(initialWhiteCrystals + 1);
+      expect(updatedPlayer.crystals.red).toBe(initialRedCrystals + 1);
+    });
+
+    it("can be played outside combat (categories include SPECIAL)", () => {
+      expect(EXPLOSIVE_BOLT.categories).toContain("special");
+    });
+  });
+
+  // ==========================================================================
+  // POWERED EFFECT TESTS
+  // ==========================================================================
+
+  describe("powered effect", () => {
+    it("is an AttackWithDefeatBonus with ranged combat type and armor reduction", () => {
+      const effect = EXPLOSIVE_BOLT.poweredEffect;
+      expect(effect.type).toBe(EFFECT_ATTACK_WITH_DEFEAT_BONUS);
+      const typed = effect as AttackWithDefeatBonusEffect;
+      expect(typed.amount).toBe(3);
+      expect(typed.combatType).toBe(COMBAT_TYPE_RANGED);
+      expect(typed.armorReductionPerDefeat).toBe(1);
+      expect(typed.reputationPerDefeat).toBe(0);
+      expect(typed.famePerDefeat).toBe(0);
+    });
+
+    it("grants Ranged Attack 3 and registers defeat tracker", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve the powered effect
+      const result = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = result.state;
+
+      const player = state.players.find((p) => p.id === "player1")!;
+      // Should have 3 ranged attack
+      expect(player.combatAccumulator.attack.ranged).toBe(3);
+      // Should have a defeat tracker registered
+      expect(player.pendingAttackDefeatFame).toHaveLength(1);
+      const tracker = player.pendingAttackDefeatFame[0]!;
+      expect(tracker.attackType).toBe(ATTACK_TYPE_RANGED);
+      expect(tracker.armorReductionPerDefeat).toBe(1);
+    });
+
+    it("reduces armor on surviving enemy when defeating one enemy in ranged phase", () => {
+      let state = createTestGameState();
+
+      // Two prowlers: armor 3, attack 4
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve powered effect: Ranged Attack 3
+      const effectResult = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult.state;
+
+      // Assign all 3 ranged attack to first enemy (prowlers have armor 3)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // End ranged/siege phase → damage resolves, first prowler defeated
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // Second prowler should have armor reduced by 1 (from 3 to 2)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        "enemy_1",
+        prowlerDef.armor,
+        prowlerDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(prowlerDef.armor - 1);
+    });
+
+    it("applies armor reduction per defeated enemy (multiple defeats)", () => {
+      let state = createTestGameState();
+
+      // Three prowlers: armor 3 each. Need to defeat 2, check armor on 3rd.
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_PROWLERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve powered effect TWICE to get 6 tracked ranged attack (2 trackers × 3 each).
+      // Each tracker independently tracks which enemies its attack contributed to defeating.
+      const effectResult1 = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult1.state;
+      const effectResult2 = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult2.state;
+
+      // Assign 3 to first enemy (tracker 1 tracks this)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // Assign 3 to second enemy (tracker 2 tracks this)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_1",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // End ranged/siege phase → 2 enemies defeated → 2 armor reductions on third
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // Third prowler should have armor reduced by 2 (from 3 to 1)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        "enemy_2",
+        prowlerDef.armor,
+        prowlerDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(Math.max(1, prowlerDef.armor - 2));
+    });
+
+    it("does not reduce armor below minimum of 1", () => {
+      let state = createTestGameState();
+
+      // 4 prowlers (armor 3). Defeat 3, check that 4th has armor clamped to 1.
+      // 3 defeats × armorReductionPerDefeat 1 = 3 reductions on prowler (armor 3).
+      // 3 - 3 = 0, but minimum armor is 1.
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_PROWLERS, ENEMY_PROWLERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve powered effect THREE times to get 9 tracked ranged attack (3 trackers × 3 each)
+      const effectResult1 = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult1.state;
+      const effectResult2 = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult2.state;
+      const effectResult3 = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult3.state;
+
+      // Defeat first prowler (tracker 1 tracks this)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // Defeat second prowler (tracker 2 tracks this)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_1",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // Defeat third prowler (tracker 3 tracks this)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_2",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // End ranged/siege phase → 3 enemies defeated → 3 reductions on 4th prowler
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // 4th prowler: armor 3 - 3 reductions = 0, clamped to min 1
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        "enemy_3",
+        prowlerDef.armor,
+        prowlerDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(1);
+    });
+
+    it("does not apply armor reduction to Fire Resistant enemies", () => {
+      let state = createTestGameState();
+
+      // Prowlers (not fire resistant) and Fire Mages (fire resistant)
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+      const fireMageDef = getEnemy(ENEMY_FIRE_MAGES);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_FIRE_MAGES],
+      }).state;
+
+      // Resolve powered effect: Ranged Attack 3
+      const effectResult = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult.state;
+
+      // Defeat the prowler (armor 3)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // End ranged/siege phase → prowler defeated
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // Fire Mages should NOT have armor reduced (Fire Resistant)
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        "enemy_1",
+        fireMageDef.armor,
+        fireMageDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(fireMageDef.armor);
+    });
+
+    it("does not apply armor reduction when no enemy is defeated", () => {
+      let state = createTestGameState();
+
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve powered effect: Ranged Attack 3
+      const effectResult = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult.state;
+
+      // Assign only 2 to first enemy (not enough to defeat armor 3)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: 2,
+      }).state;
+
+      // End ranged/siege phase → no enemy defeated
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // Neither enemy should have armor changed
+      const armor0 = getEffectiveEnemyArmor(
+        state,
+        "enemy_0",
+        prowlerDef.armor,
+        prowlerDef.resistances.length,
+        "player1"
+      );
+      const armor1 = getEffectiveEnemyArmor(
+        state,
+        "enemy_1",
+        prowlerDef.armor,
+        prowlerDef.resistances.length,
+        "player1"
+      );
+      expect(armor0).toBe(prowlerDef.armor);
+      expect(armor1).toBe(prowlerDef.armor);
+    });
+
+    it("no armor reduction when only Fire Resistant enemies survive", () => {
+      let state = createTestGameState();
+
+      const prowlerDef = getEnemy(ENEMY_PROWLERS);
+      const fireMageDef = getEnemy(ENEMY_FIRE_MAGES);
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS, ENEMY_FIRE_MAGES],
+      }).state;
+
+      // Resolve powered effect: Ranged Attack 3
+      const effectResult = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult.state;
+
+      // Defeat the prowler (armor 3)
+      state = engine.processAction(state, "player1", {
+        type: ASSIGN_ATTACK_ACTION,
+        enemyInstanceId: "enemy_0",
+        attackType: ATTACK_TYPE_RANGED,
+        element: ATTACK_ELEMENT_PHYSICAL,
+        amount: prowlerDef.armor,
+      }).state;
+
+      // End phase → prowler defeated, only fire mage survives (immune to reduction)
+      const result = engine.processAction(state, "player1", {
+        type: END_COMBAT_PHASE_ACTION,
+      });
+      state = result.state;
+
+      // Fire Mages armor should remain unchanged
+      const effectiveArmor = getEffectiveEnemyArmor(
+        state,
+        "enemy_1",
+        fireMageDef.armor,
+        fireMageDef.resistances.length,
+        "player1"
+      );
+      expect(effectiveArmor).toBe(fireMageDef.armor);
+    });
+  });
+
+  // ==========================================================================
+  // CARD METADATA TESTS
+  // ==========================================================================
+
+  describe("card metadata", () => {
+    it("can be powered by red or white mana", () => {
+      expect(EXPLOSIVE_BOLT.poweredBy).toContain(MANA_RED);
+      expect(EXPLOSIVE_BOLT.poweredBy).toContain(MANA_WHITE);
+    });
+
+    it("has sideways value of 1", () => {
+      expect(EXPLOSIVE_BOLT.sidewaysValue).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // DESCRIBE EFFECT TESTS
+  // ==========================================================================
+
+  describe("describeEffect", () => {
+    it("describes powered effect with armor reduction", () => {
+      const desc = describeEffect(EXPLOSIVE_BOLT.poweredEffect);
+      expect(desc).toContain("Attack 3");
+      expect(desc).toContain("Armor -1");
+    });
+  });
+
+  // ==========================================================================
+  // REVERSE EFFECT TESTS
+  // ==========================================================================
+
+  describe("reverseEffect", () => {
+    it("reverses ranged attack and removes tracker", () => {
+      let state = createTestGameState();
+
+      state = engine.processAction(state, "player1", {
+        type: ENTER_COMBAT_ACTION,
+        enemyIds: [ENEMY_PROWLERS],
+      }).state;
+
+      // Resolve the effect
+      const effectResult = resolveEffect(state, "player1", EXPLOSIVE_BOLT.poweredEffect, EXPLOSIVE_BOLT.id);
+      state = effectResult.state;
+
+      const player = state.players.find((p) => p.id === "player1")!;
+      expect(player.combatAccumulator.attack.ranged).toBe(3);
+      expect(player.pendingAttackDefeatFame).toHaveLength(1);
+
+      // Reverse it
+      const reversed = reverseEffect(player, EXPLOSIVE_BOLT.poweredEffect);
+      expect(reversed.combatAccumulator.attack.ranged).toBe(0);
+      expect(reversed.pendingAttackDefeatFame).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/engine/combat/__tests__/armorReductionHelpers.test.ts
+++ b/packages/core/src/engine/combat/__tests__/armorReductionHelpers.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Armor reduction helper unit tests
+ *
+ * Tests for the applyArmorReductions function used by Explosive Bolt.
+ */
+
+import { describe, it, expect } from "vitest";
+import { applyArmorReductions } from "../armorReductionHelpers.js";
+import {
+  createTestGameState,
+  createTestPlayer,
+} from "../../__tests__/testHelpers.js";
+import type { GameState } from "../../../state/GameState.js";
+import type { CombatEnemy, CombatState } from "../../../types/combat.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_CONTEXT_STANDARD,
+} from "../../../types/combat.js";
+import {
+  ENEMY_PROWLERS,
+  ENEMY_FIRE_MAGES,
+  ENEMY_DIGGERS,
+  ENEMIES,
+} from "@mage-knight/shared";
+import type { EnemyId } from "@mage-knight/shared";
+import { getEffectiveEnemyArmor } from "../../modifiers/combat.js";
+
+// ============================================================================
+// TEST HELPERS
+// ============================================================================
+
+function createCombatEnemy(
+  instanceId: string,
+  enemyId: string,
+  overrides: Partial<CombatEnemy> = {}
+): CombatEnemy {
+  const definition = ENEMIES[enemyId as keyof typeof ENEMIES];
+  if (!definition) {
+    throw new Error(`Unknown enemy: ${enemyId}`);
+  }
+  return {
+    instanceId,
+    enemyId: enemyId as EnemyId,
+    definition,
+    isBlocked: false,
+    isDefeated: false,
+    damageAssigned: false,
+    isRequiredForConquest: true,
+    ...overrides,
+  };
+}
+
+function createCombatStateWithEnemies(enemies: CombatEnemy[]): CombatState {
+  return {
+    enemies,
+    phase: COMBAT_PHASE_RANGED_SIEGE,
+    woundsThisCombat: 0,
+    woundsAddedToHandThisCombat: false,
+    attacksThisPhase: 0,
+    fameGained: 0,
+    isAtFortifiedSite: false,
+    unitsAllowed: true,
+    nightManaRules: false,
+    assaultOrigin: null,
+    combatHexCoord: null,
+    allDamageBlockedThisPhase: false,
+    discardEnemiesOnFailure: false,
+    pendingDamage: {},
+    pendingBlock: {},
+    pendingSwiftBlock: {},
+    combatContext: COMBAT_CONTEXT_STANDARD,
+    cumbersomeReductions: {},
+    usedDefend: {},
+    defendBonuses: {},
+    paidHeroesAssaultInfluence: false,
+    vampiricArmorBonus: {},
+    paidThugsDamageInfluence: {},
+    damageRedirects: {},
+  };
+}
+
+function createCombatGameState(enemies: CombatEnemy[]): GameState {
+  const player = createTestPlayer({ id: "player1" });
+  return createTestGameState({
+    players: [player],
+    combat: createCombatStateWithEnemies(enemies),
+  });
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe("applyArmorReductions", () => {
+  it("applies -1 armor to a surviving enemy", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_1", ENEMY_PROWLERS),
+    ]);
+
+    const result = applyArmorReductions(state, "player1", 1);
+
+    const prowlerDef = ENEMIES[ENEMY_PROWLERS];
+    const effectiveArmor = getEffectiveEnemyArmor(
+      result,
+      "enemy_1",
+      prowlerDef.armor,
+      prowlerDef.resistances.length,
+      "player1"
+    );
+    expect(effectiveArmor).toBe(prowlerDef.armor - 1);
+  });
+
+  it("stacks multiple reductions on same enemy when only one target", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_1", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_2", ENEMY_DIGGERS),
+    ]);
+
+    // 2 reductions but only 1 valid target
+    const result = applyArmorReductions(state, "player1", 2);
+
+    const diggerDef = ENEMIES[ENEMY_DIGGERS];
+    const effectiveArmor = getEffectiveEnemyArmor(
+      result,
+      "enemy_2",
+      diggerDef.armor,
+      diggerDef.resistances.length,
+      "player1"
+    );
+    // Diggers have armor 3, reduced by 2 → 1 (or armor - 2 if armor > 3)
+    expect(effectiveArmor).toBe(Math.max(1, diggerDef.armor - 2));
+  });
+
+  it("spreads reductions across multiple surviving enemies", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_1", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_2", ENEMY_PROWLERS),
+      createCombatEnemy("enemy_3", ENEMY_PROWLERS),
+    ]);
+
+    // 2 reductions, 2 valid targets → 1 each
+    const result = applyArmorReductions(state, "player1", 2);
+
+    const prowlerDef = ENEMIES[ENEMY_PROWLERS];
+    const armor2 = getEffectiveEnemyArmor(
+      result,
+      "enemy_2",
+      prowlerDef.armor,
+      prowlerDef.resistances.length,
+      "player1"
+    );
+    const armor3 = getEffectiveEnemyArmor(
+      result,
+      "enemy_3",
+      prowlerDef.armor,
+      prowlerDef.resistances.length,
+      "player1"
+    );
+    expect(armor2).toBe(prowlerDef.armor - 1);
+    expect(armor3).toBe(prowlerDef.armor - 1);
+  });
+
+  it("skips Fire Resistant enemies", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_1", ENEMY_FIRE_MAGES),
+      createCombatEnemy("enemy_2", ENEMY_PROWLERS),
+    ]);
+
+    const result = applyArmorReductions(state, "player1", 1);
+
+    const fireMageDef = ENEMIES[ENEMY_FIRE_MAGES];
+    const prowlerDef = ENEMIES[ENEMY_PROWLERS];
+
+    // Fire Mages should not be affected
+    const fireMageArmor = getEffectiveEnemyArmor(
+      result,
+      "enemy_1",
+      fireMageDef.armor,
+      fireMageDef.resistances.length,
+      "player1"
+    );
+    expect(fireMageArmor).toBe(fireMageDef.armor);
+
+    // Prowler should be reduced
+    const prowlerArmor = getEffectiveEnemyArmor(
+      result,
+      "enemy_2",
+      prowlerDef.armor,
+      prowlerDef.resistances.length,
+      "player1"
+    );
+    expect(prowlerArmor).toBe(prowlerDef.armor - 1);
+  });
+
+  it("does nothing when no valid targets exist", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS, { isDefeated: true }),
+      createCombatEnemy("enemy_1", ENEMY_FIRE_MAGES),
+    ]);
+
+    const before = state.activeModifiers.length;
+    const result = applyArmorReductions(state, "player1", 1);
+
+    // No new modifiers should be added (Fire Mages are immune)
+    expect(result.activeModifiers.length).toBe(before);
+  });
+
+  it("does nothing with zero reductions", () => {
+    const state = createCombatGameState([
+      createCombatEnemy("enemy_0", ENEMY_PROWLERS),
+      createCombatEnemy("enemy_1", ENEMY_PROWLERS),
+    ]);
+
+    const before = state.activeModifiers.length;
+    const result = applyArmorReductions(state, "player1", 0);
+
+    expect(result.activeModifiers.length).toBe(before);
+  });
+
+  it("does nothing when not in combat", () => {
+    const state = createTestGameState();
+    const result = applyArmorReductions(state, "player1", 2);
+    expect(result.activeModifiers.length).toBe(0);
+  });
+});

--- a/packages/core/src/engine/combat/armorReductionHelpers.ts
+++ b/packages/core/src/engine/combat/armorReductionHelpers.ts
@@ -1,0 +1,93 @@
+/**
+ * Armor reduction helpers for Explosive Bolt
+ *
+ * Applies per-defeat armor reduction modifiers to surviving enemies.
+ * For each enemy defeated by the tracked attack, another surviving enemy
+ * gets Armor -1 (minimum 1). Fire Resistant enemies are immune.
+ * Armor reduction lasts the entire combat.
+ *
+ * Distribution strategy (when no player choice):
+ * - Sorts valid targets by armor descending (highest armor first)
+ * - Applies one reduction per target, cycling through
+ * - Naturally handles stacking when reductions > targets
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import { RESIST_FIRE, CARD_EXPLOSIVE_BOLT } from "@mage-knight/shared";
+import { addModifier } from "../modifiers/index.js";
+import { hasArcaneImmunity } from "../modifiers/queries.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_ENEMY_STAT,
+  ENEMY_STAT_ARMOR,
+  SCOPE_ONE_ENEMY,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+
+/**
+ * Apply armor reduction modifiers to surviving enemies after defeat tracking.
+ *
+ * For each reduction to apply, selects a valid target from surviving enemies:
+ * - Not defeated
+ * - Not Fire Resistant (immune to armor reduction per Explosive Bolt rules)
+ * - Not Arcane Immune (blocks non-Attack/Block effects per general rules)
+ *
+ * Distributes reductions by cycling through valid targets sorted by armor
+ * (highest armor first). This naturally spreads reductions across targets,
+ * with stacking when there are more reductions than targets.
+ *
+ * @param state - Current game state (must have active combat)
+ * @param playerId - Player applying the reductions
+ * @param reductionCount - Number of -1 armor reductions to apply
+ * @returns Updated game state with armor reduction modifiers applied
+ */
+export function applyArmorReductions(
+  state: GameState,
+  playerId: string,
+  reductionCount: number
+): GameState {
+  if (reductionCount <= 0 || !state.combat) {
+    return state;
+  }
+
+  // Find valid targets: surviving, non-fire-resistant, non-arcane-immune enemies
+  const validTargets = state.combat.enemies.filter((enemy) => {
+    if (enemy.isDefeated) return false;
+    if (enemy.definition.resistances.includes(RESIST_FIRE)) return false;
+    if (hasArcaneImmunity(state, enemy.instanceId)) return false;
+    return true;
+  });
+
+  if (validTargets.length === 0) {
+    return state;
+  }
+
+  // Sort by armor descending (reduce the strongest enemies first)
+  const sortedTargets = [...validTargets].sort(
+    (a, b) => b.definition.armor - a.definition.armor
+  );
+
+  let updatedState = state;
+
+  // Distribute reductions across valid targets (cycling)
+  for (let i = 0; i < reductionCount; i++) {
+    const target = sortedTargets[i % sortedTargets.length];
+    if (!target) continue;
+
+    updatedState = addModifier(updatedState, {
+      effect: {
+        type: EFFECT_ENEMY_STAT,
+        stat: ENEMY_STAT_ARMOR,
+        amount: -1,
+        minimum: 1,
+      },
+      duration: DURATION_COMBAT,
+      scope: { type: SCOPE_ONE_ENEMY, enemyId: target.instanceId },
+      source: { type: SOURCE_CARD, cardId: CARD_EXPLOSIVE_BOLT, playerId },
+      createdAtRound: updatedState.round,
+      createdByPlayerId: playerId,
+    });
+  }
+
+  return updatedState;
+}

--- a/packages/core/src/engine/combat/attackFameTracking.ts
+++ b/packages/core/src/engine/combat/attackFameTracking.ts
@@ -177,6 +177,11 @@ export interface ResolveAttackDefeatFameResult {
   readonly updatedTrackers: readonly AttackDefeatFameTracker[];
   readonly fameToGain: number;
   readonly reputationToGain: number;
+  /**
+   * Number of armor reductions to apply to surviving enemies (Explosive Bolt).
+   * Each unit represents -1 armor to apply to one enemy (player distributes).
+   */
+  readonly armorReductionsToApply: number;
 }
 
 export function resolveAttackDefeatFameTrackers(
@@ -184,12 +189,13 @@ export function resolveAttackDefeatFameTrackers(
   defeatedEnemyIds: readonly string[]
 ): ResolveAttackDefeatFameResult {
   if (trackers.length === 0) {
-    return { updatedTrackers: trackers, fameToGain: 0, reputationToGain: 0 };
+    return { updatedTrackers: trackers, fameToGain: 0, reputationToGain: 0, armorReductionsToApply: 0 };
   }
 
   const defeated = new Set(defeatedEnemyIds);
   let fameToGain = 0;
   let reputationToGain = 0;
+  let armorReductionsToApply = 0;
   let didChange = false;
   const updatedTrackers: AttackDefeatFameTracker[] = [];
 
@@ -209,6 +215,11 @@ export function resolveAttackDefeatFameTrackers(
       }
       if (tracker.famePerDefeat) {
         fameToGain += tracker.famePerDefeat * defeatedByTrackerIds.length;
+      }
+
+      // Armor reduction per defeated enemy (Explosive Bolt)
+      if (tracker.armorReductionPerDefeat) {
+        armorReductionsToApply += tracker.armorReductionPerDefeat * defeatedByTrackerIds.length;
       }
 
       didChange = true;
@@ -234,5 +245,6 @@ export function resolveAttackDefeatFameTrackers(
     updatedTrackers: didChange ? updatedTrackers : trackers,
     fameToGain,
     reputationToGain,
+    armorReductionsToApply,
   };
 }

--- a/packages/core/src/engine/commands/combat/combatEndHandlers.ts
+++ b/packages/core/src/engine/commands/combat/combatEndHandlers.ts
@@ -53,6 +53,7 @@ import { resolveScoutFameBonus } from "../../combat/scoutFameTracking.js";
 import { resolveBowPhaseFameBonus } from "../../combat/bowPhaseFameTracking.js";
 import { resolveSoulHarvesterCrystals } from "../../combat/soulHarvesterTracking.js";
 import { resolveDuelingFameBonus } from "../../combat/duelingHelpers.js";
+import { applyArmorReductions } from "../../combat/armorReductionHelpers.js";
 
 // ============================================================================
 // Helper Functions
@@ -118,6 +119,15 @@ export function applyDefeatedEnemyRewards(
         );
         updatedState = trackerRepResult.state;
         events.push(...trackerRepResult.events);
+      }
+
+      // Apply armor reductions from defeat trackers (Explosive Bolt)
+      if (fameResult.armorReductionsToApply > 0 && updatedState.combat) {
+        updatedState = applyArmorReductions(
+          updatedState,
+          playerId,
+          fameResult.armorReductionsToApply
+        );
       }
     }
   }

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -366,6 +366,7 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     const parts = [`Attack ${e.amount}`];
     if (e.reputationPerDefeat) parts.push(`Rep +${e.reputationPerDefeat}`);
     if (e.famePerDefeat) parts.push(`Fame +${e.famePerDefeat}`);
+    if (e.armorReductionPerDefeat) parts.push(`Armor -${e.armorReductionPerDefeat} on another enemy`);
     return `${parts.join(", ")} per enemy defeated`;
   },
 

--- a/packages/core/src/engine/rules/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/rules/effectDetection/combatEffects.ts
@@ -16,6 +16,7 @@ import {
   EFFECT_DISCARD_COST,
   EFFECT_PURE_MAGIC,
   EFFECT_MANA_BOLT,
+  EFFECT_ATTACK_WITH_DEFEAT_BONUS,
 } from "../../../types/effectTypes.js";
 import {
   COMBAT_TYPE_RANGED,
@@ -30,6 +31,9 @@ import { effectHasModifier } from "./resourceEffects.js";
 export function effectHasRangedOrSiege(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
+      return effect.combatType === COMBAT_TYPE_RANGED || effect.combatType === COMBAT_TYPE_SIEGE;
+
+    case EFFECT_ATTACK_WITH_DEFEAT_BONUS:
       return effect.combatType === COMBAT_TYPE_RANGED || effect.combatType === COMBAT_TYPE_SIEGE;
 
     case EFFECT_MANA_BOLT: // Mana Bolt can provide Ranged (white) or Siege (green)
@@ -105,6 +109,9 @@ export function effectIsRangedOnlyAttack(effect: CardEffect): boolean {
     case EFFECT_GAIN_ATTACK:
       return effect.combatType === COMBAT_TYPE_RANGED;
 
+    case EFFECT_ATTACK_WITH_DEFEAT_BONUS:
+      return effect.combatType === COMBAT_TYPE_RANGED;
+
     case EFFECT_CHOICE:
       // All options must be ranged-only (no siege escape hatch)
       return effect.options.every(opt => effectIsRangedOnlyAttack(opt));
@@ -176,6 +183,7 @@ function effectHasSiegeAttack(effect: CardEffect): boolean {
 export function effectHasAttack(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
+    case EFFECT_ATTACK_WITH_DEFEAT_BONUS: // Explosive Bolt, etc. - provides attack with defeat bonuses
     case EFFECT_PURE_MAGIC: // Pure Magic can provide Attack (via red mana)
     case EFFECT_MANA_BOLT: // Mana Bolt always provides Attack (all colors → attack)
       return true;

--- a/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
+++ b/packages/core/src/engine/validActions/cards/effectDetection/combatEffects.ts
@@ -14,6 +14,7 @@ import {
   EFFECT_CONDITIONAL,
   EFFECT_SCALING,
   EFFECT_DISCARD_COST,
+  EFFECT_ATTACK_WITH_DEFEAT_BONUS,
 } from "../../../../types/effectTypes.js";
 import {
   COMBAT_TYPE_RANGED,
@@ -26,6 +27,9 @@ import {
 export function effectHasRangedOrSiege(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
+      return effect.combatType === COMBAT_TYPE_RANGED || effect.combatType === COMBAT_TYPE_SIEGE;
+
+    case EFFECT_ATTACK_WITH_DEFEAT_BONUS:
       return effect.combatType === COMBAT_TYPE_RANGED || effect.combatType === COMBAT_TYPE_SIEGE;
 
     case EFFECT_CHOICE:
@@ -93,6 +97,7 @@ export function effectHasBlock(effect: CardEffect): boolean {
 export function effectHasAttack(effect: CardEffect): boolean {
   switch (effect.type) {
     case EFFECT_GAIN_ATTACK:
+    case EFFECT_ATTACK_WITH_DEFEAT_BONUS:
       return true;
 
     case EFFECT_CHOICE:

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -804,14 +804,20 @@ export interface TrackAttackDefeatFameEffect {
  */
 export interface AttackWithDefeatBonusEffect {
   readonly type: typeof EFFECT_ATTACK_WITH_DEFEAT_BONUS;
-  /** Attack amount (melee) */
+  /** Attack amount */
   readonly amount: number;
-  /** Combat type of the attack */
+  /** Combat type of the attack (melee, ranged, siege) */
   readonly combatType: CombatType;
   /** Reputation gained per enemy defeated by this attack */
   readonly reputationPerDefeat: number;
   /** Fame gained per enemy defeated by this attack */
   readonly famePerDefeat: number;
+  /**
+   * Armor reduction to apply per enemy defeated by this attack (Explosive Bolt).
+   * For each defeated enemy, another surviving enemy gets Armor -N (min 1).
+   * Fire Resistant enemies are immune to the reduction.
+   */
+  readonly armorReductionPerDefeat?: number;
 }
 
 /**

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -337,7 +337,7 @@ export interface PendingTerrainCostReduction {
 
 /**
  * Track an attack that grants fame if it defeats at least one enemy.
- * Used by Axe Throw powered effect.
+ * Used by Axe Throw powered effect, Chivalry, and Explosive Bolt.
  */
 export interface AttackDefeatFameTracker {
   /** Source card that created the tracker (if any) */
@@ -358,6 +358,12 @@ export interface AttackDefeatFameTracker {
   readonly reputationPerDefeat?: number;
   /** Fame to gain per enemy defeated by this attack (Chivalry powered) */
   readonly famePerDefeat?: number;
+  /**
+   * Armor reduction to apply per enemy defeated by this attack (Explosive Bolt).
+   * For each defeated enemy, another surviving enemy gets Armor -armorReductionPerDefeat
+   * (minimum 1). Fire Resistant enemies are immune. Lasts entire combat.
+   */
+  readonly armorReductionPerDefeat?: number;
 }
 
 // === Tactic-specific state types ===


### PR DESCRIPTION
## Summary
- Implements all missing functionality for the Explosive Bolt advanced action card
- **Basic effect**: Take a Wound, gain a white crystal and a red crystal (compound effect)
- **Powered effect**: Ranged Attack 3 with per-defeat armor reduction (-1 armor per enemy defeated, minimum 1, Fire Resistant enemies immune)
- Armor reduction distributed automatically to surviving enemies, prioritizing highest armor first

## Changes
- **`explosive-bolt.ts`**: Updated basic effect to `compound(takeWound(1), gainCrystal(WHITE), gainCrystal(RED))` and powered effect to `rangedAttackWithArmorReduction(3, 1)`
- **`helpers.ts`**: Added `rangedAttackWithArmorReduction()` helper function
- **`types/cards.ts`** + **`types/player.ts`**: Extended `AttackWithDefeatBonusEffect` and `AttackDefeatFameTracker` with optional `armorReductionPerDefeat` field
- **`attackWithDefeatBonusEffects.ts`**: Dynamic combat type mapping (was hardcoded to melee), passes `armorReductionPerDefeat` to tracker
- **`attackFameTracking.ts`**: Accumulates `armorReductionsToApply` from defeat trackers
- **`combatEndHandlers.ts`**: Calls `applyArmorReductions()` when defeat trackers produce reductions
- **`armorReductionHelpers.ts`** (new): Applies `-1` armor modifiers to eligible surviving enemies (filters out Fire Resistant and Arcane Immune), uses `DURATION_COMBAT` scope
- **`effectDetection/combatEffects.ts`** (both copies): Added `EFFECT_ATTACK_WITH_DEFEAT_BONUS` to `effectHasRangedOrSiege`, `effectIsRangedOnlyAttack`, and `effectHasAttack` so the card is playable in ranged/siege phase
- **`describeEffect.ts`**: Updated effect description to include armor reduction info

## Test Plan
- New `explosiveBolt.test.ts` with 14 tests covering:
  - Basic effect structure (compound with wound + 2 crystals)
  - Powered effect type and metadata
  - Ranged attack + defeat tracker registration
  - Armor reduction on surviving enemy after defeat in ranged phase
  - Multiple defeats leading to stacked armor reductions
  - Minimum armor of 1 enforcement (3 defeats on armor-3 enemy)
  - Fire Resistant enemy immunity
  - No reduction when no enemies defeated
  - No reduction when only Fire Resistant enemies survive
  - Card metadata (dual poweredBy, sidewaysValue)
  - Effect description
  - Reverse effect (undo)
- New `armorReductionHelpers.test.ts` with 7 unit tests for the helper function
- All 5065 existing tests continue to pass

Closes #183