### PR TITLE
feat: add python random-policy integration harness

### DIFF
--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -51,6 +51,43 @@ asyncio.run(main())
 
 This example requires a Mage Knight server running locally. See `examples/local_dev_client.py` for a more complete example.
 
+## Random-Policy Simulation Harness
+
+The SDK includes a headless integration harness for running multiplayer games over bootstrap + WebSocket APIs without the React client.
+
+### What It Validates
+
+- Agent always selects from server-advertised `validActions`.
+- Server does not reject actions advertised as valid.
+- Turn ownership invariants stay coherent (`currentPlayerId` is always in `turnOrder`).
+- Per-run outcomes are tracked: `ended`, `max_steps`, `disconnect`, `protocol_error`, `invariant_failure`.
+- Reproducible failure artifacts include seed, action trace, and message log.
+
+### Programmatic Usage
+
+```python
+from mage_knight_sdk import RunnerConfig, run_simulations_sync, save_summary
+
+config = RunnerConfig(
+    bootstrap_api_base_url="http://127.0.0.1:3002",
+    ws_server_url="ws://127.0.0.1:3001",
+    player_count=2,
+    runs=5,
+    base_seed=42,
+    max_steps=200,
+    artifacts_dir="sim_artifacts",
+)
+
+results, summary = run_simulations_sync(config)
+save_summary("sim_artifacts/summary.json", results, summary)
+print(summary)
+```
+
+### Deterministic Failure Reproduction
+
+Use the same `base_seed`, `player_count`, and API/WS endpoints to replay the same random decision stream.
+For validation testing, you can force an invalid action via `forced_invalid_action_step` and assert it is reported as `protocol_error`.
+
 ## Generate Models
 
 Protocol models are generated from:
@@ -72,4 +109,7 @@ python3 scripts/generate_protocol_models.py
 cd packages/python-sdk
 source venv/bin/activate  # On Windows: venv\Scripts\activate
 python3 -m unittest discover -s tests -p 'test_*.py'
