### PR TITLE
fix: preserve nested choice chains in card boost resolution

### DIFF
--- a/packages/core/src/engine/__tests__/cardBoostResolution.test.ts
+++ b/packages/core/src/engine/__tests__/cardBoostResolution.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer, createUnitCombatState } from "./testHelpers.js";
+import {
+  PLAY_CARD_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  CARD_CONCENTRATION,
+  CARD_WOLFHAWK_SWIFT_REFLEXES,
+  MANA_GREEN,
+  MANA_SOURCE_TOKEN,
+  COMBAT_TYPE_RANGED,
+} from "@mage-knight/shared";
+import { COMBAT_PHASE_BLOCK } from "../../types/combat.js";
+import {
+  EFFECT_GAIN_MOVE,
+  EFFECT_GAIN_ATTACK,
+} from "../../types/effectTypes.js";
+
+describe("Card boost choice chaining", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  it("should keep a pending boosted choice when Concentration auto-selects Swift Reflexes", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CONCENTRATION, CARD_WOLFHAWK_SWIFT_REFLEXES],
+      pureMana: [{ color: MANA_GREEN, source: "die" }],
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const result = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CONCENTRATION,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_GREEN }],
+    });
+
+    const pendingChoice = result.state.players[0].pendingChoice;
+    expect(pendingChoice).not.toBeNull();
+    expect(pendingChoice?.options).toHaveLength(3);
+
+    const moveOption = pendingChoice?.options[0];
+    const attackOption = pendingChoice?.options[1];
+    expect(moveOption).toMatchObject({ type: EFFECT_GAIN_MOVE, amount: 6 });
+    expect(attackOption).toMatchObject({
+      type: EFFECT_GAIN_ATTACK,
+      amount: 5,
+      combatType: COMBAT_TYPE_RANGED,
+    });
+  });
+
+  it("should apply boosted Swift Reflexes attack after resolving the follow-up choice", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CONCENTRATION, CARD_WOLFHAWK_SWIFT_REFLEXES],
+      pureMana: [{ color: MANA_GREEN, source: "die" }],
+    });
+    const state = createTestGameState({
+      players: [player],
+      combat: createUnitCombatState(COMBAT_PHASE_BLOCK),
+    });
+
+    const afterConcentration = engine.processAction(state, "player1", {
+      type: PLAY_CARD_ACTION,
+      cardId: CARD_CONCENTRATION,
+      powered: true,
+      manaSources: [{ type: MANA_SOURCE_TOKEN, color: MANA_GREEN }],
+    });
+
+    const afterChoice = engine.processAction(afterConcentration.state, "player1", {
+      type: RESOLVE_CHOICE_ACTION,
+      choiceIndex: 1,
+    });
+
+    expect(afterChoice.state.players[0].pendingChoice).toBeNull();
+    expect(afterChoice.state.players[0].combatAccumulator.attack.ranged).toBe(5);
+    expect(afterChoice.state.players[0].playArea).toEqual(
+      expect.arrayContaining([CARD_CONCENTRATION, CARD_WOLFHAWK_SWIFT_REFLEXES])
+    );
+  });
+});

--- a/packages/core/src/engine/effects/cardBoostResolvers.ts
+++ b/packages/core/src/engine/effects/cardBoostResolvers.ts
@@ -155,8 +155,12 @@ export function resolveBoostTargetEffect(
   const boostedEffect = addBonusToEffect(targetCard.poweredEffect, effect.bonus);
   const result = resolveEffect(stateWithCardPlayed, playerId, boostedEffect, effect.targetCardId);
 
+  const nestedResolvedEffect =
+    result.resolvedEffect ?? (result.requiresChoice ? boostedEffect : undefined);
+
   return {
     ...result,
+    ...(nestedResolvedEffect && { resolvedEffect: nestedResolvedEffect }),
     description: `Boosted ${targetCard.name}: ${result.description}`,
   };
 }


### PR DESCRIPTION
## Summary
- fix nested choice chaining so auto-resolved single options can still produce a follow-up pending choice
- teach choice option extraction to fall back to  for wrapper effects
- propagate boosted inner effect metadata from card boost target resolution
- add regression coverage for powered Concentration into Swift Reflexes (including boosted follow-up choice values)

## Bug Repro Covered
- Play powered Concentration
- Select Swift Reflexes as the boosted card
- Resolve Swift Reflexes follow-up choice
- Verify boosted ranged attack is applied (5 instead of 3)

