### PR TITLE
Implement Chilling Stare attack-cancellation effects

### DIFF
--- a/packages/core/src/data/advancedActions/dual/chilling-stare.ts
+++ b/packages/core/src/data/advancedActions/dual/chilling-stare.ts
@@ -1,7 +1,25 @@
 import type { DeedCard } from "../../../types/cards.js";
 import { CATEGORY_COMBAT, DEED_CARD_TYPE_ADVANCED_ACTION } from "../../../types/cards.js";
-import { MANA_BLUE, MANA_WHITE, CARD_CHILLING_STARE } from "@mage-knight/shared";
-import { block, influence, choice } from "../helpers.js";
+import {
+  ABILITY_ASSASSINATION,
+  ABILITY_BRUTAL,
+  ABILITY_CUMBERSOME,
+  ABILITY_PARALYZE,
+  ABILITY_POISON,
+  ABILITY_SWIFT,
+  ABILITY_VAMPIRIC,
+  CARD_CHILLING_STARE,
+  MANA_BLUE,
+  MANA_WHITE,
+  RESIST_ICE,
+} from "@mage-knight/shared";
+import { choice, influence } from "../helpers.js";
+import { EFFECT_SELECT_COMBAT_ENEMY } from "../../../types/effectTypes.js";
+import {
+  DURATION_COMBAT,
+  EFFECT_ABILITY_NULLIFIER,
+  EFFECT_ENEMY_SKIP_ATTACK,
+} from "../../../types/modifierConstants.js";
 
 export const CHILLING_STARE: DeedCard = {
   id: CARD_CHILLING_STARE,
@@ -9,10 +27,100 @@ export const CHILLING_STARE: DeedCard = {
   cardType: DEED_CARD_TYPE_ADVANCED_ACTION,
   poweredBy: [MANA_BLUE, MANA_WHITE], // Can be powered by blue OR white
   categories: [CATEGORY_COMBAT],
-  // Basic: Influence 3, or a chosen enemy attack loses all attack abilities (but not its color).
-  // Powered: Influence 5, or a chosen enemy does not attack this turn.
-  // TODO: Implement enemy attack cancellation
-  basicEffect: choice(influence(3), block(3)),
-  poweredEffect: choice(influence(5), block(5)),
+  basicEffect: choice(
+    influence(3),
+    {
+      type: EFFECT_SELECT_COMBAT_ENEMY,
+      excludeResistance: RESIST_ICE,
+      // For summoner stacks, this mode targets the summoned monster, not the summoner.
+      excludeSummoners: true,
+      template: {
+        modifiers: [
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_SWIFT,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Swiftness",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_BRUTAL,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Brutal",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_POISON,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Poison",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_PARALYZE,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Paralyze",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_VAMPIRIC,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Vampiric",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_ASSASSINATION,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Assassination",
+          },
+          {
+            modifier: {
+              type: EFFECT_ABILITY_NULLIFIER,
+              ability: ABILITY_CUMBERSOME,
+              ignoreArcaneImmunity: true,
+            },
+            duration: DURATION_COMBAT,
+            description: "Target enemy attack loses Cumbersome",
+          },
+        ],
+      },
+    }
+  ),
+  poweredEffect: choice(
+    influence(5),
+    {
+      type: EFFECT_SELECT_COMBAT_ENEMY,
+      excludeArcaneImmune: true,
+      excludeResistance: RESIST_ICE,
+      // For summoner stacks, this mode targets the summoner, not summoned monsters.
+      excludeSummoned: true,
+      template: {
+        modifiers: [
+          {
+            modifier: { type: EFFECT_ENEMY_SKIP_ATTACK },
+            duration: DURATION_COMBAT,
+            description: "Target enemy does not attack",
+          },
+        ],
+      },
+    }
+  ),
   sidewaysValue: 1,
 };

