### PR TITLE
Add Bun network dev workflow scripts and URL mode selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,28 @@ The hooks configuration enables automatic asset symlinking when using git worktr
 bun run build   # Build all packages
 bun run test    # Run tests
 bun run lint    # Run linter
+bun run dev:client   # Existing local embedded-server mode
+bun run dev:server   # Standalone WebSocket server + dev room
+bun run dev:network  # Run server + client together
 ```
+
+### Local Network Multiplayer Dev Flow
+
+`dev:client` behavior is unchanged and still starts the local in-memory flow.
+
+For local multiplayer iteration:
+
+1. Run `bun run dev:network` (or run `bun run dev:server` and `bun run dev:client` separately).
+2. Copy the printed `http://localhost:3000/?...` URLs from `dev:server`.
+3. Open one URL per player in separate browser tabs/windows.
+
+The client runtime mode is selected from URL params:
+
+- Local mode (default): no mode param, or anything except `?mode=network`
+- Network mode: `?mode=network&gameId=...&playerId=...`
+- Optional network params:
+  - `serverUrl` (default: `ws://localhost:3001`)
+  - `sessionToken` (if reconnect/auth flow requires it)
 
 ## Packages
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "lint": "oxlint -c .oxlintrc.json --deny-warnings packages/*/src",
     "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist bun.lockb",
     "dev:client": "bun run --filter @mage-knight/client dev",
