### PR TITLE
Fix IMPROVISATION discard-cost playability gating

### DIFF
--- a/packages/core/src/engine/__tests__/playCard.test.ts
+++ b/packages/core/src/engine/__tests__/playCard.test.ts
@@ -181,6 +181,26 @@ describe("PLAY_CARD action", () => {
         })
       );
     });
+
+    it("should reject Improvisation when no other discardable card exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_IMPROVISATION],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: PLAY_CARD_ACTION,
+        cardId: CARD_IMPROVISATION,
+        powered: false,
+      });
+
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: INVALID_ACTION,
+          reason: "Card requires discarding another card, but no eligible card is available",
+        })
+      );
+    });
   });
 
   describe("undo", () => {

--- a/packages/core/src/engine/__tests__/playableCards.test.ts
+++ b/packages/core/src/engine/__tests__/playableCards.test.ts
@@ -271,6 +271,21 @@ describe("getPlayableCardsForCombat", () => {
       });
     });
 
+    it("should not advertise Improvisation as basic/powered when it is the only card in hand", () => {
+      const player = createTestPlayer({
+        hand: [CARD_IMPROVISATION],
+      });
+      const state = createTestGameState({ players: [player] });
+      const combat = createTestCombat(COMBAT_PHASE_ATTACK);
+
+      const result = getPlayableCardsForCombat(state, player, combat);
+      const improvisation = result.cards.find((c) => c.cardId === CARD_IMPROVISATION);
+
+      expect(improvisation).toBeDefined();
+      expect(improvisation?.canPlayBasic).toBe(false);
+      expect(improvisation?.canPlayPowered).toBe(false);
+    });
+
     it("should allow ranged/siege attacks in the attack phase", () => {
       // Per rulebook: "You can combine any Attacks: Ranged, Siege or regular.
       // In this phase, there is no difference between regular, Ranged and Siege Attacks."
@@ -660,6 +675,20 @@ describe("getPlayableCardsForCombat", () => {
       // March SHOULD be playable powered with green mana
       expect(marchCard?.canPlayPowered).toBe(true);
       expect(marchCard?.requiredMana).toBe(MANA_GREEN);
+    });
+
+    it("should not advertise Improvisation as basic/powered on normal turn when no other discard exists", () => {
+      const player = createTestPlayer({
+        hand: [CARD_IMPROVISATION],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = getPlayableCardsForNormalTurn(state, player);
+      const improvisation = result.cards.find((c) => c.cardId === CARD_IMPROVISATION);
+
+      expect(improvisation).toBeDefined();
+      expect(improvisation?.canPlayBasic).toBe(false);
+      expect(improvisation?.canPlayPowered).toBe(false);
     });
   });
 });

--- a/packages/core/src/engine/validActions/cards/normalTurn.ts
+++ b/packages/core/src/engine/validActions/cards/normalTurn.ts
@@ -22,7 +22,12 @@ import { getEffectiveSidewaysValue, isRuleActive, getModifiersForPlayer } from "
 import { RULE_WOUNDS_PLAYABLE_SIDEWAYS, EFFECT_SIDEWAYS_VALUE, SIDEWAYS_CONDITION_WITH_MANA_MATCHING_COLOR } from "../../../types/modifierConstants.js";
 import type { SidewaysValueModifier } from "../../../types/modifiers.js";
 import { getSidewaysOptionsForValue, canPlaySideways } from "../../rules/sideways.js";
-import { isNormalEffectAllowed, isTimeBendingChainPrevented, cardConsumesAction } from "../../rules/cardPlay.js";
+import {
+  isNormalEffectAllowed,
+  isTimeBendingChainPrevented,
+  cardConsumesAction,
+  isDiscardCostPayableAfterPlayingSource,
+} from "../../rules/cardPlay.js";
 
 interface CardPlayability {
   canPlayBasic: boolean;
@@ -160,6 +165,11 @@ function getCardPlayabilityForNormalTurn(
   card: DeedCard
 ): CardPlayability {
   const basicHasUsefulEffect = isNormalEffectAllowed(card.basicEffect, "basic");
+  const basicDiscardCostPayable = isDiscardCostPayableAfterPlayingSource(
+    card.basicEffect,
+    player.hand,
+    card.id
+  );
 
   const basicIsResolvable = isEffectResolvable(state, player.id, card.basicEffect);
 
@@ -167,6 +177,11 @@ function getCardPlayabilityForNormalTurn(
   const poweredHasUsefulEffect = isNormalEffectAllowed(
     card.poweredEffect,
     "powered"
+  );
+  const poweredDiscardCostPayable = isDiscardCostPayableAfterPlayingSource(
+    card.poweredEffect,
+    player.hand,
+    card.id
   );
 
   const poweredIsResolvable = isEffectResolvable(state, player.id, card.poweredEffect);
@@ -201,8 +216,8 @@ function getCardPlayabilityForNormalTurn(
   ];
 
   return {
-    canPlayBasic: basicHasUsefulEffect && basicIsResolvable,
-    canPlayPowered: poweredHasUsefulEffect && poweredIsResolvable,
+    canPlayBasic: basicHasUsefulEffect && basicDiscardCostPayable && basicIsResolvable,
+    canPlayPowered: poweredHasUsefulEffect && poweredDiscardCostPayable && poweredIsResolvable,
     canPlaySideways: sidewaysOptions.length > 0,
     sidewaysOptions,
   };


### PR DESCRIPTION
## Summary
- add a shared `rules/cardPlay` helper to evaluate whether mandatory `discard_cost` can be paid after the source card leaves hand
- use that shared rule in both `PLAY_CARD` validation and `validActions` card surfacing (normal + combat)
- add regression tests for Improvisation with no other discardable card

## Why
When IMPROVISATION was the only card in hand, it was still surfaced as playable via `PLAY_CARD` and then failed during discard-cost resolution, producing protocol-level fuzzing failures.

## Validation
- `bun run build`
- `bun run lint`
- `bun run test`
