### PR TITLE
feat: implement Krang Puppet Master skill behavior (#346)

### DIFF
--- a/packages/core/src/engine/__tests__/skillPuppetMaster.test.ts
+++ b/packages/core/src/engine/__tests__/skillPuppetMaster.test.ts
@@ -1,0 +1,1044 @@
+/**
+ * Tests for Puppet Master skill (Krang)
+ *
+ * Once per turn during combat, either:
+ * - Keep one defeated enemy token, OR
+ * - Discard a previously kept token for Attack or Block
+ *
+ * Attack = ceil(enemy_attack / 2) with matching element (melee only)
+ * Block = ceil(enemy_armor / 2) with opposite element of resistance
+ *
+ * Key rules:
+ * - Cannot keep AND expend in same turn (once per turn) (S7)
+ * - Can accumulate multiple tokens across turns (S7)
+ * - Arcane Immunity and Elusive ignored for token values (S1)
+ * - Physical resistance has no effect on Block element (S5)
+ * - Attacks are NOT ranged/siege (S9)
+ * - Usable in Dungeons/Tombs (not a unit) (S6)
+ * - Multiple attacks split into compound effect (S3)
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { createEngine, type MageKnightEngine } from "../MageKnightEngine.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import {
+  USE_SKILL_ACTION,
+  SKILL_USED,
+  INVALID_ACTION,
+  RESOLVE_CHOICE_ACTION,
+  ENEMY_PROWLERS,
+  ENEMY_GUARDSMEN,
+  ENEMY_FIRE_MAGES,
+  ENEMY_ICE_MAGES,
+  ENEMY_DELPHANA_MASTERS,
+  ENEMY_ORC_SKIRMISHERS,
+  getSkillsFromValidActions,
+} from "@mage-knight/shared";
+import type { EnemyId } from "@mage-knight/shared";
+import { Hero } from "../../types/hero.js";
+import { SKILL_KRANG_PUPPET_MASTER } from "../../data/skills/index.js";
+import { getValidActions } from "../validActions/index.js";
+import {
+  COMBAT_PHASE_RANGED_SIEGE,
+  COMBAT_PHASE_BLOCK,
+  COMBAT_PHASE_ATTACK,
+  createCombatState,
+} from "../../types/combat.js";
+import {
+  EFFECT_GAIN_ATTACK,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_COMPOUND,
+  EFFECT_PUPPET_MASTER_KEEP,
+  EFFECT_PUPPET_MASTER_EXPEND,
+} from "../../types/effectTypes.js";
+import {
+  getBlockElementFromResistances,
+  createKeptTokenFromEnemy,
+} from "../commands/skills/puppetMasterEffect.js";
+import type { KeptEnemyToken } from "../../types/player.js";
+import type { CardEffect } from "../../types/cards.js";
+import {
+  ELEMENT_PHYSICAL,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  RESIST_FIRE,
+  RESIST_ICE,
+  RESIST_PHYSICAL,
+  getEnemy,
+} from "@mage-knight/shared";
+
+function createKrangPlayer(overrides: Record<string, unknown> = {}) {
+  return createTestPlayer({
+    hero: Hero.Krang,
+    skills: [SKILL_KRANG_PUPPET_MASTER],
+    skillCooldowns: {
+      usedThisRound: [],
+      usedThisTurn: [],
+      usedThisCombat: [],
+      activeUntilNextTurn: [],
+    },
+    ...overrides,
+  });
+}
+
+/**
+ * Create a combat state with one or more defeated enemies.
+ */
+function createCombatWithDefeated(
+  enemyIds: readonly EnemyId[],
+  defeatedIndices: readonly number[] = [0],
+  phase: typeof COMBAT_PHASE_RANGED_SIEGE | typeof COMBAT_PHASE_BLOCK | typeof COMBAT_PHASE_ATTACK = COMBAT_PHASE_ATTACK
+) {
+  const combat = createCombatState(enemyIds);
+  const enemies = combat.enemies.map((e, i) => ({
+    ...e,
+    isDefeated: defeatedIndices.includes(i),
+  }));
+  return { ...combat, phase, enemies };
+}
+
+/**
+ * Create a simple kept enemy token for testing expend mode.
+ */
+function createTestToken(enemyId: EnemyId): KeptEnemyToken {
+  const def = getEnemy(enemyId);
+  return {
+    enemyId,
+    name: def.name,
+    attack: def.attack,
+    attackElement: def.attackElement,
+    attacks: def.attacks,
+    armor: def.armor,
+    resistances: def.resistances,
+  };
+}
+
+describe("Puppet Master skill", () => {
+  let engine: MageKnightEngine;
+
+  beforeEach(() => {
+    engine = createEngine();
+  });
+
+  // ======================================================================
+  // ACTIVATION
+  // ======================================================================
+
+  describe("activation", () => {
+    it("should activate during combat with defeated enemies (keep mode)", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_KRANG_PUPPET_MASTER,
+        })
+      );
+    });
+
+    it("should activate during combat with stored tokens (expend mode)", () => {
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      // Combat with alive enemy (no defeated ones) — but has stored tokens
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: SKILL_USED,
+          playerId: "player1",
+          skillId: SKILL_KRANG_PUPPET_MASTER,
+        })
+      );
+    });
+
+    it("should reject when not in combat", () => {
+      const player = createKrangPlayer();
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should reject when in combat but no defeated enemies and no stored tokens", () => {
+      const player = createKrangPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+
+    it("should reject when on cooldown (once per turn)", () => {
+      const player = createKrangPlayer({
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_KRANG_PUPPET_MASTER],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({ type: INVALID_ACTION })
+      );
+    });
+  });
+
+  // ======================================================================
+  // KEEP MODE
+  // ======================================================================
+
+  describe("keep mode", () => {
+    it("should present keep options for defeated enemies", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice;
+      expect(pending).toBeDefined();
+      expect(pending!.skillId).toBe(SKILL_KRANG_PUPPET_MASTER);
+
+      // Should have at least one keep option
+      const keepOptions = pending!.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+      expect(keepOptions.length).toBeGreaterThan(0);
+    });
+
+    it("should add token to player storage when keeping defeated enemy", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate skill
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      // Find the keep option index
+      const pending = activateResult.state.players[0]!.pendingChoice!;
+      const keepIndex = pending.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+      expect(keepIndex).toBeGreaterThanOrEqual(0);
+
+      // Resolve the choice
+      const resolveResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: keepIndex,
+        }
+      );
+
+      // Token should be stored
+      expect(resolveResult.state.players[0]!.keptEnemyTokens).toHaveLength(1);
+      const token = resolveResult.state.players[0]!.keptEnemyTokens[0]!;
+      expect(token.enemyId).toBe(ENEMY_PROWLERS);
+      expect(token.name).toBe("Prowlers");
+      expect(token.attack).toBe(4);
+      expect(token.attackElement).toBe(ELEMENT_PHYSICAL);
+      expect(token.armor).toBe(3);
+    });
+
+    it("should present multiple keep options when multiple enemies defeated", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated(
+        [ENEMY_PROWLERS, ENEMY_FIRE_MAGES],
+        [0, 1]
+      );
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice!;
+      const keepOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+      expect(keepOptions).toHaveLength(2);
+    });
+
+    it("should not show keep options for alive enemies", () => {
+      const player = createKrangPlayer();
+      // Only first enemy is defeated
+      const combat = createCombatWithDefeated(
+        [ENEMY_PROWLERS, ENEMY_GUARDSMEN],
+        [0]
+      );
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice!;
+      const keepOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+      // Only the defeated one
+      expect(keepOptions).toHaveLength(1);
+    });
+  });
+
+  // ======================================================================
+  // EXPEND MODE
+  // ======================================================================
+
+  describe("expend mode", () => {
+    it("should present expend options for stored tokens", () => {
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      // Combat with alive enemy only — forces expend mode
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice!;
+      const expendOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      expect(expendOptions).toHaveLength(1);
+    });
+
+    it("should show both keep and expend when defeated enemies AND stored tokens exist", () => {
+      const token = createTestToken(ENEMY_GUARDSMEN);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice!;
+      const keepOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+      const expendOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      expect(keepOptions.length).toBeGreaterThan(0);
+      expect(expendOptions.length).toBeGreaterThan(0);
+    });
+
+    it("should remove token from storage and create attack/block sub-choice", () => {
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate skill
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      // Find expend option
+      const pending = activateResult.state.players[0]!.pendingChoice!;
+      const expendIndex = pending.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+
+      // Resolve expend choice
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        {
+          type: RESOLVE_CHOICE_ACTION,
+          choiceIndex: expendIndex,
+        }
+      );
+
+      // Token should be removed
+      expect(expendResult.state.players[0]!.keptEnemyTokens).toHaveLength(0);
+
+      // Should have a new sub-choice: attack vs block
+      const subChoice = expendResult.state.players[0]!.pendingChoice;
+      expect(subChoice).toBeDefined();
+      expect(subChoice!.options).toHaveLength(2);
+    });
+
+    it("should grant melee attack when choosing attack option", () => {
+      const token = createTestToken(ENEMY_PROWLERS); // Attack 4 Physical
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate → Expend → Choose Attack
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      // Verify sub-choice exists
+      const subPending = expendResult.state.players[0]!.pendingChoice;
+      expect(subPending).toBeDefined();
+      expect(subPending!.options.length).toBe(2);
+
+      // Find the attack option
+      const subOptions = subPending!.options;
+      const attackIndex = subOptions.findIndex(
+        (o) => o.type === EFFECT_GAIN_ATTACK
+      );
+      expect(attackIndex).toBeGreaterThanOrEqual(0);
+
+      // Check events for INVALID_ACTION from sub-choice resolve
+      const attackResult = engine.processAction(
+        expendResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: attackIndex }
+      );
+
+      // Prowlers: attack 4 → ceil(4/2) = 2 Physical melee attack
+      const accumulator = attackResult.state.players[0]!.combatAccumulator;
+      expect(accumulator.attack.normal).toBe(2);
+    });
+
+    it("should grant block when choosing block option", () => {
+      const token = createTestToken(ENEMY_PROWLERS); // Armor 3, no resistances
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate → Expend → Choose Block
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      // Find the block option
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const blockIndex = subOptions.findIndex(
+        (o) => o.type === EFFECT_GAIN_BLOCK
+      );
+
+      const blockResult = engine.processAction(
+        expendResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: blockIndex }
+      );
+
+      // Prowlers: armor 3 → ceil(3/2) = 2 Physical block
+      const accumulator = blockResult.state.players[0]!.combatAccumulator;
+      expect(accumulator.block).toBe(2);
+      expect(accumulator.blockElements.physical).toBe(2);
+    });
+  });
+
+  // ======================================================================
+  // ATTACK CALCULATIONS
+  // ======================================================================
+
+  describe("attack calculations", () => {
+    it("should calculate ceil(attack/2) for odd attack values", () => {
+      // Prowlers: attack 4, ceil(4/2) = 2
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const attackOption = subOptions.find((o) => o.type === EFFECT_GAIN_ATTACK) as CardEffect & { amount: number };
+      expect(attackOption).toBeDefined();
+      expect(attackOption.amount).toBe(2); // ceil(4/2) = 2
+    });
+
+    it("should preserve fire element on attack", () => {
+      // Fire Mages: attack 6 Fire
+      const token = createTestToken(ENEMY_FIRE_MAGES);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const attackOption = subOptions.find((o) => o.type === EFFECT_GAIN_ATTACK) as CardEffect & { amount: number; element: string };
+      expect(attackOption.amount).toBe(3); // ceil(6/2) = 3
+      expect(attackOption.element).toBe(ELEMENT_FIRE);
+    });
+
+    it("should preserve ice element on attack", () => {
+      // Ice Mages: attack 5 Ice
+      const token = createTestToken(ENEMY_ICE_MAGES);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const attackOption = subOptions.find((o) => o.type === EFFECT_GAIN_ATTACK) as CardEffect & { amount: number; element: string };
+      expect(attackOption.amount).toBe(3); // ceil(5/2) = 3
+      expect(attackOption.element).toBe(ELEMENT_ICE);
+    });
+
+    it("should create compound effect for multi-attack enemies", () => {
+      // Orc Skirmishers: 2 attacks of 1 Physical each
+      const token = createTestToken(ENEMY_ORC_SKIRMISHERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      // Attack option should be a compound effect with 2 sub-attacks
+      const attackOption = subOptions.find(
+        (o) => o.type === EFFECT_COMPOUND || o.type === EFFECT_GAIN_ATTACK
+      );
+      expect(attackOption).toBeDefined();
+
+      if (attackOption!.type === EFFECT_COMPOUND) {
+        const compound = attackOption as CardEffect & { effects: readonly CardEffect[] };
+        expect(compound.effects).toHaveLength(2);
+        // Each attack: ceil(1/2) = 1
+        for (const sub of compound.effects) {
+          expect(sub.type).toBe(EFFECT_GAIN_ATTACK);
+          expect((sub as CardEffect & { amount: number }).amount).toBe(1);
+        }
+      }
+    });
+
+    it("should set combat type to melee (not ranged/siege) per S9", () => {
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const attackOption = subOptions.find(
+        (o) => o.type === EFFECT_GAIN_ATTACK
+      ) as CardEffect & { combatType: string };
+      expect(attackOption.combatType).toBe("melee");
+    });
+  });
+
+  // ======================================================================
+  // BLOCK CALCULATIONS (ELEMENT CONVERSION)
+  // ======================================================================
+
+  describe("block element conversion", () => {
+    it("should convert fire resistance to ice block", () => {
+      // Fire Mages: resist fire → Ice block
+      const token = createTestToken(ENEMY_FIRE_MAGES);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const blockOption = subOptions.find(
+        (o) => o.type === EFFECT_GAIN_BLOCK
+      ) as CardEffect & { amount: number; element: string };
+      expect(blockOption.amount).toBe(3); // ceil(5/2) = 3
+      expect(blockOption.element).toBe(ELEMENT_ICE);
+    });
+
+    it("should convert ice resistance to fire block", () => {
+      // Ice Mages: resist ice → Fire block
+      const token = createTestToken(ENEMY_ICE_MAGES);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const blockOption = subOptions.find(
+        (o) => o.type === EFFECT_GAIN_BLOCK
+      ) as CardEffect & { amount: number; element: string };
+      expect(blockOption.amount).toBe(3); // ceil(6/2) = 3
+      expect(blockOption.element).toBe(ELEMENT_FIRE);
+    });
+
+    it("should convert both fire+ice resistance to cold fire block", () => {
+      // Delphana Masters: resist fire + ice → ColdFire block
+      const token = createTestToken(ENEMY_DELPHANA_MASTERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const blockOption = subOptions.find(
+        (o) => o.type === EFFECT_GAIN_BLOCK
+      ) as CardEffect & { amount: number; element: string };
+      expect(blockOption.amount).toBe(4); // ceil(8/2) = 4
+      expect(blockOption.element).toBe(ELEMENT_COLD_FIRE);
+    });
+
+    it("should give physical block when enemy has no elemental resistances", () => {
+      // Prowlers: no resistances → Physical block
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+      const expendIndex = activateResult.state.players[0]!.pendingChoice!.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      const expendResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: expendIndex }
+      );
+
+      const subOptions = expendResult.state.players[0]!.pendingChoice!.options;
+      const blockOption = subOptions.find(
+        (o) => o.type === EFFECT_GAIN_BLOCK
+      ) as CardEffect & { amount: number; element: string | undefined };
+      expect(blockOption.amount).toBe(2); // ceil(3/2) = 2
+      // Physical block uses undefined element (engine convention)
+      expect(blockOption.element).toBeUndefined();
+    });
+  });
+
+  // ======================================================================
+  // getBlockElementFromResistances (UNIT TESTS)
+  // ======================================================================
+
+  describe("getBlockElementFromResistances", () => {
+    it("should return ice for fire resistance", () => {
+      expect(getBlockElementFromResistances([RESIST_FIRE])).toBe(ELEMENT_ICE);
+    });
+
+    it("should return fire for ice resistance", () => {
+      expect(getBlockElementFromResistances([RESIST_ICE])).toBe(ELEMENT_FIRE);
+    });
+
+    it("should return cold fire for both fire and ice resistance", () => {
+      expect(getBlockElementFromResistances([RESIST_FIRE, RESIST_ICE])).toBe(
+        ELEMENT_COLD_FIRE
+      );
+    });
+
+    it("should return physical for physical-only resistance (S5)", () => {
+      expect(getBlockElementFromResistances([RESIST_PHYSICAL])).toBe(
+        ELEMENT_PHYSICAL
+      );
+    });
+
+    it("should return physical for no resistances", () => {
+      expect(getBlockElementFromResistances([])).toBe(ELEMENT_PHYSICAL);
+    });
+  });
+
+  // ======================================================================
+  // createKeptTokenFromEnemy (UNIT TESTS)
+  // ======================================================================
+
+  describe("createKeptTokenFromEnemy", () => {
+    it("should capture enemy combat data", () => {
+      const combat = createCombatState([ENEMY_FIRE_MAGES]);
+      const enemy = combat.enemies[0]!;
+      const token = createKeptTokenFromEnemy(enemy);
+
+      expect(token.enemyId).toBe(ENEMY_FIRE_MAGES);
+      expect(token.name).toBe("Fire Mages");
+      expect(token.attack).toBe(6);
+      expect(token.attackElement).toBe(ELEMENT_FIRE);
+      expect(token.armor).toBe(5);
+      expect(token.resistances).toEqual([RESIST_FIRE]);
+    });
+
+    it("should capture multi-attack data", () => {
+      const combat = createCombatState([ENEMY_ORC_SKIRMISHERS]);
+      const enemy = combat.enemies[0]!;
+      const token = createKeptTokenFromEnemy(enemy);
+
+      expect(token.attacks).toHaveLength(2);
+      expect(token.attacks![0]!.damage).toBe(1);
+      expect(token.attacks![1]!.damage).toBe(1);
+    });
+  });
+
+  // ======================================================================
+  // VALID ACTIONS
+  // ======================================================================
+
+  describe("valid actions", () => {
+    it("should show Puppet Master in valid actions during combat with defeated enemies", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_KRANG_PUPPET_MASTER,
+        })
+      );
+    });
+
+    it("should show Puppet Master in valid actions during combat with stored tokens", () => {
+      const token = createTestToken(ENEMY_PROWLERS);
+      const player = createKrangPlayer({ keptEnemyTokens: [token] });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      expect(skills?.activatable).toContainEqual(
+        expect.objectContaining({
+          skillId: SKILL_KRANG_PUPPET_MASTER,
+        })
+      );
+    });
+
+    it("should not show Puppet Master outside combat", () => {
+      const player = createKrangPlayer();
+      const state = createTestGameState({ players: [player] });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_KRANG_PUPPET_MASTER,
+          })
+        );
+      }
+    });
+
+    it("should not show Puppet Master when on cooldown", () => {
+      const player = createKrangPlayer({
+        skillCooldowns: {
+          usedThisRound: [],
+          usedThisTurn: [SKILL_KRANG_PUPPET_MASTER],
+          usedThisCombat: [],
+          activeUntilNextTurn: [],
+        },
+      });
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_KRANG_PUPPET_MASTER,
+          })
+        );
+      }
+    });
+
+    it("should not show Puppet Master when no defeated enemies and no tokens", () => {
+      const player = createKrangPlayer();
+      const combat = {
+        ...createCombatState([ENEMY_PROWLERS]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const validActions = getValidActions(state, "player1");
+      const skills = getSkillsFromValidActions(validActions);
+      if (skills) {
+        expect(skills.activatable).not.toContainEqual(
+          expect.objectContaining({
+            skillId: SKILL_KRANG_PUPPET_MASTER,
+          })
+        );
+      }
+    });
+  });
+
+  // ======================================================================
+  // UNDO
+  // ======================================================================
+
+  describe("undo", () => {
+    it("should clear pending choice on undo", () => {
+      const player = createKrangPlayer();
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      // Should have pending choice
+      expect(result.state.players[0]!.pendingChoice).toBeDefined();
+
+      // Check undo is available
+      const validActions = getValidActions(result.state, "player1");
+      expect(validActions.turn.canUndo).toBe(true);
+    });
+  });
+
+  // ======================================================================
+  // TOKEN ACCUMULATION
+  // ======================================================================
+
+  describe("token accumulation", () => {
+    it("should allow accumulating multiple tokens across activations", () => {
+      // Start with one token already stored, keep another
+      const existingToken = createTestToken(ENEMY_GUARDSMEN);
+      const player = createKrangPlayer({ keptEnemyTokens: [existingToken] });
+      const combat = createCombatWithDefeated([ENEMY_PROWLERS]);
+      const state = createTestGameState({ players: [player], combat });
+
+      // Activate skill
+      const activateResult = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      // Choose to keep the defeated enemy (not expend stored)
+      const pending = activateResult.state.players[0]!.pendingChoice!;
+      const keepIndex = pending.options.findIndex(
+        (o) => o.type === EFFECT_PUPPET_MASTER_KEEP
+      );
+
+      const resolveResult = engine.processAction(
+        activateResult.state,
+        "player1",
+        { type: RESOLVE_CHOICE_ACTION, choiceIndex: keepIndex }
+      );
+
+      // Should now have 2 tokens
+      expect(resolveResult.state.players[0]!.keptEnemyTokens).toHaveLength(2);
+    });
+
+    it("should present multiple expend options when multiple tokens stored", () => {
+      const token1 = createTestToken(ENEMY_PROWLERS);
+      const token2 = createTestToken(ENEMY_FIRE_MAGES);
+      const player = createKrangPlayer({
+        keptEnemyTokens: [token1, token2],
+      });
+      const combat = {
+        ...createCombatState([ENEMY_GUARDSMEN]),
+        phase: COMBAT_PHASE_ATTACK,
+      };
+      const state = createTestGameState({ players: [player], combat });
+
+      const result = engine.processAction(state, "player1", {
+        type: USE_SKILL_ACTION,
+        skillId: SKILL_KRANG_PUPPET_MASTER,
+      });
+
+      const pending = result.state.players[0]!.pendingChoice!;
+      const expendOptions = pending.options.filter(
+        (o) => o.type === EFFECT_PUPPET_MASTER_EXPEND
+      );
+      expect(expendOptions).toHaveLength(2);
+    });
+  });
+});

