### PR TITLE
feat: add Python WebSocket client SDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Detect Python SDK related changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            python_sdk:
+              - 'packages/python-sdk/**'
+              - 'packages/shared/src/networkProtocol.ts'
+              - 'packages/shared/schemas/network-protocol/**'
+              - 'packages/server/src/WebSocketServer.ts'
+              - 'packages/server/src/GameServer.ts'
+              - '.github/workflows/ci.yml'
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -60,6 +73,24 @@ jobs:
 
       - name: Build
         run: bun run build
+
+      - name: Setup Python
+        if: steps.changes.outputs.python_sdk == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Python SDK dependencies
+        if: steps.changes.outputs.python_sdk == 'true'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e packages/python-sdk
+
+      - name: Test Python SDK
+        if: steps.changes.outputs.python_sdk == 'true'
+        run: |
+          python -m unittest packages/python-sdk/tests/test_client.py -v
+          python packages/python-sdk/tests/integration/test_websocket_client.py -v
 
       - name: Lint
         run: bun run lint

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docs/sprites/
 *.tsbuildinfo
 *.js.map
 *.d.ts.map
+*.pyc
+*.pyo
+__pycache__/
 
 # Test artifacts
 test-results/

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -1,0 +1,61 @@
+# mage-knight-ws-client
+
+Python async SDK for Mage Knight's WebSocket multiplayer protocol.
+
+## Features
+
+- Generated typed protocol models from shared JSON schema artifacts.
+- Runtime parsing/validation for all server messages.
+- Async WebSocket client with reconnect backoff.
+- Connection state transition stream (`connecting`, `connected`, `reconnecting`, `disconnected`, `error`).
+- Optional lobby subscribe/resume message support.
+
+## Install
+
+```bash
+cd packages/python-sdk
+python3 -m pip install -e .
+```
+
+## Quick Start
+
+```python
+import asyncio
+
+from mage_knight_sdk import MageKnightClient
+
+
+async def main() -> None:
+    async with MageKnightClient(
+        server_url="ws://127.0.0.1:3001",
+        game_id="g_example123",
+        player_id="player-1",
+    ) as client:
+        await client.send_action({"type": "end_turn"})
+
+        async for message in client.messages():
+            print(message)
+
+
+asyncio.run(main())
+```
+
+## Generate Models
+
+Protocol models are generated from:
+
+- `packages/shared/schemas/network-protocol/v1/client-to-server.schema.json`
+- `packages/shared/schemas/network-protocol/v1/server-to-client.schema.json`
+
+Run:
+
+```bash
+python3 packages/python-sdk/scripts/generate_protocol_models.py
+```
+
+## Local Integration Tests
+
+```bash
+cd packages/python-sdk
+python3 -m unittest discover -s tests -p 'test_*.py'
+```

