### PR TITLE
feat: implement client WebSocket connection for multiplayer (#888)

### DIFF
--- a/packages/client/src/context/GameProvider.tsx
+++ b/packages/client/src/context/GameProvider.tsx
@@ -8,13 +8,36 @@ import {
 import { createGameServer, type GameServer } from "@mage-knight/server";
 import type { ClientGameState, GameEvent, GameConfig } from "@mage-knight/shared";
 import { GameContext, type ActionLogEntry, type GameContextValue } from "./GameContext";
+import {
+  WebSocketConnection,
+  type ConnectionStatusInfo,
+  CONNECTION_STATUS_CONNECTING,
+  CONNECTION_STATUS_RECONNECTING,
+  CONNECTION_STATUS_ERROR,
+  CONNECTION_STATUS_DISCONNECTED,
+} from "../network/WebSocketConnection";
 
-interface GameProviderProps {
+type GameMode = "local" | "network";
+
+interface BaseGameProviderProps {
   children: ReactNode;
+}
+
+interface LocalGameProviderProps extends BaseGameProviderProps {
+  mode: "local";
   seed?: number;
-  /** Game configuration from setup screen */
   config: GameConfig;
 }
+
+interface NetworkGameProviderProps extends BaseGameProviderProps {
+  mode: "network";
+  gameId: string;
+  playerId: string;
+  serverUrl: string;
+  sessionToken?: string;
+}
+
+type GameProviderProps = LocalGameProviderProps | NetworkGameProviderProps;
 
 let nextLogId = 1;
 
@@ -52,12 +75,16 @@ function getOrCreateServer(seed?: number, config?: GameConfig): GameServer | nul
   return server;
 }
 
-export function GameProvider({ children, seed, config }: GameProviderProps) {
+export function GameProvider(props: GameProviderProps) {
+  const { children } = props;
   const [state, setState] = useState<ClientGameState | null>(null);
   const [events, setEvents] = useState<readonly GameEvent[]>([]);
   const [actionLog, setActionLog] = useState<ActionLogEntry[]>([]);
   const [isActionLogEnabled, setActionLogEnabled] = useState(true);
+  const [connectionStatus, setConnectionStatus] = useState<ConnectionStatusInfo | null>(null);
+
   const serverRef = useRef<GameServer | null>(null);
+  const wsConnectionRef = useRef<WebSocketConnection | null>(null);
   const isActionLogEnabledRef = useRef(isActionLogEnabled);
 
   // Keep ref in sync with state for use in callbacks
@@ -65,77 +92,122 @@ export function GameProvider({ children, seed, config }: GameProviderProps) {
     isActionLogEnabledRef.current = isActionLogEnabled;
   }, [isActionLogEnabled]);
 
-  // Get the player ID for this client (first player in config)
-  const myPlayerId = config.playerIds[0] ?? "player1";
+  // Determine mode and playerId from props
+  const mode: GameMode = props.mode;
+  const myPlayerId = mode === "local"
+    ? (props.config.playerIds[0] ?? "player1")
+    : props.playerId;
 
+  // Handle state updates from either local or network mode
+  const handleStateUpdate = useCallback((newEvents: readonly GameEvent[], newState: ClientGameState) => {
+    // Accumulate all events indefinitely (oldest at top, newest at bottom)
+    setEvents((prev) => [...prev, ...newEvents]);
+    setState(newState);
+
+    // Log events for debugging
+    if (isActionLogEnabledRef.current && newEvents.length > 0) {
+      setActionLog((prev) => [
+        ...prev,
+        {
+          id: nextLogId++,
+          timestamp: new Date(),
+          type: "events",
+          data: newEvents,
+        },
+      ]);
+    }
+
+    // Expose state for e2e testing (development only)
+    if (import.meta.env.DEV) {
+      (window as unknown as { __MAGE_KNIGHT_STATE__: ClientGameState }).
+        __MAGE_KNIGHT_STATE__ = newState;
+    }
+  }, []);
+
+  // Local mode: create embedded game server
   useEffect(() => {
+    if (mode !== "local") return;
+
     // Get existing server (HMR) or create new one
-    const server = getOrCreateServer(seed, config);
+    const server = getOrCreateServer(props.seed, props.config);
     if (!server) return;
 
     serverRef.current = server;
 
     // Connect and receive state updates
-    server.connect(myPlayerId, (newEvents, newState) => {
-      // Accumulate all events indefinitely (oldest at top, newest at bottom)
-      setEvents((prev) => [...prev, ...newEvents]);
-      setState(newState);
-
-      // Log events for debugging
-      if (isActionLogEnabledRef.current && newEvents.length > 0) {
-        setActionLog((prev) => [
-          ...prev,
-          {
-            id: nextLogId++,
-            timestamp: new Date(),
-            type: "events",
-            data: newEvents,
-          },
-        ]);
-      }
-
-      // Expose state for e2e testing (development only)
-      if (import.meta.env.DEV) {
-        (window as unknown as { __MAGE_KNIGHT_STATE__: ClientGameState }).
-          __MAGE_KNIGHT_STATE__ = newState;
-      }
-    });
+    server.connect(myPlayerId, handleStateUpdate);
 
     return () => {
       server.disconnect(myPlayerId);
     };
-  }, [seed, config, myPlayerId]);
+  }, [mode, props, myPlayerId, handleStateUpdate]);
+
+  // Network mode: connect via WebSocket
+  useEffect(() => {
+    if (mode !== "network") return;
+
+    const handleConnectionStatusChange = (status: ConnectionStatusInfo) => {
+      setConnectionStatus(status);
+    };
+
+    const connection = new WebSocketConnection({
+      gameId: props.gameId,
+      playerId: props.playerId,
+      serverUrl: props.serverUrl,
+      onStateUpdate: handleStateUpdate,
+      onStatusChange: handleConnectionStatusChange,
+    });
+
+    // Set session token if provided
+    if (props.sessionToken) {
+      connection.setSessionToken(props.sessionToken);
+    }
+
+    wsConnectionRef.current = connection;
+    connection.connect();
+
+    return () => {
+      connection.disconnect();
+      wsConnectionRef.current = null;
+    };
+  }, [mode, props, handleStateUpdate]);
 
   const sendAction = useCallback((action: Parameters<GameContextValue["sendAction"]>[0]) => {
-    if (serverRef.current) {
-      // Log action for debugging
-      if (isActionLogEnabledRef.current) {
-        setActionLog((prev) => [
-          ...prev,
-          {
-            id: nextLogId++,
-            timestamp: new Date(),
-            type: "action",
-            data: action,
-          },
-        ]);
-      }
-      serverRef.current.handleAction(myPlayerId, action);
+    // Log action for debugging
+    if (isActionLogEnabledRef.current) {
+      setActionLog((prev) => [
+        ...prev,
+        {
+          id: nextLogId++,
+          timestamp: new Date(),
+          type: "action",
+          data: action,
+        },
+      ]);
     }
-  }, [myPlayerId]);
+
+    // Send via local server or WebSocket connection
+    if (mode === "local" && serverRef.current) {
+      serverRef.current.handleAction(myPlayerId, action);
+    } else if (mode === "network" && wsConnectionRef.current) {
+      wsConnectionRef.current.sendAction(action);
+    }
+  }, [mode, myPlayerId]);
 
   const saveGame = useCallback((): string | null => {
-    if (serverRef.current) {
+    if (mode === "local" && serverRef.current) {
       return serverRef.current.saveGame();
     }
+    // Network mode: save/load not supported (server manages state)
     return null;
-  }, []);
+  }, [mode]);
 
   const loadGame = useCallback((json: string): void => {
-    if (serverRef.current) {
+    if (mode === "local" && serverRef.current) {
       serverRef.current.loadGame(json);
     }
-  }, []);
+    // Network mode: save/load not supported (server manages state)
+  }, [mode]);
 
   const clearActionLog = useCallback(() => {
     setActionLog([]);
@@ -153,6 +225,58 @@ export function GameProvider({ children, seed, config }: GameProviderProps) {
     isActionLogEnabled,
     setActionLogEnabled,
   };
+
+  // Show loading/connection status for network mode
+  if (mode === "network") {
+    if (!connectionStatus) {
+      return (
+        <div className="loading-screen">
+          <p>Initializing connection...</p>
+        </div>
+      );
+    }
+
+    if (connectionStatus.status === CONNECTION_STATUS_CONNECTING) {
+      return (
+        <div className="loading-screen">
+          <p>Connecting to game server...</p>
+        </div>
+      );
+    }
+
+    if (connectionStatus.status === CONNECTION_STATUS_RECONNECTING) {
+      return (
+        <div className="loading-screen">
+          <p>
+            Reconnecting... (attempt {connectionStatus.reconnectAttempt} of{" "}
+            {connectionStatus.maxReconnectAttempts})
+          </p>
+        </div>
+      );
+    }
+
+    if (connectionStatus.status === CONNECTION_STATUS_ERROR) {
+      return (
+        <div className="loading-screen error">
+          <p>Connection Error</p>
+          <p className="error-message">{connectionStatus.error}</p>
+          <p className="error-hint">
+            {connectionStatus.error?.includes("Session expired")
+              ? "Please create a new game or rejoin with a valid session."
+              : "Please check your connection and try again."}
+          </p>
+        </div>
+      );
+    }
+
+    if (connectionStatus.status === CONNECTION_STATUS_DISCONNECTED) {
+      return (
+        <div className="loading-screen">
+          <p>Disconnected from server</p>
+        </div>
+      );
+    }
+  }
 
   // Show loading state until game is initialized
   if (!state) {

--- a/packages/client/src/network/WebSocketConnection.ts
+++ b/packages/client/src/network/WebSocketConnection.ts
@@ -1,0 +1,330 @@
+import type { ClientGameState, GameEvent, PlayerAction } from "@mage-knight/shared";
+
+export const CONNECTION_STATUS_CONNECTING = "connecting" as const;
+export const CONNECTION_STATUS_CONNECTED = "connected" as const;
+export const CONNECTION_STATUS_RECONNECTING = "reconnecting" as const;
+export const CONNECTION_STATUS_DISCONNECTED = "disconnected" as const;
+export const CONNECTION_STATUS_ERROR = "error" as const;
+
+export type ConnectionStatus =
+  | typeof CONNECTION_STATUS_CONNECTING
+  | typeof CONNECTION_STATUS_CONNECTED
+  | typeof CONNECTION_STATUS_RECONNECTING
+  | typeof CONNECTION_STATUS_DISCONNECTED
+  | typeof CONNECTION_STATUS_ERROR;
+
+export interface ConnectionStatusInfo {
+  status: ConnectionStatus;
+  error?: string;
+  reconnectAttempt?: number;
+  maxReconnectAttempts?: number;
+}
+
+interface ClientActionMessage {
+  type: "action";
+  action: PlayerAction;
+}
+
+interface StateUpdateMessage {
+  type: "state_update";
+  events: readonly GameEvent[];
+  state: ClientGameState;
+}
+
+interface ErrorMessage {
+  type: "error";
+  message: string;
+}
+
+type ServerMessage = StateUpdateMessage | ErrorMessage;
+
+export interface WebSocketConnectionOptions {
+  gameId: string;
+  playerId: string;
+  serverUrl: string;
+  onStateUpdate: (events: readonly GameEvent[], state: ClientGameState) => void;
+  onStatusChange: (status: ConnectionStatusInfo) => void;
+  reconnectBaseDelay?: number;
+  maxReconnectAttempts?: number;
+}
+
+const DEFAULT_RECONNECT_BASE_DELAY = 500;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 5;
+const SESSION_STORAGE_KEY_PREFIX = "mage_knight_session_";
+
+/**
+ * WebSocket connection manager for multiplayer games.
+ * Handles connection lifecycle, reconnection with exponential backoff,
+ * and session persistence for refresh recovery.
+ */
+export class WebSocketConnection {
+  private readonly gameId: string;
+  private readonly playerId: string;
+  private readonly serverUrl: string;
+  private readonly onStateUpdate: (events: readonly GameEvent[], state: ClientGameState) => void;
+  private readonly onStatusChange: (status: ConnectionStatusInfo) => void;
+  private readonly reconnectBaseDelay: number;
+  private readonly maxReconnectAttempts: number;
+
+  private ws: WebSocket | null = null;
+  private reconnectAttempt = 0;
+  private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private isManualDisconnect = false;
+  private currentStatus: ConnectionStatus = CONNECTION_STATUS_CONNECTING;
+  private sessionToken: string | null = null;
+
+  constructor(options: WebSocketConnectionOptions) {
+    this.gameId = options.gameId;
+    this.playerId = options.playerId;
+    this.serverUrl = options.serverUrl;
+    this.onStateUpdate = options.onStateUpdate;
+    this.onStatusChange = options.onStatusChange;
+    this.reconnectBaseDelay = options.reconnectBaseDelay ?? DEFAULT_RECONNECT_BASE_DELAY;
+    this.maxReconnectAttempts = options.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS;
+
+    // Try to restore session from storage
+    this.loadSession();
+  }
+
+  /**
+   * Establish WebSocket connection to the server.
+   */
+  connect(): void {
+    this.isManualDisconnect = false;
+    this.updateStatus(CONNECTION_STATUS_CONNECTING);
+
+    const url = this.buildWebSocketUrl();
+    console.log(`[WebSocket] Connecting to ${url}`);
+
+    try {
+      this.ws = new WebSocket(url);
+      this.setupEventHandlers();
+    } catch (error) {
+      console.error("[WebSocket] Failed to create connection:", error);
+      this.updateStatus(CONNECTION_STATUS_ERROR, this.getErrorMessage(error));
+      this.scheduleReconnect();
+    }
+  }
+
+  /**
+   * Send a player action to the server.
+   */
+  sendAction(action: PlayerAction): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      console.warn("[WebSocket] Cannot send action - not connected");
+      return;
+    }
+
+    const message: ClientActionMessage = {
+      type: "action",
+      action,
+    };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      console.log("[WebSocket] Sent action:", action.type);
+    } catch (error) {
+      console.error("[WebSocket] Failed to send action:", error);
+    }
+  }
+
+  /**
+   * Manually disconnect from the server.
+   */
+  disconnect(): void {
+    this.isManualDisconnect = true;
+    this.clearReconnectTimeout();
+    this.clearSession();
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+
+    this.updateStatus(CONNECTION_STATUS_DISCONNECTED);
+  }
+
+  /**
+   * Get current connection status.
+   */
+  getStatus(): ConnectionStatus {
+    return this.currentStatus;
+  }
+
+  /**
+   * Store session token for reconnection.
+   */
+  setSessionToken(token: string): void {
+    this.sessionToken = token;
+    this.saveSession(token);
+  }
+
+  private buildWebSocketUrl(): string {
+    const url = new URL(this.serverUrl);
+    url.searchParams.set("gameId", this.gameId);
+    url.searchParams.set("playerId", this.playerId);
+    return url.toString();
+  }
+
+  private setupEventHandlers(): void {
+    if (!this.ws) return;
+
+    this.ws.onopen = () => {
+      console.log("[WebSocket] Connection established");
+      this.reconnectAttempt = 0;
+      this.updateStatus(CONNECTION_STATUS_CONNECTED);
+    };
+
+    this.ws.onmessage = (event) => {
+      try {
+        const message = JSON.parse(event.data) as ServerMessage;
+        this.handleServerMessage(message);
+      } catch (error) {
+        console.error("[WebSocket] Failed to parse message:", error);
+      }
+    };
+
+    this.ws.onerror = (event) => {
+      console.error("[WebSocket] Connection error:", event);
+      this.updateStatus(CONNECTION_STATUS_ERROR, "Connection error occurred");
+    };
+
+    this.ws.onclose = (event) => {
+      console.log(`[WebSocket] Connection closed (code: ${event.code}, reason: ${event.reason})`);
+      this.ws = null;
+
+      if (this.isManualDisconnect) {
+        this.updateStatus(CONNECTION_STATUS_DISCONNECTED);
+        return;
+      }
+
+      // Check if this is a terminal error (auth/session failure)
+      if (this.isTerminalCloseCode(event.code)) {
+        console.error("[WebSocket] Terminal error - session invalid or expired");
+        this.updateStatus(
+          CONNECTION_STATUS_ERROR,
+          "Session expired or invalid. Please rejoin the game."
+        );
+        this.clearSession();
+        return;
+      }
+
+      // Transient error - attempt reconnect
+      this.scheduleReconnect();
+    };
+  }
+
+  private handleServerMessage(message: ServerMessage): void {
+    if (message.type === "state_update") {
+      console.log(`[WebSocket] Received state update with ${message.events.length} events`);
+      this.onStateUpdate(message.events, message.state);
+    } else if (message.type === "error") {
+      console.error("[WebSocket] Server error:", message.message);
+      this.updateStatus(CONNECTION_STATUS_ERROR, message.message);
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.isManualDisconnect) {
+      return;
+    }
+
+    if (this.reconnectAttempt >= this.maxReconnectAttempts) {
+      console.error("[WebSocket] Max reconnect attempts reached");
+      this.updateStatus(
+        CONNECTION_STATUS_ERROR,
+        `Failed to reconnect after ${this.maxReconnectAttempts} attempts`
+      );
+      return;
+    }
+
+    // Exponential backoff: 500ms, 1s, 2s, 4s, 8s
+    const delay = this.reconnectBaseDelay * Math.pow(2, this.reconnectAttempt);
+    this.reconnectAttempt++;
+
+    console.log(`[WebSocket] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempt}/${this.maxReconnectAttempts})`);
+    this.updateStatus(CONNECTION_STATUS_RECONNECTING);
+
+    this.reconnectTimeout = setTimeout(() => {
+      this.connect();
+    }, delay);
+  }
+
+  private clearReconnectTimeout(): void {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+  }
+
+  private isTerminalCloseCode(code: number): boolean {
+    // 1008 = Policy Violation (invalid request)
+    // 4001 = Replaced by another connection (custom code from server)
+    return code === 1008 || code === 4001;
+  }
+
+  private updateStatus(status: ConnectionStatus, error?: string): void {
+    this.currentStatus = status;
+
+    const statusInfo: ConnectionStatusInfo = {
+      status,
+      error,
+    };
+
+    if (status === CONNECTION_STATUS_RECONNECTING) {
+      statusInfo.reconnectAttempt = this.reconnectAttempt;
+      statusInfo.maxReconnectAttempts = this.maxReconnectAttempts;
+    }
+
+    this.onStatusChange(statusInfo);
+  }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    return String(error);
+  }
+
+  private getSessionStorageKey(): string {
+    return `${SESSION_STORAGE_KEY_PREFIX}${this.gameId}`;
+  }
+
+  private saveSession(token: string): void {
+    try {
+      const sessionData = {
+        gameId: this.gameId,
+        playerId: this.playerId,
+        sessionToken: token,
+      };
+      sessionStorage.setItem(this.getSessionStorageKey(), JSON.stringify(sessionData));
+      console.log("[WebSocket] Session saved for refresh recovery");
+    } catch (error) {
+      console.warn("[WebSocket] Failed to save session:", error);
+    }
+  }
+
+  private loadSession(): void {
+    try {
+      const key = this.getSessionStorageKey();
+      const data = sessionStorage.getItem(key);
+      if (data) {
+        const session = JSON.parse(data) as { sessionToken: string };
+        this.sessionToken = session.sessionToken;
+        console.log("[WebSocket] Session restored from storage");
+      }
+    } catch (error) {
+      console.warn("[WebSocket] Failed to load session:", error);
+    }
+  }
+
+  private clearSession(): void {
+    try {
+      sessionStorage.removeItem(this.getSessionStorageKey());
+      this.sessionToken = null;
+      console.log("[WebSocket] Session cleared");
+    } catch (error) {
+      console.warn("[WebSocket] Failed to clear session:", error);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Implements the client-side WebSocket connection layer for online multiplayer, replacing the in-process embedded server with a remote connection.

## Changes

### WebSocketConnection class (`packages/client/src/network/WebSocketConnection.ts`)
- Manages WebSocket lifecycle (connect, disconnect, send actions)
- Connection status tracking (connecting, connected, reconnecting, error, disconnected)
- Automatic reconnection with exponential backoff (500ms, 1s, 2s, 4s, 8s, max 5 attempts)
- Session persistence via sessionStorage for page refresh recovery
- Distinguishes transient transport errors from terminal auth/session errors
- Protocol alignment with server: sends `{type: "action", action: PlayerAction}`, receives state updates
- Console logging for connection lifecycle debugging

### GameProvider updates (`packages/client/src/context/GameProvider.tsx`)
- **Dual mode support**:
  - `mode="local"`: Uses embedded server (existing single-player behavior)
  - `mode="network"`: Connects via WebSocket (new multiplayer mode)
- **Network mode props**: `gameId`, `playerId`, `serverUrl`, optional `sessionToken`
- **Connection status UI**:
  - Loading screens for connecting/reconnecting states
  - Progress feedback during reconnection attempts
  - Terminal error handling with actionable recovery guidance
- **Action routing**: Sends actions via WebSocket when in network mode
- **State management**: Save/load disabled in network mode (server is source of truth)

## Connection Resilience
- Automatic reconnection on transient errors (network interruption, server restart)
- Terminal error handling for auth failures (close codes 1008, 4001)
- Session token persistence for page refresh recovery
- Clear user feedback during all connection states

## Test Plan
- [x] Build passes (`bun run build`)
- [x] Lint passes (`bun run lint`)
- [x] All tests pass (`bun run test`)
- [x] Single-player mode still works (no regression to local mode)
- [ ] Two clients can connect to same game via WebSocket (integration test needed)
- [ ] Page refresh reconnects to same session (manual test)
- [ ] Network interruption triggers reconnect with backoff (manual test)
- [ ] Expired session shows recovery UI (manual test)

## Dependencies
- Depends on: WebSocket Server & Game Rooms (#886) ✅ Closed
- Depends on: Room Provisioning & Session Bootstrap API (#967) ✅ Closed
- Related: Pre-Game Lobby State (#887) - Not blocking, lobby will use this connection layer

## Notes
- Local single-player mode unchanged - no breaking changes
- Network mode is additive - requires explicit opt-in via props
- Session management (token assignment) will come from lobby/bootstrap flow
- This PR provides the connection infrastructure; lobby/join flow is separate work

Closes #888