### PR TITLE
refactor: align monastery AA affordability via shared rules

### DIFF
--- a/packages/core/src/engine/__tests__/siteValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/siteValidActions.test.ts
@@ -46,6 +46,43 @@ function createStateAtVillage(
   });
 }
 
+function createStateAtMonastery(influencePoints: number) {
+  const monastery: Site = {
+    type: SiteType.Monastery,
+    owner: null,
+    isConquered: false,
+    isBurned: false,
+  };
+
+  const player = createTestPlayer({
+    position: { q: 0, r: 0 },
+    influencePoints,
+  });
+
+  return createTestGameState({
+    phase: GAME_PHASE_ROUND,
+    players: [player],
+    offers: {
+      advancedActions: {
+        cards: ["agility"],
+      },
+      monasteryAdvancedActions: ["agility"],
+      spells: {
+        cards: [],
+      },
+      units: [],
+      commonSkills: [],
+    },
+    map: {
+      hexes: {
+        [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS, monastery),
+      },
+      tiles: [],
+      tileDeck: { countryside: [], core: [] },
+    },
+  });
+}
+
 describe("Site valid actions", () => {
   it("does not advertise healing when influence is below cost", () => {
     const state = createStateAtVillage(2);
@@ -84,5 +121,21 @@ describe("Site valid actions", () => {
 
     expect(options?.canInteract).toBe(false);
     expect(options?.interactOptions).toBeUndefined();
+  });
+
+  it("does not advertise monastery advanced action purchase when influence is below cost", () => {
+    const state = createStateAtMonastery(5);
+    const player = state.players[0];
+    const options = getSiteOptions(state, player);
+
+    expect(options?.interactOptions?.canBuyAdvancedActions).toBe(false);
+  });
+
+  it("advertises monastery advanced action purchase when influence meets cost", () => {
+    const state = createStateAtMonastery(6);
+    const player = state.players[0];
+    const options = getSiteOptions(state, player);
+
+    expect(options?.interactOptions?.canBuyAdvancedActions).toBe(true);
   });
 });

--- a/packages/core/src/engine/rules/siteInteraction.ts
+++ b/packages/core/src/engine/rules/siteInteraction.ts
@@ -7,7 +7,11 @@
 
 import type { Site } from "../../types/map.js";
 import { SiteType } from "../../types/map.js";
-import { SITE_PROPERTIES, getHealingCost } from "../../data/siteProperties.js";
+import {
+  SITE_PROPERTIES,
+  getHealingCost,
+  MONASTERY_AA_PURCHASE_COST,
+} from "../../data/siteProperties.js";
 
 /**
  * Check if player can interact with this site (inhabited sites).
@@ -82,6 +86,13 @@ export function canBuySpellsAtMageTower(site: Site): boolean {
  */
 export function canBuyAdvancedActionsAtMonastery(site: Site): boolean {
   return site.type === SiteType.Monastery && !site.isBurned;
+}
+
+/**
+ * Check if the player can afford a Monastery advanced action purchase.
+ */
+export function canAffordMonasteryAdvancedAction(influencePoints: number): boolean {
+  return influencePoints >= MONASTERY_AA_PURCHASE_COST;
 }
 
 /**

--- a/packages/core/src/engine/validActions/sites.ts
+++ b/packages/core/src/engine/validActions/sites.ts
@@ -28,6 +28,8 @@ import {
   canInteractWithSite,
   hasCombatRestrictions,
   canEnterAdventureSite,
+  canBuyAdvancedActionsAtMonastery,
+  canAffordMonasteryAdvancedAction,
 } from "../rules/siteInteraction.js";
 import { canTakeActionPhaseAction } from "../rules/turnStructure.js";
 
@@ -335,9 +337,9 @@ function getInteractOptions(
 
   // Check if can buy advanced actions (Monastery)
   const canBuyAdvancedActions =
-    site.type === SiteType.Monastery &&
-    !site.isBurned &&
-    state.offers.advancedActions.cards.length > 0;
+    canBuyAdvancedActionsAtMonastery(site) &&
+    state.offers.advancedActions.cards.length > 0 &&
+    canAffordMonasteryAdvancedAction(player.influencePoints);
 
   // Check if can burn monastery
   const canBurnMonastery =

--- a/packages/core/src/engine/validators/offerValidators.ts
+++ b/packages/core/src/engine/validators/offerValidators.ts
@@ -40,6 +40,10 @@ import {
 } from "../../data/siteProperties.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
 import { getActiveLearningDiscount } from "../rules/unitRecruitment.js";
+import {
+  canBuyAdvancedActionsAtMonastery,
+  canAffordMonasteryAdvancedAction,
+} from "../rules/siteInteraction.js";
 
 // === Spell Purchase Validators ===
 
@@ -211,7 +215,7 @@ export function validateAtAdvancedActionSite(
     );
   }
 
-  if (site.isBurned) {
+  if (!canBuyAdvancedActionsAtMonastery(site)) {
     return invalid(
       MONASTERY_BURNED,
       "Cannot buy advanced actions from a burned monastery"
@@ -240,7 +244,7 @@ export function validateHasInfluenceForMonasteryAA(
   }
 
   if (action.fromMonastery) {
-    if (player.influencePoints < MONASTERY_AA_PURCHASE_COST) {
+    if (!canAffordMonasteryAdvancedAction(player.influencePoints)) {
       return invalid(
         INSUFFICIENT_INFLUENCE_FOR_AA,
         `You need ${MONASTERY_AA_PURCHASE_COST} influence to buy an advanced action (have ${player.influencePoints})`


### PR DESCRIPTION
## Summary
- add shared rule helper for monastery advanced action affordability
- use the same helper in site validActions and offer validators
- add regression tests for monastery AA purchase advertisement at influence 5 vs 6

## Why
- fixes validActions/validator drift where monastery AA purchases were advertised despite insufficient influence

## Validation
- bun test packages/core/src/engine/__tests__/siteValidActions.test.ts
- bun run lint
- seed spot checks after rebuild/restart: 64, 108, 198 now end
