### PR TITLE
fix: support unit reward selection end-to-end

### DIFF
--- a/packages/client/src/components/Overlays/RewardSelection.css
+++ b/packages/client/src/components/Overlays/RewardSelection.css
@@ -49,9 +49,31 @@
   transform: translateY(-2px);
 }
 
+.reward-selection__card:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.reward-selection__card--selected {
+  border-color: #f39c12;
+  background: #1a1a3e;
+}
+
 .reward-selection__card-name {
   font-size: 1rem;
   font-weight: 500;
+}
+
+.reward-selection__disband {
+  margin-bottom: 1rem;
+}
+
+.reward-selection__disband-title {
+  font-size: 0.95rem;
+  color: #bbb;
+  margin-bottom: 0.75rem;
+  text-align: center;
 }
 
 .reward-selection__empty,


### PR DESCRIPTION
## Summary
- add `SITE_REWARD_UNIT` handling to reward validators so unit rewards can be selected via `SELECT_REWARD`
- enforce unit-offer/disband checks for unit reward selection at command limit
- implement unit reward UI in RewardSelection overlay (select recruit + optional disband target)
- add tests covering unit reward validator behavior

## Validation
- bun run --filter @mage-knight/shared build
- bun test src/engine/__tests__/ruinsRewards.test.ts (from packages/core)
- oxlint on changed files
- bun run --filter @mage-knight/core build
- bun run --filter @mage-knight/server build
- bun run --filter @mage-knight/client build
