### PR TITLE
feat: implement Circlet of Proficiency artifact (#234)

### DIFF
--- a/packages/core/src/data/artifacts/circletOfProficiency.ts
+++ b/packages/core/src/data/artifacts/circletOfProficiency.ts
@@ -8,7 +8,35 @@
  */
 
 import type { DeedCard } from "../../types/cards.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+} from "../../types/cards.js";
+import {
+  EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+  EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+} from "../../types/effectTypes.js";
 import type { CardId } from "@mage-knight/shared";
+import {
+  CARD_CIRCLET_OF_PROFICIENCY,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
 
-// TODO: Implement Circlet of Proficiency
-export const CIRCLET_OF_PROFICIENCY_CARDS: Record<CardId, DeedCard> = {};
+export const CIRCLET_OF_PROFICIENCY: DeedCard = {
+  id: CARD_CIRCLET_OF_PROFICIENCY,
+  name: "Circlet of Proficiency",
+  cardType: DEED_CARD_TYPE_ARTIFACT,
+  poweredBy: [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE],
+  categories: [CATEGORY_SPECIAL],
+  basicEffect: { type: EFFECT_CIRCLET_OF_PROFICIENCY_BASIC },
+  poweredEffect: { type: EFFECT_CIRCLET_OF_PROFICIENCY_POWERED },
+  sidewaysValue: 1,
+  destroyOnPowered: true,
+};
+
+export const CIRCLET_OF_PROFICIENCY_CARDS: Record<CardId, DeedCard> = {
+  [CARD_CIRCLET_OF_PROFICIENCY]: CIRCLET_OF_PROFICIENCY,
+};

--- a/packages/core/src/engine/__tests__/circletOfProficiency.test.ts
+++ b/packages/core/src/engine/__tests__/circletOfProficiency.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for Circlet of Proficiency artifact (#234)
+ */
+
+import { describe, expect, it } from "vitest";
+import { resolveEffect } from "../effects/index.js";
+import { getSkillOptions } from "../validActions/skills.js";
+import { createTestGameState, createTestPlayer } from "./testHelpers.js";
+import { CIRCLET_OF_PROFICIENCY } from "../../data/artifacts/circletOfProficiency.js";
+import {
+  CATEGORY_SPECIAL,
+  DEED_CARD_TYPE_ARTIFACT,
+  type CardEffect,
+} from "../../types/cards.js";
+import {
+  EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+  EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
+  EFFECT_COMPOUND,
+} from "../../types/effectTypes.js";
+import {
+  CARD_CIRCLET_OF_PROFICIENCY,
+  MANA_RED,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_WHITE,
+} from "@mage-knight/shared";
+import {
+  SKILL_ARYTHEA_DARK_PATHS,
+  SKILL_NOROWAS_INSPIRATION,
+  SKILL_NOROWAS_PRAYER_OF_WEATHER,
+  SKILL_WOLFHAWK_ON_HER_OWN,
+} from "../../data/skills/index.js";
+import { SKILL_NOROWAS_BONDS_OF_LOYALTY } from "../../data/skills/norowas/bondsOfLoyalty.js";
+
+function getPlayer(state: ReturnType<typeof createTestGameState>) {
+  return state.players[0]!;
+}
+
+function getCircletBasicOptions(result: ReturnType<typeof resolveEffect>): readonly CardEffect[] {
+  expect(result.requiresChoice).toBe(true);
+  expect(result.dynamicChoiceOptions).toBeDefined();
+  return result.dynamicChoiceOptions!;
+}
+
+describe("Circlet of Proficiency card definition", () => {
+  it("has correct metadata", () => {
+    expect(CIRCLET_OF_PROFICIENCY.id).toBe(CARD_CIRCLET_OF_PROFICIENCY);
+    expect(CIRCLET_OF_PROFICIENCY.name).toBe("Circlet of Proficiency");
+    expect(CIRCLET_OF_PROFICIENCY.cardType).toBe(DEED_CARD_TYPE_ARTIFACT);
+    expect(CIRCLET_OF_PROFICIENCY.categories).toEqual([CATEGORY_SPECIAL]);
+    expect(CIRCLET_OF_PROFICIENCY.poweredBy).toEqual([
+      MANA_RED,
+      MANA_BLUE,
+      MANA_GREEN,
+      MANA_WHITE,
+    ]);
+    expect(CIRCLET_OF_PROFICIENCY.destroyOnPowered).toBe(true);
+  });
+
+  it("uses circlet effect entries for both modes", () => {
+    expect(CIRCLET_OF_PROFICIENCY.basicEffect).toEqual({
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+    });
+    expect(CIRCLET_OF_PROFICIENCY.poweredEffect).toEqual({
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+    });
+  });
+});
+
+describe("EFFECT_CIRCLET_OF_PROFICIENCY_BASIC", () => {
+  it("offers only non-interactive activatable skills", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CIRCLET_OF_PROFICIENCY],
+      skills: [],
+    });
+    const state = createTestGameState({
+      players: [player],
+      offers: {
+        ...createTestGameState().offers,
+        commonSkills: [
+          SKILL_ARYTHEA_DARK_PATHS,
+          SKILL_NOROWAS_PRAYER_OF_WEATHER,
+          SKILL_NOROWAS_BONDS_OF_LOYALTY,
+        ],
+      },
+    });
+
+    const result = resolveEffect(state, "player1", {
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+    });
+
+    const options = getCircletBasicOptions(result);
+    expect(options).toHaveLength(1);
+
+    const onlyOption = options[0]!;
+    expect(onlyOption.type).toBe(EFFECT_COMPOUND);
+
+    const compound = onlyOption as import("../../types/cards.js").CompoundEffect;
+    expect(compound.effects).toHaveLength(2);
+    expect(compound.effects[0]).toEqual(
+      expect.objectContaining({
+        type: EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+        skillId: SKILL_ARYTHEA_DARK_PATHS,
+      })
+    );
+  });
+
+  it("uses once-per-turn skills twice", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CIRCLET_OF_PROFICIENCY],
+      skills: [],
+      influencePoints: 0,
+    });
+    const state = createTestGameState({
+      players: [player],
+      offers: {
+        ...createTestGameState().offers,
+        commonSkills: [SKILL_WOLFHAWK_ON_HER_OWN],
+      },
+    });
+
+    const basicResult = resolveEffect(state, "player1", {
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+    });
+    const options = getCircletBasicOptions(basicResult);
+
+    const chosen = options[0]!;
+    const resolved = resolveEffect(state, "player1", chosen);
+
+    expect(getPlayer(resolved.state).influencePoints).toBe(6);
+  });
+
+  it("uses once-per-round skills once", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CIRCLET_OF_PROFICIENCY],
+      skills: [],
+    });
+    const state = createTestGameState({
+      players: [player],
+      offers: {
+        ...createTestGameState().offers,
+        commonSkills: [SKILL_NOROWAS_INSPIRATION],
+      },
+    });
+
+    const result = resolveEffect(state, "player1", {
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+    });
+
+    const options = getCircletBasicOptions(result);
+    expect(options).toHaveLength(1);
+    expect(options[0]!.type).toBe(EFFECT_RESOLVE_CIRCLET_BASIC_SKILL);
+  });
+});
+
+describe("EFFECT_CIRCLET_OF_PROFICIENCY_POWERED", () => {
+  it("acquires selected skill and removes it from common offer", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CIRCLET_OF_PROFICIENCY],
+      skills: [],
+    });
+    const state = createTestGameState({
+      players: [player],
+      offers: {
+        ...createTestGameState().offers,
+        commonSkills: [SKILL_ARYTHEA_DARK_PATHS],
+      },
+    });
+
+    const entryResult = resolveEffect(state, "player1", {
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+    });
+
+    expect(entryResult.requiresChoice).toBe(true);
+    const options = entryResult.dynamicChoiceOptions!;
+    expect(options).toHaveLength(1);
+    expect(options[0]!.type).toBe(EFFECT_RESOLVE_CIRCLET_POWERED_SKILL);
+
+    const resolveResult = resolveEffect(state, "player1", options[0]!);
+    const updatedPlayer = getPlayer(resolveResult.state);
+
+    expect(updatedPlayer.skills).toContain(SKILL_ARYTHEA_DARK_PATHS);
+    expect(resolveResult.state.offers.commonSkills).not.toContain(
+      SKILL_ARYTHEA_DARK_PATHS
+    );
+  });
+
+  it("makes the acquired skill immediately activatable", () => {
+    const player = createTestPlayer({
+      hand: [CARD_CIRCLET_OF_PROFICIENCY],
+      skills: [],
+    });
+    const state = createTestGameState({
+      players: [player],
+      offers: {
+        ...createTestGameState().offers,
+        commonSkills: [SKILL_ARYTHEA_DARK_PATHS],
+      },
+    });
+
+    const entryResult = resolveEffect(state, "player1", {
+      type: EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+    });
+    const resolveResult = resolveEffect(
+      state,
+      "player1",
+      entryResult.dynamicChoiceOptions![0]!
+    );
+
+    const updatedPlayer = getPlayer(resolveResult.state);
+    const skillOptions = getSkillOptions(resolveResult.state, updatedPlayer);
+    const activatableSkillIds = new Set(
+      (skillOptions?.activatable ?? []).map((skill) => skill.skillId)
+    );
+
+    expect(activatableSkillIds.has(SKILL_ARYTHEA_DARK_PATHS)).toBe(true);
+  });
+});

