### PR TITLE
WebSocket Server & Game Rooms

### DIFF
--- a/packages/server/src/WebSocketServer.ts
+++ b/packages/server/src/WebSocketServer.ts
@@ -1,0 +1,414 @@
+import { createGameServer, type GameServer } from "./GameServer.js";
+import type {
+  ClientGameState,
+  EventCallback,
+  GameConfig,
+  GameEvent,
+  HeroId,
+  PlayerAction,
+  ScenarioId,
+} from "@mage-knight/shared";
+import { SCENARIO_FIRST_RECONNAISSANCE } from "@mage-knight/shared";
+
+export const CLIENT_MESSAGE_ACTION = "action" as const;
+export const SERVER_MESSAGE_STATE_UPDATE = "state_update" as const;
+export const SERVER_MESSAGE_ERROR = "error" as const;
+
+export const CLOSE_CODE_INVALID_REQUEST = 1008 as const;
+export const CLOSE_CODE_INTERNAL_ERROR = 1011 as const;
+export const CLOSE_CODE_REPLACED_CONNECTION = 4001 as const;
+
+export interface ClientActionMessage {
+  type: typeof CLIENT_MESSAGE_ACTION;
+  action: PlayerAction;
+}
+
+export interface StateUpdateMessage {
+  type: typeof SERVER_MESSAGE_STATE_UPDATE;
+  events: readonly GameEvent[];
+  state: ClientGameState;
+}
+
+export interface ErrorMessage {
+  type: typeof SERVER_MESSAGE_ERROR;
+  message: string;
+}
+
+export type ServerMessage = StateUpdateMessage | ErrorMessage;
+
+export interface ConnectionLike {
+  send(message: string): number;
+  close(code?: number, reason?: string): void;
+}
+
+export interface CreateGameRoomOptions {
+  playerIds: readonly string[];
+  heroIds?: readonly HeroId[];
+  scenarioId?: ScenarioId;
+  config?: GameConfig;
+  seed?: number;
+  maxPlayers?: number;
+}
+
+export interface WebSocketServerOptions {
+  port?: number;
+  host?: string;
+  cleanupTimeoutMs?: number;
+}
+
+interface GameRoom {
+  id: string;
+  gameServer: GameServer;
+  playerIds: Set<string>;
+  maxPlayers: number;
+  connections: Map<string, ConnectionLike>;
+  cleanupTimeout?: ReturnType<typeof setTimeout>;
+}
+
+interface ConnectionContext {
+  roomId: string;
+  playerId: string;
+}
+
+interface UpgradeData {
+  roomId: string;
+  playerId: string;
+}
+
+type BunServerInstance = ReturnType<typeof Bun.serve<UpgradeData>>;
+
+const DEFAULT_PORT = 3001;
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_CLEANUP_TIMEOUT_MS = 5 * 60 * 1000;
+const QUERY_GAME_ID = "gameId";
+const QUERY_PLAYER_ID = "playerId";
+const UPGRADE_FAILED_MESSAGE = "Failed to upgrade to WebSocket";
+const MISSING_CONNECTION_PARAMS_MESSAGE = "Missing required query params: gameId and playerId";
+const UNKNOWN_MESSAGE_TYPE_ERROR = "Unknown message type";
+const INVALID_JSON_ERROR = "Invalid JSON";
+const INVALID_ACTION_MESSAGE_ERROR = "Invalid action message";
+const INVALID_GAME_ID_ERROR = "Invalid game ID";
+const GAME_FULL_ERROR = "Game is full";
+const INVALID_PLAYER_ID_ERROR = "Invalid player ID for game";
+const PLAYER_REPLACED_REASON = "Replaced by a new connection";
+
+function buildStateUpdateMessage(
+  events: readonly GameEvent[],
+  state: ClientGameState
+): StateUpdateMessage {
+  return {
+    type: SERVER_MESSAGE_STATE_UPDATE,
+    events,
+    state,
+  };
+}
+
+function buildErrorMessage(message: string): ErrorMessage {
+  return {
+    type: SERVER_MESSAGE_ERROR,
+    message,
+  };
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isClientActionMessage(value: unknown): value is ClientActionMessage {
+  if (!isObject(value)) {
+    return false;
+  }
+
+  return value.type === CLIENT_MESSAGE_ACTION && "action" in value;
+}
+
+function createEventCallback(connection: ConnectionLike): EventCallback {
+  return (events, state): void => {
+    connection.send(JSON.stringify(buildStateUpdateMessage(events, state)));
+  };
+}
+
+function generateRoomId(existingIds: Set<string>): string {
+  let roomId = crypto.randomUUID().slice(0, 8);
+
+  while (existingIds.has(roomId)) {
+    roomId = crypto.randomUUID().slice(0, 8);
+  }
+
+  return roomId;
+}
+
+export class GameRoomManager {
+  private readonly rooms = new Map<string, GameRoom>();
+  private readonly connectionContexts = new Map<ConnectionLike, ConnectionContext>();
+  private readonly cleanupTimeoutMs: number;
+
+  constructor(cleanupTimeoutMs: number = DEFAULT_CLEANUP_TIMEOUT_MS) {
+    this.cleanupTimeoutMs = cleanupTimeoutMs;
+  }
+
+  createGameRoom(options: CreateGameRoomOptions): string {
+    const gameServer = createGameServer(options.seed);
+    const scenarioId = options.scenarioId ?? SCENARIO_FIRST_RECONNAISSANCE;
+    const roomId = generateRoomId(new Set(this.rooms.keys()));
+
+    gameServer.initializeGame(options.playerIds, options.heroIds, scenarioId, options.config);
+
+    const playerIds = new Set(options.playerIds);
+    const maxPlayers = options.maxPlayers ?? options.playerIds.length;
+
+    const room: GameRoom = {
+      id: roomId,
+      gameServer,
+      playerIds,
+      maxPlayers,
+      connections: new Map(),
+    };
+
+    this.rooms.set(roomId, room);
+    return roomId;
+  }
+
+  hasRoom(roomId: string): boolean {
+    return this.rooms.has(roomId);
+  }
+
+  deleteRoom(roomId: string): void {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      return;
+    }
+
+    if (room.cleanupTimeout) {
+      clearTimeout(room.cleanupTimeout);
+    }
+
+    for (const [playerId, connection] of room.connections) {
+      this.connectionContexts.delete(connection);
+      room.gameServer.disconnect(playerId);
+      connection.close();
+    }
+
+    this.rooms.delete(roomId);
+  }
+
+  handleConnectionOpen(connection: ConnectionLike, roomId: string, playerId: string): void {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      this.sendErrorAndClose(connection, INVALID_GAME_ID_ERROR);
+      return;
+    }
+
+    if (!room.playerIds.has(playerId)) {
+      this.sendErrorAndClose(connection, INVALID_PLAYER_ID_ERROR);
+      return;
+    }
+
+    const existingConnection = room.connections.get(playerId);
+    if (!existingConnection && room.connections.size >= room.maxPlayers) {
+      this.sendErrorAndClose(connection, GAME_FULL_ERROR);
+      return;
+    }
+
+    if (room.cleanupTimeout) {
+      clearTimeout(room.cleanupTimeout);
+      room.cleanupTimeout = undefined;
+    }
+
+    if (existingConnection && existingConnection !== connection) {
+      this.disconnectConnection(existingConnection, CLOSE_CODE_REPLACED_CONNECTION, PLAYER_REPLACED_REASON);
+    }
+
+    room.connections.set(playerId, connection);
+    this.connectionContexts.set(connection, { roomId, playerId });
+    room.gameServer.connect(playerId, createEventCallback(connection));
+  }
+
+  handleConnectionMessage(connection: ConnectionLike, rawMessage: string): void {
+    const context = this.connectionContexts.get(connection);
+    if (!context) {
+      this.sendErrorAndClose(connection, INVALID_GAME_ID_ERROR);
+      return;
+    }
+
+    const room = this.rooms.get(context.roomId);
+    if (!room) {
+      this.sendErrorAndClose(connection, INVALID_GAME_ID_ERROR);
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawMessage);
+    } catch {
+      this.sendError(connection, INVALID_JSON_ERROR);
+      return;
+    }
+
+    if (!isClientActionMessage(parsed)) {
+      this.sendError(connection, UNKNOWN_MESSAGE_TYPE_ERROR);
+      return;
+    }
+
+    if (!isObject(parsed.action)) {
+      this.sendError(connection, INVALID_ACTION_MESSAGE_ERROR);
+      return;
+    }
+
+    try {
+      room.gameServer.handleAction(context.playerId, parsed.action as PlayerAction);
+    } catch {
+      this.sendError(connection, INVALID_ACTION_MESSAGE_ERROR);
+    }
+  }
+
+  handleConnectionClose(connection: ConnectionLike): void {
+    this.disconnectConnection(connection);
+  }
+
+  dispose(): void {
+    for (const roomId of this.rooms.keys()) {
+      this.deleteRoom(roomId);
+    }
+  }
+
+  private disconnectConnection(connection: ConnectionLike, code?: number, reason?: string): void {
+    const context = this.connectionContexts.get(connection);
+    if (!context) {
+      if (code !== undefined || reason !== undefined) {
+        connection.close(code, reason);
+      }
+      return;
+    }
+
+    const room = this.rooms.get(context.roomId);
+    this.connectionContexts.delete(connection);
+
+    if (!room) {
+      if (code !== undefined || reason !== undefined) {
+        connection.close(code, reason);
+      }
+      return;
+    }
+
+    room.connections.delete(context.playerId);
+    room.gameServer.disconnect(context.playerId);
+
+    if (code !== undefined || reason !== undefined) {
+      connection.close(code, reason);
+    }
+
+    this.scheduleRoomCleanup(room);
+  }
+
+  private scheduleRoomCleanup(room: GameRoom): void {
+    if (room.connections.size > 0 || this.cleanupTimeoutMs <= 0) {
+      return;
+    }
+
+    room.cleanupTimeout = setTimeout(() => {
+      const currentRoom = this.rooms.get(room.id);
+      if (!currentRoom || currentRoom.connections.size > 0) {
+        return;
+      }
+
+      this.deleteRoom(room.id);
+    }, this.cleanupTimeoutMs);
+  }
+
+  private sendError(connection: ConnectionLike, message: string): void {
+    connection.send(JSON.stringify(buildErrorMessage(message)));
+  }
+
+  private sendErrorAndClose(connection: ConnectionLike, message: string): void {
+    this.sendError(connection, message);
+    connection.close(CLOSE_CODE_INVALID_REQUEST, message);
+  }
+}
+
+function toMessageString(message: string | Uint8Array): string {
+  if (typeof message === "string") {
+    return message;
+  }
+
+  return new TextDecoder().decode(message);
+}
+
+export class WebSocketGameServer {
+  private readonly port: number;
+  private readonly host: string;
+  private readonly roomManager: GameRoomManager;
+  private server?: BunServerInstance;
+
+  constructor(options: WebSocketServerOptions = {}) {
+    this.port = options.port ?? DEFAULT_PORT;
+    this.host = options.host ?? DEFAULT_HOST;
+    this.roomManager = new GameRoomManager(options.cleanupTimeoutMs);
+  }
+
+  getPort(): number {
+    return this.server?.port ?? this.port;
+  }
+
+  createGameRoom(options: CreateGameRoomOptions): string {
+    return this.roomManager.createGameRoom(options);
+  }
+
+  hasRoom(roomId: string): boolean {
+    return this.roomManager.hasRoom(roomId);
+  }
+
+  start(): void {
+    if (this.server) {
+      return;
+    }
+
+    this.server = Bun.serve<UpgradeData>({
+      port: this.port,
+      hostname: this.host,
+      fetch: (request, server): Response | undefined => {
+        const url = new URL(request.url);
+        const roomId = url.searchParams.get(QUERY_GAME_ID);
+        const playerId = url.searchParams.get(QUERY_PLAYER_ID);
+
+        if (!roomId || !playerId) {
+          return new Response(MISSING_CONNECTION_PARAMS_MESSAGE, { status: 400 });
+        }
+
+        const upgraded = server.upgrade(request, {
+          data: {
+            roomId,
+            playerId,
+          },
+        });
+
+        if (!upgraded) {
+          return new Response(UPGRADE_FAILED_MESSAGE, { status: 500 });
+        }
+
+        return undefined;
+      },
+      websocket: {
+        open: (webSocket): void => {
+          this.roomManager.handleConnectionOpen(webSocket, webSocket.data.roomId, webSocket.data.playerId);
+        },
+        message: (webSocket, message): void => {
+          this.roomManager.handleConnectionMessage(webSocket, toMessageString(message));
+        },
+        close: (webSocket): void => {
+          this.roomManager.handleConnectionClose(webSocket);
+        },
+      },
+    });
+  }
+
+  stop(closeActiveConnections: boolean = true): void {
+    this.server?.stop(closeActiveConnections);
+    this.server = undefined;
+    this.roomManager.dispose();
+  }
+}
+
+export function createWebSocketGameServer(options?: WebSocketServerOptions): WebSocketGameServer {
+  return new WebSocketGameServer(options);
+}