--- a/packages/python-sdk/examples/local_dev_client.py
+++ b/packages/python-sdk/examples/local_dev_client.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import asyncio
+
+from mage_knight_sdk import MageKnightClient
+
+
+async def main() -> None:
+    # Replace with values returned by room bootstrap.
+    game_id = "g_replace_me"
+    player_id = "player-1"
+
+    async with MageKnightClient(
+        server_url="ws://127.0.0.1:3001",
+        game_id=game_id,
+        player_id=player_id,
+    ) as client:
+        await client.send_action({"type": "end_turn"})
+
+        async for message in client.messages():
+            print(message)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/examples/reconnect_resume_client.py
+++ b/packages/python-sdk/examples/reconnect_resume_client.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+
+from mage_knight_sdk import MageKnightClient
+
+
+async def print_states(client: MageKnightClient) -> None:
+    async for state in client.state_changes():
+        print(
+            {
+                "status": state.status,
+                "occurred_at": state.occurred_at.isoformat(),
+                "error": state.error,
+                "reconnect_attempt": state.reconnect_attempt,
+            }
+        )
+
+
+async def main() -> None:
+    game_id = "g_replace_me"
+    player_id = "player-1"
+    session_token = "session_token_from_bootstrap"
+
+    client = MageKnightClient(
+        server_url="ws://127.0.0.1:3001",
+        game_id=game_id,
+        player_id=player_id,
+        session_token=session_token,
+        reconnect_base_delay=0.25,
+        max_reconnect_attempts=8,
+        subscribe_lobby_on_connect=True,
+    )
+
+    state_task = asyncio.create_task(print_states(client))
+
+    await client.connect()
+    await client.send_action({"type": "end_turn"})
+
+    try:
+        async for message in client.messages():
+            print(message)
+    finally:
+        await client.close()
+        await state_task
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -1,0 +1,28 @@
+[project]
+name = "mage-knight-ws-client"
+version = "0.1.0"
+description = "Python WebSocket client SDK for Mage Knight multiplayer"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{ name = "Mage Knight Digital" }]
+license = { text = "MIT" }
+keywords = ["mage-knight", "websocket", "sdk", "multiplayer"]
+dependencies = [
+  "websockets>=12.0,<16.0",
+]
+
+[project.optional-dependencies]
+dev = []
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/packages/python-sdk/scripts/generate_protocol_models.py
+++ b/packages/python-sdk/scripts/generate_protocol_models.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Generate typed protocol dataclasses from shared JSON schemas."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[3]
+SCHEMA_ROOT = ROOT / "packages" / "shared" / "schemas" / "network-protocol" / "v1"
+OUTPUT = ROOT / "packages" / "python-sdk" / "src" / "mage_knight_sdk" / "protocol_models.py"
+
+
+def pascal_case(value: str) -> str:
+    return "".join(part.capitalize() for part in value.replace("-", "_").split("_"))
+
+
+def class_name_for_message(message_type: str) -> str:
+    custom = {
+        "action": "ClientActionMessage",
+        "lobby_subscribe": "ClientLobbySubscribeMessage",
+        "state_update": "StateUpdateMessage",
+        "error": "ErrorMessage",
+        "lobby_state": "LobbyStateMessage",
+    }
+    return custom.get(message_type, f"{pascal_case(message_type)}Message")
+
+
+def field_type(schema: dict[str, Any], required: bool) -> str:
+    if "const" in schema:
+        return f'Literal["{schema["const"]}"]'
+
+    if "enum" in schema:
+        enum_values = ", ".join(f'"{value}"' for value in schema["enum"])
+        return f"Literal[{enum_values}]"
+
+    schema_type = schema.get("type")
+    if schema_type == "string":
+        base = "str"
+    elif schema_type == "integer":
+        base = "int"
+    elif schema_type == "number":
+        base = "float"
+    elif schema_type == "boolean":
+        base = "bool"
+    elif schema_type == "array":
+        items = schema.get("items")
+        if isinstance(items, dict) and items.get("type") == "string":
+            base = "list[str]"
+        else:
+            base = "list[Any]"
+    elif schema_type == "object":
+        base = "dict[str, Any]"
+    else:
+        base = "Any"
+
+    if not required:
+        return f"{base} | None"
+    return base
+
+
+def build_dataclass(schema: dict[str, Any]) -> tuple[str, str]:
+    properties = schema["properties"]
+    required = set(schema.get("required", []))
+    message_type = properties["type"]["const"]
+    class_name = class_name_for_message(message_type)
+
+    lines: list[str] = ["@dataclass(frozen=True)", f"class {class_name}:"]
+    for field_name, field_schema in properties.items():
+        lines.append(f"    {field_name}: {field_type(field_schema, field_name in required)}")
+
+    return class_name, "\n".join(lines)
+
+
+def load_schemas() -> tuple[dict[str, Any], dict[str, Any]]:
+    client_schema = json.loads((SCHEMA_ROOT / "client-to-server.schema.json").read_text())
+    server_schema = json.loads((SCHEMA_ROOT / "server-to-client.schema.json").read_text())
+    return client_schema, server_schema
+
+
+def render() -> str:
+    protocol_meta = json.loads((SCHEMA_ROOT / "protocol.json").read_text())
+    protocol_version = protocol_meta["protocolVersion"]
+    client_schema, server_schema = load_schemas()
+
+    client_classes: list[str] = []
+    client_names: list[str] = []
+    for variant in client_schema["oneOf"]:
+        class_name, body = build_dataclass(variant)
+        client_names.append(class_name)
+        client_classes.append(body)
+
+    server_classes: list[str] = []
+    server_names: list[str] = []
+    for variant in server_schema["oneOf"]:
+        class_name, body = build_dataclass(variant)
+        server_names.append(class_name)
+        server_classes.append(body)
+
+    known_client_types = ", ".join(
+        f'"{variant["properties"]["type"]["const"]}"' for variant in client_schema["oneOf"]
+    )
+    known_server_types = ", ".join(
+        f'"{variant["properties"]["type"]["const"]}"' for variant in server_schema["oneOf"]
+    )
+
+    return "\n".join(
+        [
+            '"""Auto-generated protocol dataclasses. Do not edit by hand."""',
+            "",
+            "from __future__ import annotations",
+            "",
+            "from dataclasses import dataclass",
+            "from typing import Any, Literal, TypeAlias",
+            "",
+            f'NETWORK_PROTOCOL_VERSION: Literal["{protocol_version}"] = "{protocol_version}"',
+            "",
+            *client_classes,
+            "",
+            *server_classes,
+            "",
+            f"ClientMessage: TypeAlias = {' | '.join(client_names)}",
+            f"ServerMessage: TypeAlias = {' | '.join(server_names)}",
+            f"KNOWN_CLIENT_MESSAGE_TYPES: tuple[str, ...] = ({known_client_types},)",
+            f"KNOWN_SERVER_MESSAGE_TYPES: tuple[str, ...] = ({known_server_types},)",
+            "",
+        ]
+    )
+
+
+def main() -> None:
+    OUTPUT.write_text(render())
+    print(f"Generated {OUTPUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python-sdk/src/mage_knight_sdk/__init__.py
+++ b/packages/python-sdk/src/mage_knight_sdk/__init__.py
@@ -1,0 +1,45 @@
+from .client import (
+    CONNECTION_STATUS_CONNECTED,
+    CONNECTION_STATUS_CONNECTING,
+    CONNECTION_STATUS_DISCONNECTED,
+    CONNECTION_STATUS_ERROR,
+    CONNECTION_STATUS_RECONNECTING,
+    ConnectionState,
+    MageKnightClient,
+)
+from .protocol import (
+    PROTOCOL_PARSE_ERROR_INVALID_ENVELOPE,
+    PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+    PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE,
+    PROTOCOL_PARSE_ERROR_UNSUPPORTED_VERSION,
+    ProtocolParseError,
+    parse_server_message,
+)
+from .protocol_models import (
+    NETWORK_PROTOCOL_VERSION,
+    ErrorMessage,
+    LobbyStateMessage,
+    ServerMessage,
+    StateUpdateMessage,
+)
+
+__all__ = [
+    "CONNECTION_STATUS_CONNECTED",
+    "CONNECTION_STATUS_CONNECTING",
+    "CONNECTION_STATUS_DISCONNECTED",
+    "CONNECTION_STATUS_ERROR",
+    "CONNECTION_STATUS_RECONNECTING",
+    "ConnectionState",
+    "ErrorMessage",
+    "LobbyStateMessage",
+    "MageKnightClient",
+    "NETWORK_PROTOCOL_VERSION",
+    "PROTOCOL_PARSE_ERROR_INVALID_ENVELOPE",
+    "PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD",
+    "PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE",
+    "PROTOCOL_PARSE_ERROR_UNSUPPORTED_VERSION",
+    "ProtocolParseError",
+    "ServerMessage",
+    "StateUpdateMessage",
+    "parse_server_message",
+]

--- a/packages/python-sdk/src/mage_knight_sdk/client.py
+++ b/packages/python-sdk/src/mage_knight_sdk/client.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, AsyncIterator, Mapping
+from urllib.parse import urlencode, urlparse, urlunparse
+
+import websockets
+from websockets.exceptions import ConnectionClosed
+
+from .protocol import (
+    NETWORK_PROTOCOL_VERSION,
+    ProtocolParseError,
+    ProtocolValidationError,
+    parse_server_message,
+    serialize_client_message,
+    validate_action_payload,
+)
+from .protocol_models import ClientActionMessage, ClientLobbySubscribeMessage, ServerMessage
+
+CONNECTION_STATUS_CONNECTING = "connecting"
+CONNECTION_STATUS_CONNECTED = "connected"
+CONNECTION_STATUS_RECONNECTING = "reconnecting"
+CONNECTION_STATUS_DISCONNECTED = "disconnected"
+CONNECTION_STATUS_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ConnectionState:
+    status: str
+    occurred_at: datetime
+    error: str | None = None
+    reconnect_attempt: int | None = None
+    max_reconnect_attempts: int | None = None
+
+
+class MageKnightClient:
+    def __init__(
+        self,
+        server_url: str,
+        game_id: str,
+        player_id: str,
+        session_token: str | None = None,
+        reconnect_base_delay: float = 0.5,
+        max_reconnect_attempts: int = 5,
+        subscribe_lobby_on_connect: bool = False,
+    ) -> None:
+        self._server_url = server_url
+        self._game_id = game_id
+        self._player_id = player_id
+        self._session_token = session_token
+        self._reconnect_base_delay = reconnect_base_delay
+        self._max_reconnect_attempts = max_reconnect_attempts
+        self._subscribe_lobby_on_connect = subscribe_lobby_on_connect
+
+        self._ws: Any = None
+        self._receiver_task: asyncio.Task[None] | None = None
+        self._messages: asyncio.Queue[ServerMessage | None] = asyncio.Queue()
+        self._states: asyncio.Queue[ConnectionState | None] = asyncio.Queue()
+        self._close_requested = False
+        self._terminated = False
+
+    async def __aenter__(self) -> MageKnightClient:
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.close()
+
+    async def connect(self) -> None:
+        if self._receiver_task and not self._receiver_task.done():
+            return
+
+        self._close_requested = False
+        self._terminated = False
+        await self._open_connection(is_reconnect=False)
+        self._receiver_task = asyncio.create_task(self._run_receiver())
+
+    async def close(self) -> None:
+        self._close_requested = True
+
+        if self._ws is not None:
+            await self._ws.close()
+
+        if self._receiver_task is not None:
+            await self._receiver_task
+            self._receiver_task = None
+
+        if not self._terminated:
+            self._terminated = True
+            await self._emit_state(CONNECTION_STATUS_DISCONNECTED)
+            await self._messages.put(None)
+            await self._states.put(None)
+
+    async def send_action(self, action: Mapping[str, Any]) -> None:
+        validate_action_payload(action)
+        if self._ws is None:
+            raise ConnectionError("WebSocket is not connected")
+
+        message = ClientActionMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="action",
+            action=dict(action),
+        )
+        await self._ws.send(json.dumps(serialize_client_message(message)))
+
+    async def send_lobby_subscribe(self) -> None:
+        if self._ws is None:
+            raise ConnectionError("WebSocket is not connected")
+
+        message = ClientLobbySubscribeMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="lobby_subscribe",
+            gameId=self._game_id,
+            playerId=self._player_id,
+            sessionToken=self._session_token,
+        )
+        await self._ws.send(json.dumps(serialize_client_message(message)))
+
+    async def messages(self) -> AsyncIterator[ServerMessage]:
+        while True:
+            message = await self._messages.get()
+            if message is None:
+                break
+            yield message
+
+    async def state_changes(self) -> AsyncIterator[ConnectionState]:
+        while True:
+            state = await self._states.get()
+            if state is None:
+                break
+            yield state
+
+    async def _open_connection(self, is_reconnect: bool, reconnect_attempt: int | None = None) -> None:
+        status = CONNECTION_STATUS_RECONNECTING if is_reconnect else CONNECTION_STATUS_CONNECTING
+        await self._emit_state(
+            status,
+            reconnect_attempt=reconnect_attempt,
+            max_reconnect_attempts=self._max_reconnect_attempts if is_reconnect else None,
+        )
+
+        self._ws = await websockets.connect(self._build_ws_url())
+
+        if self._subscribe_lobby_on_connect:
+            await self.send_lobby_subscribe()
+
+        await self._emit_state(CONNECTION_STATUS_CONNECTED)
+
+    async def _run_receiver(self) -> None:
+        while not self._close_requested:
+            try:
+                if self._ws is None:
+                    raise ConnectionError("WebSocket unavailable")
+
+                raw = await self._ws.recv()
+                payload = json.loads(raw)
+                message = parse_server_message(payload)
+                await self._messages.put(message)
+            except ProtocolParseError as error:
+                await self._emit_state(CONNECTION_STATUS_ERROR, f"{error.code}: {error}")
+                break
+            except (ProtocolValidationError, json.JSONDecodeError) as error:
+                await self._emit_state(CONNECTION_STATUS_ERROR, str(error))
+                break
+            except ConnectionClosed:
+                if self._close_requested:
+                    break
+
+                if not await self._attempt_reconnect():
+                    break
+            except Exception as error:  # pragma: no cover - defensive branch
+                if self._close_requested:
+                    break
+                if not await self._attempt_reconnect(str(error)):
+                    break
+
+        if not self._terminated:
+            self._terminated = True
+            await self._emit_state(CONNECTION_STATUS_DISCONNECTED)
+            await self._messages.put(None)
+            await self._states.put(None)
+
+    async def _attempt_reconnect(self, reason: str | None = None) -> bool:
+        last_error = reason
+
+        for attempt in range(1, self._max_reconnect_attempts + 1):
+            delay = self._reconnect_base_delay * (2 ** (attempt - 1))
+            await asyncio.sleep(delay)
+
+            try:
+                await self._open_connection(is_reconnect=True, reconnect_attempt=attempt)
+                return True
+            except Exception as error:  # pragma: no cover - exercised via integration flow
+                last_error = str(error)
+
+        await self._emit_state(
+            CONNECTION_STATUS_ERROR,
+            last_error or f"Failed to reconnect after {self._max_reconnect_attempts} attempts",
+            reconnect_attempt=self._max_reconnect_attempts,
+            max_reconnect_attempts=self._max_reconnect_attempts,
+        )
+        return False
+
+    async def _emit_state(
+        self,
+        status: str,
+        error: str | None = None,
+        reconnect_attempt: int | None = None,
+        max_reconnect_attempts: int | None = None,
+    ) -> None:
+        await self._states.put(
+            ConnectionState(
+                status=status,
+                occurred_at=datetime.now(UTC),
+                error=error,
+                reconnect_attempt=reconnect_attempt,
+                max_reconnect_attempts=max_reconnect_attempts,
+            )
+        )
+
+    def _build_ws_url(self) -> str:
+        parsed = urlparse(self._server_url)
+        query_items: dict[str, str] = {
+            "gameId": self._game_id,
+            "playerId": self._player_id,
+        }
+        if self._session_token:
+            query_items["sessionToken"] = self._session_token
+
+        query = urlencode(query_items)
+        return urlunparse(parsed._replace(query=query))

