### PR TITLE
fix: resolve seed-5 rest deadlocks in fuzzer and turn rules

### DIFF
--- a/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
+++ b/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
@@ -85,4 +85,20 @@ describe("Turn end options", () => {
       expect(validation.error.code).toBe(MUST_PLAY_OR_DISCARD_CARD);
     }
   });
+
+  it("allows end turn when hand has only wounds and no card was played", () => {
+    const player = createTestPlayer({
+      hand: ["wound"],
+      playedCardFromHandThisTurn: false,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const turnOptions = getTurnOptions(state, player);
+    expect(turnOptions.canEndTurn).toBe(true);
+
+    const validation = validateMinimumTurnRequirement(state, player.id, {
+      type: END_TURN_ACTION,
+    });
+    expect(validation.valid).toBe(true);
+  });
 });

--- a/packages/core/src/engine/rules/turnStructure.ts
+++ b/packages/core/src/engine/rules/turnStructure.ts
@@ -201,8 +201,9 @@ export function canEndTurn(state: GameState, player: Player): boolean {
     return false;
   }
 
-  // Must play or discard at least one card from hand if any are held
-  if (player.hand.length > 0 && !player.playedCardFromHandThisTurn) {
+  // Must satisfy minimum turn requirement before ending turn.
+  // This is waived when hand is empty or contains only wounds.
+  if (!hasMetMinimumTurnRequirement(player)) {
     return false;
   }
 
@@ -225,6 +226,12 @@ export function hasMetMinimumTurnRequirement(player: Player): boolean {
 
   // If player already played or discarded a card from hand, requirement is satisfied
   if (player.playedCardFromHandThisTurn) {
+    return true;
+  }
+
+  // If hand contains only wounds, requirement is waived.
+  // Wounds cannot be played and there is no generic "discard one card" action.
+  if (player.hand.every((cardId) => isWoundCard(cardId))) {
     return true;
   }
 

--- a/packages/python-sdk/tests/test_sim_random_policy.py
+++ b/packages/python-sdk/tests/test_sim_random_policy.py
@@ -93,6 +93,32 @@ class RandomPolicyTest(unittest.TestCase):
         self.assertEqual(1, len(complete_rest_actions))
         self.assertEqual(["march"], complete_rest_actions[0]["discardCardIds"])
 
+    def test_enumerate_valid_actions_complete_rest_standard_picks_non_wound(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": True,
+                    "canDeclareRest": False,
+                    "canCompleteRest": True,
+                    "restDiscard": {
+                        "allowEmptyDiscard": False,
+                        "discardableCardIds": ["wound", "rage"],
+                        "restType": "standard",
+                    },
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        complete_rest_actions = [a.action for a in actions if a.action.get("type") == "COMPLETE_REST"]
+
+        self.assertEqual(1, len(complete_rest_actions))
+        self.assertEqual(["rage"], complete_rest_actions[0]["discardCardIds"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix Python sim COMPLETE_REST payload generation to respect advertised rest constraints
- fix core minimum-turn logic to allow END_TURN when hand contains only wounds
- add regression tests for both behaviors

## Validation
- bun run lint
- bun test packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts packages/core/src/engine/__tests__/rest.test.ts
- python3 -m unittest packages/python-sdk/tests/test_sim_random_policy.py
- python3 packages/python-sdk/run_full_game.py --no-undo --seed 5
  - no longer fails at step 87 or disconnects at step 222
  - now reaches max_steps (separate looping behavior)