--- a/packages/server/src/__tests__/WebSocketServer.test.ts
+++ b/packages/server/src/__tests__/WebSocketServer.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import {
+  CLIENT_MESSAGE_ACTION,
+  CLOSE_CODE_INVALID_REQUEST,
+  GameRoomManager,
+  SERVER_MESSAGE_ERROR,
+  SERVER_MESSAGE_STATE_UPDATE,
+  type ConnectionLike,
+  type ErrorMessage,
+  type ServerMessage,
+  type StateUpdateMessage,
+} from "../WebSocketServer.js";
+import { END_TURN_ACTION } from "@mage-knight/shared";
+
+class FakeConnection implements ConnectionLike {
+  readonly sentMessages: string[] = [];
+  readonly closeCalls: Array<{ code?: number; reason?: string }> = [];
+
+  send(message: string): number {
+    this.sentMessages.push(message);
+    return message.length;
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCalls.push({ code, reason });
+  }
+}
+
+function parseMessage(rawMessage: string): ServerMessage {
+  return JSON.parse(rawMessage) as ServerMessage;
+}
+
+function findLastMessageOfType<TMessage extends ServerMessage>(
+  connection: FakeConnection,
+  type: TMessage["type"]
+): TMessage {
+  for (let index = connection.sentMessages.length - 1; index >= 0; index -= 1) {
+    const message = parseMessage(connection.sentMessages[index] as string);
+    if (message.type === type) {
+      return message as TMessage;
+    }
+  }
+
+  throw new Error(`No message found for type: ${type}`);
+}
+
+describe("GameRoomManager", () => {
+  it("creates a unique room id for each game", () => {
+    const manager = new GameRoomManager();
+    const roomIdOne = manager.createGameRoom({ playerIds: ["player1"] });
+    const roomIdTwo = manager.createGameRoom({ playerIds: ["player1"] });
+
+    expect(roomIdOne).not.toBe(roomIdTwo);
+    expect(manager.hasRoom(roomIdOne)).toBe(true);
+    expect(manager.hasRoom(roomIdTwo)).toBe(true);
+  });
+
+  it("routes actions in a room and broadcasts filtered state", () => {
+    const manager = new GameRoomManager();
+    const roomId = manager.createGameRoom({ playerIds: ["player1", "player2"] });
+    const playerOneConnection = new FakeConnection();
+    const playerTwoConnection = new FakeConnection();
+
+    manager.handleConnectionOpen(playerOneConnection, roomId, "player1");
+    manager.handleConnectionOpen(playerTwoConnection, roomId, "player2");
+
+    playerOneConnection.sentMessages.length = 0;
+    playerTwoConnection.sentMessages.length = 0;
+
+    manager.handleConnectionMessage(
+      playerOneConnection,
+      JSON.stringify({
+        type: CLIENT_MESSAGE_ACTION,
+        action: { type: END_TURN_ACTION },
+      })
+    );
+
+    const playerOneUpdate = findLastMessageOfType<StateUpdateMessage>(
+      playerOneConnection,
+      SERVER_MESSAGE_STATE_UPDATE
+    );
+    const playerTwoUpdate = findLastMessageOfType<StateUpdateMessage>(
+      playerTwoConnection,
+      SERVER_MESSAGE_STATE_UPDATE
+    );
+
+    const playerOneInOwnState = playerOneUpdate.state.players.find((player) => player.id === "player1");
+    const playerTwoInOwnState = playerTwoUpdate.state.players.find((player) => player.id === "player2");
+    const playerTwoInPlayerOneState = playerOneUpdate.state.players.find(
+      (player) => player.id === "player2"
+    );
+
+    expect(Array.isArray(playerOneInOwnState?.hand)).toBe(true);
+    expect(Array.isArray(playerTwoInOwnState?.hand)).toBe(true);
+    expect(typeof playerTwoInPlayerOneState?.hand).toBe("number");
+  });
+
+  it("returns error and closes when room id is invalid", () => {
+    const manager = new GameRoomManager();
+    const connection = new FakeConnection();
+
+    manager.handleConnectionOpen(connection, "bad-room", "player1");
+
+    const message = findLastMessageOfType<ErrorMessage>(connection, SERVER_MESSAGE_ERROR);
+    expect(message.message).toContain("Invalid game ID");
+    expect(connection.closeCalls).toHaveLength(1);
+    expect(connection.closeCalls[0]?.code).toBe(CLOSE_CODE_INVALID_REQUEST);
+  });
+
+  it("returns game full when room reaches capacity", () => {
+    const manager = new GameRoomManager();
+    const roomId = manager.createGameRoom({
+      playerIds: ["player1", "player2"],
+      maxPlayers: 1,
+    });
+
+    const playerOneConnection = new FakeConnection();
+    const playerTwoConnection = new FakeConnection();
+
+    manager.handleConnectionOpen(playerOneConnection, roomId, "player1");
+    manager.handleConnectionOpen(playerTwoConnection, roomId, "player2");
+
+    const errorMessage = findLastMessageOfType<ErrorMessage>(playerTwoConnection, SERVER_MESSAGE_ERROR);
+    expect(errorMessage.message).toContain("Game is full");
+    expect(playerTwoConnection.closeCalls).toHaveLength(1);
+    expect(playerTwoConnection.closeCalls[0]?.code).toBe(CLOSE_CODE_INVALID_REQUEST);
+  });
+
+  it("returns error for invalid JSON", () => {
+    const manager = new GameRoomManager();
+    const roomId = manager.createGameRoom({ playerIds: ["player1"] });
+    const connection = new FakeConnection();
+
+    manager.handleConnectionOpen(connection, roomId, "player1");
+    connection.sentMessages.length = 0;
+
+    manager.handleConnectionMessage(connection, "not valid json");
+
+    const errorMessage = findLastMessageOfType<ErrorMessage>(connection, SERVER_MESSAGE_ERROR);
+    expect(errorMessage.message).toContain("Invalid JSON");
+  });
+
+  it("removes empty room after timeout", async () => {
+    const manager = new GameRoomManager(10);
+    const roomId = manager.createGameRoom({ playerIds: ["player1"] });
+    const connection = new FakeConnection();
+
+    manager.handleConnectionOpen(connection, roomId, "player1");
+    manager.handleConnectionClose(connection);
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(manager.hasRoom(roomId)).toBe(false);
+  });
+});

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -14,10 +14,12 @@
  * |--------|---------|
  * | `stateFilters.ts` | Converts GameState to filtered ClientGameState |
  * | `GameServer.ts` | Multiplayer game server with player connections |