## Validation
- @mage-knight/mage-dev build: ✓ @mage-knight/mage-dev built in 4ms
@mage-knight/mage-dev build: Exited with code 0
@mage-knight/shared build: i Using bunup v0.16.22 and bun v1.3.9
@mage-knight/shared build: i Using shared/bunup.config.ts
@mage-knight/shared build: i Build started
@mage-knight/shared build: 
@mage-knight/shared build:   src/index.ts
@mage-knight/shared build: 
@mage-knight/shared build:   Output                        Raw         Gzip
@mage-knight/shared build: 
@mage-knight/shared build:   [esm] dist/index.js       177.83 KB     36.69 KB
@mage-knight/shared build:   [cjs] dist/index.cjs      207.65 KB     40.22 KB
@mage-knight/shared build:   [esm] dist/index.d.ts     344.38 KB     75.89 KB
@mage-knight/shared build:   [cjs] dist/index.d.cts    344.38 KB     75.89 KB
@mage-knight/shared build: 
@mage-knight/shared build:   4 files                   1.05 MB    228.69 KB
@mage-knight/shared build: 
@mage-knight/shared build: 
@mage-knight/shared build: ✓ Build completed in 290ms
@mage-knight/shared build: Exited with code 0
@mage-knight/core build: i Using bunup v0.16.22 and bun v1.3.9
@mage-knight/core build: i Using core/bunup.config.ts
@mage-knight/core build: i Build started
@mage-knight/core build: 
@mage-knight/core build:   src/index.ts
@mage-knight/core build: 
@mage-knight/core build:   Output                        Raw         Gzip
@mage-knight/core build: 
@mage-knight/core build:   [esm] dist/index.js       1.55 MB    260.66 KB
@mage-knight/core build:   [cjs] dist/index.cjs      1.55 MB    253.02 KB
@mage-knight/core build:   [esm] dist/index.d.ts     171.83 KB     42.89 KB
@mage-knight/core build:   [cjs] dist/index.d.cts    171.83 KB     42.89 KB
@mage-knight/core build: 
@mage-knight/core build:   4 files                   3.43 MB    599.45 KB
@mage-knight/core build: 
@mage-knight/core build: 
@mage-knight/core build: ✓ Build completed in 639ms
@mage-knight/core build: Exited with code 0
@mage-knight/server build: i Using bunup v0.16.22 and bun v1.3.9
@mage-knight/server build: i Using server/bunup.config.ts
@mage-knight/server build: i Build started
@mage-knight/server build: 
@mage-knight/server build:   src/index.ts
@mage-knight/server build: 
@mage-knight/server build:   Output                  Raw       Gzip
@mage-knight/server build: 
@mage-knight/server build:   dist/index.js      20.79 KB    5.40 KB
@mage-knight/server build:   dist/index.d.ts     5.48 KB    1.83 KB
@mage-knight/server build: 
@mage-knight/server build:   2 files            26.27 KB    7.23 KB
@mage-knight/server build: 
@mage-knight/server build: 
@mage-knight/server build: ✓ Build completed in 53ms
@mage-knight/server build: Exited with code 0
@mage-knight/client build: ✓ @mage-knight/client built in 129ms
@mage-knight/client build: Exited with code 0
- Found 0 warnings and 0 errors.
Finished in 432ms on 1463 files with 98 rules using 14 threads.
- @mage-knight/server:test | bun test v1.3.9 (cf6cdbbb)
@mage-knight/shared:test | bun test v1.3.9 (cf6cdbbb)
@mage-knight/core:test   | bun test v1.3.9 (cf6cdbbb)
@mage-knight/core:test   | Player position: {
@mage-knight/core:test   |   q: 4,
@mage-knight/core:test   |   r: -3,
@mage-knight/core:test   | }
@mage-knight/core:test   | Player tile center: {
@mage-knight/core:test   |   q: 3,
@mage-knight/core:test   |   r: -2,
@mage-knight/core:test   | }
@mage-knight/core:test   | Explore options: [
@mage-knight/core:test   |   {
@mage-knight/core:test   |     "direction": "NE",
@mage-knight/core:test   |     "targetCoord": {
@mage-knight/core:test   |       "q": 4,
@mage-knight/core:test   |       "r": -5
@mage-knight/core:test   |     },
@mage-knight/core:test   |     "fromTileCoord": {
@mage-knight/core:test   |       "q": 3,
@mage-knight/core:test   |       "r": -2
@mage-knight/core:test   |     }
@mage-knight/core:test   |   },
@mage-knight/core:test   |   {
@mage-knight/core:test   |     "direction": "E",
@mage-knight/core:test   |     "targetCoord": {
@mage-knight/core:test   |       "q": 6,
@mage-knight/core:test   |       "r": -4
@mage-knight/core:test   |     },
@mage-knight/core:test   |     "fromTileCoord": {
@mage-knight/core:test   |       "q": 3,
@mage-knight/core:test   |       "r": -2
@mage-knight/core:test   |     }
@mage-knight/core:test   |   }
@mage-knight/core:test   | ]
@mage-knight/core:test   | Target (4,-5): {
@mage-knight/core:test   |   direction: "NE",
@mage-knight/core:test   |   targetCoord: {
@mage-knight/core:test   |     q: 4,
@mage-knight/core:test   |     r: -5,
@mage-knight/core:test   |   },
@mage-knight/core:test   |   fromTileCoord: {
@mage-knight/core:test   |     q: 3,
@mage-knight/core:test   |     r: -2,
@mage-knight/core:test   |   },
@mage-knight/core:test   | }
@mage-knight/core:test   | Target (6,-4): {
@mage-knight/core:test   |   direction: "E",
@mage-knight/core:test   |   targetCoord: {
@mage-knight/core:test   |     q: 6,
@mage-knight/core:test   |     r: -4,
@mage-knight/core:test   |   },
@mage-knight/core:test   |   fromTileCoord: {
@mage-knight/core:test   |     q: 3,
@mage-knight/core:test   |     r: -2,
@mage-knight/core:test   |   },
@mage-knight/core:test   | }
@mage-knight/core:test   | === Corrected User Scenario Test ===
@mage-knight/core:test   | Reachable hexes: [ "(2,1) terminal=false", "(0,2) terminal=false", "(1,1) terminal=false",
@mage-knight/core:test   |   "(2,0) terminal=false", "(1,0) terminal=true", "(3,-1) terminal=true", "(2,-1) terminal=false"
@mage-knight/core:test   | ]
@mage-knight/core:test   | === Move from (2,0) to (2,-1) test ===
@mage-knight/core:test   | Targets: [ "(2,-1) terminal=undefined" ]
@mage-knight/core:test   | Reachable: [ "(2,-1) terminal=false" ]