--- a/packages/core/src/engine/__tests__/testHelpers.ts
+++ b/packages/core/src/engine/__tests__/testHelpers.ts
@@ -123,6 +123,7 @@ export function createTestPlayer(overrides: Partial<Player> = {}): Player {
     skillFlipState: {
       flippedSkills: [],
     },
+    keptEnemyTokens: [],
     crystals: { red: 0, blue: 0, green: 0, white: 0 },
     selectedTactic: null,
     tacticFlipped: false,

--- a/packages/core/src/engine/commands/skills/index.ts
+++ b/packages/core/src/engine/commands/skills/index.ts
@@ -93,3 +93,13 @@ export {
   removeWolfsHowlEffect,
   canActivateWolfsHowl,
 } from "./wolfsHowlEffect.js";
+
+export {
+  applyPuppetMasterEffect,
+  removePuppetMasterEffect,
+  canActivatePuppetMaster,
+  resolveKeepEnemyToken,
+  resolveExpendTokenChoice,
+  getBlockElementFromResistances,
+  createKeptTokenFromEnemy,
+} from "./puppetMasterEffect.js";

--- a/packages/core/src/engine/commands/skills/puppetMasterEffect.ts
+++ b/packages/core/src/engine/commands/skills/puppetMasterEffect.ts
@@ -1,0 +1,390 @@
+/**
+ * Puppet Master skill effect handler
+ *
+ * Krang's skill: Once per turn during combat, either:
+ * - Keep one defeated enemy token, OR
+ * - Discard a previously kept token for Attack or Block
+ *
+ * Attack = ceil(enemy_attack / 2), same element
+ * Block = ceil(enemy_armor / 2), opposite element of resistance
+ *
+ * Key rules:
+ * - Cannot keep AND expend in same turn (S7)
+ * - Can accumulate multiple tokens across turns (S7)
+ * - Arcane Immunity and Elusive ignored (S1)
+ * - Physical resistance has no effect on Block element (S5)
+ * - Attacks are NOT Ranged/Siege (S9)
+ * - Usable in Dungeons/Tombs (not a unit) (S6)
+ * - Multiple attacks can split or combine (S3)
+ *
+ * @module commands/skills/puppetMasterEffect
+ */
+
+import type { GameState } from "../../../state/GameState.js";
+import type { Player, KeptEnemyToken } from "../../../types/player.js";
+import type { CardEffect, PuppetMasterKeepEffect, PuppetMasterExpendEffect } from "../../../types/cards.js";
+import type { CombatEnemy } from "../../../types/combat.js";
+import { SKILL_KRANG_PUPPET_MASTER } from "../../../data/skills/krang/puppetMaster.js";
+import { getPlayerIndexByIdOrThrow } from "../../helpers/playerHelpers.js";
+import {
+  EFFECT_GAIN_ATTACK,
+  EFFECT_GAIN_BLOCK,
+  EFFECT_COMPOUND,
+  EFFECT_PUPPET_MASTER_KEEP,
+  EFFECT_PUPPET_MASTER_EXPEND,
+} from "../../../types/effectTypes.js";
+import type {
+  Element,
+  EnemyAttack,
+  EnemyResistances,
+} from "@mage-knight/shared";
+import {
+  ELEMENT_PHYSICAL,
+  ELEMENT_FIRE,
+  ELEMENT_ICE,
+  ELEMENT_COLD_FIRE,
+  RESIST_FIRE,
+  RESIST_ICE,
+} from "@mage-knight/shared";
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Check if Puppet Master can be activated.
+ * Requires combat AND either:
+ * - Defeated enemies to keep (keep mode), OR
+ * - Stored enemy tokens to expend (expend mode)
+ */
+export function canActivatePuppetMaster(
+  state: GameState,
+  player: Player
+): boolean {
+  if (!state.combat) return false;
+  return hasDefeatedEnemies(state) || hasKeptTokens(player);
+}
+
+/**
+ * Apply the Puppet Master skill effect.
+ *
+ * Creates a pending choice based on available modes:
+ * - If defeated enemies exist AND stored tokens exist: choice between keep/expend
+ * - If only defeated enemies: choose which enemy to keep
+ * - If only stored tokens: choose which token to expend, then attack/block choice
+ */
+export function applyPuppetMasterEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player || !state.combat) return state;
+
+  const defeated = getDefeatedEnemies(state);
+  const hasTokens = hasKeptTokens(player);
+
+  // Build the choice options
+  const options: CardEffect[] = [];
+
+  // Add "keep enemy" options (one per defeated enemy)
+  for (const enemy of defeated) {
+    options.push(createKeepEnemyEffect(enemy));
+  }
+
+  // Add "expend token" options (one per stored token, each with attack/block sub-choice)
+  if (hasTokens) {
+    for (const token of player.keptEnemyTokens) {
+      options.push(createExpendTokenEffect(token));
+    }
+  }
+
+  if (options.length === 0) return state;
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice: {
+      cardId: null,
+      skillId: SKILL_KRANG_PUPPET_MASTER,
+      unitInstanceId: null,
+      options,
+    },
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+  return { ...state, players };
+}
+
+/**
+ * Remove Puppet Master effects for undo.
+ * Clears pending choice if from Puppet Master.
+ */
+export function removePuppetMasterEffect(
+  state: GameState,
+  playerId: string
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) return state;
+
+  const updatedPlayer: Player = {
+    ...player,
+    pendingChoice:
+      player.pendingChoice?.skillId === SKILL_KRANG_PUPPET_MASTER
+        ? null
+        : player.pendingChoice,
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+  return { ...state, players };
+}
+
+// ============================================================================
+// Keep Enemy Token Logic
+// ============================================================================
+
+/**
+ * Create a "keep enemy token" effect for a defeated enemy.
+ * Uses EFFECT_PUPPET_MASTER_KEEP type which is resolved by resolveChoiceCommand.
+ */
+function createKeepEnemyEffect(enemy: CombatEnemy): PuppetMasterKeepEffect {
+  return {
+    type: EFFECT_PUPPET_MASTER_KEEP,
+    enemyInstanceId: enemy.instanceId,
+    token: createKeptTokenFromEnemy(enemy),
+    description: `Keep ${enemy.definition.name} token`,
+  };
+}
+
+/**
+ * Create a KeptEnemyToken from a defeated CombatEnemy.
+ * Preserves only attack/armor/element/resistance data per FAQ S1.
+ * Ignores Arcane Immunity, Elusive (higher armor), all other abilities.
+ */
+export function createKeptTokenFromEnemy(enemy: CombatEnemy): KeptEnemyToken {
+  return {
+    enemyId: enemy.enemyId,
+    name: enemy.definition.name,
+    attack: enemy.definition.attack,
+    attackElement: enemy.definition.attackElement,
+    attacks: enemy.definition.attacks,
+    armor: enemy.definition.armor, // Uses base armor, not Elusive value (S1)
+    resistances: enemy.definition.resistances,
+  };
+}
+
+/**
+ * Apply the "keep enemy" choice resolution.
+ * Adds the token to player's keptEnemyTokens.
+ */
+export function resolveKeepEnemyToken(
+  state: GameState,
+  playerId: string,
+  token: KeptEnemyToken
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) return state;
+
+  const updatedPlayer: Player = {
+    ...player,
+    keptEnemyTokens: [...player.keptEnemyTokens, token],
+    pendingChoice: null,
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+  return { ...state, players };
+}
+
+// ============================================================================
+// Expend Token Logic
+// ============================================================================
+
+/**
+ * Create an "expend token" effect for a stored token.
+ * This is a compound choice: first choose the token, then choose attack or block.
+ */
+function createExpendTokenEffect(token: KeptEnemyToken): PuppetMasterExpendEffect {
+  return {
+    type: EFFECT_PUPPET_MASTER_EXPEND,
+    token,
+    description: `Discard ${token.name} token for Attack or Block`,
+  };
+}
+
+/**
+ * Resolve expending a kept token.
+ * Creates a sub-choice: Attack or Block.
+ */
+export function resolveExpendTokenChoice(
+  state: GameState,
+  playerId: string,
+  token: KeptEnemyToken
+): GameState {
+  const playerIndex = getPlayerIndexByIdOrThrow(state, playerId);
+  const player = state.players[playerIndex];
+  if (!player) return state;
+
+  const attackEffects = createAttackEffectsFromToken(token);
+  const blockEffect = createBlockEffectFromToken(token);
+
+  const options: CardEffect[] = [attackEffects, blockEffect];
+
+  // Remove the token from storage
+  const updatedPlayer: Player = {
+    ...player,
+    keptEnemyTokens: player.keptEnemyTokens.filter(
+      (t) => t.enemyId !== token.enemyId || t.name !== token.name
+    ),
+    pendingChoice: {
+      cardId: null,
+      skillId: SKILL_KRANG_PUPPET_MASTER,
+      unitInstanceId: null,
+      options,
+    },
+  };
+
+  const players = [...state.players];
+  players[playerIndex] = updatedPlayer;
+  return { ...state, players };
+}
+
+// ============================================================================
+// Attack Calculation
+// ============================================================================
+
+/**
+ * Calculate attack effect(s) from a kept token.
+ * Attack = ceil(enemy_attack / 2) with matching element.
+ * Multiple attacks become a compound effect (S3).
+ * Attacks are melee (not ranged/siege) per S9.
+ */
+function createAttackEffectsFromToken(token: KeptEnemyToken): CardEffect {
+  const attacks = getTokenAttacks(token);
+
+  if (attacks.length === 1) {
+    const atk = attacks[0]!;
+    // GainAttackEffect uses undefined for physical (not ELEMENT_PHYSICAL)
+    const element = atk.element === ELEMENT_PHYSICAL ? undefined : atk.element;
+    return {
+      type: EFFECT_GAIN_ATTACK,
+      amount: Math.ceil(atk.damage / 2),
+      combatType: "melee" as const,
+      element,
+      description: `Attack ${Math.ceil(atk.damage / 2)} ${describeElement(atk.element)} (from ${token.name})`,
+    } as CardEffect;
+  }
+
+  // Multiple attacks: compound effect
+  const subEffects: CardEffect[] = attacks.map((atk) => {
+    const element = atk.element === ELEMENT_PHYSICAL ? undefined : atk.element;
+    return {
+      type: EFFECT_GAIN_ATTACK,
+      amount: Math.ceil(atk.damage / 2),
+      combatType: "melee" as const,
+      element,
+      description: `Attack ${Math.ceil(atk.damage / 2)} ${describeElement(atk.element)}`,
+    } as CardEffect;
+  });
+
+  return {
+    type: EFFECT_COMPOUND,
+    effects: subEffects,
+    description: `Attack from ${token.name}: ${subEffects.length} attacks`,
+  } as CardEffect;
+}
+
+// ============================================================================
+// Block Calculation
+// ============================================================================
+
+/**
+ * Calculate block effect from a kept token.
+ * Block = ceil(enemy_armor / 2).
+ * Element = opposite of enemy resistance:
+ * - Fire resistance → Ice Block
+ * - Ice resistance → Fire Block
+ * - Both → Cold Fire Block
+ * - Physical resistance → no effect (S5)
+ * - No resistance → Physical Block
+ */
+function createBlockEffectFromToken(token: KeptEnemyToken): CardEffect {
+  const blockAmount = Math.ceil(token.armor / 2);
+  const blockElement = getBlockElementFromResistances(token.resistances);
+  // GainBlockEffect uses undefined for physical (not ELEMENT_PHYSICAL)
+  const element = blockElement === ELEMENT_PHYSICAL ? undefined : blockElement;
+
+  return {
+    type: EFFECT_GAIN_BLOCK,
+    amount: blockAmount,
+    element,
+    description: `Block ${blockAmount} ${describeElement(blockElement)} (from ${token.name})`,
+  } as CardEffect;
+}
+
+/**
+ * Get the block element based on enemy resistances.
+ * Fire resist → Ice Block
+ * Ice resist → Fire Block
+ * Both → Cold Fire Block
+ * Physical resist → Physical Block (S5: no effect)
+ * None → Physical Block
+ */
+export function getBlockElementFromResistances(
+  resistances: EnemyResistances
+): Element {
+  const hasFire = resistances.includes(RESIST_FIRE);
+  const hasIce = resistances.includes(RESIST_ICE);
+
+  if (hasFire && hasIce) return ELEMENT_COLD_FIRE;
+  if (hasFire) return ELEMENT_ICE;
+  if (hasIce) return ELEMENT_FIRE;
+  return ELEMENT_PHYSICAL;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+function hasDefeatedEnemies(state: GameState): boolean {
+  if (!state.combat) return false;
+  return state.combat.enemies.some((e) => e.isDefeated);
+}
+
+function getDefeatedEnemies(state: GameState): readonly CombatEnemy[] {
+  if (!state.combat) return [];
+  return state.combat.enemies.filter((e) => e.isDefeated);
+}
+
+function hasKeptTokens(player: Player): boolean {
+  return player.keptEnemyTokens.length > 0;
+}
+
+/**
+ * Get attacks from a kept token, normalizing single and multi-attack forms.
+ */
+function getTokenAttacks(token: KeptEnemyToken): readonly EnemyAttack[] {
+  if (token.attacks && token.attacks.length > 0) {
+    return token.attacks;
+  }
+  return [{ damage: token.attack, element: token.attackElement }];
+}
+
+function describeElement(element: Element): string {
+  switch (element) {
+    case ELEMENT_PHYSICAL:
+      return "Physical";
+    case ELEMENT_FIRE:
+      return "Fire";
+    case ELEMENT_ICE:
+      return "Ice";
+    case ELEMENT_COLD_FIRE:
+      return "ColdFire";
+    default:
+      return "Physical";
+  }
+}
+

--- a/packages/core/src/engine/commands/useSkillCommand.ts
+++ b/packages/core/src/engine/commands/useSkillCommand.ts
@@ -42,6 +42,7 @@ import {
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_DUELING,
   SKILL_WOLFHAWK_WOLFS_HOWL,
+  SKILL_KRANG_PUPPET_MASTER,
 } from "../../data/skills/index.js";
 import {
   applyWhoNeedsMagicEffect,
@@ -78,6 +79,8 @@ import {
   removeDuelingEffect,
   applyWolfsHowlEffect,
   removeWolfsHowlEffect,
+  applyPuppetMasterEffect,
+  removePuppetMasterEffect,
 } from "./skills/index.js";
 import { getPlayerIndexByIdOrThrow } from "../helpers/playerHelpers.js";
 import { restoreMana } from "./helpers/manaConsumptionHelpers.js";
@@ -194,6 +197,9 @@ function applyCustomSkillEffect(
     case SKILL_WOLFHAWK_WOLFS_HOWL:
       return applyWolfsHowlEffect(state, playerId);
 
+    case SKILL_KRANG_PUPPET_MASTER:
+      return applyPuppetMasterEffect(state, playerId);
+
     default:
       // Skill has no custom handler - will use generic effect resolution
       return state;
@@ -263,6 +269,9 @@ function removeCustomSkillEffect(
     case SKILL_WOLFHAWK_WOLFS_HOWL:
       return removeWolfsHowlEffect(state, playerId);
 
+    case SKILL_KRANG_PUPPET_MASTER:
+      return removePuppetMasterEffect(state, playerId);
+
     default:
       return state;
   }
@@ -290,6 +299,7 @@ function hasCustomHandler(skillId: SkillId): boolean {
     SKILL_WOLFHAWK_KNOW_YOUR_PREY,
     SKILL_WOLFHAWK_DUELING,
     SKILL_WOLFHAWK_WOLFS_HOWL,
+    SKILL_KRANG_PUPPET_MASTER,
   ].includes(skillId);
 }
 

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -76,6 +76,7 @@ import { registerPeacefulMomentEffects } from "./peacefulMomentEffects.js";
 import { registerStoutResolveEffects } from "./stoutResolveEffects.js";
 import { registerUnitModifierEffects } from "./unitModifierEffects.js";
 import { registerRushOfAdrenalineEffects } from "./rushOfAdrenalineEffects.js";
+import { registerPuppetMasterEffects } from "./puppetMasterEffects.js";
 
 // ============================================================================
 // INITIALIZATION
@@ -286,4 +287,7 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Rush of Adrenaline effects (wound-triggered card draws)
   registerRushOfAdrenalineEffects();
+
+  // Puppet Master effects (keep/expend enemy tokens)
+  registerPuppetMasterEffects();
 }

--- a/packages/core/src/engine/effects/puppetMasterEffects.ts
+++ b/packages/core/src/engine/effects/puppetMasterEffects.ts
@@ -1,0 +1,53 @@
+/**
+ * Puppet Master Effect Handlers
+ *
+ * Handles the two custom effect types for the Puppet Master skill:
+ * - EFFECT_PUPPET_MASTER_KEEP: Keep a defeated enemy token
+ * - EFFECT_PUPPET_MASTER_EXPEND: Discard a kept token (creates sub-choice for attack/block)
+ *
+ * @module effects/puppetMasterEffects
+ */
+
+import { registerEffect } from "./effectRegistry.js";
+import {
+  EFFECT_PUPPET_MASTER_KEEP,
+  EFFECT_PUPPET_MASTER_EXPEND,
+} from "../../types/effectTypes.js";
+import {
+  resolveKeepEnemyToken,
+  resolveExpendTokenChoice,
+} from "../commands/skills/puppetMasterEffect.js";
+import type { PuppetMasterKeepEffect, PuppetMasterExpendEffect } from "../../types/cards.js";
+
+// ============================================================================
+// REGISTRATION
+// ============================================================================
+
+export function registerPuppetMasterEffects(): void {
+  // Keep enemy token effect
+  registerEffect(EFFECT_PUPPET_MASTER_KEEP, (state, playerId, effect) => {
+    const keepEffect = effect as PuppetMasterKeepEffect;
+    const newState = resolveKeepEnemyToken(state, playerId, keepEffect.token);
+    return {
+      state: newState,
+      description: `Kept ${keepEffect.token.name} token`,
+    };
+  });
+
+  // Expend token effect - creates a sub-choice for attack or block
+  registerEffect(EFFECT_PUPPET_MASTER_EXPEND, (state, playerId, effect) => {
+    const expendEffect = effect as PuppetMasterExpendEffect;
+    const newState = resolveExpendTokenChoice(
+      state,
+      playerId,
+      expendEffect.token
+    );
+
+    // This creates a new pending choice (attack vs block), so it requires choice
+    return {
+      state: newState,
+      requiresChoice: true,
+      description: `Discarding ${expendEffect.token.name} token - choose Attack or Block`,
+    };
+  });
+}

--- a/packages/core/src/engine/validActions/skills.ts
+++ b/packages/core/src/engine/validActions/skills.ts
@@ -78,6 +78,7 @@ import {
   SKILL_KRANG_ARCANE_DISGUISE,
   SKILL_WOLFHAWK_WOLFS_HOWL,
   SKILL_KRANG_SHAMANIC_RITUAL,
+  SKILL_KRANG_PUPPET_MASTER,
 } from "../../data/skills/index.js";
 import { CATEGORY_COMBAT, CATEGORY_MOVEMENT } from "../../types/cards.js";
 import {
@@ -97,6 +98,7 @@ import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { hexKey } from "@mage-knight/shared";
 import { canActivateUniversalPower } from "../commands/skills/universalPowerEffect.js";
 import { canActivateWolfsHowl } from "../commands/skills/wolfsHowlEffect.js";
+import { canActivatePuppetMaster } from "../commands/skills/puppetMasterEffect.js";
 import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
 /**
@@ -164,6 +166,7 @@ const IMPLEMENTED_SKILLS = new Set([
   SKILL_KRANG_ARCANE_DISGUISE,
   SKILL_WOLFHAWK_WOLFS_HOWL,
   SKILL_KRANG_SHAMANIC_RITUAL,
+  SKILL_KRANG_PUPPET_MASTER,
 ]);
 
 const INTERACTIVE_ONCE_PER_ROUND = new Set([SKILL_ARYTHEA_RITUAL_OF_PAIN, SKILL_TOVAK_MANA_OVERLOAD, SKILL_NOROWAS_PRAYER_OF_WEATHER, SKILL_GOLDYX_SOURCE_OPENING, SKILL_WOLFHAWK_WOLFS_HOWL]);
@@ -237,6 +240,10 @@ function canActivateSkill(
     case SKILL_WOLFHAWK_DUELING:
       // Must be in combat with eligible enemies that are alive and still attacking
       return canActivateDueling(state);
+
+    case SKILL_KRANG_PUPPET_MASTER:
+      // Must be in combat with defeated enemies to keep or stored tokens to expend
+      return canActivatePuppetMaster(state, player);
 
     default:
       // No special requirements

--- a/packages/core/src/engine/validators/skillValidators.ts
+++ b/packages/core/src/engine/validators/skillValidators.ts
@@ -53,6 +53,7 @@ import {
   SKILL_WOLFHAWK_KNOW_YOUR_PREY,
   SKILL_WOLFHAWK_TAUNT,
   SKILL_WOLFHAWK_DUELING,
+  SKILL_KRANG_PUPPET_MASTER,
   SKILL_BRAEVALAR_REGENERATE,
   SKILL_KRANG_REGENERATE,
   SKILL_BRAEVALAR_NATURES_VENGEANCE,
@@ -71,6 +72,7 @@ import { isPlayerAtInteractionSite } from "../rules/siteInteraction.js";
 import { canActivateUniversalPower } from "../commands/skills/universalPowerEffect.js";
 import { canActivateKnowYourPrey } from "../commands/skills/knowYourPreyEffect.js";
 import { canActivateDueling } from "../commands/skills/duelingEffect.js";
+import { canActivatePuppetMaster } from "../commands/skills/puppetMasterEffect.js";
 import { isManaColorAllowed } from "../rules/mana.js";
 import { isMotivationSkill, isMotivationCooldownActive } from "../rules/motivation.js";
 
@@ -472,6 +474,16 @@ export const validateSkillRequirements: Validator = (
       return invalid(
         SKILL_NO_VALID_TARGET,
         "Dueling requires an eligible enemy that is alive and still attacking"
+      );
+    }
+  }
+
+  // Puppet Master: requires defeated enemies to keep or stored tokens to expend
+  if (useSkillAction.skillId === SKILL_KRANG_PUPPET_MASTER) {
+    if (!canActivatePuppetMaster(state, player)) {
+      return invalid(
+        SKILL_NO_VALID_TARGET,
+        "Puppet Master requires defeated enemies or stored enemy tokens"
       );
     }
   }

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -22,6 +22,7 @@ import {
   MANA_WHITE,
 } from "@mage-knight/shared";
 import type { ModifierEffect, ModifierDuration, ModifierScope } from "./modifiers.js";
+import type { KeptEnemyToken } from "./player.js";
 import type { CombatPhase } from "./combat.js";
 import type { SourceDieId } from "./mana.js";
 import {
@@ -163,6 +164,8 @@ import {
   EFFECT_SELECT_UNIT_FOR_MODIFIER,
   EFFECT_RESOLVE_UNIT_MODIFIER_TARGET,
   EFFECT_RUSH_OF_ADRENALINE,
+  EFFECT_PUPPET_MASTER_KEEP,
+  EFFECT_PUPPET_MASTER_EXPEND,
   MANA_ANY,
   type CombatType,
   type BasicCardColor,
@@ -1946,6 +1949,25 @@ export interface RushOfAdrenalineEffect {
   readonly mode: "basic" | "powered";
 }
 
+/**
+ * Keep a defeated enemy token (Puppet Master skill).
+ */
+export interface PuppetMasterKeepEffect {
+  readonly type: typeof EFFECT_PUPPET_MASTER_KEEP;
+  readonly enemyInstanceId: string;
+  readonly token: KeptEnemyToken;
+  readonly description: string;
+}
+
+/**
+ * Expend a kept enemy token for attack or block (Puppet Master skill).
+ */
+export interface PuppetMasterExpendEffect {
+  readonly type: typeof EFFECT_PUPPET_MASTER_EXPEND;
+  readonly token: KeptEnemyToken;
+  readonly description: string;
+}
+
 // Union of all card effects
 export type CardEffect =
   | GainMoveEffect
@@ -2085,7 +2107,9 @@ export type CardEffect =
   | PeacefulMomentRefreshEffect
   | SelectUnitForModifierEffect
   | ResolveUnitModifierTargetEffect
-  | RushOfAdrenalineEffect;
+  | RushOfAdrenalineEffect
+  | PuppetMasterKeepEffect
+  | PuppetMasterExpendEffect;
 
 // === Card Definition ===
 

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -496,3 +496,9 @@ export const EFFECT_RESOLVE_SPELL_FORGE_CRYSTAL = "resolve_spell_forge_crystal" 
 // Basic: Set up wound-triggered draw modifier (first 3 wounds → draw 1 each). Retroactive.
 // Powered: Throw away first wound + draw 1, then draw 1 per wound (next 3). Retroactive.
 export const EFFECT_RUSH_OF_ADRENALINE = "rush_of_adrenaline" as const;
+
+// === Puppet Master Skill Effects ===
+// Keep a defeated enemy token for later use
+export const EFFECT_PUPPET_MASTER_KEEP = "puppet_master_keep" as const;
+// Expend a kept enemy token for Attack or Block
+export const EFFECT_PUPPET_MASTER_EXPEND = "puppet_master_expend" as const;

--- a/packages/core/src/types/player.ts
+++ b/packages/core/src/types/player.ts
@@ -412,6 +412,23 @@ export interface BannerAttachment {
   readonly isUsedThisRound: boolean;
 }
 
+/**
+ * Stored enemy token from Puppet Master skill.
+ * Preserves only the stats relevant for Attack/Block calculation (FAQ S1).
+ */
+export interface KeptEnemyToken {
+  readonly enemyId: import("@mage-knight/shared").EnemyId;
+  readonly name: string;
+  /** Single attack value (legacy). Used when attacks array is absent. */
+  readonly attack: number;
+  /** Single attack element (legacy). Used when attacks array is absent. */
+  readonly attackElement: import("@mage-knight/shared").Element;
+  /** Multiple attacks (overrides attack/attackElement when present). */
+  readonly attacks?: readonly import("@mage-knight/shared").EnemyAttack[];
+  readonly armor: number;
+  readonly resistances: import("@mage-knight/shared").EnemyResistances;
+}
+
 export interface Player {
   readonly id: string;
   readonly hero: Hero; // which hero they're playing
@@ -448,6 +465,9 @@ export interface Player {
   readonly skills: readonly SkillId[];
   readonly skillCooldowns: SkillCooldowns;
   readonly skillFlipState: SkillFlipState;
+
+  // Puppet Master: accumulated enemy tokens (persists across turns)
+  readonly keptEnemyTokens: readonly KeptEnemyToken[];
 
   // Crystals (max 3 each)
   readonly crystals: Crystals;

--- a/packages/server/src/GameServer.ts
+++ b/packages/server/src/GameServer.ts
@@ -540,6 +540,7 @@ export class GameServer {
       skillFlipState: {
         flippedSkills: [],
       },
+      keptEnemyTokens: [],
       crystals: { red: 0, blue: 0, green: 0, white: 0 },
       selectedTactic: null,
       tacticFlipped: false,

--- a/packages/server/src/__tests__/stateFilters.test.ts
+++ b/packages/server/src/__tests__/stateFilters.test.ts
@@ -63,6 +63,7 @@ function createMinimalGameState(): GameState {
         skills: [],
         skillCooldowns: { usedThisRound: [], usedThisTurn: [], usedThisCombat: [], activeUntilNextTurn: [] },
         skillFlipState: { flippedSkills: [] },
+        keptEnemyTokens: [],
         crystals: { red: 0, blue: 0, green: 0, white: 0 },
         selectedTactic: null,
         tacticFlipped: false,

--- a/packages/server/src/stateFilters.ts
+++ b/packages/server/src/stateFilters.ts
@@ -183,6 +183,15 @@ export function toClientPlayer(player: Player, forPlayerId: string): ClientPlaye
     })),
 
     skills: player.skills,
+    keptEnemyTokens: player.keptEnemyTokens.map((token) => ({
+      enemyId: token.enemyId,
+      name: token.name,
+      attack: token.attack,
+      attackElement: token.attackElement,
+      attacks: token.attacks,
+      armor: token.armor,
+      resistances: token.resistances,
+    })),
     crystals: player.crystals,
 
     movePoints: player.movePoints,

--- a/packages/shared/src/types/clientState.ts
+++ b/packages/shared/src/types/clientState.ts
@@ -17,7 +17,7 @@ import type { ManaTokenSource } from "../valueConstants.js";
 import type { UnitState } from "../unitState.js";
 import type { TacticId } from "../tactics.js";
 import type { ValidActions } from "./validActions.js";
-import type { EnemyId, EnemyAbilityType, EnemyResistances, Element, EnemyColor } from "../enemies/index.js";
+import type { EnemyId, EnemyAttack, EnemyAbilityType, EnemyResistances, Element, EnemyColor } from "../enemies/index.js";
 import type { CombatPhase } from "../combatPhases.js";
 import type { SiteReward } from "../siteRewards.js";
 import type { RuinsTokenId } from "../ruinsTokens.js";
@@ -36,6 +36,17 @@ export interface ClientPendingLevelUpReward {
   readonly level: number;
   /** 2 skills drawn from hero's remaining pool */
   readonly drawnSkills: readonly SkillId[];
+}
+
+// Kept enemy token from Puppet Master skill
+export interface ClientKeptEnemyToken {
+  readonly enemyId: EnemyId;
+  readonly name: string;
+  readonly attack: number;
+  readonly attackElement: Element;
+  readonly attacks?: readonly EnemyAttack[];
+  readonly armor: number;
+  readonly resistances: EnemyResistances;
 }
 
 // Pending choice - when a card or skill requires player selection
@@ -156,6 +167,9 @@ export interface ClientPlayer {
 
   // Skills (public - which skills you have)
   readonly skills: readonly SkillId[];
+
+  // Puppet Master: kept enemy tokens (public)
+  readonly keptEnemyTokens: readonly ClientKeptEnemyToken[];
 
   // Turn state
   readonly movePoints: number;


### PR DESCRIPTION
## Summary
- Implements Krang's Puppet Master combat skill with full keep/expend enemy token mechanics
- **Keep mode**: Defeated enemies can be stored as tokens during combat (preserving attack/armor/element/resistance data)
- **Expend mode**: Stored tokens can be discarded for Attack (ceil(enemy_attack/2), matching element, melee only) or Block (ceil(enemy_armor/2), opposite element of resistance)
- Element conversion: Fire resist → Ice block, Ice resist → Fire block, Both → Cold Fire block, Physical resist → no effect
- Multi-attack enemies produce compound attack effects
- Once per turn cooldown ensures keep and expend are mutually exclusive

## Changes
- **New files**: `puppetMasterEffect.ts` (core handler), `puppetMasterEffects.ts` (effect registry), `skillPuppetMaster.test.ts` (38 tests)
- **Modified**: Player type (KeptEnemyToken storage), CardEffect union (2 new effect types), effect registrations, valid actions, validators, client state, server state filters

## Test plan
- [x] 38 comprehensive tests covering activation, keep mode, expend mode, attack/block calculations, element conversion, valid actions, undo, and token accumulation
- [x] Full build passes
- [x] Lint passes (0 warnings, 0 errors)
- [x] All 5268 tests pass across all packages

Closes #346