--- a/packages/core/src/engine/__tests__/cardChillingStare.test.ts
+++ b/packages/core/src/engine/__tests__/cardChillingStare.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import { isAbilityNullified, doesEnemyAttackThisCombat } from "../modifiers/combat.js";
+import {
+  ABILITY_ASSASSINATION,
+  ABILITY_POISON,
+  CARD_CHILLING_STARE,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_RANGED_SIEGE,
+  getEnemy,
+  ENEMY_GUNNERS,
+  ENEMY_ORC_SUMMONERS,
+  ENEMY_SORCERERS,
+  ENEMY_DIGGERS,
+  ENTER_COMBAT_ACTION,
+  MANA_SOURCE_TOKEN,
+  MANA_WHITE,
+  PLAY_CARD_ACTION,
+  RESOLVE_CHOICE_ACTION,
+} from "@mage-knight/shared";
+import {
+  EFFECT_ABILITY_NULLIFIER,
+  EFFECT_ENEMY_SKIP_ATTACK,
+} from "../../types/modifierConstants.js";
+
+describe("Chilling Stare", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  it("basic can be used outside combat for Influence 3", () => {
+    const player = createTestPlayer({ hand: [CARD_CHILLING_STARE] });
+    let state = createTestGameState({ players: [player] });
+
+    const playResult = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: false,
+    });
+    state = playResult.state;
+
+    if (state.players[0]?.pendingChoice) {
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+    }
+
+    expect(state.players[0]?.influencePoints).toBe(3);
+  });
+
+  it("basic removes attack abilities on Arcane Immune enemies (but keeps attack element)", () => {
+    const player = createTestPlayer({ hand: [CARD_CHILLING_STARE] });
+    let state = createTestGameState({ players: [player] });
+
+    state = engine.processAction(state, "player1", {
+      type: ENTER_COMBAT_ACTION,
+      enemyIds: [ENEMY_SORCERERS],
+    }).state;
+
+    const enemyInstanceId = state.combat?.enemies[0]?.instanceId ?? "";
+    const beforeAttackElement = state.combat?.enemies[0]?.definition.attackElement;
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: false,
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    if (state.players[0]?.pendingChoice) {
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+    }
+
+    expect(isAbilityNullified(state, "player1", enemyInstanceId, ABILITY_POISON)).toBe(true);
+    expect(isAbilityNullified(state, "player1", enemyInstanceId, ABILITY_ASSASSINATION)).toBe(true);
+    expect(state.combat?.enemies[0]?.definition.attackElement).toBe(beforeAttackElement);
+  });
+
+  it("basic enemy-cancellation mode is blocked by Ice Resistance", () => {
+    const player = createTestPlayer({ hand: [CARD_CHILLING_STARE] });
+    let state = createTestGameState({ players: [player] });
+
+    state = engine.processAction(state, "player1", {
+      type: ENTER_COMBAT_ACTION,
+      enemyIds: [ENEMY_GUNNERS],
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: false,
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    const nullifiers = state.activeModifiers.filter(
+      (m) => m.effect.type === EFFECT_ABILITY_NULLIFIER
+    );
+    expect(nullifiers).toHaveLength(0);
+  });
+
+  it("powered enemy-cancellation mode is blocked by Arcane Immunity and Ice Resistance", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CHILLING_STARE],
+      pureMana: [{ color: MANA_WHITE, source: "token" }],
+    });
+    let state = createTestGameState({ players: [player] });
+
+    state = engine.processAction(state, "player1", {
+      type: ENTER_COMBAT_ACTION,
+      enemyIds: [ENEMY_SORCERERS, ENEMY_GUNNERS],
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    const skipAttack = state.activeModifiers.filter(
+      (m) => m.effect.type === EFFECT_ENEMY_SKIP_ATTACK
+    );
+    expect(skipAttack).toHaveLength(0);
+  });
+
+  it("basic targets summoned monsters (not summoners)", () => {
+    const summonerId = "enemy_summoner";
+    const summonedId = "enemy_summoned";
+    const otherEnemyId = "enemy_other";
+    const player = createTestPlayer({ hand: [CARD_CHILLING_STARE] });
+    const combat = createUnitCombatState(COMBAT_PHASE_BLOCK);
+    let state = createTestGameState({
+      players: [player],
+      combat: {
+        ...combat,
+        phase: COMBAT_PHASE_BLOCK,
+        enemies: [
+          {
+            instanceId: summonerId,
+            enemyId: ENEMY_ORC_SUMMONERS,
+            definition: getEnemy(ENEMY_ORC_SUMMONERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: true,
+            isSummonerHidden: true,
+          },
+          {
+            instanceId: summonedId,
+            enemyId: ENEMY_DIGGERS,
+            definition: getEnemy(ENEMY_DIGGERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: false,
+            summonedByInstanceId: summonerId,
+          },
+          {
+            instanceId: otherEnemyId,
+            enemyId: ENEMY_DIGGERS,
+            definition: getEnemy(ENEMY_DIGGERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: true,
+          },
+        ],
+      },
+    });
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: false,
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    const options = state.players[0]?.pendingChoice?.options ?? [];
+    const targetIds = options
+      .map((o) => (o as { enemyInstanceId?: string }).enemyInstanceId)
+      .filter((id): id is string => id !== undefined);
+
+    expect(targetIds).toContain(summonedId);
+    expect(targetIds).not.toContain(summonerId);
+  });
+
+  it("powered targets summoners (not summoned monsters)", () => {
+    const summonerId = "enemy_summoner";
+    const summonedId = "enemy_summoned";
+    const otherEnemyId = "enemy_other";
+    const player = createTestPlayer({
+      hand: [CARD_CHILLING_STARE],
+      pureMana: [{ color: MANA_WHITE, source: "token" }],
+    });
+    const combat = createUnitCombatState(COMBAT_PHASE_RANGED_SIEGE);
+    let state = createTestGameState({
+      players: [player],
+      combat: {
+        ...combat,
+        phase: COMBAT_PHASE_RANGED_SIEGE,
+        enemies: [
+          {
+            instanceId: summonerId,
+            enemyId: ENEMY_ORC_SUMMONERS,
+            definition: getEnemy(ENEMY_ORC_SUMMONERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: true,
+            isSummonerHidden: false,
+          },
+          {
+            instanceId: summonedId,
+            enemyId: ENEMY_DIGGERS,
+            definition: getEnemy(ENEMY_DIGGERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: false,
+            summonedByInstanceId: summonerId,
+          },
+          {
+            instanceId: otherEnemyId,
+            enemyId: ENEMY_DIGGERS,
+            definition: getEnemy(ENEMY_DIGGERS),
+            isBlocked: false,
+            isDefeated: false,
+            damageAssigned: false,
+            isRequiredForConquest: true,
+          },
+        ],
+      },
+    });
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    const options = state.players[0]?.pendingChoice?.options ?? [];
+    const targetIds = options
+      .map((o) => (o as { enemyInstanceId?: string }).enemyInstanceId)
+      .filter((id): id is string => id !== undefined);
+
+    expect(targetIds).toContain(summonerId);
+    expect(targetIds).not.toContain(summonedId);
+  });
+
+  it("powered applies skip-attack to valid targets", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CHILLING_STARE],
+      pureMana: [{ color: MANA_WHITE, source: "token" }],
+    });
+    let state = createTestGameState({ players: [player] });
+
+    state = engine.processAction(state, "player1", {
+      type: ENTER_COMBAT_ACTION,
+      enemyIds: [ENEMY_DIGGERS],
+    }).state;
+
+    const enemyInstanceId = state.combat?.enemies[0]?.instanceId ?? "";
+
+    state = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CHILLING_STARE,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_WHITE }],
+    }).state;
+
+    state = engine.processAction(state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    }).state;
+
+    if (state.players[0]?.pendingChoice) {
+      state = engine.processAction(state, "player1", {
+        type: RESOLVE_CHOICE_ACTION,
+        choiceIndex: 0,
+      }).state;
+    }
+
+    expect(doesEnemyAttackThisCombat(state, enemyInstanceId)).toBe(false);
+  });
+});

