### PR TITLE
fix: advertise constrained reroll dice and gate interact after acting

### DIFF
--- a/packages/core/src/engine/__tests__/siteValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/siteValidActions.test.ts
@@ -73,4 +73,16 @@ describe("Site valid actions", () => {
     expect(options?.interactOptions?.canHeal).toBe(false);
     expect(options?.interactOptions?.healCost).toBe(3);
   });
+
+  it("does not advertise interact after player has taken action", () => {
+    const state = createStateAtVillage(6);
+    const player = {
+      ...state.players[0],
+      hasTakenActionThisTurn: true,
+    };
+    const options = getSiteOptions(state, player);
+
+    expect(options?.canInteract).toBe(false);
+    expect(options?.interactOptions).toBeUndefined();
+  });
 });

--- a/packages/core/src/engine/__tests__/tactics.test.ts
+++ b/packages/core/src/engine/__tests__/tactics.test.ts
@@ -9,6 +9,7 @@ import {
   TACTIC_PLANNING,
   TACTIC_FROM_THE_DUSK,
   TACTIC_MANA_STEAL,
+  TACTIC_MANA_SEARCH,
   TACTIC_RETHINK,
   TACTIC_MIDNIGHT_MEDITATION,
   TACTIC_SELECTED,
@@ -19,6 +20,7 @@ import {
   ALL_DAY_TACTICS,
   MANA_RED,
   MANA_BLUE,
+  MANA_GOLD,
   TACTIC_DECISION_RETHINK,
   TACTIC_DECISION_MIDNIGHT_MEDITATION,
   DECLARE_REST_ACTION,
@@ -591,6 +593,36 @@ describe("Tactics Selection", () => {
         "march",
         "swiftness",
         "rage",
+      ]);
+    });
+
+    it("advertises requiredFirstDiceIds for Mana Search reroll constraints", () => {
+      const baseState = createTacticsSelectionState(["player1"], "night");
+      const state = {
+        ...baseState,
+        roundPhase: ROUND_PHASE_PLAYER_TURNS,
+        players: baseState.players.map((p) =>
+          p.id === "player1"
+            ? {
+                ...p,
+                selectedTactic: TACTIC_MANA_SEARCH,
+              }
+            : p
+        ),
+        source: {
+          ...baseState.source,
+          dice: [
+            { id: "die_0", color: MANA_BLUE, isDepleted: false, takenByPlayerId: null },
+            { id: "die_1", color: MANA_GOLD, isDepleted: true, takenByPlayerId: null },
+          ],
+        },
+      };
+
+      const validActions = getValidActions(state, "player1");
+      expect(validActions.mode).toBe("normal_turn");
+      expect(validActions.tacticEffects?.canRerollSourceDice?.mustPickDepletedFirst).toBe(true);
+      expect(validActions.tacticEffects?.canRerollSourceDice?.requiredFirstDiceIds).toEqual([
+        "die_1",
       ]);
     });
 

--- a/packages/core/src/engine/rules/tactics.ts
+++ b/packages/core/src/engine/rules/tactics.ts
@@ -13,7 +13,10 @@ import {
   TACTIC_LONG_NIGHT,
   TACTIC_MIDNIGHT_MEDITATION,
   TACTIC_SPARING_POWER,
+  TACTIC_MANA_SEARCH,
+  MANA_GOLD,
 } from "@mage-knight/shared";
+import type { SourceDie } from "../../types/mana.js";
 
 /**
  * The Right Moment (Day 6):
@@ -127,4 +130,39 @@ export function getTacticActivationFailureReason(
   }
 
   return null;
+}
+
+/**
+ * Get source dice available to Mana Search for this player.
+ */
+export function getManaSearchAvailableDice(
+  state: GameState,
+  player: Player
+): readonly SourceDie[] {
+  return state.source.dice.filter(
+    (d) => d.takenByPlayerId === null || d.takenByPlayerId === player.id
+  );
+}
+
+/**
+ * Get the constrained subset for Mana Search when gold/depleted dice must be rerolled first.
+ */
+export function getManaSearchRequiredFirstDiceIds(
+  state: GameState,
+  player: Player
+): readonly string[] {
+  return getManaSearchAvailableDice(state, player)
+    .filter((d) => d.isDepleted || d.color === MANA_GOLD)
+    .map((d) => d.id);
+}
+
+/**
+ * Check if the player can currently use Mana Search.
+ */
+export function canUseManaSearch(state: GameState, player: Player): boolean {
+  return (
+    player.selectedTactic === TACTIC_MANA_SEARCH &&
+    !player.tacticState?.manaSearchUsedThisTurn &&
+    !player.usedManaFromSource
+  );
 }