--- a/packages/core/src/engine/commands/choice/choiceResolution.ts
+++ b/packages/core/src/engine/commands/choice/choiceResolution.ts
@@ -33,6 +33,7 @@ import {
   EFFECT_PEACEFUL_MOMENT_CONVERT,
   EFFECT_PEACEFUL_MOMENT_HEAL,
   EFFECT_PEACEFUL_MOMENT_REFRESH,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
 } from "../../../types/effectTypes.js";
 import { describeEffect, isEffectResolvable } from "../../effects/index.js";
 import type { EffectResolutionResult } from "../../effects/index.js";
@@ -85,6 +86,7 @@ const DYNAMIC_CHOICE_EFFECTS = new Set<string>([
   EFFECT_PEACEFUL_MOMENT_CONVERT,
   EFFECT_PEACEFUL_MOMENT_HEAL,
   EFFECT_PEACEFUL_MOMENT_REFRESH,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
 ]);
 
 function buildPendingChoice(

--- a/packages/core/src/engine/effects/circletOfProficiencyEffects.ts
+++ b/packages/core/src/engine/effects/circletOfProficiencyEffects.ts
@@ -1,0 +1,324 @@
+/**
+ * Circlet of Proficiency effect handlers.
+ *
+ * Basic: Use one non-interactive skill from common offer or your own skills.
+ * - Once-per-turn skills are used twice.
+ * - Once-per-round skills are used once.
+ *
+ * Powered: Select a skill from common offer or your own skills and keep it
+ * permanently (as if acquired through level up).
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type {
+  CardEffect,
+  ResolveCircletBasicSkillEffect,
+  ResolveCircletPoweredSkillEffect,
+} from "../../types/cards.js";
+import type { EffectResolutionResult } from "./types.js";
+import type { SkillId } from "@mage-knight/shared";
+import {
+  SKILLS,
+  SKILL_USAGE_ONCE_PER_TURN,
+  SKILL_USAGE_ONCE_PER_ROUND,
+  SKILL_KRANG_MASTER_OF_CHAOS,
+} from "../../data/skills/index.js";
+import { SKILL_NOROWAS_BONDS_OF_LOYALTY } from "../../data/skills/norowas/bondsOfLoyalty.js";
+import {
+  createMasterOfChaosState,
+  rollMasterOfChaosInitialPosition,
+} from "../rules/masterOfChaos.js";
+import { getSkillOptions } from "../validActions/skills.js";
+import { createUseSkillCommand } from "../commands/useSkillCommand.js";
+import { registerEffect } from "./effectRegistry.js";
+import { getPlayerContext } from "./effectHelpers.js";
+import { updatePlayer } from "./atomicHelpers.js";
+import { shuffleWithRng } from "../../utils/rng.js";
+import {
+  EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+  EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
+  EFFECT_COMPOUND,
+} from "../../types/effectTypes.js";
+
+function getCombinedSkills(state: GameState, player: Player): SkillId[] {
+  const combined = [...state.offers.commonSkills, ...player.skills];
+  return Array.from(new Set(combined));
+}
+
+function buildCircletBasicOptions(state: GameState, player: Player): CardEffect[] {
+  const combinedSkills = getCombinedSkills(state, player);
+  if (combinedSkills.length === 0) {
+    return [];
+  }
+
+  const virtualPlayer: Player = {
+    ...player,
+    skills: combinedSkills,
+  };
+
+  const activatableSkills = getSkillOptions(state, virtualPlayer)?.activatable ?? [];
+  const activatableSkillIds = new Set(activatableSkills.map((skill) => skill.skillId));
+
+  const options: CardEffect[] = [];
+
+  for (const skillId of combinedSkills) {
+    const skill = SKILLS[skillId];
+    if (!skill) {
+      continue;
+    }
+
+    if (
+      skill.usageType !== SKILL_USAGE_ONCE_PER_TURN &&
+      skill.usageType !== SKILL_USAGE_ONCE_PER_ROUND
+    ) {
+      continue;
+    }
+
+    if (!activatableSkillIds.has(skillId)) {
+      continue;
+    }
+
+    const resolveOne: ResolveCircletBasicSkillEffect = {
+      type: EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+      skillId,
+      skillName: skill.name,
+    };
+
+    if (skill.usageType === SKILL_USAGE_ONCE_PER_TURN) {
+      options.push({
+        type: EFFECT_COMPOUND,
+        effects: [resolveOne, resolveOne],
+      });
+    } else {
+      options.push(resolveOne);
+    }
+  }
+
+  return options;
+}
+
+function handleCircletBasic(
+  state: GameState,
+  player: Player
+): EffectResolutionResult {
+  const options = buildCircletBasicOptions(state, player);
+  if (options.length === 0) {
+    return {
+      state,
+      description: "Circlet of Proficiency: no eligible non-interactive skills",
+    };
+  }
+
+  return {
+    state,
+    description: "Circlet of Proficiency: choose a non-interactive skill",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+function wrapPendingChoiceOptionsWithRemainingEffects(
+  options: readonly CardEffect[],
+  remainingEffects: readonly CardEffect[] | undefined
+): readonly CardEffect[] {
+  if (!remainingEffects || remainingEffects.length === 0) {
+    return options;
+  }
+
+  return options.map((option) => ({
+    type: EFFECT_COMPOUND,
+    effects: [option, ...remainingEffects],
+  }));
+}
+
+function resolveCircletBasicSkill(
+  state: GameState,
+  playerId: string,
+  effect: ResolveCircletBasicSkillEffect
+): EffectResolutionResult {
+  const skill = SKILLS[effect.skillId];
+  if (!skill) {
+    return {
+      state,
+      description: `Circlet of Proficiency: unknown skill ${effect.skillId}`,
+    };
+  }
+
+  const result = createUseSkillCommand({
+    playerId,
+    skillId: effect.skillId,
+  }).execute(state);
+
+  const { playerIndex, player } = getPlayerContext(result.state, playerId);
+  const pendingChoice = player.pendingChoice;
+
+  if (!pendingChoice) {
+    return {
+      state: result.state,
+      description: `Circlet of Proficiency: used ${skill.name}`,
+    };
+  }
+
+  const wrappedOptions = wrapPendingChoiceOptionsWithRemainingEffects(
+    pendingChoice.options,
+    pendingChoice.remainingEffects
+  );
+
+  const clearedPlayer: Player = {
+    ...player,
+    pendingChoice: null,
+  };
+
+  const clearedState = updatePlayer(result.state, playerIndex, clearedPlayer);
+
+  return {
+    state: clearedState,
+    description: `Circlet of Proficiency: choose ${skill.name} effect`,
+    requiresChoice: true,
+    dynamicChoiceOptions: wrappedOptions,
+  };
+}
+
+function buildCircletPoweredOptions(state: GameState, player: Player): ResolveCircletPoweredSkillEffect[] {
+  return getCombinedSkills(state, player)
+    .map((skillId) => {
+      const skill = SKILLS[skillId];
+      if (!skill) {
+        return null;
+      }
+
+      return {
+        type: EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
+        skillId,
+        skillName: skill.name,
+      } as ResolveCircletPoweredSkillEffect;
+    })
+    .filter((option): option is ResolveCircletPoweredSkillEffect => option !== null);
+}
+
+function handleCircletPowered(
+  state: GameState,
+  player: Player
+): EffectResolutionResult {
+  const options = buildCircletPoweredOptions(state, player);
+  if (options.length === 0) {
+    return {
+      state,
+      description: "Circlet of Proficiency: no skills available to acquire",
+    };
+  }
+
+  return {
+    state,
+    description: "Circlet of Proficiency: choose a skill to acquire",
+    requiresChoice: true,
+    dynamicChoiceOptions: options,
+  };
+}
+
+function removeOneSkillFromCommonOffer(
+  commonSkills: readonly SkillId[],
+  skillId: SkillId
+): SkillId[] {
+  const updated = [...commonSkills];
+  const index = updated.indexOf(skillId);
+  if (index >= 0) {
+    updated.splice(index, 1);
+  }
+  return updated;
+}
+
+function resolveCircletPoweredSkill(
+  state: GameState,
+  playerId: string,
+  effect: ResolveCircletPoweredSkillEffect
+): EffectResolutionResult {
+  const { playerIndex, player } = getPlayerContext(state, playerId);
+  const alreadyHasSkill = player.skills.includes(effect.skillId);
+
+  let updatedRng = state.rng;
+  let updatedRegularUnitsDeck = [...state.decks.regularUnits];
+  let updatedUnitOffer = [...state.offers.units];
+  let updatedBondsBonusUnits = [...state.offers.bondsOfLoyaltyBonusUnits];
+
+  let updatedPlayer: Player = {
+    ...player,
+    skills: alreadyHasSkill ? player.skills : [...player.skills, effect.skillId],
+  };
+
+  if (!alreadyHasSkill && effect.skillId === SKILL_KRANG_MASTER_OF_CHAOS) {
+    const { position, rng } = rollMasterOfChaosInitialPosition(updatedRng);
+    updatedRng = rng;
+    updatedPlayer = {
+      ...updatedPlayer,
+      masterOfChaosState: createMasterOfChaosState(position, false),
+    };
+  }
+
+  if (!alreadyHasSkill && effect.skillId === SKILL_NOROWAS_BONDS_OF_LOYALTY) {
+    const { result: shuffled, rng } = shuffleWithRng(updatedRegularUnitsDeck, updatedRng);
+    updatedRng = rng;
+
+    const bonusCount = Math.min(2, shuffled.length);
+    const bonusUnits = shuffled.slice(0, bonusCount);
+
+    updatedRegularUnitsDeck = shuffled.slice(bonusCount);
+    updatedUnitOffer = [...updatedUnitOffer, ...bonusUnits];
+    updatedBondsBonusUnits = [...updatedBondsBonusUnits, ...bonusUnits];
+  }
+
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = updatedPlayer;
+
+  const updatedState: GameState = {
+    ...state,
+    players: updatedPlayers,
+    offers: {
+      ...state.offers,
+      commonSkills: removeOneSkillFromCommonOffer(state.offers.commonSkills, effect.skillId),
+      units: updatedUnitOffer,
+      bondsOfLoyaltyBonusUnits: updatedBondsBonusUnits,
+    },
+    decks: {
+      ...state.decks,
+      regularUnits: updatedRegularUnitsDeck,
+    },
+    rng: updatedRng,
+  };
+
+  return {
+    state: updatedState,
+    description: `Circlet of Proficiency: acquired ${effect.skillName}`,
+  };
+}
+
+export function registerCircletOfProficiencyEffects(): void {
+  registerEffect(EFFECT_CIRCLET_OF_PROFICIENCY_BASIC, (state, playerId) => {
+    const { player } = getPlayerContext(state, playerId);
+    return handleCircletBasic(state, player);
+  });
+
+  registerEffect(EFFECT_RESOLVE_CIRCLET_BASIC_SKILL, (state, playerId, effect) => {
+    return resolveCircletBasicSkill(
+      state,
+      playerId,
+      effect as ResolveCircletBasicSkillEffect
+    );
+  });
+
+  registerEffect(EFFECT_CIRCLET_OF_PROFICIENCY_POWERED, (state, playerId) => {
+    const { player } = getPlayerContext(state, playerId);
+    return handleCircletPowered(state, player);
+  });
+
+  registerEffect(EFFECT_RESOLVE_CIRCLET_POWERED_SKILL, (state, playerId, effect) => {
+    return resolveCircletPoweredSkill(
+      state,
+      playerId,
+      effect as ResolveCircletPoweredSkillEffect
+    );
+  });
+}

--- a/packages/core/src/engine/effects/describeEffect.ts
+++ b/packages/core/src/engine/effects/describeEffect.ts
@@ -104,6 +104,10 @@ import {
   EFFECT_HAND_LIMIT_BONUS,
   EFFECT_TOME_OF_ALL_SPELLS,
   EFFECT_RESOLVE_TOME_SPELL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+  EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
   EFFECT_MYSTERIOUS_BOX,
   EFFECT_RESOLVE_MYSTERIOUS_BOX_USE,
   EFFECT_SPELL_FORGE_BASIC,
@@ -686,6 +690,24 @@ const descriptionHandlers: Partial<Record<EffectType, DescriptionHandler>> = {
     const e = effect as import("../../types/cards.js").ResolveTomeSpellEffect;
     const modeStr = e.mode === "basic" ? "basic" : "powered";
     return `Use ${e.spellName}'s ${modeStr} effect from the Spell Offer`;
+  },
+
+  [EFFECT_CIRCLET_OF_PROFICIENCY_BASIC]: () => {
+    return "Choose a non-interactive skill and use it (once-per-turn skills are used twice)";
+  },
+
+  [EFFECT_RESOLVE_CIRCLET_BASIC_SKILL]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveCircletBasicSkillEffect;
+    return `Use ${e.skillName}`;
+  },
+
+  [EFFECT_CIRCLET_OF_PROFICIENCY_POWERED]: () => {
+    return "Choose a skill from common offer or your own skills and acquire it";
+  },
+
+  [EFFECT_RESOLVE_CIRCLET_POWERED_SKILL]: (effect) => {
+    const e = effect as import("../../types/cards.js").ResolveCircletPoweredSkillEffect;
+    return `Acquire ${e.skillName}`;
   },
 
   [EFFECT_MYSTERIOUS_BOX]: () => {

--- a/packages/core/src/engine/effects/effectRegistrations.ts
+++ b/packages/core/src/engine/effects/effectRegistrations.ts
@@ -70,6 +70,7 @@ import { registerShapeshiftEffects } from "./shapeshiftEffects.js";
 import { registerBloodOfAncientsEffects } from "./bloodOfAncientsEffects.js";
 import { registerHandLimitBonusEffects } from "./handLimitBonusEffects.js";
 import { registerTomeOfAllSpellsEffects } from "./tomeOfAllSpellsEffects.js";
+import { registerCircletOfProficiencyEffects } from "./circletOfProficiencyEffects.js";
 import { registerMysteriousBoxEffects } from "./mysteriousBoxEffects.js";
 import { registerSpellForgeEffects } from "./spellForgeEffects.js";
 import { registerKnowYourPreyEffects } from "./knowYourPreyEffects.js";
@@ -271,6 +272,9 @@ function registerAllEffects(resolver: EffectHandler): void {
 
   // Tome of All Spells effects (discard card, cast spell from offer for free)
   registerTomeOfAllSpellsEffects(resolver);
+
+  // Circlet of Proficiency effects (borrow/acquire skills)
+  registerCircletOfProficiencyEffects();
 
   // Mysterious Box effects (artifact reveal and polymorphic artifact use)
   registerMysteriousBoxEffects(resolver);

--- a/packages/core/src/engine/effects/effectUndoContext.ts
+++ b/packages/core/src/engine/effects/effectUndoContext.ts
@@ -19,6 +19,8 @@ import type { CardEffect, ManaDrawSetColorEffect, ResolveBoostTargetEffect } fro
 import {
   EFFECT_MANA_DRAW_SET_COLOR,
   EFFECT_RESOLVE_BOOST_TARGET,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+  EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
   EFFECT_RESOLVE_MYSTERIOUS_BOX_USE,
 } from "../../types/effectTypes.js";
 import { getCard } from "../helpers/cardLookup.js";
@@ -62,13 +64,35 @@ export interface MysteriousBoxUseUndoContext {
 }
 
 /**
+ * Undo context for EFFECT_RESOLVE_CIRCLET_BASIC_SKILL
+ * Captures full pre-resolution state because skill execution can modify
+ * many subsystems (cooldowns, modifiers, choices, source, etc.).
+ */
+export interface CircletBasicSkillUndoContext {
+  readonly type: typeof EFFECT_RESOLVE_CIRCLET_BASIC_SKILL;
+  readonly stateSnapshot: GameState;
+}
+
+/**
+ * Undo context for EFFECT_RESOLVE_CIRCLET_POWERED_SKILL
+ * Captures full pre-resolution state because acquisition may affect offers,
+ * decks, RNG, and player skill state.
+ */
+export interface CircletPoweredSkillUndoContext {
+  readonly type: typeof EFFECT_RESOLVE_CIRCLET_POWERED_SKILL;
+  readonly stateSnapshot: GameState;
+}
+
+/**
  * Union of all effect undo contexts
  * Add new context types here as needed
  */
 export type EffectUndoContext =
   | ManaDrawSetColorUndoContext
   | CardBoostUndoContext
-  | MysteriousBoxUseUndoContext;
+  | MysteriousBoxUseUndoContext
+  | CircletBasicSkillUndoContext
+  | CircletPoweredSkillUndoContext;
 
 // === Capture Functions ===
 
@@ -132,6 +156,20 @@ export function captureUndoContext(
     case EFFECT_RESOLVE_MYSTERIOUS_BOX_USE: {
       return {
         type: EFFECT_RESOLVE_MYSTERIOUS_BOX_USE,
+        stateSnapshot: state,
+      };
+    }
+
+    case EFFECT_RESOLVE_CIRCLET_BASIC_SKILL: {
+      return {
+        type: EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+        stateSnapshot: state,
+      };
+    }
+
+    case EFFECT_RESOLVE_CIRCLET_POWERED_SKILL: {
+      return {
+        type: EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
         stateSnapshot: state,
       };
     }
@@ -256,6 +294,14 @@ export function applyUndoContext(
     }
 
     case EFFECT_RESOLVE_MYSTERIOUS_BOX_USE: {
+      return context.stateSnapshot;
+    }
+
+    case EFFECT_RESOLVE_CIRCLET_BASIC_SKILL: {
+      return context.stateSnapshot;
+    }
+
+    case EFFECT_RESOLVE_CIRCLET_POWERED_SKILL: {
       return context.stateSnapshot;
     }
   }

--- a/packages/core/src/engine/effects/index.ts
+++ b/packages/core/src/engine/effects/index.ts
@@ -375,6 +375,11 @@ export {
   registerTomeOfAllSpellsEffects,
 } from "./tomeOfAllSpellsEffects.js";
 
+// Circlet of Proficiency effects (borrow/acquire skills from common offer)
+export {
+  registerCircletOfProficiencyEffects,
+} from "./circletOfProficiencyEffects.js";
+
 // Mysterious Box effects (artifact reveal and polymorphic artifact use)
 export {
   registerMysteriousBoxEffects,

--- a/packages/core/src/types/cards.ts
+++ b/packages/core/src/types/cards.ts
@@ -156,6 +156,10 @@ import {
   EFFECT_HAND_LIMIT_BONUS,
   EFFECT_TOME_OF_ALL_SPELLS,
   EFFECT_RESOLVE_TOME_SPELL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_BASIC,
+  EFFECT_RESOLVE_CIRCLET_BASIC_SKILL,
+  EFFECT_CIRCLET_OF_PROFICIENCY_POWERED,
+  EFFECT_RESOLVE_CIRCLET_POWERED_SKILL,
   EFFECT_MYSTERIOUS_BOX,
   EFFECT_RESOLVE_MYSTERIOUS_BOX_USE,
   EFFECT_SPELL_FORGE_BASIC,
@@ -1879,6 +1883,40 @@ export interface ResolveTomeSpellEffect {
 }
 
 /**
+ * Circlet of Proficiency basic effect entry point.
+ * Select and use a non-interactive skill from common offer or own skills.
+ */
+export interface CircletOfProficiencyBasicEffect {
+  readonly type: typeof EFFECT_CIRCLET_OF_PROFICIENCY_BASIC;
+}
+
+/**
+ * Internal: resolve one use of a selected skill for Circlet basic.
+ */
+export interface ResolveCircletBasicSkillEffect {
+  readonly type: typeof EFFECT_RESOLVE_CIRCLET_BASIC_SKILL;
+  readonly skillId: SkillId;
+  readonly skillName: string;
+}
+
+/**
+ * Circlet of Proficiency powered effect entry point.
+ * Select and permanently acquire a skill from common offer or own skills.
+ */
+export interface CircletOfProficiencyPoweredEffect {
+  readonly type: typeof EFFECT_CIRCLET_OF_PROFICIENCY_POWERED;
+}
+
+/**
+ * Internal: resolve the selected Circlet powered skill acquisition.
+ */
+export interface ResolveCircletPoweredSkillEffect {
+  readonly type: typeof EFFECT_RESOLVE_CIRCLET_POWERED_SKILL;
+  readonly skillId: SkillId;
+  readonly skillName: string;
+}
+
+/**
  * Mysterious Box effect entry point.
  * Reveal the top artifact deck card and choose how to use Mysterious Box this turn.
  */
@@ -2193,6 +2231,10 @@ export type CardEffect =
   | HandLimitBonusEffect
   | TomeOfAllSpellsEffect
   | ResolveTomeSpellEffect
+  | CircletOfProficiencyBasicEffect
+  | ResolveCircletBasicSkillEffect
+  | CircletOfProficiencyPoweredEffect
+  | ResolveCircletPoweredSkillEffect
   | MysteriousBoxEffect
   | ResolveMysteriousBoxUseEffect
   | SpellForgeBasicEffect

--- a/packages/core/src/types/effectTypes.ts
+++ b/packages/core/src/types/effectTypes.ts
@@ -449,6 +449,16 @@ export const EFFECT_TOME_OF_ALL_SPELLS = "tome_of_all_spells" as const;
 // of matching color, then resolves that spell's basic or powered effect (no mana cost).
 export const EFFECT_RESOLVE_TOME_SPELL = "resolve_tome_spell" as const;
 
+// === Circlet of Proficiency Effects ===
+// Basic: Use a non-interactive skill from common offer or own skills.
+export const EFFECT_CIRCLET_OF_PROFICIENCY_BASIC = "circlet_of_proficiency_basic" as const;
+// Internal: Resolve one use of the selected skill.
+export const EFFECT_RESOLVE_CIRCLET_BASIC_SKILL = "resolve_circlet_basic_skill" as const;
+// Powered: Acquire a skill from common offer or own skills permanently.
+export const EFFECT_CIRCLET_OF_PROFICIENCY_POWERED = "circlet_of_proficiency_powered" as const;
+// Internal: Resolve the selected skill acquisition.
+export const EFFECT_RESOLVE_CIRCLET_POWERED_SKILL = "resolve_circlet_powered_skill" as const;
+
 // === Mysterious Box Effects ===
 // Reveal top artifact from deck and choose how to use Mysterious Box this turn.
 export const EFFECT_MYSTERIOUS_BOX = "mysterious_box" as const;


### PR DESCRIPTION
## Summary
- implement Circlet of Proficiency artifact card definition (basic + powered, destroy on powered)
- add Circlet effect handlers for basic skill borrowing and powered skill acquisition
- wire new Circlet effects into effect registration, resolvability, descriptions, and choice undo context
- add focused Circlet tests covering option filtering, once-per-turn double use, powered acquisition, and immediate usability

## Validation
- bun run build
- bun run lint
- bun run test

Closes #234