+    "dev:server": "bun run packages/server/dev.ts",
+    "dev:network": "bun run --parallel dev:server dev:client",
     "mage-dev": "bun packages/mage-dev/dist/cli.js"
   },
   "devDependencies": {

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,6 +14,52 @@ import { GameView } from "./components/GameView";
 import { DebugPanel } from "./components/DebugPanel";
 import { SetupScreen } from "./components/Setup";
 
+const MODE_PARAM = "mode" as const;
+const MODE_NETWORK = "network" as const;
+const SERVER_URL_PARAM = "serverUrl" as const;
+const GAME_ID_PARAM = "gameId" as const;
+const PLAYER_ID_PARAM = "playerId" as const;
+const SESSION_TOKEN_PARAM = "sessionToken" as const;
+const DEFAULT_NETWORK_SERVER_URL = "ws://localhost:3001" as const;
+
+interface RuntimeNetworkConfig {
+  serverUrl: string;
+  gameId: string;
+  playerId: string;
+  sessionToken?: string;
+}
+
+function getRuntimeNetworkConfig(): RuntimeNetworkConfig | null {
+  const urlParams = new URLSearchParams(window.location.search);
+  const mode = urlParams.get(MODE_PARAM);
+
+  if (mode !== MODE_NETWORK) {
+    return null;
+  }
+
+  const gameId = urlParams.get(GAME_ID_PARAM);
+  const playerId = urlParams.get(PLAYER_ID_PARAM);
+
+  if (!gameId || !playerId) {
+    return null;
+  }
+
+  const serverUrl = urlParams.get(SERVER_URL_PARAM) ?? DEFAULT_NETWORK_SERVER_URL;
+  const sessionToken = urlParams.get(SESSION_TOKEN_PARAM) ?? undefined;
+
+  return {
+    serverUrl,
+    gameId,
+    playerId,
+    sessionToken,
+  };
+}
+
+function isNetworkModeRequested(): boolean {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(MODE_PARAM) === MODE_NETWORK;
+}
+
 // Get seed from URL param (?seed=12345) or use current time
 // This allows reproducible games for testing and debugging
 function getGameSeed(): number {
@@ -32,10 +78,64 @@ function getGameSeed(): number {
 }
 
 const GAME_SEED = getGameSeed();
+const RUNTIME_NETWORK_CONFIG = getRuntimeNetworkConfig();
+const NETWORK_MODE_REQUESTED = isNetworkModeRequested();
 
 export function App() {
   // Game configuration state - null until setup is complete
   const [gameConfig, setGameConfig] = useState<GameConfig | null>(null);
+
+  const gameShell = (
+    <TurnNotificationProvider>
+      <AnimationDispatcherProvider>
+        <GameIntroProvider>
+          <CinematicProvider>
+            <OverlayProvider>
+              <DebugDisplayProvider>
+                <PixiAppProvider>
+                  <CardMenuPositionProvider>
+                    <CardInteractionProvider>
+                      <GameView />
+                      <DebugPanel />
+                    </CardInteractionProvider>
+                  </CardMenuPositionProvider>
+                </PixiAppProvider>
+              </DebugDisplayProvider>
+            </OverlayProvider>
+          </CinematicProvider>
+        </GameIntroProvider>
+      </AnimationDispatcherProvider>
+    </TurnNotificationProvider>
+  );
+
+  if (RUNTIME_NETWORK_CONFIG) {
+    return (
+      <GameProvider
+        mode="network"
+        serverUrl={RUNTIME_NETWORK_CONFIG.serverUrl}
+        gameId={RUNTIME_NETWORK_CONFIG.gameId}
+        playerId={RUNTIME_NETWORK_CONFIG.playerId}
+        sessionToken={RUNTIME_NETWORK_CONFIG.sessionToken}
+      >
+        {gameShell}
+      </GameProvider>
+    );
+  }
+
+  if (NETWORK_MODE_REQUESTED) {
+    return (
+      <div className="loading-screen error">
+        <p>Missing network connection parameters.</p>
+        <p className="error-message">
+          Required URL params: <code>?mode=network&gameId=...&playerId=...</code>
+        </p>
+        <p className="error-hint">
+          Optional params: <code>serverUrl=ws://localhost:3001</code> and{" "}
+          <code>sessionToken=...</code>
+        </p>
+      </div>
+    );
+  }
 
   // Show setup screen until configuration is complete
   if (!gameConfig) {
@@ -45,26 +145,7 @@ export function App() {
   // Once setup is complete, render the game
   return (
     <GameProvider seed={GAME_SEED} config={gameConfig}>
-      <TurnNotificationProvider>
-        <AnimationDispatcherProvider>
-          <GameIntroProvider>
-            <CinematicProvider>
-              <OverlayProvider>
-                <DebugDisplayProvider>
-                  <PixiAppProvider>
-                    <CardMenuPositionProvider>
-                      <CardInteractionProvider>
-                        <GameView />
-                        <DebugPanel />
-                      </CardInteractionProvider>
-                    </CardMenuPositionProvider>
-                  </PixiAppProvider>
-                </DebugDisplayProvider>
-              </OverlayProvider>
-            </CinematicProvider>
-          </GameIntroProvider>
-        </AnimationDispatcherProvider>
-      </TurnNotificationProvider>
+      {gameShell}
     </GameProvider>
   );
 }

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -144,7 +144,7 @@ export function App() {
 
   // Once setup is complete, render the game
   return (
-    <GameProvider seed={GAME_SEED} config={gameConfig}>
+    <GameProvider mode="local" seed={GAME_SEED} config={gameConfig}>
       {gameShell}
     </GameProvider>
   );

--- a/packages/server/dev.ts
+++ b/packages/server/dev.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env bun
+
+import { createWebSocketGameServer } from "./src/index.js";
+
+const PORT_ENV = "PORT";
+const HOST_ENV = "HOST";
+const CLIENT_HOST_ENV = "CLIENT_HOST";
+const PLAYER_IDS_ENV = "PLAYER_IDS";
+const DEFAULT_PORT = 3001;
+const DEFAULT_HOST = "0.0.0.0";
+const DEFAULT_CLIENT_HOST = "localhost";
+const DEFAULT_PLAYER_IDS = ["player1", "player2"];
+
+function parsePlayerIds(rawValue: string | undefined): string[] {
+  if (!rawValue) {
+    return [...DEFAULT_PLAYER_IDS];
+  }
+
+  const ids = rawValue
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+
+  return ids.length > 0 ? ids : [...DEFAULT_PLAYER_IDS];
+}
+
+const portFromEnv = Number.parseInt(Bun.env[PORT_ENV] ?? "", 10);
+const port = Number.isNaN(portFromEnv) ? DEFAULT_PORT : portFromEnv;
+const host = Bun.env[HOST_ENV] ?? DEFAULT_HOST;
+const clientHost = Bun.env[CLIENT_HOST_ENV] ?? DEFAULT_CLIENT_HOST;
+const playerIds = parsePlayerIds(Bun.env[PLAYER_IDS_ENV]);
+
+const webSocketServer = createWebSocketGameServer({ host, port });
+webSocketServer.start();
+
+const gameId = webSocketServer.createGameRoom({
+  playerIds,
+  maxPlayers: playerIds.length,
+});
+const serverUrl = `ws://${clientHost}:${webSocketServer.getPort()}`;
+
+console.log(`WebSocket dev server listening on ws://${host}:${webSocketServer.getPort()}`);
+console.log(`Created local dev room gameId=${gameId} players=${playerIds.join(",")}`);
+console.log("Open one URL per player:");
+for (const playerId of playerIds) {
+  const params = new URLSearchParams({
+    mode: "network",
+    serverUrl,
+    gameId,
+    playerId,
+  });
+  console.log(`http://localhost:3000/?${params.toString()}`);
+}
+
+const shutdown = (): void => {
+  webSocketServer.stop();
+  process.exit(0);
+};
+
+process.on("SIGINT", shutdown);
+process.on("SIGTERM", shutdown);
+


### PR DESCRIPTION
## Summary
- add `dev:server` and `dev:network` root scripts while keeping existing `dev:client` behavior unchanged
- add `packages/server/dev.ts` to start a standalone WS server and auto-create a local dev room with ready-to-open client URLs
- add runtime startup mode support in the client via URL params (`?mode=network&gameId=...&playerId=...`)
- document the local network multiplayer workflow and URL params in the root README

## Validation
- `bun run build`
- `bun run lint`
- `bun run test`
- smoke test: `bun run dev:server` (confirmed WS server start + URL output)

Closes #978