### PR TITLE
fix: align turn, knockout, and block declaration rules

### DIFF
--- a/packages/core/src/engine/__tests__/bloodRitual.test.ts
+++ b/packages/core/src/engine/__tests__/bloodRitual.test.ts
@@ -375,10 +375,10 @@ describe("Blood Ritual Advanced Action", () => {
   });
 
   describe("FAQ rulings", () => {
-    it("S3: Wound counts toward knockout in combat", () => {
-      // Start with 4 wounds already in hand - one more will cause knockout
+    it("S3: Self-inflicted wound counts toward knockout tracking during combat", () => {
       const state = createCombatStateWithBloodRitual({
-        hand: [CARD_BLOOD_RITUAL, CARD_WOUND, CARD_WOUND, CARD_WOUND, CARD_WOUND],
+        hand: [CARD_BLOOD_RITUAL],
+        handLimit: 1,
       });
 
       // Play the card
@@ -392,7 +392,9 @@ describe("Blood Ritual Advanced Action", () => {
       const woundCount = playResult.state.players[0].hand.filter(
         (c) => c === CARD_WOUND
       ).length;
-      expect(woundCount).toBe(5);
+      expect(woundCount).toBe(1);
+      expect(playResult.state.combat?.woundsThisCombat).toBe(1);
+      expect(playResult.state.players[0].knockedOut).toBe(true);
     });
 
     it("wound should go to player hand", () => {

--- a/packages/core/src/engine/__tests__/coldToughnessIntegration.test.ts
+++ b/packages/core/src/engine/__tests__/coldToughnessIntegration.test.ts
@@ -24,8 +24,8 @@ import {
   ENTER_COMBAT_ACTION,
   END_COMBAT_PHASE_ACTION,
   DECLARE_BLOCK_ACTION,
+  INVALID_ACTION,
   ENEMY_BLOCKED,
-  BLOCK_FAILED,
   ELEMENT_PHYSICAL,
   ELEMENT_COLD_FIRE,
   ENEMY_HIGH_DRAGON,
@@ -131,9 +131,8 @@ describe("Cold Toughness Integration", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 2,
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 3, have 2",
         })
       );
     });
@@ -205,9 +204,8 @@ describe("Cold Toughness Integration", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 4,
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 6, have 4",
         })
       );
     });
@@ -292,9 +290,8 @@ describe("Cold Toughness Integration", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 3, // No bonus despite modifier being active
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 4, have 3",
         })
       );
     });
@@ -393,9 +390,8 @@ describe("Cold Toughness Integration", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 5, // 3 efficient + floor(5/2) = 5
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 6, have 5",
         })
       );
     });

--- a/packages/core/src/engine/__tests__/combatBlocking.test.ts
+++ b/packages/core/src/engine/__tests__/combatBlocking.test.ts
@@ -16,7 +16,6 @@ import {
   DECLARE_ATTACK_ACTION,
   INVALID_ACTION,
   ENEMY_BLOCKED,
-  BLOCK_FAILED,
   ENEMY_DEFEATED,
   ENEMY_ORC,
   ENEMY_WOLF_RIDERS,
@@ -101,7 +100,7 @@ describe("Combat Blocking", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(true);
     });
 
-    it("should fail block with insufficient value", () => {
+    it("should reject block declaration with insufficient value", () => {
       let state = createTestGameState();
 
       state = engine.processAction(state, "player1", {
@@ -125,10 +124,8 @@ describe("Combat Blocking", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 2,
-          requiredBlock: 3,
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 3, have 2",
         })
       );
     });
@@ -184,14 +181,12 @@ describe("Combat Blocking", () => {
         targetEnemyInstanceId: "enemy_0",
       });
 
-      // Should fail - need 6 block (3 * 2) due to Swift
+      // Should be rejected - need 6 block (3 * 2) due to Swift
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 4,
-          requiredBlock: 6, // 3 * 2 = 6 due to Swift
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 6, have 4",
         })
       );
     });