--- a/packages/core/src/engine/rules/turnStructure.ts
+++ b/packages/core/src/engine/rules/turnStructure.ts
@@ -99,6 +99,16 @@ export function canDeclareRest(state: GameState, player: Player): boolean {
 }
 
 /**
+ * Check if the player can still take an action-phase action this turn.
+ *
+ * Action-phase actions are gated by whether the player has already consumed
+ * their action for the turn.
+ */
+export function canTakeActionPhaseAction(player: Player): boolean {
+  return !player.hasTakenActionThisTurn;
+}
+
+/**
  * Check if player can complete rest (discard cards to finish resting).
  *
  * Requirements:

--- a/packages/core/src/engine/validActions/sites.ts
+++ b/packages/core/src/engine/validActions/sites.ts
@@ -29,6 +29,7 @@ import {
   hasCombatRestrictions,
   canEnterAdventureSite,
 } from "../rules/siteInteraction.js";
+import { canTakeActionPhaseAction } from "../rules/turnStructure.js";
 
 // =============================================================================
 // MAIN FUNCTION
@@ -64,7 +65,7 @@ export function getSiteOptions(
     !player.isResting &&
     !mustAnnounceEndOfRound(state, player) &&
     canEnterAdventureSite(site) &&
-    !player.hasTakenActionThisTurn &&
+    canTakeActionPhaseAction(player) &&
     !(site.type === SiteType.AncientRuins && ruinsHasAltarToken);
 
   // Build enter description
@@ -87,7 +88,7 @@ export function getSiteOptions(
   const canInteract =
     !player.isResting &&
     !mustAnnounceEndOfRound(state, player) &&
-    !player.hasTakenActionThisTurn &&
+    canTakeActionPhaseAction(player) &&
     canInteractWithSite(site);
   const interactOptions = canInteract
     ? getInteractOptions(state, player, site)

--- a/packages/core/src/engine/validActions/sites.ts
+++ b/packages/core/src/engine/validActions/sites.ts
@@ -87,6 +87,7 @@ export function getSiteOptions(
   const canInteract =
     !player.isResting &&
     !mustAnnounceEndOfRound(state, player) &&
+    !player.hasTakenActionThisTurn &&
     canInteractWithSite(site);
   const interactOptions = canInteract
     ? getInteractOptions(state, player, site)

--- a/packages/core/src/engine/validActions/tactics.ts
+++ b/packages/core/src/engine/validActions/tactics.ts
@@ -227,6 +227,7 @@ export function getManaSearchOptions(
   return {
     maxDice: 2,
     mustPickDepletedFirst: restrictedDice.length > 0,
+    requiredFirstDiceIds: restrictedDice.map((d) => d.id),
     availableDiceIds: availableDice.map((d) => d.id),
   };
 }

--- a/packages/core/src/engine/validActions/tactics.ts
+++ b/packages/core/src/engine/validActions/tactics.ts
@@ -16,16 +16,17 @@ import {
   TACTIC_LONG_NIGHT,
   TACTIC_MIDNIGHT_MEDITATION,
   TACTIC_RETHINK,
-  TACTIC_MANA_SEARCH,
   TACTIC_SPARING_POWER,
   TACTIC_MANA_STEAL,
   TACTIC_PREPARATION,
-  MANA_GOLD,
   BASIC_MANA_COLORS,
 } from "@mage-knight/shared";
 import {
   getTacticActivationFailureReason,
   isPendingTacticDecisionStillValid,
+  canUseManaSearch,
+  getManaSearchAvailableDice,
+  getManaSearchRequiredFirstDiceIds,
 } from "../rules/tactics.js";
 
 /**
@@ -195,39 +196,21 @@ export function getManaSearchOptions(
   state: GameState,
   player: Player
 ): TacticEffectsOptions["canRerollSourceDice"] {
-  // Must have Mana Search tactic
-  if (player.selectedTactic !== TACTIC_MANA_SEARCH) {
+  if (!canUseManaSearch(state, player)) {
     return undefined;
   }
 
-  // Cannot use if already used this turn
-  if (player.tacticState?.manaSearchUsedThisTurn) {
-    return undefined;
-  }
-
-  // Cannot use after taking mana from source
-  if (player.usedManaFromSource) {
-    return undefined;
-  }
-
-  // Get available dice (not taken by other players)
-  const availableDice = state.source.dice.filter(
-    (d) => d.takenByPlayerId === null || d.takenByPlayerId === player.id
-  );
-
+  const availableDice = getManaSearchAvailableDice(state, player);
   if (availableDice.length === 0) {
     return undefined;
   }
 
-  // Check if there are gold/depleted dice that must be picked first
-  const restrictedDice = availableDice.filter(
-    (d) => d.isDepleted || d.color === MANA_GOLD
-  );
+  const requiredFirstDiceIds = getManaSearchRequiredFirstDiceIds(state, player);
 
   return {
     maxDice: 2,
-    mustPickDepletedFirst: restrictedDice.length > 0,
-    requiredFirstDiceIds: restrictedDice.map((d) => d.id),
+    mustPickDepletedFirst: requiredFirstDiceIds.length > 0,
+    requiredFirstDiceIds,
     availableDiceIds: availableDice.map((d) => d.id),
   };
 }

--- a/packages/core/src/engine/validators/turnValidators.ts
+++ b/packages/core/src/engine/validators/turnValidators.ts
@@ -16,7 +16,10 @@ import {
   WRONG_PHASE,
 } from "./validationCodes.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
-import { hasMetMinimumTurnRequirement } from "../rules/turnStructure.js";
+import {
+  hasMetMinimumTurnRequirement,
+  canTakeActionPhaseAction,
+} from "../rules/turnStructure.js";
 
 // Check it's this player's turn
 export function validateIsPlayersTurn(
@@ -68,7 +71,7 @@ export function validateHasNotActed(
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
-  if (player.hasTakenActionThisTurn) {
+  if (!canTakeActionPhaseAction(player)) {
     return invalid(ALREADY_ACTED, "You have already taken an action this turn");
   }
   return valid();

--- a/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
+++ b/packages/python-sdk/src/mage_knight_sdk/protocol_models.py
@@ -5,39 +5,39 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, TypeAlias
 
-NETWORK_PROTOCOL_VERSION: Literal["1.2.1"] = "1.2.1"
+NETWORK_PROTOCOL_VERSION: Literal["1.2.2"] = "1.2.2"
 
 @dataclass(frozen=True)
 class ClientActionMessage:
     action: Any
-    protocolVersion: Literal["1.2.1"]
+    protocolVersion: Literal["1.2.2"]
     type: Literal["action"]
 @dataclass(frozen=True)
 class ClientLobbySubscribeMessage:
     gameId: str
     playerId: str
-    protocolVersion: Literal["1.2.1"]
+    protocolVersion: Literal["1.2.2"]
     sessionToken: str | None
     type: Literal["lobby_subscribe"]
 
 @dataclass(frozen=True)
 class StateUpdateMessage:
     events: list[Any]
-    protocolVersion: Literal["1.2.1"]
+    protocolVersion: Literal["1.2.2"]
     state: Any
     type: Literal["state_update"]
 @dataclass(frozen=True)
 class ErrorMessage:
     errorCode: str | None
     message: str
-    protocolVersion: Literal["1.2.1"]
+    protocolVersion: Literal["1.2.2"]
     type: Literal["error"]
 @dataclass(frozen=True)
 class LobbyStateMessage:
     gameId: str
     maxPlayers: int
     playerIds: list[str]
-    protocolVersion: Literal["1.2.1"]
+    protocolVersion: Literal["1.2.2"]
     status: Literal["lobby", "started"]
     type: Literal["lobby_state"]
 

--- a/packages/python-sdk/src/mage_knight_sdk/sim/generated_action_enumerator.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/generated_action_enumerator.py
@@ -935,9 +935,9 @@ def _actions_normal_turn(state: dict[str, Any], valid_actions: dict[str, Any], p
                 )
 
         can_reroll = _as_dict(tactic_effects.get("canRerollSourceDice"))
-        dice_ids = [die_id for die_id in _as_list(can_reroll.get("availableDiceIds") if can_reroll else None) if isinstance(die_id, str)]
-        if dice_ids:
-            actions.append(CandidateAction({"type": ACTION_REROLL_SOURCE_DICE, "dieIds": [dice_ids[0]]}, "normal.tactic.reroll"))
+        selected_die_ids = _select_reroll_die_ids(state, can_reroll)
+        if selected_die_ids:
+            actions.append(CandidateAction({"type": ACTION_REROLL_SOURCE_DICE, "dieIds": selected_die_ids}, "normal.tactic.reroll"))
 
     if turn is not None:
         if bool(turn.get("canCompleteRest")):
@@ -969,6 +969,49 @@ def _append_common_blocking_actions(valid_actions: dict[str, Any], actions: list
         actions.append(CandidateAction({"type": ACTION_UNDO}, "turn.undo"))
     if bool(turn.get("canEndTurn")):
         actions.append(CandidateAction({"type": ACTION_END_TURN}, "turn.end_turn"))
+
+
+def _select_reroll_die_ids(state: dict[str, Any], can_reroll: dict[str, Any] | None) -> list[str]:
+    if can_reroll is None:
+        return []
+
+    available_ids = [
+        die_id
+        for die_id in _as_list(can_reroll.get("availableDiceIds"))
+        if isinstance(die_id, str)
+    ]
+    if not available_ids:
+        return []
+
+    if bool(can_reroll.get("mustPickDepletedFirst")):
+        required_first_ids = [
+            die_id
+            for die_id in _as_list(can_reroll.get("requiredFirstDiceIds"))
+            if isinstance(die_id, str) and die_id in available_ids
+        ]
+        if required_first_ids:
+            return [required_first_ids[0]]
+
+        # Backward-compatible fallback for older servers that do not provide
+        # requiredFirstDiceIds: derive the constrained subset from source dice.
+        source = _as_dict(state.get("source"))
+        source_dice = _as_list(source.get("dice") if source else None)
+        prioritized_ids: list[str] = []
+        for die in source_dice:
+            payload = _as_dict(die)
+            if payload is None:
+                continue
+            die_id = _as_str(payload.get("id"))
+            if die_id is None or die_id not in available_ids:
+                continue
+            color = _as_str(payload.get("color")) or ""
+            is_depleted = bool(payload.get("isDepleted"))
+            if is_depleted or color.lower() == "gold":
+                prioritized_ids.append(die_id)
+        if prioritized_ids:
+            return [prioritized_ids[0]]
+
+    return [available_ids[0]]
 
 
 def _is_wound_card_id(card_id: str) -> bool:

--- a/packages/python-sdk/tests/test_sim_random_policy.py
+++ b/packages/python-sdk/tests/test_sim_random_policy.py
@@ -119,6 +119,75 @@ class RandomPolicyTest(unittest.TestCase):
         self.assertEqual(1, len(complete_rest_actions))
         self.assertEqual(["rage"], complete_rest_actions[0]["discardCardIds"])
 
+    def test_enumerate_valid_actions_reroll_uses_required_first_dice_ids(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "source": {
+                "dice": [
+                    {"id": "die_0", "color": "blue", "isDepleted": False},
+                    {"id": "die_1", "color": "gold", "isDepleted": True},
+                    {"id": "die_2", "color": "white", "isDepleted": False},
+                ]
+            },
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": False,
+                    "canDeclareRest": False,
+                },
+                "tacticEffects": {
+                    "canRerollSourceDice": {
+                        "availableDiceIds": ["die_0", "die_1", "die_2"],
+                        "requiredFirstDiceIds": ["die_1"],
+                        "maxDice": 2,
+                        "mustPickDepletedFirst": True,
+                    }
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        reroll_actions = [a.action for a in actions if a.action.get("type") == "REROLL_SOURCE_DICE"]
+
+        self.assertEqual(1, len(reroll_actions))
+        self.assertEqual(["die_1"], reroll_actions[0]["dieIds"])
+
+    def test_enumerate_valid_actions_reroll_fallback_uses_depleted_when_required(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "source": {
+                "dice": [
+                    {"id": "die_0", "color": "blue", "isDepleted": False},
+                    {"id": "die_1", "color": "gold", "isDepleted": True},
+                    {"id": "die_2", "color": "white", "isDepleted": False},
+                ]
+            },
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": False,
+                    "canDeclareRest": False,
+                },
+                "tacticEffects": {
+                    "canRerollSourceDice": {
+                        "availableDiceIds": ["die_0", "die_1", "die_2"],
+                        "maxDice": 2,
+                        "mustPickDepletedFirst": True,
+                    }
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        reroll_actions = [a.action for a in actions if a.action.get("type") == "REROLL_SOURCE_DICE"]
+
+        self.assertEqual(1, len(reroll_actions))
+        self.assertEqual(["die_1"], reroll_actions[0]["dieIds"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/shared/schemas/network-protocol/v1/client-game-state.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/client-game-state.schema.json
@@ -2763,12 +2763,20 @@
         },
         "mustPickDepletedFirst": {
           "type": "boolean"
+        },
+        "requiredFirstDiceIds": {
+          "description": "Explicit constrained subset when mustPickDepletedFirst is true.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [
         "availableDiceIds",
         "maxDice",
-        "mustPickDepletedFirst"
+        "mustPickDepletedFirst",
+        "requiredFirstDiceIds"
       ],
       "type": "object"
     },

--- a/packages/shared/schemas/network-protocol/v1/client-to-server.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/client-to-server.schema.json
@@ -9,7 +9,7 @@
           "$ref": "player-action.schema.json"
         },
         "protocolVersion": {
-          "const": "1.2.1"
+          "const": "1.2.2"
         },
         "type": {
           "const": "action"
@@ -34,7 +34,7 @@
           "type": "string"
         },
         "protocolVersion": {
-          "const": "1.2.1"
+          "const": "1.2.2"
         },
         "sessionToken": {
           "minLength": 1,

--- a/packages/shared/schemas/network-protocol/v1/protocol.json
+++ b/packages/shared/schemas/network-protocol/v1/protocol.json
@@ -7,5 +7,5 @@
     "client-game-state.schema.json"
   ],
   "generatedAt": "static",
-  "protocolVersion": "1.2.1"
+  "protocolVersion": "1.2.2"
 }

--- a/packages/shared/schemas/network-protocol/v1/server-to-client.schema.json
+++ b/packages/shared/schemas/network-protocol/v1/server-to-client.schema.json
@@ -12,7 +12,7 @@
           "type": "array"
         },
         "protocolVersion": {
-          "const": "1.2.1"
+          "const": "1.2.2"
         },
         "state": {
           "$ref": "client-game-state.schema.json"
@@ -41,7 +41,7 @@
           "type": "string"
         },
         "protocolVersion": {
-          "const": "1.2.1"
+          "const": "1.2.2"
         },
         "type": {
           "const": "error"
@@ -74,7 +74,7 @@
           "type": "array"
         },
         "protocolVersion": {
-          "const": "1.2.1"
+          "const": "1.2.2"
         },
         "status": {
           "enum": [

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -155,6 +155,7 @@ export { LocalConnection } from "./connection.js";
 // Network protocol
 export {
   NETWORK_PROTOCOL_VERSION_1,
+  NETWORK_PROTOCOL_VERSION_2,
   NETWORK_PROTOCOL_VERSION,
   CLIENT_MESSAGE_ACTION,
   CLIENT_MESSAGE_LOBBY_SUBSCRIBE,

--- a/packages/shared/src/networkProtocol.ts
+++ b/packages/shared/src/networkProtocol.ts
@@ -4,7 +4,8 @@ import type { GameEvent } from "./events/index.js";
 import type { ClientGameState } from "./types/clientState.js";
 
 export const NETWORK_PROTOCOL_VERSION_1 = "1.2.1" as const;
-export const NETWORK_PROTOCOL_VERSION = NETWORK_PROTOCOL_VERSION_1;
+export const NETWORK_PROTOCOL_VERSION_2 = "1.2.2" as const;
+export const NETWORK_PROTOCOL_VERSION = NETWORK_PROTOCOL_VERSION_2;
 
 export type NetworkProtocolVersion = typeof NETWORK_PROTOCOL_VERSION;
 

--- a/packages/shared/src/types/validActions.ts
+++ b/packages/shared/src/types/validActions.ts
@@ -728,6 +728,8 @@ export interface ActivatableTacticOptions {
 export interface ManaSearchOptions {
   readonly maxDice: number;
   readonly mustPickDepletedFirst: boolean;
+  /** Explicit constrained subset when mustPickDepletedFirst is true. */
+  readonly requiredFirstDiceIds: readonly string[];
   readonly availableDiceIds: readonly string[];
 }
 


### PR DESCRIPTION
## Summary
- extend Mana Search validActions with explicit constrained reroll subset: `requiredFirstDiceIds`
- update sim reroll selection to use `requiredFirstDiceIds` first, with backward-compatible fallback to source dice
- align site validActions with interact validators by disabling `canInteract` after the player has already taken an action
- add regression tests for site interaction gating and sim reroll selection

## Why
- seed 9: invariant failure from choosing a non-depleted die despite `mustPickDepletedFirst`
- seed 14: invariant failure from `INTERACT` being advertised while validator rejected with `ALREADY_ACTED`

## Validation
- bun run lint
- bun test packages/core/src/engine/__tests__/siteValidActions.test.ts
- python3 -m unittest packages/python-sdk/tests/test_sim_random_policy.py
- python3 packages/python-sdk/run_full_game.py --no-undo --seed 9  -> ended (180)
- python3 packages/python-sdk/run_full_game.py --no-undo --seed 14 -> ended (185)
