### PR TITLE
Fix BUY_HEALING routing and align village healing availability

### DIFF
--- a/packages/core/src/engine/__tests__/siteValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/siteValidActions.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  createTestGameState,
+  createTestPlayer,
+  createTestHex,
+} from "./testHelpers.js";
+import {
+  CARD_WOUND,
+  CARD_MARCH,
+  GAME_PHASE_ROUND,
+  TERRAIN_PLAINS,
+  hexKey,
+} from "@mage-knight/shared";
+import type { CardId } from "@mage-knight/shared";
+import { SiteType } from "../../types/map.js";
+import type { Site } from "../../types/map.js";
+import { getSiteOptions } from "../validActions/sites.js";
+
+function createStateAtVillage(
+  influencePoints: number,
+  hand: readonly CardId[] = [CARD_WOUND, CARD_MARCH]
+) {
+  const village: Site = {
+    type: SiteType.Village,
+    owner: null,
+    isConquered: false,
+    isBurned: false,
+  };
+
+  const player = createTestPlayer({
+    position: { q: 0, r: 0 },
+    influencePoints,
+    hand,
+  });
+
+  return createTestGameState({
+    phase: GAME_PHASE_ROUND,
+    players: [player],
+    map: {
+      hexes: {
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS, village),
+      },
+      tiles: [],
+      tileDeck: { countryside: [], core: [] },
+    },
+  });
+}
+
+describe("Site valid actions", () => {
+  it("does not advertise healing when influence is below cost", () => {
+    const state = createStateAtVillage(2);
+    const player = state.players[0];
+    const options = getSiteOptions(state, player);
+
+    expect(options?.interactOptions?.canHeal).toBe(false);
+    expect(options?.interactOptions?.healCost).toBe(3);
+  });
+
+  it("advertises healing when influence meets village cost", () => {
+    const state = createStateAtVillage(3);
+    const player = state.players[0];
+    const options = getSiteOptions(state, player);
+
+    expect(options?.interactOptions?.canHeal).toBe(true);
+    expect(options?.interactOptions?.healCost).toBe(3);
+  });
+
+  it("does not advertise healing when player has no wounds", () => {
+    const state = createStateAtVillage(6, [CARD_MARCH]);
+    const player = state.players[0];
+    const options = getSiteOptions(state, player);
+
+    expect(options?.interactOptions?.canHeal).toBe(false);
+    expect(options?.interactOptions?.healCost).toBe(3);
+  });
+});

