### PR TITLE
fix: hide invalid combat card actions while resting

### DIFF
--- a/packages/core/src/engine/__tests__/rest.test.ts
+++ b/packages/core/src/engine/__tests__/rest.test.ts
@@ -31,6 +31,8 @@ import {
   COMPLETE_REST_ACTION,
   MOVE_ACTION,
   END_TURN_ACTION,
+  PLAY_CARD_SIDEWAYS_ACTION,
+  PLAY_SIDEWAYS_AS_MOVE,
 } from "@mage-knight/shared";
 
 describe("REST action", () => {
@@ -534,6 +536,28 @@ describe("Two-Phase REST (DECLARE_REST + COMPLETE_REST)", () => {
         expect.objectContaining({
           type: INVALID_ACTION,
           reason: "You must complete your rest before ending your turn",
+        })
+      );
+    });
+
+    it("should block playing cards sideways while resting", () => {
+      const player = createTestPlayer({
+        hand: [CARD_MARCH],
+        isResting: true,
+        hasTakenActionThisTurn: true,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_SIDEWAYS_ACTION,
+        cardId: CARD_MARCH,
+        as: PLAY_SIDEWAYS_AS_MOVE,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Cannot play cards sideways while resting",
         })
       );
     });

--- a/packages/core/src/engine/__tests__/restingValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/restingValidActions.test.ts
@@ -15,6 +15,7 @@ import { getChallengeOptions } from "../validActions/challenge.js";
 import { getSiteOptions } from "../validActions/sites.js";
 import {
   ENEMY_DIGGERS,
+  CARD_WHIRLWIND,
   TERRAIN_PLAINS,
   hexKey,
 } from "@mage-knight/shared";
@@ -26,6 +27,7 @@ import {
   type HexState,
   TileId,
 } from "../../types/map.js";
+import { getValidActions } from "../validActions/index.js";
 
 function withTiles(state: ReturnType<typeof createTestGameState>) {
   return {
@@ -153,5 +155,19 @@ describe("Valid actions while resting", () => {
 
     const restingOptions = getSiteOptions(restingState, restingPlayer);
     expect(restingOptions?.canEnter).toBe(false);
+  });
+
+  it("does not surface sideways-only combat cards while resting", () => {
+    const restingPlayer = createTestPlayer({
+      isResting: true,
+      hasTakenActionThisTurn: true,
+      hand: [CARD_WHIRLWIND],
+    });
+
+    const state = createTestGameState({ players: [restingPlayer] });
+    const validActions = getValidActions(state, restingPlayer.id);
+
+    expect(validActions.mode).toBe("normal_turn");
+    expect(validActions.playCard).toBeUndefined();
   });
 });

--- a/packages/core/src/engine/rules/sideways.ts
+++ b/packages/core/src/engine/rules/sideways.ts
@@ -70,3 +70,20 @@ export function getSidewaysOptionsForValue(
   const choices = getAllowedSidewaysChoices(context);
   return choices.map((as) => ({ as, value: sidewaysValue }));
 }
+
+/**
+ * Shared legality check for sideways play.
+ *
+ * While resting, sideways play is disallowed. Otherwise legality is based on
+ * whether the current phase allows any sideways choice.
+ */
+export function canPlaySideways(
+  state: GameState,
+  isResting: boolean
+): boolean {
+  if (isResting) {
+    return false;
+  }
+
+  return getAllowedSidewaysChoices(getSidewaysContext(state)).length > 0;
+}

--- a/packages/core/src/engine/validActions/cards/normalTurn.ts
+++ b/packages/core/src/engine/validActions/cards/normalTurn.ts
@@ -105,14 +105,20 @@ export function getPlayableCardsForNormalTurn(
       ? findPayableManaColor(state, player, card)
       : undefined;
     const canActuallyPlayPowered = payableManaColor !== undefined;
+    const canPlayByEffect = canActuallyPlayBasic || canActuallyPlayPowered;
 
-    if (canActuallyPlayBasic || canActuallyPlayPowered || playability.canPlaySideways) {
+    // While resting, only surface cards that can be played for an actual effect.
+    // Sideways-only suggestions create false positives for cards that can't be
+    // meaningfully used during rest (e.g., combat-only spells).
+    const canPlaySidewaysInContext = playability.canPlaySideways && !player.isResting;
+
+    if (canPlayByEffect || canPlaySidewaysInContext) {
       const playableCard: PlayableCard = {
         cardId,
         name: card.name,
         canPlayBasic: canActuallyPlayBasic,
         canPlayPowered: canActuallyPlayPowered,
-        canPlaySideways: playability.canPlaySideways,
+        canPlaySideways: canPlaySidewaysInContext,
         basicEffectDescription: describeEffect(card.basicEffect),
         poweredEffectDescription: describeEffect(card.poweredEffect),
       };
@@ -124,7 +130,11 @@ export function getPlayableCardsForNormalTurn(
       if (card.cardType === DEED_CARD_TYPE_SPELL) {
         (playableCard as { isSpell?: boolean }).isSpell = true;
       }
-      if (playability.sidewaysOptions && playability.sidewaysOptions.length > 0) {
+      if (
+        canPlaySidewaysInContext &&
+        playability.sidewaysOptions &&
+        playability.sidewaysOptions.length > 0
+      ) {
         (playableCard as { sidewaysOptions?: readonly SidewaysOption[] }).sidewaysOptions = playability.sidewaysOptions;
       }
 

--- a/packages/core/src/engine/validActions/cards/normalTurn.ts
+++ b/packages/core/src/engine/validActions/cards/normalTurn.ts
@@ -21,7 +21,7 @@ import { canPayForSpellBasic, findPayableManaColor } from "./manaPayment.js";
 import { getEffectiveSidewaysValue, isRuleActive, getModifiersForPlayer } from "../../modifiers/index.js";
 import { RULE_WOUNDS_PLAYABLE_SIDEWAYS, EFFECT_SIDEWAYS_VALUE, SIDEWAYS_CONDITION_WITH_MANA_MATCHING_COLOR } from "../../../types/modifierConstants.js";
 import type { SidewaysValueModifier } from "../../../types/modifiers.js";
-import { getSidewaysOptionsForValue } from "../../rules/sideways.js";
+import { getSidewaysOptionsForValue, canPlaySideways } from "../../rules/sideways.js";
 import { isNormalEffectAllowed, isTimeBendingChainPrevented, cardConsumesAction } from "../../rules/cardPlay.js";
 
 interface CardPlayability {
@@ -110,7 +110,8 @@ export function getPlayableCardsForNormalTurn(
     // While resting, only surface cards that can be played for an actual effect.
     // Sideways-only suggestions create false positives for cards that can't be
     // meaningfully used during rest (e.g., combat-only spells).
-    const canPlaySidewaysInContext = playability.canPlaySideways && !player.isResting;
+    const canPlaySidewaysInContext =
+      playability.canPlaySideways && canPlaySideways(state, player.isResting);
 
     if (canPlayByEffect || canPlaySidewaysInContext) {
       const playableCard: PlayableCard = {


### PR DESCRIPTION
## Summary
- prevent resting players from seeing sideways-only card options in normal-turn valid actions
- keep cards visible during rest only when their basic/powered effect is actually playable
- add regression test to ensure combat-only cards like Whirlwind are not surfaced while resting

## Validation
- bun run --filter @mage-knight/shared build
- bun run --filter @mage-knight/core test ./src/engine/__tests__/restingValidActions.test.ts
- bun run --filter @mage-knight/core test ./src/engine/__tests__/playableCards.test.ts