--- a/packages/core/src/engine/effects/combatEffects.ts
+++ b/packages/core/src/engine/effects/combatEffects.ts
@@ -40,6 +40,7 @@ import { registerEffect } from "./effectRegistry.js";
 import { addModifier } from "../modifiers/index.js";
 import {
   DURATION_COMBAT,
+  EFFECT_ABILITY_NULLIFIER,
   EFFECT_DEFEAT_IF_BLOCKED,
   EFFECT_ENEMY_STAT,
   EFFECT_GRANT_ENEMY_ABILITY,
@@ -120,6 +121,11 @@ export function resolveSelectCombatEnemy(
         e.definition.abilities.includes(ABILITY_SUMMON) ||
         e.definition.abilities.includes(ABILITY_SUMMON_GREEN)
       ) return false;
+    }
+
+    // Filter out summoned enemies (e.g., Chilling Stare powered must target summoner)
+    if (effect.excludeSummoned && e.summonedByInstanceId !== undefined) {
+      return false;
     }
 
     return true;
@@ -248,9 +254,17 @@ export function resolveCombatEnemyTarget(
       const isAttackReduction =
         mod.modifier.type === EFFECT_ENEMY_STAT &&
         mod.modifier.stat === ENEMY_STAT_ATTACK;
+      const isArcaneBypassAbilityNullifier =
+        mod.modifier.type === EFFECT_ABILITY_NULLIFIER &&
+        mod.modifier.ignoreArcaneImmunity === true;
       const isGrantCumbersome =
         mod.modifier.type === EFFECT_GRANT_ENEMY_ABILITY;
-      if (hasArcaneImmunity && !isAttackReduction && !isGrantCumbersome) {
+      if (
+        hasArcaneImmunity &&
+        !isAttackReduction &&
+        !isArcaneBypassAbilityNullifier &&
+        !isGrantCumbersome
+      ) {
         descriptions.push(`${effect.enemyName} has Arcane Immunity (modifier blocked)`);
         continue;
       }

--- a/packages/core/src/engine/modifiers/combat.ts
+++ b/packages/core/src/engine/modifiers/combat.ts
@@ -229,10 +229,7 @@ export function isAbilityNullified(
   enemyId: string,
   abilityType: EnemyAbility["type"]
 ): boolean {
-  // Arcane Immunity blocks ability nullification effects
-  if (hasArcaneImmunity(state, enemyId)) {
-    return false;
-  }
+  const enemyHasArcaneImmunity = hasArcaneImmunity(state, enemyId);
 
   const modifiers = getModifiersForPlayer(state, playerId)
     .filter((m) => m.effect.type === EFFECT_ABILITY_NULLIFIER)
@@ -242,6 +239,12 @@ export function isAbilityNullified(
     }));
 
   for (const mod of modifiers) {
+    // Arcane Immunity blocks standard ability nullification effects.
+    // Some effects can explicitly bypass this with ignoreArcaneImmunity.
+    if (enemyHasArcaneImmunity && !mod.effect.ignoreArcaneImmunity) {
+      continue;
+    }
+
     // Check scope targets this enemy
     if (mod.scope.type === SCOPE_ONE_ENEMY && mod.scope.enemyId !== enemyId)
       continue;

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -557,6 +557,8 @@ export interface SelectCombatEnemyEffect {
   readonly excludeResistance?: ResistanceType;
   /** If true, exclude Summoner enemies (with ABILITY_SUMMON or ABILITY_SUMMON_GREEN) from targeting */
   readonly excludeSummoners?: boolean;
+  /** If true, exclude summoned enemies (those with summonedByInstanceId set) from targeting */
+  readonly excludeSummoned?: boolean;
   /**
    * Maximum number of enemies that can be targeted (default: 1).
    * When > 1, after each selection the player can choose another target or stop.

--- a/packages/core/src/types/modifiers.ts
+++ b/packages/core/src/types/modifiers.ts
@@ -259,6 +259,11 @@ export interface RuleOverrideModifier {
 export interface AbilityNullifierModifier {
   readonly type: typeof EFFECT_ABILITY_NULLIFIER;
   readonly ability: EnemyAbility["type"] | typeof ABILITY_ANY;
+  /**
+   * If true, this nullifier can affect Arcane Immune enemies.
+   * Use sparingly for effects that explicitly bypass Arcane Immunity.
+   */
+  readonly ignoreArcaneImmunity?: boolean;
 }
 
 // Enemy skip attack modifier (e.g., "enemy does not attack this combat")


### PR DESCRIPTION
## Summary
- implement Chilling Stare basic effect as a combat target choice that removes attack abilities (Swiftness, Brutal, Poison, Paralyze, Vampiric, Assassination, Cumbersome)
- implement Chilling Stare powered effect as a combat target choice that prevents the enemy from attacking this combat
- enforce issue-specific immunity/targeting behavior: basic is blocked by Ice Resistance and bypasses Arcane Immunity for attack-ability removal; powered is blocked by Arcane Immunity and Ice Resistance
- add `excludeSummoned` support to combat enemy targeting and an `ignoreArcaneImmunity` option for ability nullifiers
- add focused regression tests for outside-combat influence, immunity interactions, summoner/summoned targeting, and skip-attack application

## Verification
- bun run build
- bun run lint
- bun run test

Closes #185