### PR TITLE
Fix rest->challenge action leak and centralize challenge rules

### DIFF
--- a/packages/core/src/engine/__tests__/restingValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/restingValidActions.test.ts
@@ -95,6 +95,42 @@ describe("Valid actions while resting", () => {
     expect(getChallengeOptions(restingState, restingPlayer)).toBeUndefined();
   });
 
+  it("hides challenge options after action is consumed", () => {
+    const enemyToken = createEnemyTokenId(ENEMY_DIGGERS);
+    const rampagingHex: HexState = {
+      ...createTestHex(1, 0, TERRAIN_PLAINS),
+      rampagingEnemies: [RampagingEnemyType.OrcMarauder],
+      enemies: [createHexEnemy(enemyToken)],
+    };
+
+    const activePlayer = createTestPlayer({
+      movePoints: 4,
+      isResting: false,
+      hasTakenActionThisTurn: false,
+    });
+    const baseState = createTestGameState({ players: [activePlayer] });
+    const activeState = {
+      ...baseState,
+      map: {
+        ...baseState.map,
+        hexes: {
+          ...baseState.map.hexes,
+          [hexKey({ q: 1, r: 0 })]: rampagingHex,
+        },
+      },
+    };
+
+    expect(getChallengeOptions(activeState, activePlayer)).toBeDefined();
+
+    const actedPlayer = { ...activePlayer, hasTakenActionThisTurn: true };
+    const actedState = {
+      ...activeState,
+      players: [actedPlayer],
+    };
+
+    expect(getChallengeOptions(actedState, actedPlayer)).toBeUndefined();
+  });
+
   it("blocks site interaction options while resting", () => {
     const monasterySite: Site = {
       type: SiteType.Monastery,

--- a/packages/core/src/engine/rules/challenge.ts
+++ b/packages/core/src/engine/rules/challenge.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared rampaging challenge rules.
+ *
+ * These helpers are used by both validators and ValidActions computation
+ * to prevent rule drift.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { HexCoord } from "@mage-knight/shared";
+import { getAllNeighbors, hexKey } from "@mage-knight/shared";
+
+/**
+ * Check whether a player can initiate challenge flow this turn.
+ * This does not include "must announce end of round" gating, which is handled
+ * in higher-level turn validators/valid-actions helpers.
+ */
+export function canChallengeRampaging(
+  state: GameState,
+  player: Player
+): boolean {
+  if (!player.position) {
+    return false;
+  }
+
+  if (player.isResting) {
+    return false;
+  }
+
+  if (player.hasTakenActionThisTurn) {
+    return false;
+  }
+
+  if (state.combat !== null) {
+    return false;
+  }
+
+  if (player.hasCombattedThisTurn) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Check if two coordinates are adjacent on the hex grid.
+ */
+export function isChallengeTargetAdjacent(
+  source: HexCoord,
+  target: HexCoord
+): boolean {
+  const dq = target.q - source.q;
+  const dr = target.r - source.r;
+
+  const adjacentOffsets = [
+    { q: 1, r: 0 },
+    { q: 1, r: -1 },
+    { q: 0, r: -1 },
+    { q: -1, r: 0 },
+    { q: -1, r: 1 },
+    { q: 0, r: 1 },
+  ];
+
+  return adjacentOffsets.some((offset) => offset.q === dq && offset.r === dr);
+}
+
+/**
+ * Check if a hex contains challengeable rampaging enemies.
+ */
+export function hasChallengeableRampagingEnemiesAtHex(
+  state: GameState,
+  targetHex: HexCoord
+): boolean {
+  const hex = state.map.hexes[hexKey(targetHex)];
+  if (!hex) {
+    return false;
+  }
+
+  return hex.rampagingEnemies.length > 0 && hex.enemies.length > 0;
+}
+
+/**
+ * Get all adjacent rampaging-enemy hexes the player can currently challenge.
+ */
+export function getChallengeableRampagingHexes(
+  state: GameState,
+  player: Player
+): HexCoord[] {
+  if (!canChallengeRampaging(state, player) || !player.position) {
+    return [];
+  }
+
+  const neighbors = getAllNeighbors(player.position);
+  const targetHexes: HexCoord[] = [];
+
+  for (const neighbor of neighbors) {
+    if (hasChallengeableRampagingEnemiesAtHex(state, neighbor)) {
+      targetHexes.push(neighbor);
+    }
+  }
+
+  return targetHexes;
+}

--- a/packages/core/src/engine/validActions/challenge.ts
+++ b/packages/core/src/engine/validActions/challenge.ts
@@ -40,6 +40,11 @@ export function getChallengeOptions(
     return undefined;
   }
 
+  // Challenge is an action-phase activity; cannot do it after resting/interacting/etc.
+  if (player.hasTakenActionThisTurn) {
+    return undefined;
+  }
+
   // Can't challenge if already in combat
   if (isInCombat(state)) {
     return undefined;

--- a/packages/core/src/engine/validActions/challenge.ts
+++ b/packages/core/src/engine/validActions/challenge.ts
@@ -7,9 +7,9 @@
 
 import type { GameState } from "../../state/GameState.js";
 import type { Player } from "../../types/player.js";
-import type { ChallengeOptions, HexCoord } from "@mage-knight/shared";
-import { getAllNeighbors, hexKey } from "@mage-knight/shared";
-import { isInCombat, mustAnnounceEndOfRound } from "./helpers.js";
+import type { ChallengeOptions } from "@mage-knight/shared";
+import { mustAnnounceEndOfRound } from "./helpers.js";
+import { getChallengeableRampagingHexes } from "../rules/challenge.js";
 
 /**
  * Get challenge options for a player.
@@ -25,54 +25,12 @@ export function getChallengeOptions(
   state: GameState,
   player: Player
 ): ChallengeOptions | undefined {
-  // Must be on the map
-  if (!player.position) {
-    return undefined;
-  }
-
   // Must announce end of round before taking other actions
   if (mustAnnounceEndOfRound(state, player)) {
     return undefined;
   }
 
-  // Can't challenge while resting
-  if (player.isResting) {
-    return undefined;
-  }
-
-  // Challenge is an action-phase activity; cannot do it after resting/interacting/etc.
-  if (player.hasTakenActionThisTurn) {
-    return undefined;
-  }
-
-  // Can't challenge if already in combat
-  if (isInCombat(state)) {
-    return undefined;
-  }
-
-  // Can't challenge if already fought this turn (one combat per turn rule)
-  if (player.hasCombattedThisTurn) {
-    return undefined;
-  }
-
-  // Find adjacent hexes with rampaging enemies
-  const targetHexes: HexCoord[] = [];
-  const neighbors = getAllNeighbors(player.position);
-
-  for (const neighborCoord of neighbors) {
-    const key = hexKey(neighborCoord);
-    const hex = state.map.hexes[key];
-
-    // Skip if hex doesn't exist
-    if (!hex) continue;
-
-    // Check if hex has rampaging enemies that can be challenged
-    // rampagingEnemies array indicates enemies that ARRIVED as rampaging (can be challenged)
-    // enemies array contains the actual enemy tokens to fight
-    if (hex.rampagingEnemies.length > 0 && hex.enemies.length > 0) {
-      targetHexes.push(neighborCoord);
-    }
-  }
+  const targetHexes = getChallengeableRampagingHexes(state, player);
 
   // Return undefined if no valid targets
   if (targetHexes.length === 0) {

--- a/packages/core/src/engine/validators/registry/combatRegistry.ts
+++ b/packages/core/src/engine/validators/registry/combatRegistry.ts
@@ -33,6 +33,7 @@ import {
 import {
   validateIsPlayersTurn,
   validateRoundPhase,
+  validateHasNotActed,
 } from "../turnValidators.js";
 
 // Choice validators
@@ -139,6 +140,7 @@ export const combatRegistry: Record<string, Validator[]> = {
     validateNoChoicePending,
     validateMustAnnounceEndOfRound, // Must announce if deck+hand empty
     validateNotRestingForCombat, // Cannot challenge while resting (FAQ S3)
+    validateHasNotActed, // Challenge uses action phase
     validateChallengePlayerOnMap,
     validateChallengeNotInCombat, // Can't challenge while in combat
     validateNoCombatThisTurn, // One combat per turn rule

--- a/packages/core/src/engine/validators/routing/combat.ts
+++ b/packages/core/src/engine/validators/routing/combat.ts
@@ -19,6 +19,7 @@ import {
 import {
   validateIsPlayersTurn,
   validateRoundPhase,
+  validateHasNotActed,
 } from "../turnValidators.js";
 
 import {
@@ -100,6 +101,7 @@ export const combatValidatorRegistry: ValidatorRegistry = {
     validateNoBlockingTacticDecisionPending, // Must resolve pending tactic decision first
     validateMustAnnounceEndOfRound, // Must announce if deck+hand empty
     validateNotRestingForCombat, // Cannot challenge while resting (FAQ S3)
+    validateHasNotActed, // Challenge consumes action phase; disallow after rest/other action
     validateChallengeNotInCombat,
     validateNoCombatThisTurn,
     validateChallengePlayerOnMap,


### PR DESCRIPTION
## Summary
- block CHALLENGE_RAMPAGING after an action is consumed (including DECLARE_REST + COMPLETE_REST in the same turn)
- align valid actions so challenge options are hidden after action consumption
- centralize rampaging challenge logic in core/src/engine/rules/challenge.ts and reuse it from validators/validActions to keep rules as single source of truth

## Tests
- bun test src/engine/__tests__/restingValidActions.test.ts src/engine/__tests__/combatPositionValidation.test.ts (from packages/core)
- bun run --filter @mage-knight/core test

Closes #38
