### PR TITLE
fix: multi-attack enemies broken in block and damage phases

### DIFF
--- a/packages/client/src/components/Combat/CombatOverlay.tsx
+++ b/packages/client/src/components/Combat/CombatOverlay.tsx
@@ -399,7 +399,7 @@ function CombatOverlayInner({ combat, combatOptions }: CombatOverlayProps) {
       setSelectedDamageOption(damageOption);
     } else {
       // No units available - assign all damage to hero
-      sendAction({ type: ASSIGN_DAMAGE_ACTION, enemyInstanceId });
+      sendAction({ type: ASSIGN_DAMAGE_ACTION, enemyInstanceId, attackIndex: damageOption?.attackIndex });
     }
   }, [sendAction, combatOptions?.damageAssignments]);
 
@@ -411,10 +411,11 @@ function CombatOverlayInner({ combat, combatOptions }: CombatOverlayProps) {
         type: ASSIGN_DAMAGE_ACTION,
         enemyInstanceId,
         assignments,
+        attackIndex: selectedDamageOption?.attackIndex,
       });
       setSelectedDamageOption(null);
     },
-    [sendAction]
+    [sendAction, selectedDamageOption]
   );
 
   // Handle damage assignment panel cancel
@@ -508,8 +509,13 @@ function CombatOverlayInner({ combat, combatOptions }: CombatOverlayProps) {
 
   const handleCommitBlock = useCallback((enemyInstanceId: string) => {
     triggerEffect("block");
-    sendAction({ type: DECLARE_BLOCK_ACTION, targetEnemyInstanceId: enemyInstanceId });
-  }, [sendAction, triggerEffect]);
+    const blockState = combatOptions?.enemyBlockStates?.find(e => e.enemyInstanceId === enemyInstanceId);
+    sendAction({
+      type: DECLARE_BLOCK_ACTION,
+      targetEnemyInstanceId: enemyInstanceId,
+      attackIndex: blockState?.attackIndex,
+    });
+  }, [sendAction, triggerEffect, combatOptions?.enemyBlockStates]);
 
   // ========================================
   // Drag & Drop Handlers (PixiJS)