+
+# Harness integration tests (includes CI-friendly smoke run)
+python3 -m unittest discover -s tests/integration -p 'test_sim_runner.py'
 ```

--- a/packages/python-sdk/src/mage_knight_sdk/__init__.py
+++ b/packages/python-sdk/src/mage_knight_sdk/__init__.py
@@ -22,6 +22,14 @@ from .protocol_models import (
     ServerMessage,
     StateUpdateMessage,
 )
+from .sim import (
+    RunnerConfig,
+    RunResult,
+    RunSummary,
+    run_simulations,
+    run_simulations_sync,
+    save_summary,
+)
 
 __all__ = [
     "CONNECTION_STATUS_CONNECTED",
@@ -41,5 +49,11 @@ __all__ = [
     "ProtocolParseError",
     "ServerMessage",
     "StateUpdateMessage",
+    "RunnerConfig",
+    "RunResult",
+    "RunSummary",
+    "run_simulations",
+    "run_simulations_sync",
+    "save_summary",
     "parse_server_message",
 ]

--- a/packages/python-sdk/src/mage_knight_sdk/sim/__init__.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/__init__.py
@@ -1,0 +1,11 @@
+from .runner import RunnerConfig, run_simulations, run_simulations_sync, save_summary
+from .reporting import RunResult, RunSummary
+
+__all__ = [
+    "RunnerConfig",
+    "RunResult",
+    "RunSummary",
+    "run_simulations",
+    "run_simulations_sync",
+    "save_summary",
+]

--- a/packages/python-sdk/src/mage_knight_sdk/sim/bootstrap.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/bootstrap.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from urllib import request
+from urllib.error import HTTPError, URLError
+
+
+@dataclass(frozen=True)
+class BootstrapSession:
+    game_id: str
+    player_id: str
+    session_token: str
+
+
+class BootstrapError(RuntimeError):
+    pass
+
+
+def create_game(api_base_url: str, player_count: int, seed: int | None = None) -> BootstrapSession:
+    payload: dict[str, Any] = {"playerCount": player_count}
+    if seed is not None:
+        payload["seed"] = seed
+    data = _post_json(f"{api_base_url.rstrip('/')}/games", payload)
+    return _parse_session(data)
+
+
+def join_game(api_base_url: str, game_id: str, session_token: str | None = None) -> BootstrapSession:
+    payload: dict[str, Any] = {}
+    if session_token is not None:
+        payload["sessionToken"] = session_token
+    data = _post_json(f"{api_base_url.rstrip('/')}/games/{game_id}/join", payload)
+    return _parse_session(data)
+
+
+def _post_json(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    encoded = json.dumps(payload).encode("utf-8")
+    req = request.Request(
+        url,
+        data=encoded,
+        method="POST",
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+    )
+
+    try:
+        with request.urlopen(req, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            data = json.loads(raw)
+    except HTTPError as error:
+        body = error.read().decode("utf-8", errors="replace")
+        raise BootstrapError(f"Bootstrap API returned {error.code}: {body}") from error
+    except URLError as error:
+        raise BootstrapError(f"Bootstrap API request failed: {error}") from error
+    except json.JSONDecodeError as error:
+        raise BootstrapError(f"Bootstrap API returned invalid JSON: {error}") from error
+
+    if not isinstance(data, dict):
+        raise BootstrapError("Bootstrap API response must be a JSON object")
+    return data
+
+
+def _parse_session(payload: dict[str, Any]) -> BootstrapSession:
+    game_id = payload.get("gameId")
+    player_id = payload.get("playerId")
+    session_token = payload.get("sessionToken")
+
+    if not isinstance(game_id, str) or not game_id:
+        raise BootstrapError("Bootstrap response is missing a valid gameId")
+    if not isinstance(player_id, str) or not player_id:
+        raise BootstrapError("Bootstrap response is missing a valid playerId")
+    if not isinstance(session_token, str) or not session_token:
+        raise BootstrapError("Bootstrap response is missing a valid sessionToken")
+
+    return BootstrapSession(game_id=game_id, player_id=player_id, session_token=session_token)

--- a/packages/python-sdk/src/mage_knight_sdk/sim/invariants.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/invariants.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+INVALID_ACTION_EVENT = "INVALID_ACTION"
+PHASE_END = "end"
+
+
+class InvariantViolation(RuntimeError):
+    pass
+
+
+@dataclass
+class StateInvariantTracker:
+    previous_state: dict[str, Any] | None = None
+
+    def check_state(self, state: dict[str, Any]) -> None:
+        current_player = state.get("currentPlayerId")
+        turn_order = state.get("turnOrder")
+
+        if not isinstance(turn_order, list) or not turn_order:
+            raise InvariantViolation("turnOrder must be a non-empty list")
+
+        if not isinstance(current_player, str) or current_player not in turn_order:
+            raise InvariantViolation(
+                f"currentPlayerId must exist in turnOrder (current={current_player!r}, turnOrder={turn_order!r})"
+            )
+
+        if len(set(turn_order)) != len(turn_order):
+            raise InvariantViolation(f"turnOrder contains duplicates: {turn_order!r}")
+
+        if self.previous_state is not None:
+            previous_turn_order = self.previous_state.get("turnOrder")
+            previous_current_player = self.previous_state.get("currentPlayerId")
+            if isinstance(previous_turn_order, list) and previous_turn_order:
+                if isinstance(previous_current_player, str) and previous_current_player in previous_turn_order:
+                    if current_player not in previous_turn_order and current_player not in turn_order:
+                        raise InvariantViolation(
+                            "currentPlayerId changed to an unknown player across state transition"
+                        )
+
+        self.previous_state = state
+
+
+def assert_action_not_rejected(events: list[Any], action_type: str, player_id: str) -> None:
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("type") != INVALID_ACTION_EVENT:
+            continue
+        if event.get("playerId") == player_id and event.get("actionType") == action_type:
+            reason = event.get("reason", "Unknown reason")
+            raise InvariantViolation(
+                f"Server rejected action {action_type} for {player_id} despite it being advertised valid: {reason}"
+            )
+
+
+def is_terminal_state(state: dict[str, Any]) -> bool:
+    return state.get("phase") == PHASE_END

--- a/packages/python-sdk/src/mage_knight_sdk/sim/random_policy.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/random_policy.py
@@ -706,7 +706,7 @@ def _actions_normal_turn(state: dict[str, Any], valid_actions: dict[str, Any], p
             continue
         direction_value = payload.get("direction")
         from_tile = payload.get("fromTileCoord")
-        if isinstance(direction_value, int) and isinstance(from_tile, dict):
+        if isinstance(direction_value, str) and isinstance(from_tile, dict):
             actions.append(
                 CandidateAction(
                     {"type": ACTION_EXPLORE, "direction": direction_value, "fromTileCoord": from_tile},

--- a/packages/python-sdk/src/mage_knight_sdk/sim/random_policy.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/random_policy.py
@@ -1,0 +1,954 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any
+
+
+ACTION_ACTIVATE_TACTIC = "ACTIVATE_TACTIC"
+ACTION_ANNOUNCE_END_OF_ROUND = "ANNOUNCE_END_OF_ROUND"
+ACTION_ASSIGN_ATTACK = "ASSIGN_ATTACK"
+ACTION_ASSIGN_BANNER = "ASSIGN_BANNER"
+ACTION_ASSIGN_BLOCK = "ASSIGN_BLOCK"
+ACTION_ASSIGN_DAMAGE = "ASSIGN_DAMAGE"
+ACTION_BUY_HEALING = "BUY_HEALING"
+ACTION_BUY_SPELL = "BUY_SPELL"
+ACTION_BURN_MONASTERY = "BURN_MONASTERY"
+ACTION_CHALLENGE_RAMPAGING = "CHALLENGE_RAMPAGING"
+ACTION_CHOOSE_LEVEL_UP_REWARDS = "CHOOSE_LEVEL_UP_REWARDS"
+ACTION_CONVERT_INFLUENCE_TO_BLOCK = "CONVERT_INFLUENCE_TO_BLOCK"
+ACTION_CONVERT_MOVE_TO_ATTACK = "CONVERT_MOVE_TO_ATTACK"
+ACTION_DECLARE_REST = "DECLARE_REST"
+ACTION_END_COMBAT_PHASE = "END_COMBAT_PHASE"
+ACTION_END_TURN = "END_TURN"
+ACTION_ENTER_SITE = "ENTER_SITE"
+ACTION_EXPLORE = "EXPLORE"
+ACTION_INTERACT = "INTERACT"
+ACTION_LEARN_ADVANCED_ACTION = "LEARN_ADVANCED_ACTION"
+ACTION_MOVE = "MOVE"
+ACTION_PAY_HEROES_ASSAULT_INFLUENCE = "PAY_HEROES_ASSAULT_INFLUENCE"
+ACTION_PAY_THUGS_DAMAGE_INFLUENCE = "PAY_THUGS_DAMAGE_INFLUENCE"
+ACTION_PLAY_CARD = "PLAY_CARD"
+ACTION_PLAY_CARD_SIDEWAYS = "PLAY_CARD_SIDEWAYS"
+ACTION_PLUNDER_VILLAGE = "PLUNDER_VILLAGE"
+ACTION_RECRUIT_UNIT = "RECRUIT_UNIT"
+ACTION_RESOLVE_ARTIFACT_CRYSTAL_COLOR = "RESOLVE_ARTIFACT_CRYSTAL_COLOR"
+ACTION_RESOLVE_BANNER_PROTECTION = "RESOLVE_BANNER_PROTECTION"
+ACTION_RESOLVE_BOOK_OF_WISDOM = "RESOLVE_BOOK_OF_WISDOM"
+ACTION_RESOLVE_CHOICE = "RESOLVE_CHOICE"
+ACTION_RESOLVE_CRYSTAL_JOY_RECLAIM = "RESOLVE_CRYSTAL_JOY_RECLAIM"
+ACTION_RESOLVE_DECOMPOSE = "RESOLVE_DECOMPOSE"
+ACTION_RESOLVE_DEEP_MINE = "RESOLVE_DEEP_MINE"
+ACTION_RESOLVE_DISCARD = "RESOLVE_DISCARD"
+ACTION_RESOLVE_DISCARD_FOR_ATTACK = "RESOLVE_DISCARD_FOR_ATTACK"
+ACTION_RESOLVE_DISCARD_FOR_BONUS = "RESOLVE_DISCARD_FOR_BONUS"
+ACTION_RESOLVE_DISCARD_FOR_CRYSTAL = "RESOLVE_DISCARD_FOR_CRYSTAL"
+ACTION_RESOLVE_HEX_COST_REDUCTION = "RESOLVE_HEX_COST_REDUCTION"
+ACTION_RESOLVE_MEDITATION = "RESOLVE_MEDITATION"
+ACTION_RESOLVE_SOURCE_OPENING_REROLL = "RESOLVE_SOURCE_OPENING_REROLL"
+ACTION_RESOLVE_STEADY_TEMPO = "RESOLVE_STEADY_TEMPO"
+ACTION_RESOLVE_TACTIC_DECISION = "RESOLVE_TACTIC_DECISION"
+ACTION_RESOLVE_TERRAIN_COST_REDUCTION = "RESOLVE_TERRAIN_COST_REDUCTION"
+ACTION_RESOLVE_TRAINING = "RESOLVE_TRAINING"
+ACTION_RESOLVE_UNIT_MAINTENANCE = "RESOLVE_UNIT_MAINTENANCE"
+ACTION_REROLL_SOURCE_DICE = "REROLL_SOURCE_DICE"
+ACTION_SELECT_REWARD = "SELECT_REWARD"
+ACTION_SELECT_TACTIC = "SELECT_TACTIC"
+ACTION_SPEND_MOVE_ON_CUMBERSOME = "SPEND_MOVE_ON_CUMBERSOME"
+ACTION_UNDO = "UNDO"
+ACTION_USE_BANNER_FEAR = "USE_BANNER_FEAR"
+ACTION_USE_SKILL = "USE_SKILL"
+
+MODE_COMBAT = "combat"
+MODE_NORMAL_TURN = "normal_turn"
+MODE_PENDING_CHOICE = "pending_choice"
+MODE_PENDING_TACTIC_DECISION = "pending_tactic_decision"
+MODE_TACTICS_SELECTION = "tactics_selection"
+
+
+@dataclass(frozen=True)
+class CandidateAction:
+    action: dict[str, Any]
+    source: str
+
+
+class RandomValidActionPolicy:
+    def choose_action(self, state: dict[str, Any], player_id: str, rng: random.Random) -> CandidateAction | None:
+        candidates = enumerate_valid_actions(state, player_id)
+        if not candidates:
+            return None
+        return rng.choice(candidates)
+
+
+def enumerate_valid_actions(state: dict[str, Any], player_id: str) -> list[CandidateAction]:
+    valid_actions = _as_dict(state.get("validActions"))
+    if valid_actions is None:
+        return []
+
+    mode = _as_str(valid_actions.get("mode"))
+    if mode is None:
+        return []
+
+    actions: list[CandidateAction] = []
+
+    if mode == MODE_TACTICS_SELECTION:
+        tactics = _as_dict(valid_actions.get("tactics"))
+        available = _as_list(tactics.get("availableTactics") if tactics else None)
+        for tactic_id in available:
+            if isinstance(tactic_id, str):
+                actions.append(CandidateAction({"type": ACTION_SELECT_TACTIC, "tacticId": tactic_id}, "tactics.available"))
+        return actions
+
+    if mode == MODE_PENDING_TACTIC_DECISION:
+        decision = _as_dict(valid_actions.get("tacticDecision"))
+        if decision is None:
+            return actions
+        decision_type = _as_str(decision.get("type"))
+        if decision_type is None:
+            return actions
+
+        if decision_type in {"rethink", "midnight_meditation"}:
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_RESOLVE_TACTIC_DECISION,
+                        "decision": {"type": decision_type, "cardIds": []},
+                    },
+                    "pending_tactic_decision.cards",
+                )
+            )
+        elif decision_type == "mana_steal":
+            available_dice = _as_list(decision.get("availableDiceIds"))
+            for die_id in available_dice:
+                if isinstance(die_id, str):
+                    actions.append(
+                        CandidateAction(
+                            {
+                                "type": ACTION_RESOLVE_TACTIC_DECISION,
+                                "decision": {"type": decision_type, "dieId": die_id},
+                            },
+                            "pending_tactic_decision.die",
+                        )
+                    )
+        elif decision_type == "preparation":
+            snapshot = _as_list(decision.get("deckSnapshot"))
+            for card_id in snapshot:
+                if isinstance(card_id, str):
+                    actions.append(
+                        CandidateAction(
+                            {
+                                "type": ACTION_RESOLVE_TACTIC_DECISION,
+                                "decision": {"type": decision_type, "cardId": card_id},
+                            },
+                            "pending_tactic_decision.card",
+                        )
+                    )
+        elif decision_type == "sparing_power":
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_RESOLVE_TACTIC_DECISION,
+                        "decision": {"type": decision_type, "choice": "take"},
+                    },
+                    "pending_tactic_decision.sparing.take",
+                )
+            )
+            if bool(decision.get("canStash")):
+                actions.append(
+                    CandidateAction(
+                        {
+                            "type": ACTION_RESOLVE_TACTIC_DECISION,
+                            "decision": {"type": decision_type, "choice": "stash"},
+                        },
+                        "pending_tactic_decision.sparing.stash",
+                    )
+                )
+        return actions
+
+    if mode == MODE_PENDING_CHOICE:
+        player = _find_player(state, player_id)
+        pending_choice = _as_dict(player.get("pendingChoice") if player else None)
+        options = _as_list(pending_choice.get("options") if pending_choice else None)
+        for idx, _ in enumerate(options):
+            actions.append(CandidateAction({"type": ACTION_RESOLVE_CHOICE, "choiceIndex": idx}, "pending_choice.index"))
+        return actions
+
+    _append_common_blocking_actions(valid_actions, actions)
+
+    pending_dispatch = {
+        "pending_glade_wound": _actions_pending_glade,
+        "pending_deep_mine": _actions_pending_deep_mine,
+        "pending_discard_cost": _actions_pending_discard_cost,
+        "pending_discard_for_attack": _actions_pending_discard_for_attack,
+        "pending_discard_for_bonus": _actions_pending_discard_for_bonus,
+        "pending_discard_for_crystal": _actions_pending_discard_for_crystal,
+        "pending_artifact_crystal_color": _actions_pending_artifact_crystal_color,
+        "pending_decompose": _actions_pending_decompose,
+        "pending_maximal_effect": _actions_pending_maximal_effect,
+        "pending_book_of_wisdom": _actions_pending_book_of_wisdom,
+        "pending_training": _actions_pending_training,
+        "pending_crystal_joy_reclaim": _actions_pending_crystal_joy,
+        "pending_steady_tempo": _actions_pending_steady_tempo,
+        "pending_meditation": _actions_pending_meditation,
+        "pending_banner_protection": _actions_pending_banner_protection,
+        "pending_source_opening_reroll": _actions_pending_source_opening_reroll,
+        "pending_level_up": _actions_pending_level_up,
+        "pending_unit_maintenance": _actions_pending_unit_maintenance,
+        "pending_hex_cost_reduction": _actions_pending_hex_cost_reduction,
+        "pending_terrain_cost_reduction": _actions_pending_terrain_cost_reduction,
+    }
+
+    resolver = pending_dispatch.get(mode)
+    if resolver is not None:
+        actions.extend(resolver(valid_actions))
+        return actions
+
+    if mode == MODE_COMBAT:
+        actions.extend(_actions_combat(valid_actions))
+        return actions
+
+    if mode == MODE_NORMAL_TURN:
+        actions.extend(_actions_normal_turn(state, valid_actions, player_id))
+        return actions
+
+    return actions
+
+
+def _actions_pending_glade(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    glade = _as_dict(valid_actions.get("gladeWound"))
+    if glade is None:
+        return []
+
+    actions: list[CandidateAction] = [CandidateAction({"type": "RESOLVE_GLADE_WOUND", "choice": "skip"}, "glade.skip")]
+    if bool(glade.get("hasWoundsInHand")):
+        actions.append(CandidateAction({"type": "RESOLVE_GLADE_WOUND", "choice": "hand"}, "glade.hand"))
+    if bool(glade.get("hasWoundsInDiscard")):
+        actions.append(CandidateAction({"type": "RESOLVE_GLADE_WOUND", "choice": "discard"}, "glade.discard"))
+    return actions
+
+
+def _actions_pending_deep_mine(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    deep_mine = _as_dict(valid_actions.get("deepMine"))
+    colors = _as_list(deep_mine.get("availableColors") if deep_mine else None)
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_DEEP_MINE, "color": color}, "deep_mine.color")
+        for color in colors
+        if isinstance(color, str)
+    ]
+
+
+def _actions_pending_discard_cost(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("discardCost"))
+    if options is None:
+        return []
+    available = [card for card in _as_list(options.get("availableCardIds")) if isinstance(card, str)]
+    count = int(options.get("count", 0))
+    actions: list[CandidateAction] = []
+    if count > 0 and len(available) >= count:
+        actions.append(
+            CandidateAction({"type": ACTION_RESOLVE_DISCARD, "cardIds": available[:count]}, "discard_cost.required")
+        )
+    if bool(options.get("optional")):
+        actions.append(CandidateAction({"type": ACTION_RESOLVE_DISCARD, "cardIds": []}, "discard_cost.optional_skip"))
+    return actions
+
+
+def _actions_pending_discard_for_attack(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("discardForAttack"))
+    if options is None:
+        return []
+    available = [card for card in _as_list(options.get("availableCardIds")) if isinstance(card, str)]
+    actions = [CandidateAction({"type": ACTION_RESOLVE_DISCARD_FOR_ATTACK, "cardIds": []}, "discard_for_attack.none")]
+    for card in available:
+        actions.append(CandidateAction({"type": ACTION_RESOLVE_DISCARD_FOR_ATTACK, "cardIds": [card]}, "discard_for_attack.one"))
+    return actions
+
+
+def _actions_pending_discard_for_bonus(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("discardForBonus"))
+    if options is None:
+        return []
+    count = int(options.get("choiceCount", 0))
+    return [
+        CandidateAction(
+            {"type": ACTION_RESOLVE_DISCARD_FOR_BONUS, "cardIds": [], "choiceIndex": idx},
+            "discard_for_bonus.choice",
+        )
+        for idx in range(count)
+    ]
+
+
+def _actions_pending_discard_for_crystal(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("discardForCrystal"))
+    if options is None:
+        return []
+    available = [card for card in _as_list(options.get("availableCardIds")) if isinstance(card, str)]
+    actions: list[CandidateAction] = []
+    for card in available:
+        actions.append(
+            CandidateAction(
+                {"type": ACTION_RESOLVE_DISCARD_FOR_CRYSTAL, "cardId": card},
+                "discard_for_crystal.card",
+            )
+        )
+    if bool(options.get("optional")):
+        actions.append(CandidateAction({"type": ACTION_RESOLVE_DISCARD_FOR_CRYSTAL, "cardId": None}, "discard_for_crystal.skip"))
+    return actions
+
+
+def _actions_pending_artifact_crystal_color(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("artifactCrystalColor"))
+    colors = _as_list(options.get("availableColors") if options else None)
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_ARTIFACT_CRYSTAL_COLOR, "color": color}, "artifact_crystal_color")
+        for color in colors
+        if isinstance(color, str)
+    ]
+
+
+def _actions_pending_decompose(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("decompose"))
+    cards = _as_list(options.get("availableCardIds") if options else None)
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_DECOMPOSE, "cardId": card_id}, "decompose.card")
+        for card_id in cards
+        if isinstance(card_id, str)
+    ]
+
+
+def _actions_pending_maximal_effect(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("maximalEffect"))
+    cards = _as_list(options.get("availableCardIds") if options else None)
+    return [
+        CandidateAction({"type": "RESOLVE_MAXIMAL_EFFECT", "cardId": card_id}, "maximal_effect.card")
+        for card_id in cards
+        if isinstance(card_id, str)
+    ]
+
+
+def _actions_pending_book_of_wisdom(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("bookOfWisdom"))
+    if options is None:
+        return []
+    if _as_str(options.get("phase")) == "select_from_offer":
+        cards = _as_list(options.get("availableOfferCards"))
+    else:
+        cards = _as_list(options.get("availableCardIds"))
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_BOOK_OF_WISDOM, "cardId": card_id}, "book_of_wisdom.card")
+        for card_id in cards
+        if isinstance(card_id, str)
+    ]
+
+
+def _actions_pending_training(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("training"))
+    if options is None:
+        return []
+    if _as_str(options.get("phase")) == "select_from_offer":
+        cards = _as_list(options.get("availableOfferCards"))
+    else:
+        cards = _as_list(options.get("availableCardIds"))
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_TRAINING, "cardId": card_id}, "training.card")
+        for card_id in cards
+        if isinstance(card_id, str)
+    ]
+
+
+def _actions_pending_crystal_joy(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("crystalJoyReclaim"))
+    cards = _as_list(options.get("eligibleCardIds") if options else None)
+    actions = [CandidateAction({"type": ACTION_RESOLVE_CRYSTAL_JOY_RECLAIM}, "crystal_joy.skip")]
+    actions.extend(
+        CandidateAction({"type": ACTION_RESOLVE_CRYSTAL_JOY_RECLAIM, "cardId": card_id}, "crystal_joy.card")
+        for card_id in cards
+        if isinstance(card_id, str)
+    )
+    return actions
+
+
+def _actions_pending_steady_tempo(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("steadyTempo"))
+    if options is None:
+        return []
+    if bool(options.get("canPlace")):
+        return [
+            CandidateAction({"type": ACTION_RESOLVE_STEADY_TEMPO, "place": True}, "steady_tempo.place"),
+            CandidateAction({"type": ACTION_RESOLVE_STEADY_TEMPO, "place": False}, "steady_tempo.skip"),
+        ]
+    return [CandidateAction({"type": ACTION_RESOLVE_STEADY_TEMPO, "place": False}, "steady_tempo.skip")]
+
+
+def _actions_pending_meditation(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("meditation"))
+    if options is None:
+        return []
+
+    phase = _as_str(options.get("phase"))
+    if phase == "place_cards":
+        return [
+            CandidateAction({"type": ACTION_RESOLVE_MEDITATION, "placeOnTop": True}, "meditation.place.top"),
+            CandidateAction({"type": ACTION_RESOLVE_MEDITATION, "placeOnTop": False}, "meditation.place.bottom"),
+        ]
+
+    eligible = [card for card in _as_list(options.get("eligibleCardIds")) if isinstance(card, str)]
+    count = int(options.get("selectCount", 0))
+    selected = eligible[: max(count, 0)]
+    return [CandidateAction({"type": ACTION_RESOLVE_MEDITATION, "selectedCardIds": selected}, "meditation.select")]
+
+
+def _actions_pending_banner_protection(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_BANNER_PROTECTION, "removeAll": True}, "banner_protection.remove"),
+        CandidateAction({"type": ACTION_RESOLVE_BANNER_PROTECTION, "removeAll": False}, "banner_protection.skip"),
+    ]
+
+
+def _actions_pending_source_opening_reroll(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_SOURCE_OPENING_REROLL, "reroll": True}, "source_opening.reroll"),
+        CandidateAction({"type": ACTION_RESOLVE_SOURCE_OPENING_REROLL, "reroll": False}, "source_opening.keep"),
+    ]
+
+
+def _actions_pending_level_up(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("levelUpRewards"))
+    if options is None:
+        return []
+
+    level = options.get("level")
+    available_aas = [card for card in _as_list(options.get("availableAAs")) if isinstance(card, str)]
+    drawn = [skill for skill in _as_list(options.get("drawnSkills")) if isinstance(skill, str)]
+    common = [skill for skill in _as_list(options.get("commonPoolSkills")) if isinstance(skill, str)]
+
+    if not isinstance(level, int) or not available_aas:
+        return []
+
+    actions: list[CandidateAction] = []
+    if drawn:
+        actions.append(
+            CandidateAction(
+                {
+                    "type": ACTION_CHOOSE_LEVEL_UP_REWARDS,
+                    "level": level,
+                    "skillChoice": {"fromCommonPool": False, "skillId": drawn[0]},
+                    "advancedActionId": available_aas[0],
+                },
+                "level_up.drawn",
+            )
+        )
+    if common:
+        actions.append(
+            CandidateAction(
+                {
+                    "type": ACTION_CHOOSE_LEVEL_UP_REWARDS,
+                    "level": level,
+                    "skillChoice": {"fromCommonPool": True, "skillId": common[0]},
+                    "advancedActionId": available_aas[0],
+                },
+                "level_up.common",
+            )
+        )
+
+    return actions
+
+
+def _actions_pending_unit_maintenance(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("unitMaintenance"))
+    units = _as_list(options.get("units") if options else None)
+    if not units:
+        return []
+
+    first = _as_dict(units[0])
+    if first is None:
+        return []
+
+    unit_instance_id = _as_str(first.get("unitInstanceId"))
+    if unit_instance_id is None:
+        return []
+
+    colors = [color for color in _as_list(first.get("availableCrystalColors")) if isinstance(color, str)]
+    actions = [
+        CandidateAction(
+            {"type": ACTION_RESOLVE_UNIT_MAINTENANCE, "unitInstanceId": unit_instance_id, "keepUnit": False},
+            "unit_maintenance.disband",
+        )
+    ]
+    for color in colors:
+        actions.append(
+            CandidateAction(
+                {
+                    "type": ACTION_RESOLVE_UNIT_MAINTENANCE,
+                    "unitInstanceId": unit_instance_id,
+                    "keepUnit": True,
+                    "crystalColor": color,
+                    "newManaTokenColor": color,
+                },
+                "unit_maintenance.keep",
+            )
+        )
+    return actions
+
+
+def _actions_pending_hex_cost_reduction(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("hexCostReduction"))
+    coords = _as_list(options.get("availableCoordinates") if options else None)
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_HEX_COST_REDUCTION, "coordinate": coord}, "hex_cost_reduction.coordinate")
+        for coord in coords
+        if isinstance(coord, dict)
+    ]
+
+
+def _actions_pending_terrain_cost_reduction(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    options = _as_dict(valid_actions.get("terrainCostReduction"))
+    terrains = _as_list(options.get("availableTerrains") if options else None)
+    return [
+        CandidateAction({"type": ACTION_RESOLVE_TERRAIN_COST_REDUCTION, "terrain": terrain}, "terrain_cost_reduction.terrain")
+        for terrain in terrains
+        if isinstance(terrain, str)
+    ]
+
+
+def _actions_combat(valid_actions: dict[str, Any]) -> list[CandidateAction]:
+    actions: list[CandidateAction] = []
+    combat = _as_dict(valid_actions.get("combat"))
+    if combat is None:
+        return actions
+
+    for option in _as_list(combat.get("assignableAttacks")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        enemy = _as_str(payload.get("enemyInstanceId"))
+        attack_type = _as_str(payload.get("attackType"))
+        element = _as_str(payload.get("element"))
+        amount = payload.get("amount")
+        if enemy and attack_type and element and isinstance(amount, int):
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_ASSIGN_ATTACK,
+                        "enemyInstanceId": enemy,
+                        "attackType": attack_type,
+                        "element": element,
+                        "amount": amount,
+                    },
+                    "combat.assign_attack",
+                )
+            )
+
+    for option in _as_list(combat.get("assignableBlocks")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        enemy = _as_str(payload.get("enemyInstanceId"))
+        element = _as_str(payload.get("element"))
+        amount = payload.get("amount")
+        if enemy and element and isinstance(amount, int):
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_ASSIGN_BLOCK,
+                        "enemyInstanceId": enemy,
+                        "element": element,
+                        "amount": amount,
+                    },
+                    "combat.assign_block",
+                )
+            )
+
+    for option in _as_list(combat.get("damageAssignments")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        enemy = _as_str(payload.get("enemyInstanceId"))
+        if enemy is None:
+            continue
+        action = {"type": ACTION_ASSIGN_DAMAGE, "enemyInstanceId": enemy}
+        attack_index = payload.get("attackIndex")
+        if isinstance(attack_index, int):
+            action["attackIndex"] = attack_index
+        actions.append(CandidateAction(action, "combat.assign_damage"))
+
+    for option in _as_list(combat.get("blocks")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        enemy = _as_str(payload.get("enemyInstanceId"))
+        if enemy is None:
+            continue
+        action = {"type": "DECLARE_BLOCK", "targetEnemyInstanceId": enemy}
+        attack_index = payload.get("attackIndex")
+        if isinstance(attack_index, int):
+            action["attackIndex"] = attack_index
+        actions.append(CandidateAction(action, "combat.declare_block"))
+
+    for option in _as_list(combat.get("moveToAttackConversions")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        conversion_type = _as_str(payload.get("attackType"))
+        cost_per_point = payload.get("costPerPoint")
+        max_gainable = payload.get("maxAttackGainable")
+        if conversion_type and isinstance(cost_per_point, int) and isinstance(max_gainable, int) and max_gainable > 0:
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_CONVERT_MOVE_TO_ATTACK,
+                        "movePointsToSpend": cost_per_point,
+                        "conversionType": conversion_type,
+                    },
+                    "combat.convert_move_to_attack",
+                )
+            )
+
+    influence_conversion = _as_dict(combat.get("influenceToBlockConversion"))
+    if influence_conversion is not None:
+        cost_per_point = influence_conversion.get("costPerPoint")
+        max_gainable = influence_conversion.get("maxBlockGainable")
+        if isinstance(cost_per_point, int) and isinstance(max_gainable, int) and max_gainable > 0:
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_CONVERT_INFLUENCE_TO_BLOCK,
+                        "influencePointsToSpend": cost_per_point,
+                    },
+                    "combat.convert_influence_to_block",
+                )
+            )
+
+    for option in _as_list(combat.get("cumbersomeOptions")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        enemy = _as_str(payload.get("enemyInstanceId"))
+        max_reduction = payload.get("maxAdditionalReduction")
+        if enemy and isinstance(max_reduction, int) and max_reduction > 0:
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_SPEND_MOVE_ON_CUMBERSOME,
+                        "enemyInstanceId": enemy,
+                        "movePointsToSpend": 1,
+                    },
+                    "combat.cumbersome",
+                )
+            )
+
+    for option in _as_list(combat.get("thugsDamagePaymentOptions")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        unit_instance_id = _as_str(payload.get("unitInstanceId"))
+        can_afford = bool(payload.get("canAfford"))
+        already_paid = bool(payload.get("alreadyPaid"))
+        if unit_instance_id and can_afford and not already_paid:
+            actions.append(
+                CandidateAction(
+                    {
+                        "type": ACTION_PAY_THUGS_DAMAGE_INFLUENCE,
+                        "unitInstanceId": unit_instance_id,
+                    },
+                    "combat.thugs_payment",
+                )
+            )
+
+    if bool(combat.get("canPayHeroesAssaultInfluence")):
+        actions.append(CandidateAction({"type": ACTION_PAY_HEROES_ASSAULT_INFLUENCE}, "combat.heroes_assault_payment"))
+
+    for option in _as_list(combat.get("bannerFearOptions")):
+        payload = _as_dict(option)
+        if payload is None:
+            continue
+        unit_instance_id = _as_str(payload.get("unitInstanceId"))
+        targets = _as_list(payload.get("targets"))
+        for target in targets:
+            target_payload = _as_dict(target)
+            if target_payload is None or unit_instance_id is None:
+                continue
+            target_enemy = _as_str(target_payload.get("enemyInstanceId"))
+            if target_enemy is None:
+                continue
+            action = {
+                "type": ACTION_USE_BANNER_FEAR,
+                "unitInstanceId": unit_instance_id,
+                "targetEnemyInstanceId": target_enemy,
+            }
+            attack_index = target_payload.get("attackIndex")
+            if isinstance(attack_index, int):
+                action["attackIndex"] = attack_index
+            actions.append(CandidateAction(action, "combat.banner_fear"))
+
+    if bool(combat.get("canEndPhase")):
+        actions.append(CandidateAction({"type": ACTION_END_COMBAT_PHASE}, "combat.end_phase"))
+
+    return actions
+
+
+def _actions_normal_turn(state: dict[str, Any], valid_actions: dict[str, Any], player_id: str) -> list[CandidateAction]:
+    actions: list[CandidateAction] = []
+    turn = _as_dict(valid_actions.get("turn"))
+
+    for target in _as_list(_as_dict(valid_actions.get("move")) and _as_dict(valid_actions.get("move")) .get("targets")):
+        payload = _as_dict(target)
+        if payload is None:
+            continue
+        hex_coord = payload.get("hex")
+        if isinstance(hex_coord, dict):
+            actions.append(CandidateAction({"type": ACTION_MOVE, "target": hex_coord}, "normal.move"))
+
+    explore = _as_dict(valid_actions.get("explore"))
+    for direction in _as_list(explore.get("directions") if explore else None):
+        payload = _as_dict(direction)
+        if payload is None:
+            continue
+        direction_value = payload.get("direction")
+        from_tile = payload.get("fromTileCoord")
+        if isinstance(direction_value, int) and isinstance(from_tile, dict):
+            actions.append(
+                CandidateAction(
+                    {"type": ACTION_EXPLORE, "direction": direction_value, "fromTileCoord": from_tile},
+                    "normal.explore",
+                )
+            )
+
+    site = _as_dict(valid_actions.get("sites"))
+    if site is not None:
+        if bool(site.get("canEnter")):
+            actions.append(CandidateAction({"type": ACTION_ENTER_SITE}, "normal.site.enter"))
+        if bool(site.get("canInteract")):
+            actions.append(CandidateAction({"type": ACTION_INTERACT}, "normal.site.interact"))
+
+        interact_options = _as_dict(site.get("interactOptions"))
+        offers = _as_dict(state.get("offers"))
+        if interact_options is not None:
+            if bool(interact_options.get("canHeal")):
+                actions.append(CandidateAction({"type": ACTION_BUY_HEALING, "amount": 1}, "normal.site.heal"))
+            if bool(interact_options.get("canBuySpells")):
+                spells = _as_dict(offers.get("spells") if offers else None)
+                for card_id in _as_list(spells.get("cards") if spells else None):
+                    if isinstance(card_id, str):
+                        actions.append(CandidateAction({"type": ACTION_BUY_SPELL, "cardId": card_id}, "normal.site.buy_spell"))
+            if bool(interact_options.get("canBuyAdvancedActions")):
+                monastery = _as_list(offers.get("monasteryAdvancedActions") if offers else None)
+                for card_id in monastery:
+                    if isinstance(card_id, str):
+                        actions.append(
+                            CandidateAction(
+                                {
+                                    "type": ACTION_LEARN_ADVANCED_ACTION,
+                                    "cardId": card_id,
+                                    "fromMonastery": True,
+                                },
+                                "normal.site.buy_aa",
+                            )
+                        )
+            if bool(interact_options.get("canBurnMonastery")):
+                actions.append(CandidateAction({"type": ACTION_BURN_MONASTERY}, "normal.site.burn_monastery"))
+            if bool(interact_options.get("canPlunderVillage")):
+                actions.append(CandidateAction({"type": ACTION_PLUNDER_VILLAGE}, "normal.site.plunder_village"))
+
+    challenge = _as_dict(valid_actions.get("challenge"))
+    for target_hex in _as_list(challenge.get("targetHexes") if challenge else None):
+        if isinstance(target_hex, dict):
+            actions.append(CandidateAction({"type": ACTION_CHALLENGE_RAMPAGING, "targetHex": target_hex}, "normal.challenge"))
+
+    play_card = _as_dict(valid_actions.get("playCard"))
+    for card in _as_list(play_card.get("cards") if play_card else None):
+        payload = _as_dict(card)
+        if payload is None:
+            continue
+        card_id = _as_str(payload.get("cardId"))
+        if card_id is None:
+            continue
+
+        if bool(payload.get("canPlayBasic")):
+            actions.append(CandidateAction({"type": ACTION_PLAY_CARD, "cardId": card_id, "powered": False}, "normal.play_card.basic"))
+
+        if bool(payload.get("canPlaySideways")):
+            for option in _as_list(payload.get("sidewaysOptions")):
+                sideways = _as_dict(option)
+                if sideways is None:
+                    continue
+                as_value = _as_str(sideways.get("as"))
+                if as_value:
+                    actions.append(
+                        CandidateAction(
+                            {"type": ACTION_PLAY_CARD_SIDEWAYS, "cardId": card_id, "as": as_value},
+                            "normal.play_card.sideways",
+                        )
+                    )
+
+    units = _as_dict(valid_actions.get("units"))
+    player = _find_player(state, player_id)
+    for recruit in _as_list(units.get("recruitable") if units else None):
+        payload = _as_dict(recruit)
+        if payload is None:
+            continue
+        unit_id = _as_str(payload.get("unitId"))
+        cost = payload.get("cost")
+        if unit_id and isinstance(cost, int) and bool(payload.get("canAfford")):
+            action: dict[str, Any] = {
+                "type": ACTION_RECRUIT_UNIT,
+                "unitId": unit_id,
+                "influenceSpent": cost,
+            }
+            if bool(payload.get("requiresDisband")) and player:
+                unit_list = _as_list(player.get("units"))
+                if unit_list:
+                    first_unit = _as_dict(unit_list[0])
+                    unit_instance_id = _as_str(first_unit.get("instanceId") if first_unit else None)
+                    if unit_instance_id:
+                        action["disbandUnitInstanceId"] = unit_instance_id
+            actions.append(CandidateAction(action, "normal.units.recruit"))
+
+    for unit in _as_list(units.get("activatable") if units else None):
+        payload = _as_dict(unit)
+        if payload is None:
+            continue
+        unit_instance_id = _as_str(payload.get("unitInstanceId"))
+        if unit_instance_id is None:
+            continue
+        for ability in _as_list(payload.get("abilities")):
+            ability_payload = _as_dict(ability)
+            if ability_payload is None:
+                continue
+            if not bool(ability_payload.get("canActivate")):
+                continue
+            if ability_payload.get("manaCost") is not None:
+                continue
+            index = ability_payload.get("index")
+            if isinstance(index, int):
+                actions.append(
+                    CandidateAction(
+                        {
+                            "type": "ACTIVATE_UNIT",
+                            "unitInstanceId": unit_instance_id,
+                            "abilityIndex": index,
+                        },
+                        "normal.units.activate",
+                    )
+                )
+
+    skills = _as_dict(valid_actions.get("skills"))
+    for skill in _as_list(skills.get("activatable") if skills else None):
+        payload = _as_dict(skill)
+        if payload is None:
+            continue
+        skill_id = _as_str(payload.get("skillId"))
+        if skill_id:
+            actions.append(CandidateAction({"type": ACTION_USE_SKILL, "skillId": skill_id}, "normal.skills.activate"))
+
+    returnable_skills = _as_dict(valid_actions.get("returnableSkills"))
+    for skill in _as_list(returnable_skills.get("returnable") if returnable_skills else None):
+        payload = _as_dict(skill)
+        if payload is None:
+            continue
+        skill_id = _as_str(payload.get("skillId"))
+        if skill_id:
+            actions.append(CandidateAction({"type": "RETURN_INTERACTIVE_SKILL", "skillId": skill_id}, "normal.skills.return"))
+
+    learning = _as_dict(valid_actions.get("learningAAPurchase"))
+    if learning is not None and bool(learning.get("canAfford")):
+        for card_id in _as_list(learning.get("availableCards")):
+            if isinstance(card_id, str):
+                actions.append(
+                    CandidateAction(
+                        {
+                            "type": ACTION_LEARN_ADVANCED_ACTION,
+                            "cardId": card_id,
+                            "fromMonastery": False,
+                            "fromLearning": True,
+                        },
+                        "normal.learning_aa",
+                    )
+                )
+
+    banners = _as_dict(valid_actions.get("banners"))
+    for banner in _as_list(banners.get("assignable") if banners else None):
+        payload = _as_dict(banner)
+        if payload is None:
+            continue
+        banner_card_id = _as_str(payload.get("bannerCardId"))
+        if banner_card_id is None:
+            continue
+        for unit_id in _as_list(payload.get("targetUnits")):
+            if isinstance(unit_id, str):
+                actions.append(
+                    CandidateAction(
+                        {
+                            "type": ACTION_ASSIGN_BANNER,
+                            "bannerCardId": banner_card_id,
+                            "targetUnitInstanceId": unit_id,
+                        },
+                        "normal.banners.assign",
+                    )
+                )
+
+    tactic_effects = _as_dict(valid_actions.get("tacticEffects"))
+    if tactic_effects is not None:
+        if player:
+            selected_tactic_id = _as_str(player.get("selectedTacticId"))
+            can_activate = _as_dict(tactic_effects.get("canActivate"))
+            if selected_tactic_id and can_activate and any(bool(val) for val in can_activate.values()):
+                actions.append(
+                    CandidateAction(
+                        {"type": ACTION_ACTIVATE_TACTIC, "tacticId": selected_tactic_id},
+                        "normal.tactic.activate",
+                    )
+                )
+
+        can_reroll = _as_dict(tactic_effects.get("canRerollSourceDice"))
+        dice_ids = [die_id for die_id in _as_list(can_reroll.get("availableDiceIds") if can_reroll else None) if isinstance(die_id, str)]
+        if dice_ids:
+            actions.append(CandidateAction({"type": ACTION_REROLL_SOURCE_DICE, "dieIds": [dice_ids[0]]}, "normal.tactic.reroll"))
+
+    if turn is not None:
+        if bool(turn.get("canDeclareRest")):
+            actions.append(CandidateAction({"type": ACTION_DECLARE_REST}, "normal.turn.declare_rest"))
+        if bool(turn.get("canEndTurn")):
+            actions.append(CandidateAction({"type": ACTION_END_TURN}, "normal.turn.end_turn"))
+        if bool(turn.get("canAnnounceEndOfRound")):
+            actions.append(CandidateAction({"type": ACTION_ANNOUNCE_END_OF_ROUND}, "normal.turn.announce_end_round"))
+
+    return actions
+
+
+def _append_common_blocking_actions(valid_actions: dict[str, Any], actions: list[CandidateAction]) -> None:
+    turn = _as_dict(valid_actions.get("turn"))
+    if turn is None:
+        return
+
+    if bool(turn.get("canUndo")):
+        actions.append(CandidateAction({"type": ACTION_UNDO}, "turn.undo"))
+    if bool(turn.get("canEndTurn")):
+        actions.append(CandidateAction({"type": ACTION_END_TURN}, "turn.end_turn"))
+
+
+def _find_player(state: dict[str, Any], player_id: str) -> dict[str, Any] | None:
+    players = _as_list(state.get("players"))
+    for entry in players:
+        payload = _as_dict(entry)
+        if payload and payload.get("id") == player_id:
+            return payload
+    return None
+
+
+def _as_dict(value: Any) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+def _as_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    return []
+
+
+def _as_str(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/packages/python-sdk/src/mage_knight_sdk/sim/reporting.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/reporting.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+OUTCOME_ENDED = "ended"
+OUTCOME_MAX_STEPS = "max_steps"
+OUTCOME_DISCONNECT = "disconnect"
+OUTCOME_PROTOCOL_ERROR = "protocol_error"
+OUTCOME_INVARIANT_FAILURE = "invariant_failure"
+
+
+@dataclass(frozen=True)
+class ActionTraceEntry:
+    step: int
+    player_id: str
+    action: dict[str, Any]
+    source: str
+    mode: str
+    current_player_id: str
+
+
+@dataclass(frozen=True)
+class MessageLogEntry:
+    player_id: str
+    message_type: str
+    payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_index: int
+    seed: int
+    outcome: str
+    steps: int
+    game_id: str
+    reason: str | None = None
+    failure_artifact_path: str | None = None
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    total_runs: int
+    ended: int
+    max_steps: int
+    disconnect: int
+    protocol_error: int
+    invariant_failure: int
+
+
+def summarize(results: list[RunResult]) -> RunSummary:
+    counts = {
+        OUTCOME_ENDED: 0,
+        OUTCOME_MAX_STEPS: 0,
+        OUTCOME_DISCONNECT: 0,
+        OUTCOME_PROTOCOL_ERROR: 0,
+        OUTCOME_INVARIANT_FAILURE: 0,
+    }
+    for result in results:
+        counts[result.outcome] = counts.get(result.outcome, 0) + 1
+
+    return RunSummary(
+        total_runs=len(results),
+        ended=counts[OUTCOME_ENDED],
+        max_steps=counts[OUTCOME_MAX_STEPS],
+        disconnect=counts[OUTCOME_DISCONNECT],
+        protocol_error=counts[OUTCOME_PROTOCOL_ERROR],
+        invariant_failure=counts[OUTCOME_INVARIANT_FAILURE],
+    )
+
+
+def write_failure_artifact(
+    output_dir: str,
+    run_result: RunResult,
+    action_trace: list[ActionTraceEntry],
+    message_log: list[MessageLogEntry],
+) -> str:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    target_dir = Path(output_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    path = target_dir / f"run_{run_result.run_index}_seed_{run_result.seed}_{timestamp}.json"
+    payload = {
+        "run": asdict(run_result),
+        "actionTrace": [asdict(entry) for entry in action_trace],
+        "messageLog": [asdict(entry) for entry in message_log],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return str(path)

--- a/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
@@ -1,0 +1,479 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from mage_knight_sdk.client import MageKnightClient
+from mage_knight_sdk.protocol_models import ErrorMessage, StateUpdateMessage
+
+from .bootstrap import BootstrapSession, create_game, join_game
+from .invariants import InvariantViolation, StateInvariantTracker, assert_action_not_rejected, is_terminal_state
+from .random_policy import CandidateAction, RandomValidActionPolicy, enumerate_valid_actions
+from .reporting import (
+    ActionTraceEntry,
+    MessageLogEntry,
+    OUTCOME_DISCONNECT,
+    OUTCOME_ENDED,
+    OUTCOME_INVARIANT_FAILURE,
+    OUTCOME_MAX_STEPS,
+    OUTCOME_PROTOCOL_ERROR,
+    RunResult,
+    RunSummary,
+    summarize,
+    write_failure_artifact,
+)
+
+
+@dataclass(frozen=True)
+class RunnerConfig:
+    bootstrap_api_base_url: str
+    ws_server_url: str
+    player_count: int = 2
+    runs: int = 1
+    max_steps: int = 250
+    base_seed: int = 1
+    action_timeout_seconds: float = 5.0
+    artifacts_dir: str = "sim_artifacts"
+    subscribe_lobby_on_connect: bool = False
+    forced_invalid_action_step: int | None = None
+
+
+@dataclass
+class AgentRuntime:
+    session: BootstrapSession
+    client: MageKnightClient
+    state_tracker: StateInvariantTracker
+    latest_state: dict[str, Any] | None = None
+    last_events: list[Any] | None = None
+    message_version: int = 0
+    last_error_message: str | None = None
+
+
+@dataclass
+class SimulationOutcome:
+    result: RunResult
+    trace: list[ActionTraceEntry]
+    messages: list[MessageLogEntry]
+
+
+async def run_simulations(config: RunnerConfig) -> tuple[list[RunResult], RunSummary]:
+    results: list[RunResult] = []
+    for run_index in range(config.runs):
+        run_seed = config.base_seed + run_index
+        outcome = await _run_single_simulation(run_index=run_index, seed=run_seed, config=config)
+        results.append(outcome.result)
+    return results, summarize(results)
+
+
+async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig) -> SimulationOutcome:
+    rng = random.Random(seed)
+    policy = RandomValidActionPolicy()
+
+    trace: list[ActionTraceEntry] = []
+    messages: list[MessageLogEntry] = []
+
+    created = create_game(config.bootstrap_api_base_url, player_count=config.player_count, seed=seed)
+    sessions = [created]
+    for _ in range(config.player_count - 1):
+        sessions.append(join_game(config.bootstrap_api_base_url, created.game_id))
+
+    agents: list[AgentRuntime] = []
+    listeners: list[asyncio.Task[None]] = []
+    state_update_event = asyncio.Event()
+
+    try:
+        for session in sessions:
+            client = MageKnightClient(
+                server_url=config.ws_server_url,
+                game_id=session.game_id,
+                player_id=session.player_id,
+                session_token=session.session_token,
+                subscribe_lobby_on_connect=config.subscribe_lobby_on_connect,
+            )
+            await client.connect()
+
+            runtime = AgentRuntime(
+                session=session,
+                client=client,
+                state_tracker=StateInvariantTracker(),
+            )
+            agents.append(runtime)
+            listeners.append(
+                asyncio.create_task(_listen_for_messages(runtime, state_update_event, messages))
+            )
+
+        await _wait_for_initial_states(agents, state_update_event, timeout_seconds=config.action_timeout_seconds)
+
+        step = 0
+        while step < config.max_steps:
+            actor = _find_actor_for_next_action(agents)
+            if actor is None:
+                try:
+                    await _wait_for_state_update_event(
+                        state_update_event, timeout_seconds=config.action_timeout_seconds
+                    )
+                except TimeoutError:
+                    return _finish_run(
+                        config=config,
+                        run_index=run_index,
+                        seed=seed,
+                        game_id=created.game_id,
+                        outcome=OUTCOME_DISCONNECT,
+                        steps=step,
+                        reason="Timed out waiting for active player update",
+                        trace=trace,
+                        messages=messages,
+                    )
+                actor = _find_actor_for_next_action(agents)
+
+            if actor is None:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_DISCONNECT,
+                    steps=step,
+                    reason="No active player state available before timeout",
+                    trace=trace,
+                    messages=messages,
+                )
+
+            state = actor.latest_state
+            if state is None:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_DISCONNECT,
+                    steps=step,
+                    reason=f"Missing latest state for {actor.session.player_id}",
+                    trace=trace,
+                    messages=messages,
+                )
+
+            mode = _mode(state)
+            candidate = policy.choose_action(state, actor.session.player_id, rng)
+            if candidate is None:
+                try:
+                    await _wait_for_state_update_event(
+                        state_update_event, timeout_seconds=config.action_timeout_seconds
+                    )
+                except TimeoutError:
+                    return _finish_run(
+                        config=config,
+                        run_index=run_index,
+                        seed=seed,
+                        game_id=created.game_id,
+                        outcome=OUTCOME_DISCONNECT,
+                        steps=step,
+                        reason=f"Timed out waiting for actionable state (mode={mode})",
+                        trace=trace,
+                        messages=messages,
+                    )
+                continue
+
+            all_candidates = enumerate_valid_actions(state, actor.session.player_id)
+            candidate_keys = {_action_key(entry.action) for entry in all_candidates}
+            chosen_key = _action_key(candidate.action)
+            if chosen_key not in candidate_keys:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_INVARIANT_FAILURE,
+                    steps=step,
+                    reason="Chosen action was not present in valid action snapshot",
+                    trace=trace,
+                    messages=messages,
+                )
+
+            action_to_send = candidate.action
+            if config.forced_invalid_action_step is not None and step == config.forced_invalid_action_step:
+                action_to_send = {"type": "NOT_A_REAL_ACTION"}
+
+            trace.append(
+                ActionTraceEntry(
+                    step=step,
+                    player_id=actor.session.player_id,
+                    action=action_to_send,
+                    source=candidate.source,
+                    mode=mode,
+                    current_player_id=str(state.get("currentPlayerId")),
+                )
+            )
+
+            pre_version = actor.message_version
+            await actor.client.send_action(action_to_send)
+
+            try:
+                await _wait_for_player_update(
+                    actor,
+                    pre_version=pre_version,
+                    state_update_event=state_update_event,
+                    timeout_seconds=config.action_timeout_seconds,
+                )
+            except TimeoutError:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_DISCONNECT,
+                    steps=step + 1,
+                    reason=f"Timed out waiting for update after action {action_to_send['type']}",
+                    trace=trace,
+                    messages=messages,
+                )
+            except InvariantViolation as error:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_INVARIANT_FAILURE,
+                    steps=step + 1,
+                    reason=str(error),
+                    trace=trace,
+                    messages=messages,
+                )
+
+            if actor.last_error_message is not None:
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_PROTOCOL_ERROR,
+                    steps=step + 1,
+                    reason=actor.last_error_message,
+                    trace=trace,
+                    messages=messages,
+                )
+
+            if config.forced_invalid_action_step is None:
+                try:
+                    assert_action_not_rejected(
+                        events=actor.last_events or [],
+                        action_type=str(action_to_send.get("type", "")),
+                        player_id=actor.session.player_id,
+                    )
+                except InvariantViolation as error:
+                    return _finish_run(
+                        config=config,
+                        run_index=run_index,
+                        seed=seed,
+                        game_id=created.game_id,
+                        outcome=OUTCOME_INVARIANT_FAILURE,
+                        steps=step + 1,
+                        reason=str(error),
+                        trace=trace,
+                        messages=messages,
+                    )
+
+            if any(agent.latest_state is not None and is_terminal_state(agent.latest_state) for agent in agents):
+                return _finish_run(
+                    config=config,
+                    run_index=run_index,
+                    seed=seed,
+                    game_id=created.game_id,
+                    outcome=OUTCOME_ENDED,
+                    steps=step + 1,
+                    reason=None,
+                    trace=trace,
+                    messages=messages,
+                )
+
+            step += 1
+
+        return _finish_run(
+            config=config,
+            run_index=run_index,
+            seed=seed,
+            game_id=created.game_id,
+            outcome=OUTCOME_MAX_STEPS,
+            steps=config.max_steps,
+            reason=None,
+            trace=trace,
+            messages=messages,
+        )
+    finally:
+        for task in listeners:
+            task.cancel()
+        await asyncio.gather(*listeners, return_exceptions=True)
+        for agent in agents:
+            await agent.client.close()
+
+
+async def _listen_for_messages(
+    runtime: AgentRuntime,
+    state_update_event: asyncio.Event,
+    messages: list[MessageLogEntry],
+) -> None:
+    async for message in runtime.client.messages():
+        if isinstance(message, StateUpdateMessage):
+            payload = {
+                "protocolVersion": message.protocolVersion,
+                "type": message.type,
+                "events": message.events,
+                "state": message.state,
+            }
+            messages.append(
+                MessageLogEntry(
+                    player_id=runtime.session.player_id,
+                    message_type=message.type,
+                    payload=payload,
+                )
+            )
+            runtime.latest_state = message.state
+            runtime.last_events = list(message.events)
+            runtime.message_version += 1
+            runtime.state_tracker.check_state(runtime.latest_state)
+            state_update_event.set()
+        elif isinstance(message, ErrorMessage):
+            payload = {
+                "protocolVersion": message.protocolVersion,
+                "type": message.type,
+                "message": message.message,
+                "errorCode": message.errorCode,
+            }
+            messages.append(
+                MessageLogEntry(
+                    player_id=runtime.session.player_id,
+                    message_type=message.type,
+                    payload=payload,
+                )
+            )
+            runtime.last_error_message = f"Server error: {message.message} ({message.errorCode})"
+            runtime.message_version += 1
+            state_update_event.set()
+
+
+async def _wait_for_initial_states(
+    agents: list[AgentRuntime],
+    state_update_event: asyncio.Event,
+    timeout_seconds: float,
+) -> None:
+    while any(agent.latest_state is None for agent in agents):
+        await _wait_for_state_update_event(state_update_event, timeout_seconds=timeout_seconds)
+
+
+async def _wait_for_player_update(
+    actor: AgentRuntime,
+    pre_version: int,
+    state_update_event: asyncio.Event,
+    timeout_seconds: float,
+) -> None:
+    while actor.message_version <= pre_version:
+        await _wait_for_state_update_event(state_update_event, timeout_seconds=timeout_seconds)
+
+
+async def _wait_for_state_update_event(state_update_event: asyncio.Event, timeout_seconds: float) -> None:
+    try:
+        await asyncio.wait_for(state_update_event.wait(), timeout=timeout_seconds)
+    except asyncio.TimeoutError as error:
+        raise TimeoutError("Timed out waiting for state update") from error
+    finally:
+        state_update_event.clear()
+
+
+def _find_actor_for_next_action(agents: list[AgentRuntime]) -> AgentRuntime | None:
+    # Prefer whichever actor owns the global turn and has actionable choices.
+    for runtime in agents:
+        state = runtime.latest_state
+        if state is None:
+            continue
+        current_player_id = state.get("currentPlayerId")
+        if current_player_id == runtime.session.player_id:
+            if enumerate_valid_actions(state, runtime.session.player_id):
+                return runtime
+
+    # During tactics selection and certain interstitial phases, a non-current
+    # player may still need to act. Fall back to any actionable player state.
+    for runtime in agents:
+        state = runtime.latest_state
+        if state is None:
+            continue
+        if enumerate_valid_actions(state, runtime.session.player_id):
+            return runtime
+
+    return None
+
+
+def _finish_run(
+    config: RunnerConfig,
+    run_index: int,
+    seed: int,
+    game_id: str,
+    outcome: str,
+    steps: int,
+    reason: str | None,
+    trace: list[ActionTraceEntry],
+    messages: list[MessageLogEntry],
+) -> SimulationOutcome:
+    run_result = RunResult(
+        run_index=run_index,
+        seed=seed,
+        outcome=outcome,
+        steps=steps,
+        game_id=game_id,
+        reason=reason,
+    )
+
+    artifact_outcomes = {
+        OUTCOME_DISCONNECT,
+        OUTCOME_PROTOCOL_ERROR,
+        OUTCOME_INVARIANT_FAILURE,
+    }
+    if outcome in artifact_outcomes:
+        artifact_path = write_failure_artifact(
+            output_dir=config.artifacts_dir,
+            run_result=run_result,
+            action_trace=trace,
+            message_log=messages,
+        )
+        run_result = RunResult(
+            run_index=run_result.run_index,
+            seed=run_result.seed,
+            outcome=run_result.outcome,
+            steps=run_result.steps,
+            game_id=run_result.game_id,
+            reason=run_result.reason,
+            failure_artifact_path=artifact_path,
+        )
+
+    return SimulationOutcome(result=run_result, trace=trace, messages=messages)
+
+
+def _mode(state: dict[str, Any]) -> str:
+    valid_actions = state.get("validActions")
+    if not isinstance(valid_actions, dict):
+        return "unknown"
+    mode = valid_actions.get("mode")
+    if isinstance(mode, str):
+        return mode
+    return "unknown"
+
+
+def _action_key(action: dict[str, Any]) -> str:
+    return json.dumps(action, sort_keys=True, separators=(",", ":"))
+
+
+def run_simulations_sync(config: RunnerConfig) -> tuple[list[RunResult], RunSummary]:
+    return asyncio.run(run_simulations(config))
+
+
+def save_summary(path: str, results: list[RunResult], summary: RunSummary) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary": summary.__dict__,
+        "runs": [result.__dict__ for result in results],
+    }
+    target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/packages/python-sdk/tests/integration/sim_harness_test_server.ts
+++ b/packages/python-sdk/tests/integration/sim_harness_test_server.ts
@@ -1,0 +1,158 @@
+import { randomUUID } from "node:crypto";
+
+import { createWebSocketGameServer } from "../../../server/src/WebSocketServer.ts";
+
+interface RoomSession {
+  playerId: string;
+  sessionToken: string;
+}
+
+interface RoomRecord {
+  gameId: string;
+  playerCount: number;
+  sessionsByToken: Map<string, RoomSession>;
+  sessionsByPlayerId: Map<string, RoomSession>;
+  nextPlayerNumber: number;
+}
+
+const host = "127.0.0.1";
+
+const wsServer = createWebSocketGameServer({ host, port: 0 });
+wsServer.start();
+
+const roomsById = new Map<string, RoomRecord>();
+
+const httpServer = Bun.serve({
+  hostname: host,
+  port: 0,
+  async fetch(request) {
+    const url = new URL(request.url);
+
+    if (request.method !== "POST") {
+      return json({ error: "method_not_allowed" }, 405);
+    }
+
+    if (url.pathname === "/games") {
+      return handleCreateGame(request);
+    }
+
+    const joinMatch = url.pathname.match(/^\/games\/([^/]+)\/join$/);
+    if (joinMatch) {
+      return handleJoinGame(request, joinMatch[1]);
+    }
+
+    return json({ error: "not_found" }, 404);
+  },
+});
+
+function parseJson(request: Request): Promise<Record<string, unknown>> {
+  return request.json().catch(() => ({}));
+}
+
+async function handleCreateGame(request: Request): Promise<Response> {
+  const body = await parseJson(request);
+  const playerCount = body.playerCount;
+  const seed = body.seed;
+
+  if (playerCount !== 2 && playerCount !== 3 && playerCount !== 4) {
+    return json({ error: "invalid_player_count" }, 400);
+  }
+
+  const playerIds = Array.from({ length: playerCount }, (_, i) => `player-${i + 1}`);
+  const gameId = wsServer.createGameRoom({
+    playerIds,
+    maxPlayers: playerCount,
+    seed: typeof seed === "number" ? seed : undefined,
+  });
+
+  const creatorSession: RoomSession = {
+    playerId: playerIds[0],
+    sessionToken: randomUUID(),
+  };
+
+  const room: RoomRecord = {
+    gameId,
+    playerCount,
+    sessionsByToken: new Map([[creatorSession.sessionToken, creatorSession]]),
+    sessionsByPlayerId: new Map([[creatorSession.playerId, creatorSession]]),
+    nextPlayerNumber: 2,
+  };
+  roomsById.set(gameId, room);
+
+  return json({
+    gameId,
+    playerId: creatorSession.playerId,
+    sessionToken: creatorSession.sessionToken,
+  });
+}
+
+async function handleJoinGame(request: Request, gameId: string): Promise<Response> {
+  const room = roomsById.get(gameId);
+  if (!room) {
+    return json({ error: "game_not_found" }, 404);
+  }
+
+  const body = await parseJson(request);
+  const sessionToken = body.sessionToken;
+
+  if (typeof sessionToken === "string") {
+    const resumed = room.sessionsByToken.get(sessionToken);
+    if (!resumed) {
+      return json({ error: "invalid_session" }, 400);
+    }
+
+    return json({
+      gameId,
+      playerId: resumed.playerId,
+      sessionToken: resumed.sessionToken,
+    });
+  }
+
+  if (room.nextPlayerNumber > room.playerCount) {
+    return json({ error: "game_full" }, 409);
+  }
+
+  const session: RoomSession = {
+    playerId: `player-${room.nextPlayerNumber}`,
+    sessionToken: randomUUID(),
+  };
+
+  room.nextPlayerNumber += 1;
+  room.sessionsByToken.set(session.sessionToken, session);
+  room.sessionsByPlayerId.set(session.playerId, session);
+
+  return json({
+    gameId,
+    playerId: session.playerId,
+    sessionToken: session.sessionToken,
+  });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+console.log(
+  JSON.stringify({
+    wsPort: wsServer.getPort(),
+    apiPort: httpServer.port,
+  })
+);
+
+const shutdown = (): void => {
+  httpServer.stop();
+  wsServer.stop();
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+
+setInterval(() => {
+  // Keep process alive for integration tests.
+}, 1000);

--- a/packages/python-sdk/tests/integration/test_sim_runner.py
+++ b/packages/python-sdk/tests/integration/test_sim_runner.py
@@ -5,6 +5,7 @@ import json
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 SDK_SRC = REPO_ROOT / "packages/python-sdk/src"
@@ -12,6 +13,7 @@ if str(SDK_SRC) not in sys.path:
     sys.path.insert(0, str(SDK_SRC))
 
 from mage_knight_sdk.sim.runner import RunnerConfig, run_simulations
+from mage_knight_sdk.sim.invariants import InvariantViolation
 
 
 class SimulationRunnerIntegrationTest(unittest.IsolatedAsyncioTestCase):
@@ -97,6 +99,27 @@ class SimulationRunnerIntegrationTest(unittest.IsolatedAsyncioTestCase):
         result = results[0]
 
         self.assertEqual("protocol_error", result.outcome)
+        self.assertIsNotNone(result.failure_artifact_path)
+
+    async def test_invariant_violation_is_reported_as_invariant_failure(self) -> None:
+        config = RunnerConfig(
+            bootstrap_api_base_url=self.api_url,
+            ws_server_url=self.ws_url,
+            player_count=2,
+            runs=1,
+            base_seed=444,
+            max_steps=5,
+            artifacts_dir=str(self.repo_root / "packages/python-sdk/.sim-artifacts-test"),
+        )
+
+        with patch(
+            "mage_knight_sdk.sim.invariants.StateInvariantTracker.check_state",
+            side_effect=InvariantViolation("forced_invariant_failure"),
+        ):
+            results, _summary = await run_simulations(config)
+
+        result = results[0]
+        self.assertEqual("invariant_failure", result.outcome)
         self.assertIsNotNone(result.failure_artifact_path)
 
     async def _read_stderr(self) -> str:

--- a/packages/python-sdk/tests/integration/test_sim_runner.py
+++ b/packages/python-sdk/tests/integration/test_sim_runner.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+SDK_SRC = REPO_ROOT / "packages/python-sdk/src"
+if str(SDK_SRC) not in sys.path:
+    sys.path.insert(0, str(SDK_SRC))
+
+from mage_knight_sdk.sim.runner import RunnerConfig, run_simulations
+
+
+class SimulationRunnerIntegrationTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.repo_root = REPO_ROOT
+        self.server_script = self.repo_root / "packages/python-sdk/tests/integration/sim_harness_test_server.ts"
+
+        self.server = await asyncio.create_subprocess_exec(
+            "bun",
+            "run",
+            str(self.server_script),
+            cwd=str(self.repo_root),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        assert self.server.stdout is not None
+        line = await asyncio.wait_for(self.server.stdout.readline(), timeout=10)
+        if not line:
+            stderr = await self._read_stderr()
+            raise RuntimeError(f"Sim test server failed to start. stderr: {stderr}")
+
+        payload = json.loads(line.decode("utf-8"))
+        self.ws_url = f"ws://127.0.0.1:{payload['wsPort']}"
+        self.api_url = f"http://127.0.0.1:{payload['apiPort']}"
+
+    async def asyncTearDown(self) -> None:
+        if self.server.returncode is None:
+            self.server.terminate()
+            try:
+                await asyncio.wait_for(self.server.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                self.server.kill()
+                await self.server.wait()
+
+    async def test_smoke_run_is_ci_friendly(self) -> None:
+        config = RunnerConfig(
+            bootstrap_api_base_url=self.api_url,
+            ws_server_url=self.ws_url,
+            player_count=2,
+            runs=1,
+            base_seed=100,
+            max_steps=20,
+            artifacts_dir=str(self.repo_root / "packages/python-sdk/.sim-artifacts-test"),
+        )
+
+        results, summary = await run_simulations(config)
+
+        self.assertEqual(1, len(results))
+        self.assertEqual(1, summary.total_runs)
+        self.assertIn(results[0].outcome, {"ended", "max_steps"})
+
+    async def test_multi_run_fuzz_reports_outcomes(self) -> None:
+        config = RunnerConfig(
+            bootstrap_api_base_url=self.api_url,
+            ws_server_url=self.ws_url,
+            player_count=2,
+            runs=3,
+            base_seed=200,
+            max_steps=10,
+            artifacts_dir=str(self.repo_root / "packages/python-sdk/.sim-artifacts-test"),
+        )
+
+        results, summary = await run_simulations(config)
+
+        self.assertEqual(3, len(results))
+        self.assertEqual(3, summary.total_runs)
+        self.assertEqual(3, summary.ended + summary.max_steps + summary.disconnect + summary.protocol_error + summary.invariant_failure)
+
+    async def test_injected_invalid_action_is_detected(self) -> None:
+        config = RunnerConfig(
+            bootstrap_api_base_url=self.api_url,
+            ws_server_url=self.ws_url,
+            player_count=2,
+            runs=1,
+            base_seed=333,
+            max_steps=15,
+            forced_invalid_action_step=0,
+            artifacts_dir=str(self.repo_root / "packages/python-sdk/.sim-artifacts-test"),
+        )
+
+        results, _summary = await run_simulations(config)
+        result = results[0]
+
+        self.assertEqual("protocol_error", result.outcome)
+        self.assertIsNotNone(result.failure_artifact_path)
+
+    async def _read_stderr(self) -> str:
+        if self.server.stderr is None:
+            return ""
+
+        chunks: list[str] = []
+        while True:
+            line = await self.server.stderr.readline()
+            if not line:
+                break
+            chunks.append(line.decode("utf-8"))
+
+        return "".join(chunks)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/python-sdk/tests/test_sim_random_policy.py
+++ b/packages/python-sdk/tests/test_sim_random_policy.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SDK_SRC = REPO_ROOT / "packages/python-sdk/src"
+if str(SDK_SRC) not in sys.path:
+    sys.path.insert(0, str(SDK_SRC))
+
+from mage_knight_sdk.sim.random_policy import enumerate_valid_actions
+
+
+class RandomPolicyTest(unittest.TestCase):
+    def test_enumerate_valid_actions_includes_explore_for_string_direction(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": False,
+                    "canDeclareRest": False,
+                },
+                "explore": {
+                    "directions": [
+                        {
+                            "direction": "NE",
+                            "fromTileCoord": {"q": 0, "r": 0},
+                            "targetCoord": {"q": 1, "r": -1},
+                        }
+                    ]
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        explore_actions = [a.action for a in actions if a.action.get("type") == "EXPLORE"]
+
+        self.assertEqual(1, len(explore_actions))
+        self.assertEqual("NE", explore_actions[0]["direction"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a Python random-policy simulation harness under `packages/python-sdk/src/mage_knight_sdk/sim`
- include bootstrap API client (`POST /games`, `POST /games/:gameId/join`), seeded multi-run orchestration, valid-action policy, invariant checks, and failure artifact emission
- export harness APIs from `packages/python-sdk/src/mage_knight_sdk/__init__.py`
- document harness usage and reproducibility workflow in `packages/python-sdk/README.md`
- add integration coverage with a Bun bootstrap+WebSocket fixture server and new tests:
  - smoke run completes with `ended` or `max_steps`
  - multi-run fuzz summary reports outcomes across seeds
  - injected invalid action is detected and reported with artifact output

## Validation
- `bun run build`
- `bun run lint`
- `bun run test`
- `cd packages/python-sdk && . .venv/bin/activate && python -m unittest discover -s tests -p 'test_*.py'`
- `cd packages/python-sdk && . .venv/bin/activate && python -m unittest discover -s tests/integration -p 'test_*.py'`

Closes #971