+ * | `WebSocketServer.ts` | WebSocket transport with game-room management |
  * | `singlePlayerGame.ts` | Single-player game setup with LocalConnection |
  *
  * @module server
  */
+import { createWebSocketGameServer } from "./WebSocketServer.js";
 
 // State filtering
 export {
@@ -31,9 +33,30 @@ export {
 
 // Multiplayer game server
 export { GameServer, createGameServer } from "./GameServer.js";
+export {
+  WebSocketGameServer,
+  createWebSocketGameServer,
+  GameRoomManager,
+  CLIENT_MESSAGE_ACTION,
+  SERVER_MESSAGE_STATE_UPDATE,
+  SERVER_MESSAGE_ERROR,
+} from "./WebSocketServer.js";
 
 // Single-player game
 export { createGame, type GameInstance } from "./singlePlayerGame.js";
 
 // Re-export types
 export type { EventCallback } from "@mage-knight/shared";
+
+const PORT_ENV = "PORT";
+const DEFAULT_WEB_SOCKET_PORT = 3001;
+
+if (import.meta.main) {
+  const portFromEnv = Number.parseInt(Bun.env[PORT_ENV] ?? "", 10);
+  const port = Number.isNaN(portFromEnv) ? DEFAULT_WEB_SOCKET_PORT : portFromEnv;
+
+  const webSocketServer = createWebSocketGameServer({ port });
+  webSocketServer.start();
+
+  console.log(`WebSocket game server listening on port ${webSocketServer.getPort()}`);
+}


### PR DESCRIPTION
## Summary
- add a new `WebSocketGameServer` with room lifecycle management around `GameServer`
- implement room creation, player connection routing, action forwarding, state broadcast, and disconnect cleanup
- add protocol/error handling for invalid game IDs, full games, unknown players, invalid JSON, and invalid action payloads
- export websocket server APIs from `@mage-knight/server` and allow standalone startup from `packages/server/src/index.ts`
- add `GameRoomManager` tests for broadcast behavior, per-player filtering, error paths, and room cleanup timeout
- keep room orchestration separate from transport wiring so we can adapt to Agones-style allocation/topology later

## Validation
- `bun run build`
- `bun run lint`
- `bun run test`

Closes #886