@@ -332,10 +327,8 @@ describe("Combat Blocking", () => {
       expect(result.state.combat?.enemies[0].isBlocked).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_0",
-          blockValue: 4, // 8 / 2 = 4
-          requiredBlock: 6,
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 6, have 4",
         })
       );
     });

--- a/packages/core/src/engine/__tests__/combatMultiAttack.test.ts
+++ b/packages/core/src/engine/__tests__/combatMultiAttack.test.ts
@@ -27,7 +27,6 @@ import {
   ASSIGN_DAMAGE_ACTION,
   INVALID_ACTION,
   ENEMY_BLOCKED,
-  BLOCK_FAILED,
   DAMAGE_ASSIGNED,
   ELEMENT_PHYSICAL,
   ELEMENT_FIRE,
@@ -246,8 +245,8 @@ describe("Combat Multi-Attack", () => {
       expect(result.state.combat?.enemies[0].attacksBlocked?.[0]).toBe(false);
       expect(result.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          attackIndex: 0,
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 3, have 2",
         })
       );
     });

--- a/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
+++ b/packages/core/src/engine/__tests__/pendingRewardsTurn.test.ts
@@ -10,6 +10,7 @@ import { validateRestCompleted } from "../validators/restValidators.js";
 import { validateMinimumTurnRequirement } from "../validators/turnValidators.js";
 import {
   END_TURN_ACTION,
+  CARD_WOUND,
   CARD_MARCH,
   SITE_REWARD_SPELL,
   type SiteReward,
@@ -86,19 +87,22 @@ describe("Turn end options", () => {
     }
   });
 
-  it("allows end turn when hand has only wounds and no card was played", () => {
+  it("disables end turn when hand has only wounds and no card was played", () => {
     const player = createTestPlayer({
-      hand: ["wound"],
+      hand: [CARD_WOUND],
       playedCardFromHandThisTurn: false,
     });
     const state = createTestGameState({ players: [player] });
 
     const turnOptions = getTurnOptions(state, player);
-    expect(turnOptions.canEndTurn).toBe(true);
+    expect(turnOptions.canEndTurn).toBe(false);
 
     const validation = validateMinimumTurnRequirement(state, player.id, {
       type: END_TURN_ACTION,
     });
-    expect(validation.valid).toBe(true);
+    expect(validation.valid).toBe(false);
+    if (!validation.valid) {
+      expect(validation.error.code).toBe(MUST_PLAY_OR_DISCARD_CARD);
+    }
   });
 });