--- a/packages/core/src/engine/combat/enemyAttackHelpers.ts
+++ b/packages/core/src/engine/combat/enemyAttackHelpers.ts
@@ -273,6 +273,36 @@ export function initializeAttacksDamageAssigned(
 }
 
 /**
+ * Find the index of the first unblocked, uncancelled attack for an enemy.
+ * Used as a fallback when no attackIndex is specified in block commands.
+ *
+ * @param enemy - Combat enemy instance
+ * @returns Index of the first unblocked attack, or 0 if all are blocked
+ */
+export function findFirstUnblockedAttack(enemy: CombatEnemy): number {
+  const count = getEnemyAttackCount(enemy);
+  for (let i = 0; i < count; i++) {
+    if (!isAttackBlocked(enemy, i) && !isAttackCancelled(enemy, i)) return i;
+  }
+  return 0; // fallback
+}
+
+/**
+ * Find the index of the first unblocked, uncancelled, unassigned attack.
+ * Used as a fallback when no attackIndex is specified in damage assignment commands.
+ *
+ * @param enemy - Combat enemy instance
+ * @returns Index of the first unassigned attack, or 0 if all are assigned
+ */
+export function findFirstUnassignedAttack(enemy: CombatEnemy): number {
+  const count = getEnemyAttackCount(enemy);
+  for (let i = 0; i < count; i++) {
+    if (!isAttackBlocked(enemy, i) && !isAttackCancelled(enemy, i) && !isAttackDamageAssigned(enemy, i)) return i;
+  }
+  return 0; // fallback
+}
+
+/**
  * Get the effective attack element for an enemy after element conversion modifiers.
  * Used by block and damage calculations to account for Know Your Prey element conversion.
  *

--- a/packages/core/src/engine/commands/combat/assignDamageCommand.ts
+++ b/packages/core/src/engine/commands/combat/assignDamageCommand.ts
@@ -28,6 +28,7 @@ import {
   isAttackBlocked,
   isAttackDamageAssigned,
   getEffectiveEnemyAttackElement,
+  findFirstUnassignedAttack,
 } from "../../combat/enemyAttackHelpers.js";
 import {
   getEffectiveDamage,
@@ -84,8 +85,8 @@ export function createAssignDamageCommand(
         throw new Error(`Enemy not found: ${params.enemyInstanceId}`);
       }
 
-      // Get the attack index (default to 0 for single-attack enemies)
-      const attackIndex = params.attackIndex ?? 0;
+      // Get the attack index (auto-resolve to first unassigned for multi-attack enemies)
+      const attackIndex = params.attackIndex ?? findFirstUnassignedAttack(enemy);
       const attackCount = getEnemyAttackCount(enemy);
 
       // Validate attack index

--- a/packages/core/src/engine/commands/combat/declareBlockCommand.ts
+++ b/packages/core/src/engine/commands/combat/declareBlockCommand.ts
@@ -31,6 +31,7 @@ import {
   getEnemyAttackCount,
   isAttackBlocked,
   getEffectiveEnemyAttackElement,
+  findFirstUnblockedAttack,
 } from "../../combat/enemyAttackHelpers.js";
 import { getCumbersomeReducedAttack } from "../../combat/cumbersomeHelpers.js";
 import { isSwiftActive } from "../../combat/swiftHelpers.js";
@@ -157,8 +158,8 @@ export function createDeclareBlockCommand(
         throw new Error(`Enemy not found: ${params.targetEnemyInstanceId}`);
       }
 
-      // Get the attack index (default to 0 for single-attack enemies)
-      const attackIndex = params.attackIndex ?? 0;
+      // Get the attack index (auto-resolve to first unblocked for multi-attack enemies)
+      const attackIndex = params.attackIndex ?? findFirstUnblockedAttack(enemy);
       const attackCount = getEnemyAttackCount(enemy);
 
       // Validate attack index

--- a/packages/core/src/engine/validators/combatValidators/targetValidators.ts
+++ b/packages/core/src/engine/validators/combatValidators/targetValidators.ts
@@ -32,6 +32,8 @@ import {
   isAttackBlocked,
   isAttackDamageAssigned,
   isEnemyFullyBlocked,
+  findFirstUnblockedAttack,
+  findFirstUnassignedAttack,
 } from "../../combat/enemyAttackHelpers.js";
 
 // Target enemy must exist and not be defeated (for block)
@@ -64,8 +66,8 @@ export function validateBlockTargetEnemy(
     );
   }
 
-  // Get attack index (default to 0 for single-attack enemies)
-  const attackIndex = action.attackIndex ?? 0;
+  // Get attack index (auto-resolve to first unblocked for multi-attack enemies)
+  const attackIndex = action.attackIndex ?? findFirstUnblockedAttack(enemy);
   const attackCount = getEnemyAttackCount(enemy);
 
   // Validate attack index is in range
@@ -125,8 +127,8 @@ export function validateAssignDamageTargetEnemy(
     );
   }
 
-  // Get attack index (default to 0 for single-attack enemies)
-  const attackIndex = action.attackIndex ?? 0;
+  // Get attack index (auto-resolve to first unassigned for multi-attack enemies)
+  const attackIndex = action.attackIndex ?? findFirstUnassignedAttack(enemy);
   const attackCount = getEnemyAttackCount(enemy);
 
   // Validate attack index is in range

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -421,6 +421,11 @@ export interface EnemyBlockState {
   readonly isBrutal: boolean;
   readonly isBlocked: boolean;
   readonly isDefeated: boolean;
+  /**
+   * For multi-attack enemies, the index of the first unblocked/uncancelled attack
+   * that this block state represents. Undefined for single-attack enemies.
+   */
+  readonly attackIndex?: number;
 
   /** Raw pending block (what's been assigned) */
   readonly pendingBlock: ElementalDamageValues;


### PR DESCRIPTION
## Summary
- Multi-attack enemies with `attack: 0` and `attacks` array (e.g., Zombie Horde) were invisible in block phase and couldn't cycle through sequential damage assignment
- Block filter, `computeEnemyBlockState`, validators, commands, and client handlers all used the legacy `attack` field or defaulted `attackIndex` to 0 instead of auto-resolving

## Changes
- **Block filter** (`combatBlock.ts`): checks `attacks` array via `getEnemyAttacks()` instead of legacy `enemy.definition.attack`
- **`computeEnemyBlockState`** (`combatBlock.ts`): uses first unblocked attack's damage/element, adds `attackIndex` to returned state
- **Helpers** (`enemyAttackHelpers.ts`): added `findFirstUnblockedAttack()` and `findFirstUnassignedAttack()`
- **Validators** (`targetValidators.ts`): auto-resolve `attackIndex` via helpers instead of defaulting to 0
- **Commands** (`assignDamageCommand.ts`, `declareBlockCommand.ts`): auto-resolve `attackIndex` via helpers
- **Client** (`CombatOverlay.tsx`): passes `attackIndex` from block state and damage options in handlers
- **Shared type** (`validActions.ts`): added optional `attackIndex` to `EnemyBlockState`

## Test plan
- [x] 5 new tests added covering block filter, block state values, and auto-resolve behavior
- [x] All 5093 tests pass
- [x] Build and lint clean
- [ ] Manual: fight Zombie Horde — block phase shows attacks, damage phase cycles through all 3