### PR TITLE
Fix resting deadlock in no-undo sim runs

### DIFF
--- a/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
+++ b/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
@@ -55,6 +55,18 @@ describe("Turn end options", () => {
     }
   });
 
+  it("keeps complete rest available while resting even when deck+hand are empty", () => {
+    const player = createTestPlayer({
+      isResting: true,
+      deck: [],
+      hand: [],
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const turnOptions = getTurnOptions(state, player);
+    expect(turnOptions.canCompleteRest).toBe(true);
+  });
+
   it("disables end turn when minimum turn requirement not met", () => {
     const player = createTestPlayer({
       hand: [CARD_MARCH],

--- a/packages/core/src/engine/__tests__/rest.test.ts
+++ b/packages/core/src/engine/__tests__/rest.test.ts
@@ -623,6 +623,7 @@ describe("Two-Phase REST (DECLARE_REST + COMPLETE_REST)", () => {
       // Per FAQ Q2 A2: If you heal all wounds during rest, Slow Recovery with no discard is valid
       const player = createTestPlayer({
         hand: [],
+        deck: [],
         discard: [],
         isResting: true,
         hasTakenActionThisTurn: true,

--- a/packages/core/src/engine/validActions/turn.ts
+++ b/packages/core/src/engine/validActions/turn.ts
@@ -27,7 +27,7 @@ import {
 export function getTurnOptions(state: GameState, player: Player): TurnOptions {
   const mustAnnounce = mustAnnounceEndOfRound(state, player);
   const canDeclareRestOption = canDeclareRest(state, player);
-  const canCompleteRestOption = canCompleteRest(player) && !mustAnnounce;
+  const canCompleteRestOption = canCompleteRest(player);
 
   return {
     canEndTurn: canEndTurn(state, player),
@@ -62,4 +62,3 @@ function checkCanAnnounceEndOfRound(state: GameState, player: Player): boolean {
 
   return true;
 }
-

--- a/packages/core/src/engine/validActions/turn.ts
+++ b/packages/core/src/engine/validActions/turn.ts
@@ -12,7 +12,6 @@ import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
 import type { TurnOptions } from "@mage-knight/shared";
 import { canUndo } from "../commands/stack.js";
-import { mustAnnounceEndOfRound } from "./helpers.js";
 import {
   getAvailableRestTypes,
   canDeclareRest,
@@ -25,7 +24,6 @@ import {
  * Get available turn options for a player.
  */
 export function getTurnOptions(state: GameState, player: Player): TurnOptions {
-  const mustAnnounce = mustAnnounceEndOfRound(state, player);
   const canDeclareRestOption = canDeclareRest(state, player);
   const canCompleteRestOption = canCompleteRest(player);
 

--- a/packages/core/src/engine/validators/roundValidators.ts
+++ b/packages/core/src/engine/validators/roundValidators.ts
@@ -81,6 +81,12 @@ export function validateMustAnnounceEndOfRound(
   const player = getPlayerById(state, playerId);
   if (!player) return invalid(PLAYER_NOT_FOUND, "Player not found");
 
+  // While resting, the player must be able to resolve COMPLETE_REST first.
+  // Announce/forfeit enforcement applies after the resting flow is completed.
+  if (player.isResting) {
+    return valid();
+  }
+
   if (mustAnnounceEndOfRoundAtTurnStart(state, player)) {
     return invalid(
       MUST_ANNOUNCE_END_OF_ROUND,


### PR DESCRIPTION
## Summary
Fixes a dead-end state where `--no-undo` fuzz runs could stall in `normal_turn` with only `UNDO` available while the player was resting.

Root cause:
- `getTurnOptions` suppressed `canCompleteRest` when `mustAnnounceEndOfRound` was true.
- `validateMustAnnounceEndOfRound` also blocked actions while `isResting=true`.
- In `isResting + deck=[] + hand=[]`, this prevented `COMPLETE_REST`, leaving no forward progress except `UNDO`.

## Changes
- `packages/core/src/engine/validActions/turn.ts`
  - always allow `canCompleteRest` when `canCompleteRest(player)` is true
- `packages/core/src/engine/validators/roundValidators.ts`
  - skip announce/forfeit enforcement while the player is in resting state
- tests:
  - `packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts`
  - `packages/core/src/engine/__tests__/rest.test.ts`

## Validation
- `bun test packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts packages/core/src/engine/__tests__/rest.test.ts`
- End-to-end sim against fresh built server (`seed=2`, `--no-undo`):
  - before: disconnect at step 47 (`Timed out waiting for actionable state`)
  - after: `outcome=ended`, `steps=188`