--- a/packages/core/src/engine/commands/factories/index.ts
+++ b/packages/core/src/engine/commands/factories/index.ts
@@ -50,6 +50,7 @@ import {
   RECRUIT_UNIT_ACTION,
   ACTIVATE_UNIT_ACTION,
   INTERACT_ACTION,
+  BUY_HEALING_ACTION,
   ANNOUNCE_END_OF_ROUND_ACTION,
   ENTER_SITE_ACTION,
   SELECT_TACTIC_ACTION,
@@ -152,6 +153,7 @@ export {
 // Site factories
 export {
   createInteractCommandFromAction,
+  createBuyHealingCommandFromAction,
   createEnterSiteCommandFromAction,
   createAltarTributeCommandFromAction,
   createResolveGladeWoundCommandFromAction,
@@ -267,6 +269,7 @@ import {
 
 import {
   createInteractCommandFromAction,
+  createBuyHealingCommandFromAction,
   createEnterSiteCommandFromAction,
   createAltarTributeCommandFromAction,
   createResolveGladeWoundCommandFromAction,
@@ -360,6 +363,7 @@ export const commandFactoryRegistry: Record<string, CommandFactory> = {
   [RECRUIT_UNIT_ACTION]: createRecruitUnitCommandFromAction,
   [ACTIVATE_UNIT_ACTION]: createActivateUnitCommandFromAction,
   [INTERACT_ACTION]: createInteractCommandFromAction,
+  [BUY_HEALING_ACTION]: createBuyHealingCommandFromAction,
   [ANNOUNCE_END_OF_ROUND_ACTION]: createAnnounceEndOfRoundCommandFromAction,
   [ENTER_SITE_ACTION]: createEnterSiteCommandFromAction,
   [ALTAR_TRIBUTE_ACTION]: createAltarTributeCommandFromAction,

--- a/packages/core/src/engine/commands/factories/sites.ts
+++ b/packages/core/src/engine/commands/factories/sites.ts
@@ -20,6 +20,7 @@ import type { CommandFactory } from "./types.js";
 import type { PlayerAction, GladeWoundChoice, BasicManaColor, CardId } from "@mage-knight/shared";
 import {
   INTERACT_ACTION,
+  BUY_HEALING_ACTION,
   ENTER_SITE_ACTION,
   ALTAR_TRIBUTE_ACTION,
   RESOLVE_GLADE_WOUND_ACTION,
@@ -92,6 +93,28 @@ export const createInteractCommandFromAction: CommandFactory = (
     playerId,
     healing: action.healing ?? 0,
     influenceAvailable,
+    previousHand: [...player.hand],
+  });
+};
+
+/**
+ * Buy healing command factory.
+ * Creates an interaction command that purchases healing at the current site.
+ */
+export const createBuyHealingCommandFromAction: CommandFactory = (
+  state,
+  playerId,
+  action
+) => {
+  if (action.type !== BUY_HEALING_ACTION) return null;
+
+  const player = getPlayerById(state, playerId);
+  if (!player) return null;
+
+  return createInteractCommand({
+    playerId,
+    healing: action.amount,
+    influenceAvailable: player.influencePoints,
     previousHand: [...player.hand],
   });
 };

--- a/packages/core/src/engine/validActions/sites.ts
+++ b/packages/core/src/engine/validActions/sites.ts
@@ -9,6 +9,7 @@ import type { SiteOptions, InteractOptions } from "@mage-knight/shared";
 import {
   hexKey,
   TIME_OF_DAY_DAY,
+  CARD_WOUND,
   getRuinsTokenDefinition,
   isAltarToken,
   isEnemyToken,
@@ -311,6 +312,12 @@ function getInteractOptions(
   site: Site
 ): InteractOptions {
   const healCost = HEALING_COSTS[site.type];
+  const woundsInHand = player.hand.filter((cardId) => cardId === CARD_WOUND).length;
+  const canHeal =
+    healCost !== undefined &&
+    !site.isBurned &&
+    player.influencePoints >= healCost &&
+    woundsInHand > 0;
 
   // Check if can recruit (needs units in offer, site not burned)
   const canRecruit = state.offers.units.length > 0 && !site.isBurned;
@@ -345,7 +352,7 @@ function getInteractOptions(
     !player.hasMovedThisTurn;
 
   const result: InteractOptions = {
-    canHeal: healCost !== undefined && !site.isBurned,
+    canHeal,
     canRecruit,
     canBuySpells,
     canBuyAdvancedActions,

--- a/packages/core/src/engine/validators/registry/interactionRegistry.ts
+++ b/packages/core/src/engine/validators/registry/interactionRegistry.ts
@@ -4,7 +4,12 @@
  */
 
 import type { Validator } from "../types.js";
-import { INTERACT_ACTION, ENTER_SITE_ACTION, ALTAR_TRIBUTE_ACTION } from "@mage-knight/shared";
+import {
+  INTERACT_ACTION,
+  BUY_HEALING_ACTION,
+  ENTER_SITE_ACTION,
+  ALTAR_TRIBUTE_ACTION,
+} from "@mage-knight/shared";
 
 // Turn validators
 import {
@@ -46,6 +51,18 @@ import {
 
 export const interactionRegistry: Record<string, Validator[]> = {
   [INTERACT_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateNoPendingLevelUpRewards, // Must select level up rewards first
+    validateMustAnnounceEndOfRound, // Must announce if deck+hand empty
+    validateNotRestingForInteraction, // Cannot interact with sites while resting (FAQ S5)
+    validateHasNotActed,
+    validateAtInhabitedSite,
+    validateSiteAccessible,
+    validateHealingPurchase,
+  ],
+  [BUY_HEALING_ACTION]: [
     validateIsPlayersTurn,
     validateRoundPhase,
     validateNoChoicePending,

--- a/packages/core/src/engine/validators/routing/sites.ts
+++ b/packages/core/src/engine/validators/routing/sites.ts
@@ -5,6 +5,7 @@
 import type { ValidatorRegistry } from "./types.js";
 import {
   INTERACT_ACTION,
+  BUY_HEALING_ACTION,
   ENTER_SITE_ACTION,
   BUY_SPELL_ACTION,
   LEARN_ADVANCED_ACTION_ACTION,
@@ -73,6 +74,19 @@ import {
 
 export const siteValidatorRegistry: ValidatorRegistry = {
   [INTERACT_ACTION]: [
+    validateIsPlayersTurn,
+    validateRoundPhase,
+    validateNoChoicePending,
+    validateNoBlockingTacticDecisionPending, // Must resolve pending tactic decision first
+    validateNoPendingLevelUpRewards, // Must select level up rewards first
+    validateMustAnnounceEndOfRound, // Must announce if deck+hand empty
+    validateNotRestingForInteraction, // Cannot interact with sites while resting (FAQ S5)
+    validateHasNotActed,
+    validateAtInhabitedSite,
+    validateSiteAccessible,
+    validateHealingPurchase,
+  ],
+  [BUY_HEALING_ACTION]: [
     validateIsPlayersTurn,
     validateRoundPhase,
     validateNoChoicePending,


### PR DESCRIPTION
## Summary
- wire `BUY_HEALING` into core command factory routing so it no longer returns "Action not implemented"
- map `BUY_HEALING` to the same site-interaction validation pipeline as `INTERACT`
- enforce healing affordability in validation (including site cost + available influence)
- align site valid-actions so healing is only advertised when actually buyable now (enough influence + at least one wound in hand)
- add tests for both `BUY_HEALING` behavior and site valid-actions healing gating

## Files changed
- `packages/core/src/engine/commands/factories/sites.ts`
- `packages/core/src/engine/commands/factories/index.ts`
- `packages/core/src/engine/validators/interactValidators.ts`
- `packages/core/src/engine/validators/registry/interactionRegistry.ts`
- `packages/core/src/engine/validators/routing/sites.ts`
- `packages/core/src/engine/validActions/sites.ts`
- `packages/core/src/engine/__tests__/siteInteraction.test.ts`
- `packages/core/src/engine/__tests__/siteValidActions.test.ts`

## Validation
- Could not run full verification in this worktree because local tools/deps are missing in this environment (`@mage-knight/shared` resolution for isolated core test runs, `oxlint`, `bunup`).