--- a/packages/core/src/engine/commands/combat/__tests__/cumbersome.test.ts
+++ b/packages/core/src/engine/commands/combat/__tests__/cumbersome.test.ts
@@ -18,7 +18,6 @@ import {
   INVALID_ACTION,
   MOVE_SPENT_ON_CUMBERSOME,
   ENEMY_BLOCKED,
-  BLOCK_FAILED,
   type EnemyId,
 } from "@mage-knight/shared";
 import {
@@ -435,8 +434,8 @@ describe("Cumbersome Ability", () => {
 
       expect(blockResult.events).toContainEqual(
         expect.objectContaining({
-          type: BLOCK_FAILED,
-          enemyInstanceId: "enemy_cumbersome_0",
+          type: INVALID_ACTION,
+          reason: "Insufficient block: need 3, have 2",
         })
       );
     });

--- a/packages/core/src/engine/effects/woundApplicationHelpers.ts
+++ b/packages/core/src/engine/effects/woundApplicationHelpers.ts
@@ -1,0 +1,87 @@
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import type { CardId } from "@mage-knight/shared";
+import { CARD_WOUND } from "@mage-knight/shared";
+import {
+  discardNonWoundsFromHand,
+  isKnockoutTriggered,
+} from "../rules/knockout.js";
+
+/**
+ * Apply wounds to hand from non-enemy sources (card/effect costs and effects).
+ *
+ * If this happens during combat for the active player, wounds contribute to
+ * combat knockout tracking (FAQ: self-inflicted wounds during combat count).
+ */
+export function applyWoundsToHand(
+  state: GameState,
+  playerIndex: number,
+  amount: number
+): GameState {
+  if (amount <= 0) {
+    return state;
+  }
+
+  const player = state.players[playerIndex];
+  if (!player) {
+    return state;
+  }
+
+  const woundsToAdd: CardId[] = Array(amount).fill(CARD_WOUND);
+  let updatedPlayer: Player = {
+    ...player,
+    hand: [...player.hand, ...woundsToAdd],
+    woundsReceivedThisTurn: {
+      hand: player.woundsReceivedThisTurn.hand + amount,
+      discard: player.woundsReceivedThisTurn.discard,
+    },
+  };
+
+  let updatedCombat = state.combat;
+  const currentPlayerId = state.turnOrder[state.currentPlayerIndex];
+  const isCurrentCombatPlayer =
+    updatedCombat !== null && currentPlayerId === player.id;
+
+  if (updatedCombat !== null && isCurrentCombatPlayer) {
+    const totalWoundsThisCombat = updatedCombat.woundsThisCombat + amount;
+    const knockedOut = isKnockoutTriggered(
+      totalWoundsThisCombat,
+      player.handLimit
+    );
+
+    if (knockedOut) {
+      const knockoutCards = discardNonWoundsFromHand(
+        updatedPlayer.hand,
+        updatedPlayer.discard
+      );
+      updatedPlayer = {
+        ...updatedPlayer,
+        hand: knockoutCards.hand,
+        discard: knockoutCards.discard,
+        knockedOut: true,
+      };
+    }
+
+    updatedCombat = {
+      ...updatedCombat,
+      woundsThisCombat: totalWoundsThisCombat,
+      woundsAddedToHandThisCombat:
+        updatedCombat.woundsAddedToHandThisCombat || amount > 0,
+    };
+  }
+
+  const updatedPlayers = [...state.players];
+  updatedPlayers[playerIndex] = updatedPlayer;
+
+  const newWoundPileCount =
+    state.woundPileCount === null
+      ? null
+      : Math.max(0, state.woundPileCount - amount);
+
+  return {
+    ...state,
+    players: updatedPlayers,
+    combat: updatedCombat,
+    woundPileCount: newWoundPileCount,
+  };
+}

--- a/packages/core/src/engine/rules/combatBlocking.ts
+++ b/packages/core/src/engine/rules/combatBlocking.ts
@@ -87,7 +87,12 @@ export function getBlockDeclarationStatus(
   );
 
   if (effectiveAttack <= 0) {
-    return noBlock;
+    return {
+      canDeclare: true,
+      attackIndex: resolvedAttackIndex,
+      requiredBlock: 0,
+      availableEffectiveBlock: 0,
+    };
   }
 
   const requiredBlock = swiftActive ? effectiveAttack * 2 : effectiveAttack;

--- a/packages/core/src/engine/rules/combatBlocking.ts
+++ b/packages/core/src/engine/rules/combatBlocking.ts
@@ -1,0 +1,123 @@
+/**
+ * Shared combat blocking declaration rules.
+ *
+ * These helpers are used by both validators and ValidActions computation
+ * to prevent rule drift.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { CombatEnemy, PendingElementalDamage } from "../../types/combat.js";
+import type { Element } from "@mage-knight/shared";
+import { createEmptyPendingDamage } from "../../types/combat.js";
+import { getFinalBlockValue } from "../combat/elementalCalc.js";
+import {
+  findFirstUnblockedAttack,
+  getEnemyAttack,
+  getEnemyAttackCount,
+  getEffectiveEnemyAttackElement,
+  isAttackBlocked,
+  isAttackCancelled,
+} from "../combat/enemyAttackHelpers.js";
+import { doesEnemyAttackThisCombat, getEffectiveEnemyAttack, getNaturesVengeanceAttackBonus } from "../modifiers/index.js";
+import { getCumbersomeReducedAttack } from "../combat/cumbersomeHelpers.js";
+import { isSwiftActive } from "../combat/swiftHelpers.js";
+import { getColdToughnessBlockBonus } from "../combat/coldToughnessHelpers.js";
+
+function pendingBlockToSources(
+  pending: PendingElementalDamage
+): { element: Element; value: number }[] {
+  const sources: { element: Element; value: number }[] = [];
+
+  if (pending.physical > 0) sources.push({ element: "physical" as Element, value: pending.physical });
+  if (pending.fire > 0) sources.push({ element: "fire" as Element, value: pending.fire });
+  if (pending.ice > 0) sources.push({ element: "ice" as Element, value: pending.ice });
+  if (pending.coldFire > 0) sources.push({ element: "cold_fire" as Element, value: pending.coldFire });
+
+  return sources;
+}
+
+export interface BlockDeclarationStatus {
+  readonly canDeclare: boolean;
+  readonly attackIndex: number;
+  readonly requiredBlock: number;
+  readonly availableEffectiveBlock: number;
+}
+
+/**
+ * Check if current pending block is sufficient to declare block against an enemy attack.
+ */
+export function getBlockDeclarationStatus(
+  state: GameState,
+  playerId: string,
+  enemy: CombatEnemy,
+  attackIndex?: number
+): BlockDeclarationStatus {
+  const resolvedAttackIndex = attackIndex ?? findFirstUnblockedAttack(enemy);
+  const noBlock: BlockDeclarationStatus = {
+    canDeclare: false,
+    attackIndex: resolvedAttackIndex,
+    requiredBlock: 0,
+    availableEffectiveBlock: 0,
+  };
+
+  if (!state.combat) return noBlock;
+  if (resolvedAttackIndex < 0 || resolvedAttackIndex >= getEnemyAttackCount(enemy)) {
+    return noBlock;
+  }
+  if (enemy.isDefeated || enemy.isSummonerHidden) return noBlock;
+  if (isAttackBlocked(enemy, resolvedAttackIndex)) return noBlock;
+  if (isAttackCancelled(enemy, resolvedAttackIndex)) return noBlock;
+  if (!doesEnemyAttackThisCombat(state, enemy.instanceId)) return noBlock;
+
+  const swiftActive = isSwiftActive(state, playerId, enemy);
+  const attack = getEnemyAttack(enemy, resolvedAttackIndex);
+  const naturesVengeanceBonus = getNaturesVengeanceAttackBonus(state, playerId);
+  const effectiveAttackBeforeCumbersome =
+    getEffectiveEnemyAttack(
+      state,
+      enemy.instanceId,
+      attack.damage,
+      resolvedAttackIndex
+    ) + naturesVengeanceBonus;
+  const effectiveAttack = getCumbersomeReducedAttack(
+    state,
+    playerId,
+    enemy,
+    effectiveAttackBeforeCumbersome
+  );
+
+  if (effectiveAttack <= 0) {
+    return noBlock;
+  }
+
+  const requiredBlock = swiftActive ? effectiveAttack * 2 : effectiveAttack;
+  const pendingBlock =
+    state.combat.pendingBlock[enemy.instanceId] ?? createEmptyPendingDamage();
+  const pendingSwiftBlock =
+    state.combat.pendingSwiftBlock[enemy.instanceId] ?? createEmptyPendingDamage();
+
+  const baseSources = pendingBlockToSources(pendingBlock);
+  const coldToughnessBonus = getColdToughnessBlockBonus(state, playerId, enemy);
+  const sourcesWithBonus =
+    coldToughnessBonus > 0
+      ? [...baseSources, { element: "ice" as Element, value: coldToughnessBonus }]
+      : baseSources;
+  const sources = swiftActive
+    ? [...sourcesWithBonus, ...pendingBlockToSources(pendingSwiftBlock)]
+    : sourcesWithBonus;
+
+  const effectiveElement = getEffectiveEnemyAttackElement(state, enemy, attack.element);
+  const availableEffectiveBlock = getFinalBlockValue(
+    sources,
+    effectiveElement,
+    state,
+    playerId
+  );
+
+  return {
+    canDeclare: availableEffectiveBlock >= requiredBlock,
+    attackIndex: resolvedAttackIndex,
+    requiredBlock,
+    availableEffectiveBlock,
+  };
+}

--- a/packages/core/src/engine/rules/knockout.ts
+++ b/packages/core/src/engine/rules/knockout.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared knockout rules.
+ *
+ * These pure helpers are used by combat commands and effect handlers so
+ * knockout behavior stays consistent regardless of wound source.
+ */
+
+import type { CardId } from "@mage-knight/shared";
+import { CARD_WOUND } from "@mage-knight/shared";
+
+/**
+ * Knockout triggers when wounds taken during a single combat reach/exceed
+ * the hero's unmodified hand limit (printed on level token).
+ */
+export function isKnockoutTriggered(
+  woundsThisCombat: number,
+  unmodifiedHandLimit: number
+): boolean {
+  return woundsThisCombat >= unmodifiedHandLimit;
+}
+
+/**
+ * On knockout, immediately discard all non-wound cards from hand.
+ */
+export function discardNonWoundsFromHand(
+  hand: readonly CardId[],
+  discard: readonly CardId[]
+): {
+  hand: readonly CardId[];
+  discard: readonly CardId[];
+} {
+  const woundsInHand = hand.filter((cardId) => cardId === CARD_WOUND);
+  const nonWoundsInHand = hand.filter((cardId) => cardId !== CARD_WOUND);
+
+  return {
+    hand: woundsInHand,
+    discard: [...discard, ...nonWoundsInHand],
+  };
+}

--- a/packages/core/src/engine/rules/turnStructure.ts
+++ b/packages/core/src/engine/rules/turnStructure.ts
@@ -212,7 +212,7 @@ export function canEndTurn(state: GameState, player: Player): boolean {
   }
 
   // Must satisfy minimum turn requirement before ending turn.
-  // This is waived when hand is empty or contains only wounds.
+  // This is waived only when hand is empty.
   if (!hasMetMinimumTurnRequirement(player)) {
     return false;
   }
@@ -226,7 +226,7 @@ export function canEndTurn(state: GameState, player: Player): boolean {
  * Per rulebook Minimum Turn S1: "Every turn you must play at least one card from your hand.
  * Failing that, you must discard one unplayed card from your hand."
  *
- * Requirement is waived if player has no cards in hand.
+ * Requirement is waived only if player has no cards in hand.
  */
 export function hasMetMinimumTurnRequirement(player: Player): boolean {
   // If player has no cards in hand, requirement is waived
@@ -236,12 +236,6 @@ export function hasMetMinimumTurnRequirement(player: Player): boolean {
 
   // If player already played or discarded a card from hand, requirement is satisfied
   if (player.playedCardFromHandThisTurn) {
-    return true;
-  }
-
-  // If hand contains only wounds, requirement is waived.
-  // Wounds cannot be played and there is no generic "discard one card" action.
-  if (player.hand.every((cardId) => isWoundCard(cardId))) {
     return true;
   }
 

--- a/packages/core/src/engine/validActions/__tests__/combatValidActions.test.ts
+++ b/packages/core/src/engine/validActions/__tests__/combatValidActions.test.ts
@@ -15,6 +15,7 @@ import { createEngine } from "../../MageKnightEngine.js";
 import {
   ENTER_COMBAT_ACTION,
   ENEMY_PROWLERS,
+  ENEMY_ORC,
   ENEMY_FIRE_MAGES,
   ENEMY_DIGGERS,
   ENEMY_ORC_WAR_BEASTS,
@@ -607,6 +608,55 @@ describe("getCombatOptions", () => {
       // Should have block-specific fields instead
       expect(options?.availableAttack).toBeUndefined();
       expect(options?.assignableAttacks).toBeUndefined();
+    });
+  });
+
+  describe("block declaration advertising", () => {
+    it("does not advertise block targets when pending block is insufficient", () => {
+      let state = setupCombatState([ENEMY_ORC], COMBAT_PHASE_BLOCK);
+
+      // Orc requires 3 block; only 2 pending is insufficient to declare.
+      if (state.combat) {
+        state = {
+          ...state,
+          combat: {
+            ...state.combat,
+            pendingBlock: {
+              ...state.combat.pendingBlock,
+              enemy_0: { physical: 2, fire: 0, ice: 0, coldFire: 0 },
+            },
+          },
+        };
+      }
+
+      const options = getCombatOptions(state);
+      expect(options?.blocks).toEqual([]);
+    });
+
+    it("advertises block target when pending block is sufficient", () => {
+      let state = setupCombatState([ENEMY_ORC], COMBAT_PHASE_BLOCK);
+
+      if (state.combat) {
+        state = {
+          ...state,
+          combat: {
+            ...state.combat,
+            pendingBlock: {
+              ...state.combat.pendingBlock,
+              enemy_0: { physical: 3, fire: 0, ice: 0, coldFire: 0 },
+            },
+          },
+        };
+      }
+
+      const options = getCombatOptions(state);
+      expect(options?.blocks).toHaveLength(1);
+      expect(options?.blocks?.[0]).toEqual(
+        expect.objectContaining({
+          enemyInstanceId: "enemy_0",
+          requiredBlock: 3,
+        })
+      );
     });
   });
 

--- a/packages/core/src/engine/validActions/combatBlock.ts
+++ b/packages/core/src/engine/validActions/combatBlock.ts
@@ -52,6 +52,7 @@ import {
 } from "../combat/cumbersomeHelpers.js";
 import { getColdToughnessBlockBonus } from "../combat/coldToughnessHelpers.js";
 import { canUseBannerFear, getCancellableAttacks } from "../rules/banners.js";
+import { getBlockDeclarationStatus } from "../rules/combatBlocking.js";
 import { getModifiersForPlayer } from "../modifiers/index.js";
 import type { InfluenceToBlockConversionModifier } from "../../types/modifiers.js";
 import { EFFECT_INFLUENCE_TO_BLOCK_CONVERSION } from "../../types/modifierConstants.js";
@@ -569,6 +570,11 @@ export function getBlockOptions(
 
       // Swift enemies require 2x block
       const requiredBlock = isSwift ? effectiveAttack * 2 : effectiveAttack;
+
+      if (playerId) {
+        const status = getBlockDeclarationStatus(state, playerId, enemy, attackIndex);
+        if (!status.canDeclare) continue;
+      }
 
       // Build the base option (use effective element after conversion modifiers)
       const effectiveElement = getEffectiveEnemyAttackElement(state, enemy, attack.element);


### PR DESCRIPTION
## Summary\n- enforce minimum-turn rule so all-wounds hands cannot  without rest discard flow\n- add shared knockout rules and apply combat knockout tracking to self-inflicted wounds during combat\n- add shared block declaration rule and use it in both ValidActions and validators so  is only advertised/accepted when sufficient block exists\n\n## Details\n- Added shared rule modules:\n  - \n  - \n- Added shared effect helper:\n  - \n- Updated combat/effect paths to use shared rule logic:\n  - , , , , \n- Updated valid-actions + validator alignment for block declaration:\n  - \n  - \n- Added/updated tests for turn-end, knockout, block advertising, and insufficient block behavior\n\n## Verification\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- bun test v1.3.9 (cf6cdbbb)\n- Found 0 warnings and 0 errors.
Finished in 390ms on 1495 files with 98 rules using 14 threads.