### PR TITLE
feat: add rest discard options to validActions

### DIFF
--- a/packages/core/src/engine/validActions/turn.ts
+++ b/packages/core/src/engine/validActions/turn.ts
@@ -18,6 +18,7 @@ import {
   canDeclareRest,
   canCompleteRest,
   canEndTurn,
+  getRestDiscardableCards,
 } from "../rules/turnStructure.js";
 
 /**
@@ -37,6 +38,7 @@ export function getTurnOptions(state: GameState, player: Player): TurnOptions {
     canDeclareRest: canDeclareRestOption,
     canCompleteRest: canCompleteRestOption,
     isResting: player.isResting,
+    restDiscard: canCompleteRestOption ? getRestDiscardableCards(player) : undefined,
   };
 }
 

--- a/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
+++ b/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
@@ -5,39 +5,39 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
-NETWORK_PROTOCOL_VERSION: Literal["1.1.0"] = "1.1.0"
+NETWORK_PROTOCOL_VERSION: Literal["1.2.0"] = "1.2.0"
 
 @dataclass(frozen=True)
 class ClientActionMessage:
     action: Any
-    protocolVersion: Literal["1.1.0"]
+    protocolVersion: Literal["1.2.0"]
     type: Literal["action"]
 @dataclass(frozen=True)
 class ClientLobbySubscribeMessage:
     gameId: str
     playerId: str
-    protocolVersion: Literal["1.1.0"]
+    protocolVersion: Literal["1.2.0"]
     sessionToken: str | None
     type: Literal["lobby_subscribe"]
 
 @dataclass(frozen=True)
 class StateUpdateMessage:
     events: list[Any]
-    protocolVersion: Literal["1.1.0"]
+    protocolVersion: Literal["1.2.0"]
     state: Any
     type: Literal["state_update"]
 @dataclass(frozen=True)
 class ErrorMessage:
     errorCode: str | None
     message: str
-    protocolVersion: Literal["1.1.0"]
+    protocolVersion: Literal["1.2.0"]
     type: Literal["error"]
 @dataclass(frozen=True)
 class LobbyStateMessage:
     gameId: str
     maxPlayers: int
     playerIds: list[str]
-    protocolVersion: Literal["1.1.0"]
+    protocolVersion: Literal["1.2.0"]
     status: Literal["lobby", "started"]
     type: Literal["lobby_state"]
 

--- a/packages/shared/schemas/network-protocol/v1/client-game-state.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/client-game-state.schema.json
@@ -3684,6 +3684,33 @@
       ],
       "type": "string"
     },
+    "RestDiscardOptions": {
+      "additionalProperties": false,
+      "description": "Options for completing rest when in resting state",
+      "properties": {
+        "allowEmptyDiscard": {
+          "description": "True if slow recovery with empty hand (all wounds healed)",
+          "type": "boolean"
+        },
+        "discardableCardIds": {
+          "description": "Cards that can be discarded (excludes wounds for standard rest)",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "restType": {
+          "$ref": "#/definitions/RestType",
+          "description": "Whether this will be standard rest (has non-wounds) or slow recovery (wounds only)"
+        }
+      },
+      "required": [
+        "allowEmptyDiscard",
+        "discardableCardIds",
+        "restType"
+      ],
+      "type": "object"
+    },
     "RestType": {
       "enum": [
         "slow_recovery",
@@ -4192,6 +4219,10 @@
         "isResting": {
           "description": "Whether player is currently in resting state",
           "type": "boolean"
+        },
+        "restDiscard": {
+          "$ref": "#/definitions/RestDiscardOptions",
+          "description": "Rest discard options (only present when isResting && canCompleteRest)"
         },
         "restTypes": {
           "items": {

--- a/packages/shared/schemas/network-protocol/v1/client-to-server.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/client-to-server.schema.json
@@ -9,7 +9,7 @@
           "$ref": "player-action.schema.json"
         },
         "protocolVersion": {
-          "const": "1.1.0"
+          "const": "1.2.0"
         },
         "type": {
           "const": "action"
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "protocolVersion": {
-          "const": "1.1.0"
+          "const": "1.2.0"
         },
         "sessionToken": {
           "minLength": 1,

--- a/packages/shared/schemas/network-protocol/v1/protocol.json
+++ b/packages/shared/schemas/network-protocol/v1/protocol.json
@@ -7,5 +7,5 @@
     "client-game-state.schema.json"
   ],
   "generatedAt": "static",
-  "protocolVersion": "1.1.0"
+  "protocolVersion": "1.2.0"
 }

--- a/packages/shared/schemas/network-protocol/v1/server-to-client.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/server-to-client.schema.json
@@ -12,7 +12,7 @@
           "type": "array"
         },
         "protocolVersion": {
-          "const": "1.1.0"
+          "const": "1.2.0"
         },
         "state": {
           "$ref": "client-game-state.schema.json"
@@ -41,7 +41,7 @@
           "type": "string"
         },
         "protocolVersion": {
-          "const": "1.1.0"
+          "const": "1.2.0"
         },
         "type": {
           "const": "error"
@@ -74,7 +74,7 @@
           "type": "array"
         },
         "protocolVersion": {
-          "const": "1.1.0"
+          "const": "1.2.0"
         },
         "status": {
           "enum": [

--- a/packages/shared/src/networkProtocol.ts
+++ b/packages/shared/src/networkProtocol.ts
@@ -3,7 +3,7 @@ import { KNOWN_ACTION_TYPES } from "./actions.js";
 import type { GameEvent } from "./events/index.js";
 import type { ClientGameState } from "./types/clientState.js";
 
-export const NETWORK_PROTOCOL_VERSION_1 = "1.1.0" as const;
+export const NETWORK_PROTOCOL_VERSION_1 = "1.2.0" as const;
 export const NETWORK_PROTOCOL_VERSION = NETWORK_PROTOCOL_VERSION_1;
 
 export type NetworkProtocolVersion = typeof NETWORK_PROTOCOL_VERSION;

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -658,6 +658,16 @@ export interface AvailableDie {
 // Turn structure
 // ============================================================================
 
+/** Options for completing rest when in resting state */
+export interface RestDiscardOptions {
+  /** Cards that can be discarded (excludes wounds for standard rest) */
+  readonly discardableCardIds: readonly CardId[];
+  /** Whether this will be standard rest (has non-wounds) or slow recovery (wounds only) */
+  readonly restType: RestType;
+  /** True if slow recovery with empty hand (all wounds healed) */
+  readonly allowEmptyDiscard: boolean;
+}
+
 export interface TurnOptions {
   readonly canEndTurn: boolean;
   readonly canAnnounceEndOfRound: boolean;
@@ -671,6 +681,8 @@ export interface TurnOptions {
   readonly canCompleteRest: boolean;
   /** Whether player is currently in resting state */
   readonly isResting: boolean;
+  /** Rest discard options (only present when isResting && canCompleteRest) */
+  readonly restDiscard?: RestDiscardOptions;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Adds `restDiscard` field to `TurnOptions` in validActions that explicitly advertises which cards can be discarded when completing rest. This eliminates the need for clients/fuzzers to duplicate game logic.

## Problem

When `isResting: true`, the server only returned:
```json
{
  "canCompleteRest": true,
  "isResting": true
}
```

But didn't tell the client:
- Which cards can be discarded
- What type of rest this will be (standard vs slow recovery)  
- Whether empty discard is allowed (all wounds healed scenario)

This forced the fuzzer to duplicate game logic to figure out valid discards, violating the architecture principle that **validActions is the single source of truth**.

## Solution

Added `RestDiscardOptions` to `TurnOptions`:

```typescript
interface RestDiscardOptions {
  discardableCardIds: readonly CardId[];  // Cards that can be discarded
  restType: RestType;                     // "standard" or "slow_recovery"
  allowEmptyDiscard: boolean;             // True if empty hand (all wounds healed)
}

interface TurnOptions {
  // ... existing fields ...
  restDiscard?: RestDiscardOptions;  // Only present when isResting && canCompleteRest
}
```

## Changes

1. **Added rule function** (`core/src/engine/rules/turnStructure.ts`):
   - `getRestDiscardableCards()` - single source of truth for rest discard logic
   - Handles standard rest, slow recovery, and empty hand cases

2. **Updated validActions** (`core/src/engine/validActions/turn.ts`):
   - `getTurnOptions()` now populates `restDiscard` when player is resting

3. **Updated types** (`shared/src/types/validActions.ts`):
   - Added `RestDiscardOptions` interface
   - Added `restDiscard?` field to `TurnOptions`

4. **Regenerated schema** (`shared/schemas/network-protocol/v1/client-game-state.schema.json`):
   - Reflects new `restDiscard` field in client state

## Architecture Alignment

This follows the established pattern:
- **Rules** (`rules/turnStructure.ts`) = single source of truth
- **ValidActions** (`validActions/turn.ts`) = imports rules to advertise options
- **Validators** = import same rules to validate actions
- **Client/Fuzzer** = picks from advertised options (no game logic duplication)

## Testing

- ✅ All existing tests pass (5259 tests in core, 70 in server, 41 in shared)
- ✅ Lint passes with 0 warnings
- ✅ Build succeeds
- ✅ Logic verified with standalone test covering all scenarios

## Usage Example

Now the fuzzer can simply:

```typescript
if (validActions.turn.restDiscard) {
  const { discardableCardIds, restType, allowEmptyDiscard } = validActions.turn.restDiscard;
  
  if (allowEmptyDiscard) {
    return { type: "COMPLETE_REST", discardCardIds: [] };
  } else if (restType === "standard") {
    // Pick exactly 1 non-wound + any wounds from discardableCardIds
  } else {
    // Pick exactly 1 wound from discardableCardIds
  }
}
```

No game logic duplication needed!