--- a/packages/python-sdk/src/mage_knight_sdk/protocol.py
+++ b/packages/python-sdk/src/mage_knight_sdk/protocol.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Mapping
+
+from .protocol_models import (
+    KNOWN_CLIENT_MESSAGE_TYPES,
+    KNOWN_SERVER_MESSAGE_TYPES,
+    NETWORK_PROTOCOL_VERSION,
+    ClientActionMessage,
+    ClientLobbySubscribeMessage,
+    ClientMessage,
+    ErrorMessage,
+    LobbyStateMessage,
+    ServerMessage,
+    StateUpdateMessage,
+)
+
+PROTOCOL_PARSE_ERROR_INVALID_ENVELOPE = "invalid_envelope"
+PROTOCOL_PARSE_ERROR_UNSUPPORTED_VERSION = "unsupported_version"
+PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE = "unknown_message_type"
+PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD = "invalid_payload"
+
+
+class ProtocolParseError(ValueError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ProtocolValidationError(ValueError):
+    pass
+
+
+def serialize_client_message(message: ClientMessage) -> dict[str, Any]:
+    return asdict(message)
+
+
+def parse_client_message(value: Any) -> ClientMessage:
+    envelope = _validate_envelope(value, KNOWN_CLIENT_MESSAGE_TYPES)
+    message_type = envelope["type"]
+
+    if message_type == "action":
+        action = envelope.get("action")
+        if not isinstance(action, Mapping) or not _non_empty_string(action.get("type")):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "Action message payload must include a non-empty action.type string.",
+            )
+
+        return ClientActionMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="action",
+            action=dict(action),
+        )
+
+    if message_type == "lobby_subscribe":
+        game_id = envelope.get("gameId")
+        player_id = envelope.get("playerId")
+        session_token = envelope.get("sessionToken")
+
+        if not _non_empty_string(game_id):
+            raise ProtocolParseError(PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD, "lobby_subscribe requires gameId.")
+
+        if not _non_empty_string(player_id):
+            raise ProtocolParseError(PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD, "lobby_subscribe requires playerId.")
+
+        if session_token is not None and not _non_empty_string(session_token):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "lobby_subscribe sessionToken must be a non-empty string when provided.",
+            )
+
+        return ClientLobbySubscribeMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="lobby_subscribe",
+            gameId=game_id,
+            playerId=player_id,
+            sessionToken=session_token,
+        )
+
+    raise ProtocolParseError(
+        PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE,
+        f"Unknown client message type: {message_type}.",
+    )
+
+
+def parse_server_message(value: Any) -> ServerMessage:
+    envelope = _validate_envelope(value, KNOWN_SERVER_MESSAGE_TYPES)
+    message_type = envelope["type"]
+
+    if message_type == "state_update":
+        events = envelope.get("events")
+        state = envelope.get("state")
+        if not isinstance(events, list) or not isinstance(state, Mapping):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "state_update requires events[] and state object.",
+            )
+
+        return StateUpdateMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="state_update",
+            events=list(events),
+            state=dict(state),
+        )
+
+    if message_type == "error":
+        message = envelope.get("message")
+        error_code = envelope.get("errorCode")
+
+        if not _non_empty_string(message):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "error requires a non-empty message.",
+            )
+
+        if error_code is not None and not _non_empty_string(error_code):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "errorCode must be a non-empty string when provided.",
+            )
+
+        return ErrorMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="error",
+            message=message,
+            errorCode=error_code,
+        )
+
+    if message_type == "lobby_state":
+        game_id = envelope.get("gameId")
+        status = envelope.get("status")
+        player_ids = envelope.get("playerIds")
+        max_players = envelope.get("maxPlayers")
+
+        if not _non_empty_string(game_id):
+            raise ProtocolParseError(PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD, "lobby_state requires gameId.")
+
+        if status not in {"lobby", "started"}:
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "lobby_state status must be lobby or started.",
+            )
+
+        if not isinstance(player_ids, list) or any(not _non_empty_string(item) for item in player_ids):
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "lobby_state requires playerIds[] of strings.",
+            )
+
+        if not isinstance(max_players, int) or max_players <= 0:
+            raise ProtocolParseError(
+                PROTOCOL_PARSE_ERROR_INVALID_PAYLOAD,
+                "lobby_state requires maxPlayers integer > 0.",
+            )
+
+        return LobbyStateMessage(
+            protocolVersion=NETWORK_PROTOCOL_VERSION,
+            type="lobby_state",
+            gameId=game_id,
+            status=status,
+            playerIds=list(player_ids),
+            maxPlayers=max_players,
+        )
+
+    raise ProtocolParseError(
+        PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE,
+        f"Unknown server message type: {message_type}.",
+    )
+
+
+def _validate_envelope(value: Any, known_types: tuple[str, ...]) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProtocolParseError(PROTOCOL_PARSE_ERROR_INVALID_ENVELOPE, "Message must be a JSON object.")
+
+    message_type = value.get("type")
+    if not _non_empty_string(message_type):
+        raise ProtocolParseError(
+            PROTOCOL_PARSE_ERROR_INVALID_ENVELOPE,
+            "Message type must be a non-empty string.",
+        )
+
+    if value.get("protocolVersion") != NETWORK_PROTOCOL_VERSION:
+        raise ProtocolParseError(
+            PROTOCOL_PARSE_ERROR_UNSUPPORTED_VERSION,
+            f"Unsupported protocol version: {value.get('protocolVersion')}.",
+        )
+
+    if message_type not in known_types:
+        raise ProtocolParseError(
+            PROTOCOL_PARSE_ERROR_UNKNOWN_MESSAGE_TYPE,
+            f"Unknown message type: {message_type}.",
+        )
+
+    return value
+
+
+def validate_action_payload(action: Mapping[str, Any]) -> None:
+    if not _non_empty_string(action.get("type")):
+        raise ProtocolValidationError("action must include a non-empty 'type' field")
+
+
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and len(value) > 0

