### PR TITLE
Fix sim deadlock after end-turn and add timeout diagnostics

### DIFF
--- a/packages/core/src/engine/__tests__/scenarioSystem.test.ts
+++ b/packages/core/src/engine/__tests__/scenarioSystem.test.ts
@@ -344,6 +344,34 @@ describe("Scenario System", () => {
         { playerId: "player1", score: 15 },
       ]);
     });
+
+    it("should end game when scenario total round limit is reached", () => {
+      let state = createGameStateWithTileDeck();
+
+      // Simulate reaching the configured round cap without scenario end trigger.
+      state = {
+        ...state,
+        round: state.scenarioConfig.totalRounds,
+        scenarioEndTriggered: false,
+        finalTurnsRemaining: null,
+        players: state.players.map(p => ({ ...p, fame: 12 })),
+      };
+
+      const endRoundCommand = createEndRoundCommand();
+      const result = endRoundCommand.execute(state);
+
+      expect(result.state.gameEnded).toBe(true);
+      expect(result.state.winningPlayerId).toBe("player1");
+
+      const roundEndEvent = result.events.find(e => e.type === ROUND_ENDED);
+      expect(roundEndEvent).toBeDefined();
+
+      const gameEndEvent = result.events.find(e => e.type === GAME_ENDED);
+      expect(gameEndEvent).toBeDefined();
+      expect(gameEndEvent?.type === GAME_ENDED && gameEndEvent.finalScores).toEqual([
+        { playerId: "player1", score: 12 },
+      ]);
+    });
   });
 
   describe("City entry restriction", () => {

--- a/packages/core/src/engine/commands/endRound/gameEnd.ts
+++ b/packages/core/src/engine/commands/endRound/gameEnd.ts
@@ -26,12 +26,16 @@ export function checkGameEnd(
   state: GameState,
   oldRound: number
 ): GameEndCheckResult {
-  // Check if we're in final turns (scenario end was triggered)
-  if (
-    !state.scenarioEndTriggered ||
-    state.finalTurnsRemaining === null ||
-    state.finalTurnsRemaining <= 0
-  ) {
+  const reachedRoundLimit = oldRound >= state.scenarioConfig.totalRounds;
+  const shouldEndFromFinalTurns =
+    state.scenarioEndTriggered &&
+    state.finalTurnsRemaining !== null &&
+    state.finalTurnsRemaining > 0;
+
+  // End conditions:
+  // 1. Round ended during final turns after scenario trigger.
+  // 2. Scenario round limit reached.
+  if (!shouldEndFromFinalTurns && !reachedRoundLimit) {
     return { gameEnded: false, events: [] };
   }
 

--- a/packages/python-sdk/src/mage_knight_sdk/sim/generated_action_enumerator.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/generated_action_enumerator.py
@@ -940,6 +940,23 @@ def _actions_normal_turn(state: dict[str, Any], valid_actions: dict[str, Any], p
             actions.append(CandidateAction({"type": ACTION_REROLL_SOURCE_DICE, "dieIds": [dice_ids[0]]}, "normal.tactic.reroll"))
 
     if turn is not None:
+        if bool(turn.get("canCompleteRest")):
+            rest_discard = _as_dict(turn.get("restDiscard"))
+            discardable = [card for card in _as_list(rest_discard.get("discardableCardIds") if rest_discard else None) if isinstance(card, str)]
+            if discardable:
+                actions.append(
+                    CandidateAction(
+                        {"type": ACTION_COMPLETE_REST, "discardCardIds": [discardable[0]]},
+                        "normal.turn.complete_rest.one",
+                    )
+                )
+            if bool(rest_discard.get("allowEmptyDiscard") if rest_discard else False):
+                actions.append(
+                    CandidateAction(
+                        {"type": ACTION_COMPLETE_REST, "discardCardIds": []},
+                        "normal.turn.complete_rest.empty",
+                    )
+                )
         if bool(turn.get("canDeclareRest")):
             actions.append(CandidateAction({"type": ACTION_DECLARE_REST}, "normal.turn.declare_rest"))
         if bool(turn.get("canEndTurn")):

--- a/packages/python-sdk/src/mage_knight_sdk/sim/reporting.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/reporting.py
@@ -39,6 +39,7 @@ class RunResult:
     steps: int
     game_id: str
     reason: str | None = None
+    timeout_debug: dict[str, Any] | None = None
     failure_artifact_path: str | None = None
 
 
@@ -89,5 +90,7 @@ def write_failure_artifact(
         "actionTrace": [asdict(entry) for entry in action_trace],
         "messageLog": [asdict(entry) for entry in message_log],
     }
+    if run_result.timeout_debug is not None:
+        payload["timeoutDebug"] = run_result.timeout_debug
     path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return str(path)

--- a/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
@@ -133,6 +133,12 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                         state_update_event, timeout_seconds=config.action_timeout_seconds
                     )
                 except TimeoutError:
+                    timeout_reason, timeout_debug = _build_timeout_diagnostics(
+                        base_reason="Timed out waiting for active player update",
+                        agents=agents,
+                        allow_undo=config.allow_undo,
+                        trace=trace,
+                    )
                     return _finish_run(
                         config=config,
                         run_index=run_index,
@@ -140,7 +146,8 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                         game_id=created.game_id,
                         outcome=OUTCOME_DISCONNECT,
                         steps=step,
-                        reason="Timed out waiting for active player update",
+                        reason=timeout_reason,
+                        timeout_debug=timeout_debug,
                         trace=trace,
                         messages=messages,
                     )
@@ -189,24 +196,11 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
             mode = _mode(state)
             all_candidates = enumerate_valid_actions(state, actor.session.player_id)
 
-            # If UNDO is disabled, filter it out and check for dead-end states
+            # If UNDO is disabled, filter it out. Some intermediate snapshots can
+            # briefly expose only UNDO while follow-up state updates are in flight.
+            # Treat this as temporarily non-actionable instead of an invariant failure.
             if not config.allow_undo:
                 non_undo_candidates = [c for c in all_candidates if c.action.get("type") != "UNDO"]
-
-                # If UNDO is the only option when it's disabled, that's an error state
-                if not non_undo_candidates and all_candidates:
-                    return _finish_run(
-                        config=config,
-                        run_index=run_index,
-                        seed=seed,
-                        game_id=created.game_id,
-                        outcome=OUTCOME_INVARIANT_FAILURE,
-                        steps=step,
-                        reason="UNDO was the only valid action available (dead-end state detected)",
-                        trace=trace,
-                        messages=messages,
-                    )
-
                 all_candidates = non_undo_candidates
 
             if not all_candidates:
@@ -215,6 +209,12 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                         state_update_event, timeout_seconds=config.action_timeout_seconds
                     )
                 except TimeoutError:
+                    timeout_reason, timeout_debug = _build_timeout_diagnostics(
+                        base_reason=f"Timed out waiting for actionable state (mode={mode})",
+                        agents=agents,
+                        allow_undo=config.allow_undo,
+                        trace=trace,
+                    )
                     return _finish_run(
                         config=config,
                         run_index=run_index,
@@ -222,7 +222,8 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                         game_id=created.game_id,
                         outcome=OUTCOME_DISCONNECT,
                         steps=step,
-                        reason=f"Timed out waiting for actionable state (mode={mode})",
+                        reason=timeout_reason,
+                        timeout_debug=timeout_debug,
                         trace=trace,
                         messages=messages,
                     )
@@ -270,6 +271,12 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                     timeout_seconds=config.action_timeout_seconds,
                 )
             except TimeoutError:
+                timeout_reason, timeout_debug = _build_timeout_diagnostics(
+                    base_reason=f"Timed out waiting for update after action {action_to_send['type']}",
+                    agents=agents,
+                    allow_undo=config.allow_undo,
+                    trace=trace,
+                )
                 return _finish_run(
                     config=config,
                     run_index=run_index,
@@ -277,7 +284,8 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                     game_id=created.game_id,
                     outcome=OUTCOME_DISCONNECT,
                     steps=step + 1,
-                    reason=f"Timed out waiting for update after action {action_to_send['type']}",
+                    reason=timeout_reason,
+                    timeout_debug=timeout_debug,
                     trace=trace,
                     messages=messages,
                 )
@@ -476,6 +484,7 @@ def _finish_run(
     reason: str | None,
     trace: list[ActionTraceEntry],
     messages: list[MessageLogEntry],
+    timeout_debug: dict[str, Any] | None = None,
 ) -> SimulationOutcome:
     run_result = RunResult(
         run_index=run_index,
@@ -484,6 +493,7 @@ def _finish_run(
         steps=steps,
         game_id=game_id,
         reason=reason,
+        timeout_debug=timeout_debug,
     )
 
     artifact_outcomes = {
@@ -505,6 +515,7 @@ def _finish_run(
             steps=run_result.steps,
             game_id=run_result.game_id,
             reason=run_result.reason,
+            timeout_debug=run_result.timeout_debug,
             failure_artifact_path=artifact_path,
         )
 
@@ -523,6 +534,106 @@ def _mode(state: dict[str, Any]) -> str:
 
 def _action_key(action: dict[str, Any]) -> str:
     return json.dumps(action, sort_keys=True, separators=(",", ":"))
+
+
+def _build_timeout_diagnostics(
+    base_reason: str,
+    agents: list[AgentRuntime],
+    allow_undo: bool,
+    trace: list[ActionTraceEntry],
+) -> tuple[str, dict[str, Any]]:
+    last_trace = trace[-1] if trace else None
+    last_action_debug: dict[str, Any] | None = None
+    if last_trace is not None:
+        last_action_debug = {
+            "step": last_trace.step,
+            "playerId": last_trace.player_id,
+            "mode": last_trace.mode,
+            "actionType": str(last_trace.action.get("type")),
+            "source": last_trace.source,
+        }
+
+    player_snapshots = [_runtime_timeout_snapshot(agent, allow_undo) for agent in agents]
+    timeout_debug = {
+        "baseReason": base_reason,
+        "lastAction": last_action_debug,
+        "players": player_snapshots,
+    }
+
+    if last_action_debug is None:
+        last_action_fragment = "none"
+    else:
+        last_action_fragment = (
+            f"step={last_action_debug['step']},player={last_action_debug['playerId']},"
+            f"mode={last_action_debug['mode']},action={last_action_debug['actionType']}"
+        )
+
+    player_fragments = [_format_timeout_player_snapshot(snapshot) for snapshot in player_snapshots]
+    players_fragment = " || ".join(player_fragments) if player_fragments else "none"
+    return (
+        f"{base_reason}; last_action={last_action_fragment}; players={players_fragment}",
+        timeout_debug,
+    )
+
+
+def _runtime_timeout_snapshot(runtime: AgentRuntime, allow_undo: bool) -> dict[str, Any]:
+    state = runtime.latest_state
+    if state is None:
+        return {
+            "playerId": runtime.session.player_id,
+            "state": "missing",
+            "messageVersion": runtime.message_version,
+            "lastError": runtime.last_error_message,
+            "invariantError": runtime.invariant_error,
+        }
+
+    mode = _mode(state)
+    current_player_id = state.get("currentPlayerId")
+    valid_actions = state.get("validActions")
+    turn = valid_actions.get("turn") if isinstance(valid_actions, dict) else None
+    turn_flags = "none"
+    if isinstance(turn, dict):
+        turn_flags = (
+            f"undo={bool(turn.get('canUndo'))},end={bool(turn.get('canEndTurn'))},"
+            f"declare_rest={bool(turn.get('canDeclareRest'))},complete_rest={bool(turn.get('canCompleteRest'))},"
+            f"rest={bool(turn.get('canRest'))},announce={bool(turn.get('canAnnounceEndOfRound'))}"
+        )
+
+    all_candidates = enumerate_valid_actions(state, runtime.session.player_id)
+    non_undo_candidates = [c for c in all_candidates if c.action.get("type") != "UNDO"]
+    effective_candidates = all_candidates if allow_undo else non_undo_candidates
+    candidate_types = sorted({str(c.action.get("type", "?")) for c in effective_candidates})
+    return {
+        "playerId": runtime.session.player_id,
+        "state": "present",
+        "mode": mode,
+        "currentPlayerId": current_player_id,
+        "messageVersion": runtime.message_version,
+        "rawActionCount": len(all_candidates),
+        "effectiveActionCount": len(effective_candidates),
+        "effectiveActionTypes": candidate_types,
+        "turnFlags": turn_flags,
+        "lastError": runtime.last_error_message,
+        "invariantError": runtime.invariant_error,
+    }
+
+
+def _format_timeout_player_snapshot(snapshot: dict[str, Any]) -> str:
+    if snapshot.get("state") == "missing":
+        return (
+            f"{snapshot['playerId']}:state=missing,msg_version={snapshot['messageVersion']},"
+            f"last_error={snapshot.get('lastError')},invariant={snapshot.get('invariantError')}"
+        )
+
+    candidate_types = snapshot.get("effectiveActionTypes")
+    candidate_preview = ",".join(candidate_types[:6]) if isinstance(candidate_types, list) and candidate_types else "none"
+    return (
+        f"{snapshot['playerId']}:mode={snapshot.get('mode')},current={snapshot.get('currentPlayerId')},"
+        f"msg_version={snapshot.get('messageVersion')},raw_actions={snapshot.get('rawActionCount')},"
+        f"effective_actions={snapshot.get('effectiveActionCount')},types={candidate_preview},"
+        f"turn={snapshot.get('turnFlags')},last_error={snapshot.get('lastError')},"
+        f"invariant={snapshot.get('invariantError')}"
+    )
 
 
 def run_simulations_sync(config: RunnerConfig) -> tuple[list[RunResult], RunSummary]:

--- a/packages/python-sdk/tests/test_sim_random_policy.py
+++ b/packages/python-sdk/tests/test_sim_random_policy.py
@@ -67,6 +67,32 @@ class RandomPolicyTest(unittest.TestCase):
             tactic_actions[0],
         )
 
+    def test_enumerate_valid_actions_includes_complete_rest(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": True,
+                    "canDeclareRest": False,
+                    "canCompleteRest": True,
+                    "restDiscard": {
+                        "allowEmptyDiscard": False,
+                        "discardableCardIds": ["march"],
+                        "restType": "standard",
+                    },
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        complete_rest_actions = [a.action for a in actions if a.action.get("type") == "COMPLETE_REST"]
+
+        self.assertEqual(1, len(complete_rest_actions))
+        self.assertEqual(["march"], complete_rest_actions[0]["discardCardIds"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/server/src/stateFilters.ts
+++ b/packages/server/src/stateFilters.ts
@@ -31,6 +31,7 @@ import type {
   ClientRuinsToken,
   ClientDummyPlayer,
 } from "@mage-knight/shared";
+import { ROUND_PHASE_TACTICS_SELECTION } from "@mage-knight/shared";
 
 /**
  * Convert full GameState to ClientGameState for a specific player.
@@ -40,12 +41,17 @@ export function toClientState(
   state: GameState,
   forPlayerId: string
 ): ClientGameState {
+  const currentPlayerId =
+    state.roundPhase === ROUND_PHASE_TACTICS_SELECTION
+      ? (state.currentTacticSelector ?? "")
+      : (state.turnOrder[state.currentPlayerIndex] ?? "");
+
   return {
     phase: state.phase,
     roundPhase: state.roundPhase,
     timeOfDay: state.timeOfDay,
     round: state.round,
-    currentPlayerId: state.turnOrder[state.currentPlayerIndex] ?? "",
+    currentPlayerId,
     turnOrder: state.turnOrder,
     endOfRoundAnnouncedBy: state.endOfRoundAnnouncedBy,
 


### PR DESCRIPTION
## Summary
- fix end-round termination to end the game when the scenario round cap is reached (prevents entering tactics selection with no available tactics)
- improve client state filtering so `currentPlayerId` reflects `currentTacticSelector` during tactics selection
- add richer simulator timeout diagnostics and include structured `timeoutDebug` in failure artifacts
- enumerate `COMPLETE_REST` actions from `validActions.turn` so no-undo runs can progress through rest completion

## Validation
- `bun test packages/core/src/engine/__tests__/scenarioSystem.test.ts`
- `bun test packages/server/src/__tests__/stateFilters.test.ts`
- `pytest packages/python-sdk/tests/test_sim_random_policy.py -q`
- `python3 packages/python-sdk/run_full_game.py --no-undo --seed 3` (verified timeout diagnostics + artifact `timeoutDebug`)
