### PR TITLE
Fix end-turn loop after GAME_ENDED and harden sim terminal detection

### DIFF
--- a/packages/core/src/engine/__tests__/scenarioSystem.test.ts
+++ b/packages/core/src/engine/__tests__/scenarioSystem.test.ts
@@ -27,6 +27,7 @@ import {
   ROUND_ENDED,
   MOVE_ACTION,
   GAME_PHASE_ROUND,
+  GAME_PHASE_END,
   hexKey,
   type CardId,
   MAP_SHAPE_WEDGE,
@@ -301,6 +302,7 @@ describe("Scenario System", () => {
 
       expect(result.state.finalTurnsRemaining).toBe(0);
       expect(result.state.gameEnded).toBe(true);
+      expect(result.state.phase).toBe(GAME_PHASE_END);
       expect(result.state.winningPlayerId).toBe("player1");
 
       // Check for game ended event
@@ -330,6 +332,7 @@ describe("Scenario System", () => {
 
       // Game should end immediately
       expect(result.state.gameEnded).toBe(true);
+      expect(result.state.phase).toBe(GAME_PHASE_END);
       expect(result.state.finalTurnsRemaining).toBe(0);
       expect(result.state.winningPlayerId).toBe("player1");
 
@@ -361,6 +364,7 @@ describe("Scenario System", () => {
       const result = endRoundCommand.execute(state);
 
       expect(result.state.gameEnded).toBe(true);
+      expect(result.state.phase).toBe(GAME_PHASE_END);
       expect(result.state.winningPlayerId).toBe("player1");
 
       const roundEndEvent = result.events.find(e => e.type === ROUND_ENDED);

--- a/packages/core/src/engine/commands/endRound/gameEnd.ts
+++ b/packages/core/src/engine/commands/endRound/gameEnd.ts
@@ -11,7 +11,7 @@
 
 import type { GameState } from "../../../state/GameState.js";
 import type { GameEvent } from "@mage-knight/shared";
-import { ROUND_ENDED, GAME_ENDED } from "@mage-knight/shared";
+import { ROUND_ENDED, GAME_ENDED, GAME_PHASE_END } from "@mage-knight/shared";
 import {
   calculateFinalScores,
   createDefaultScoringConfig,
@@ -75,6 +75,7 @@ export function checkGameEnd(
     gameEnded: true,
     events,
     state: {
+      phase: GAME_PHASE_END,
       finalTurnsRemaining: 0,
       gameEnded: true,
       winningPlayerId,

--- a/packages/core/src/engine/commands/endTurn/index.ts
+++ b/packages/core/src/engine/commands/endTurn/index.ts
@@ -17,7 +17,7 @@ import type { GameState } from "../../../state/GameState.js";
 import type { Player } from "../../../types/player.js";
 import type { SourceDieId } from "../../../types/mana.js";
 import type { GameEvent } from "@mage-knight/shared";
-import { TURN_ENDED, GAME_ENDED } from "@mage-knight/shared";
+import { TURN_ENDED, GAME_ENDED, GAME_PHASE_END } from "@mage-knight/shared";
 import { expireModifiers } from "../../modifiers/index.js";
 import { EXPIRATION_TURN_END } from "../../../types/modifierConstants.js";
 import { END_TURN_COMMAND } from "../commandTypes.js";
@@ -431,6 +431,7 @@ export function createEndTurnCommand(params: EndTurnCommandParams): Command {
 
         newState = {
           ...newState,
+          phase: GAME_PHASE_END,
           gameEnded: true,
           winningPlayerId,
         };

--- a/packages/python-sdk/src/mage_knight_sdk/sim/invariants.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/invariants.py
@@ -5,6 +5,7 @@ from typing import Any
 
 
 INVALID_ACTION_EVENT = "INVALID_ACTION"
+GAME_ENDED_EVENT = "GAME_ENDED"
 PHASE_END = "end"
 
 
@@ -59,3 +60,10 @@ def assert_action_not_rejected(events: list[Any], action_type: str, player_id: s
 
 def is_terminal_state(state: dict[str, Any]) -> bool:
     return state.get("phase") == PHASE_END
+
+
+def is_terminal_events(events: list[Any]) -> bool:
+    for event in events:
+        if isinstance(event, dict) and event.get("type") == GAME_ENDED_EVENT:
+            return True
+    return False

--- a/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/runner.py
@@ -11,7 +11,13 @@ from mage_knight_sdk.client import MageKnightClient
 from mage_knight_sdk.protocol_models import ErrorMessage, StateUpdateMessage
 
 from .bootstrap import BootstrapSession, create_game, join_game
-from .invariants import InvariantViolation, StateInvariantTracker, assert_action_not_rejected, is_terminal_state
+from .invariants import (
+    InvariantViolation,
+    StateInvariantTracker,
+    assert_action_not_rejected,
+    is_terminal_events,
+    is_terminal_state,
+)
 from .random_policy import CandidateAction, RandomValidActionPolicy, enumerate_valid_actions
 from .reporting import (
     ActionTraceEntry,
@@ -335,7 +341,11 @@ async def _run_single_simulation(run_index: int, seed: int, config: RunnerConfig
                         messages=messages,
                     )
 
-            if any(agent.latest_state is not None and is_terminal_state(agent.latest_state) for agent in agents):
+            if any(
+                (agent.latest_state is not None and is_terminal_state(agent.latest_state))
+                or is_terminal_events(agent.last_events or [])
+                for agent in agents
+            ):
                 return _finish_run(
                     config=config,
                     run_index=run_index,


### PR DESCRIPTION
## Root cause
The repeated `END_TURN` loop is not Long Night itself. In the reproduced trace, `TURN_ENDED.nextPlayerId` becomes `null` repeatedly, which means round-end handling is being reached. However, some game-end paths left `phase` as `round`, so clients/sim still saw actionable `END_TURN` states and continued indefinitely.

## Changes
- set `phase = end` in both game-end paths:
  - end-round game end (`checkGameEnd`)
  - direct end-turn game end when final turns hit zero
- harden simulator terminal detection:
  - treat `GAME_ENDED` events as terminal even if state phase is not `end`

## Files
- `packages/core/src/engine/commands/endRound/gameEnd.ts`
- `packages/core/src/engine/commands/endTurn/index.ts`
- `packages/core/src/engine/__tests__/scenarioSystem.test.ts`
- `packages/python-sdk/src/mage_knight_sdk/sim/invariants.py`
- `packages/python-sdk/src/mage_knight_sdk/sim/runner.py`

## Validation
- `bun test packages/core/src/engine/__tests__/scenarioSystem.test.ts`
- `pytest packages/python-sdk/tests/test_sim_random_policy.py -q`
- Reproduced and analyzed seed trace showing repeated `TURN_ENDED -> nextPlayerId: null`