--- a/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
+++ b/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
@@ -1,0 +1,47 @@
+"""Auto-generated protocol dataclasses. Do not edit by hand."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, TypeAlias
+
+NETWORK_PROTOCOL_VERSION: Literal["1.0.0"] = "1.0.0"
+
+@dataclass(frozen=True)
+class ClientActionMessage:
+    action: dict[str, Any]
+    protocolVersion: Literal["1.0.0"]
+    type: Literal["action"]
+@dataclass(frozen=True)
+class ClientLobbySubscribeMessage:
+    gameId: str
+    playerId: str
+    protocolVersion: Literal["1.0.0"]
+    sessionToken: str | None
+    type: Literal["lobby_subscribe"]
+
+@dataclass(frozen=True)
+class StateUpdateMessage:
+    events: list[Any]
+    protocolVersion: Literal["1.0.0"]
+    state: dict[str, Any]
+    type: Literal["state_update"]
+@dataclass(frozen=True)
+class ErrorMessage:
+    errorCode: str | None
+    message: str
+    protocolVersion: Literal["1.0.0"]
+    type: Literal["error"]
+@dataclass(frozen=True)
+class LobbyStateMessage:
+    gameId: str
+    maxPlayers: int
+    playerIds: list[str]
+    protocolVersion: Literal["1.0.0"]
+    status: Literal["lobby", "started"]
+    type: Literal["lobby_state"]
+
+ClientMessage: TypeAlias = ClientActionMessage | ClientLobbySubscribeMessage
+ServerMessage: TypeAlias = StateUpdateMessage | ErrorMessage | LobbyStateMessage
+KNOWN_CLIENT_MESSAGE_TYPES: tuple[str, ...] = ("action", "lobby_subscribe",)
+KNOWN_SERVER_MESSAGE_TYPES: tuple[str, ...] = ("state_update", "error", "lobby_state",)

--- a/packages/python-sdk/tests/integration/test_websocket_client.py
+++ b/packages/python-sdk/tests/integration/test_websocket_client.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SDK_SRC = REPO_ROOT / "packages/python-sdk/src"
+if str(SDK_SRC) not in sys.path:
+    sys.path.insert(0, str(SDK_SRC))
+
+from mage_knight_sdk import (
+    CONNECTION_STATUS_CONNECTED,
+    CONNECTION_STATUS_CONNECTING,
+    CONNECTION_STATUS_DISCONNECTED,
+    CONNECTION_STATUS_ERROR,
+    CONNECTION_STATUS_RECONNECTING,
+    MageKnightClient,
+    StateUpdateMessage,
+)
+
+
+class WebSocketClientIntegrationTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.repo_root = REPO_ROOT
+        self.server_script = self.repo_root / "packages/python-sdk/tests/integration/ws_test_server.ts"
+
+        self.server = await asyncio.create_subprocess_exec(
+            "bun",
+            "run",
+            str(self.server_script),
+            cwd=str(self.repo_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert self.server.stdout is not None
+        line = await asyncio.wait_for(self.server.stdout.readline(), timeout=10)
+        if not line:
+            stderr = await self._read_stderr()
+            raise RuntimeError(f"Test server failed to start. stderr: {stderr}")
+
+        payload = json.loads(line.decode("utf-8"))
+        self.port = payload["port"]
+        self.game_id = payload["gameId"]
+        self.player_id = payload["playerId"]
+
+    async def asyncTearDown(self) -> None:
+        if self.server.returncode is None:
+            self.server.terminate()
+            try:
+                await asyncio.wait_for(self.server.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self.server.kill()
+                await self.server.wait()
+
+    async def test_connect_send_action_and_receive_state_updates(self) -> None:
+        client = MageKnightClient(
+            server_url=f"ws://127.0.0.1:{self.port}",
+            game_id=self.game_id,
+            player_id=self.player_id,
+            reconnect_base_delay=0.05,
+            max_reconnect_attempts=3,
+        )
+
+        await client.connect()
+
+        message_stream = client.messages()
+        initial = await asyncio.wait_for(anext(message_stream), timeout=10)
+        self.assertIsInstance(initial, StateUpdateMessage)
+
+        await client.send_action({"type": "end_turn"})
+
+        found_action_update = False
+        for _ in range(8):
+            message = await asyncio.wait_for(anext(message_stream), timeout=5)
+            if isinstance(message, StateUpdateMessage) and len(message.events) > 0:
+                found_action_update = True
+                break
+
+        self.assertTrue(found_action_update)
+        await client.close()
+
+    async def test_emits_reconnect_and_error_states_on_interruption(self) -> None:
+        client = MageKnightClient(
+            server_url=f"ws://127.0.0.1:{self.port}",
+            game_id=self.game_id,
+            player_id=self.player_id,
+            reconnect_base_delay=0.05,
+            max_reconnect_attempts=2,
+        )
+
+        await client.connect()
+
+        self.server.terminate()
+        await asyncio.wait_for(self.server.wait(), timeout=5)
+
+        states: list[str] = []
+        async for state in client.state_changes():
+            states.append(state.status)
+            if state.status in {CONNECTION_STATUS_ERROR, CONNECTION_STATUS_DISCONNECTED}:
+                break
+
+        await client.close()
+
+        self.assertIn(CONNECTION_STATUS_CONNECTING, states)
+        self.assertIn(CONNECTION_STATUS_CONNECTED, states)
+        self.assertIn(CONNECTION_STATUS_RECONNECTING, states)
+        self.assertIn(CONNECTION_STATUS_ERROR, states)
+
+    async def _read_stderr(self) -> str:
+        if self.server.stderr is None:
+            return ""
+
+        chunks: list[str] = []
+        while True:
+            line = await self.server.stderr.readline()
+            if not line:
+                break
+            chunks.append(line.decode("utf-8"))
+
+        return "".join(chunks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/python-sdk/tests/integration/ws_test_server.ts
+++ b/packages/python-sdk/tests/integration/ws_test_server.ts
@@ -1,0 +1,29 @@
+import { createWebSocketGameServer } from "../../../server/src/WebSocketServer.ts";
+
+const server = createWebSocketGameServer({ host: "127.0.0.1", port: 0 });
+server.start();
+
+const gameId = server.createGameRoom({
+  playerIds: ["player-1", "player-2"],
+  maxPlayers: 2,
+});
+
+const payload = {
+  port: server.getPort(),
+  gameId,
+  playerId: "player-1",
+};
+
+console.log(JSON.stringify(payload));
+
+const shutdown = (): void => {
+  server.stop();
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+setInterval(() => {
+  // Keep process alive for integration tests.
+}, 1000);

--- a/packages/python-sdk/tests/test_client.py
+++ b/packages/python-sdk/tests/test_client.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SDK_SRC = REPO_ROOT / "packages/python-sdk/src"
+if str(SDK_SRC) not in sys.path:
+    sys.path.insert(0, str(SDK_SRC))
+
+from mage_knight_sdk.client import MageKnightClient
+
+
+class _FakeWebSocket:
+    def __init__(self, recv_error: Exception | None = None) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+        self._recv_error = recv_error
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def recv(self) -> str:
+        if self._recv_error is not None:
+            raise self._recv_error
+        await asyncio.sleep(3600)
+        return ""
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class MageKnightClientUnitTest(unittest.IsolatedAsyncioTestCase):
+    async def test_send_lobby_subscribe_omits_null_session_token(self) -> None:
+        client = MageKnightClient(
+            server_url="ws://127.0.0.1:3001",
+            game_id="g_test",
+            player_id="player-1",
+            session_token=None,
+        )
+        fake_ws = _FakeWebSocket()
+        client._ws = fake_ws
+
+        await client.send_lobby_subscribe()
+
+        payload = json.loads(fake_ws.sent[0])
+        self.assertNotIn("sessionToken", payload)
+        self.assertEqual(payload["type"], "lobby_subscribe")
+
+    async def test_close_cancels_reconnect_backoff_sleep(self) -> None:
+        client = MageKnightClient(
+            server_url="ws://127.0.0.1:3001",
+            game_id="g_test",
+            player_id="player-1",
+            reconnect_base_delay=5.0,
+            max_reconnect_attempts=2,
+        )
+        client._ws = _FakeWebSocket(recv_error=RuntimeError("boom"))
+        client._receiver_task = asyncio.create_task(client._run_receiver())
+
+        await asyncio.sleep(0.05)
+
+        started = time.monotonic()
+        await client.close()
+        elapsed = time.monotonic() - started
+
+        self.assertLess(elapsed, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new Python SDK package at `packages/python-sdk` for Mage Knight WebSocket multiplayer
- generate typed protocol dataclasses from shared v1 JSON schema artifacts
- implement async `MageKnightClient` with connect/send/message stream, reconnect backoff, optional lobby subscribe, and connection state transitions
- add local usage examples and integration tests that launch a real Bun WebSocket server process

## Verification
- `bun run build && bun run lint && bun run test`
- `.venv/bin/python packages/python-sdk/tests/integration/test_websocket_client.py -v`

Closes #969
