### PR TITLE
fix: handle pending tactic decisions advertised during normal_turn

### DIFF
--- a/packages/python-sdk/tests/test_sim_random_policy.py
+++ b/packages/python-sdk/tests/test_sim_random_policy.py
@@ -188,6 +188,39 @@ class RandomPolicyTest(unittest.TestCase):
         self.assertEqual(1, len(reroll_actions))
         self.assertEqual(["die_1"], reroll_actions[0]["dieIds"])
 
+    def test_enumerate_valid_actions_includes_pending_tactic_decision_in_normal_turn(self) -> None:
+        state = {
+            "players": [{"id": "player-1"}],
+            "validActions": {
+                "mode": "normal_turn",
+                "turn": {
+                    "canEndTurn": False,
+                    "canAnnounceEndOfRound": False,
+                    "canUndo": False,
+                    "canDeclareRest": False,
+                },
+                "tacticEffects": {
+                    "pendingDecision": {
+                        "type": "midnight_meditation",
+                        "availableCardIds": [],
+                        "maxCards": 5,
+                    }
+                },
+            },
+        }
+
+        actions = enumerate_valid_actions(state, "player-1")
+        tactic_actions = [a.action for a in actions if a.action.get("type") == "RESOLVE_TACTIC_DECISION"]
+
+        self.assertEqual(1, len(tactic_actions))
+        self.assertEqual(
+            {
+                "type": "RESOLVE_TACTIC_DECISION",
+                "decision": {"type": "midnight_meditation", "cardIds": []},
+            },
+            tactic_actions[0],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix Python sim action enumeration to resolve tactic decisions from `tacticEffects.pendingDecision` in `normal_turn` mode
- refactor tactic decision action construction into shared helper logic for both `pending_tactic_decision` and `normal_turn` paths
- add regression test covering pending Midnight Meditation decision advertised during `normal_turn`

## Why
- seed 15 hit a dead-end because the server advertised a pending tactic decision in `normal_turn`, but the sim only emitted `RESOLVE_TACTIC_DECISION` when mode was `pending_tactic_decision`

## Validation
- python3 -m unittest packages/python-sdk/tests/test_sim_random_policy.py
- python3 packages/python-sdk/run_full_game.py --no-undo --seed 15
  - outcome: ended (steps: 184)
