### PR TITLE
fix: prevent all-wounds post-combat dead-end by allowing slow recovery declare

### DIFF
--- a/packages/core/src/engine/__tests__/rest.test.ts
+++ b/packages/core/src/engine/__tests__/rest.test.ts
@@ -444,6 +444,26 @@ describe("Two-Phase REST (DECLARE_REST + COMPLETE_REST)", () => {
       );
     });
 
+    it("should allow declare rest after action when hand is all wounds", () => {
+      const player = createTestPlayer({
+        hand: [CARD_WOUND, CARD_WOUND],
+        hasTakenActionThisTurn: true,
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = engine.processAction(state, "player1", {
+        type: DECLARE_REST_ACTION,
+      });
+
+      expect(result.state.players[0].isResting).toBe(true);
+      expect(result.events).toContainEqual(
+        expect.objectContaining({
+          type: REST_DECLARED,
+          playerId: "player1",
+        })
+      );
+    });
+
     it("should reject if already moved this turn (rest means no movement phase)", () => {
       // Per FAQ: "Resting doesn't prevent you from playing cards: it merely prevents
       // you from Moving..." - this means rest and movement are mutually exclusive.

--- a/packages/core/src/engine/__tests__/restingValidActions.test.ts
+++ b/packages/core/src/engine/__tests__/restingValidActions.test.ts
@@ -15,6 +15,7 @@ import { getChallengeOptions } from "../validActions/challenge.js";
 import { getSiteOptions } from "../validActions/sites.js";
 import {
   ENEMY_DIGGERS,
+  CARD_WOUND,
   CARD_WHIRLWIND,
   TERRAIN_PLAINS,
   hexKey,
@@ -205,5 +206,20 @@ describe("Valid actions while resting", () => {
 
     expect(validActions.mode).toBe("normal_turn");
     expect(validActions.playCard).toBeUndefined();
+  });
+
+  it("offers declare rest after action when hand is all wounds", () => {
+    const player = createTestPlayer({
+      hasTakenActionThisTurn: true,
+      hand: [CARD_WOUND, CARD_WOUND],
+      isResting: false,
+    });
+    const state = createTestGameState({ players: [player] });
+
+    const validActions = getValidActions(state, player.id);
+
+    expect(validActions.mode).toBe("normal_turn");
+    expect(validActions.turn?.canDeclareRest).toBe(true);
+    expect(validActions.turn?.restTypes).toEqual(["slow_recovery"]);
   });
 });

--- a/packages/core/src/engine/rules/turnStructure.ts
+++ b/packages/core/src/engine/rules/turnStructure.ts
@@ -85,8 +85,12 @@ export function canDeclareRest(state: GameState, player: Player): boolean {
     return false;
   }
 
-  // Can't declare rest if already taken an action
-  if (player.hasTakenActionThisTurn) {
+  const hasOnlyWoundsInHand =
+    player.hand.length > 0 && player.hand.every((cardId) => isWoundCard(cardId));
+
+  // Rest normally requires no prior action, but Slow Recovery is allowed
+  // after acting when the hand is all wounds to avoid dead-end turns.
+  if (player.hasTakenActionThisTurn && !hasOnlyWoundsInHand) {
     return false;
   }
 

--- a/packages/core/src/engine/validators/turnValidators.ts
+++ b/packages/core/src/engine/validators/turnValidators.ts
@@ -4,7 +4,7 @@
 
 import type { GameState } from "../../state/GameState.js";
 import type { PlayerAction } from "@mage-knight/shared";
-import { GAME_PHASE_ROUND } from "@mage-knight/shared";
+import { DECLARE_REST_ACTION, GAME_PHASE_ROUND } from "@mage-knight/shared";
 import type { ValidationResult } from "./types.js";
 import { valid, invalid } from "./types.js";
 import {
@@ -19,6 +19,7 @@ import { getPlayerById } from "../helpers/playerHelpers.js";
 import {
   hasMetMinimumTurnRequirement,
   canTakeActionPhaseAction,
+  isWoundCard,
 } from "../rules/turnStructure.js";
 
 // Check it's this player's turn
@@ -65,12 +66,21 @@ export function validateNotInCombat(
 export function validateHasNotActed(
   state: GameState,
   playerId: string,
-  _action: PlayerAction
+  action: PlayerAction
 ): ValidationResult {
   const player = getPlayerById(state, playerId);
   if (!player) {
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
+
+  if (
+    action.type === DECLARE_REST_ACTION &&
+    player.hand.length > 0 &&
+    player.hand.every((cardId) => isWoundCard(cardId))
+  ) {
+    return valid();
+  }
+
   if (!canTakeActionPhaseAction(player)) {
     return invalid(ALREADY_ACTED, "You have already taken an action this turn");
   }


### PR DESCRIPTION
## Problem
Seed `263` started timing out in a dead-end state after combat:
- active player had only wound cards in hand
- `hasTakenActionThisTurn = true`
- `canEndTurn = false` (minimum turn requirement)
- `canDeclareRest = false` (action already taken)

This produced `mode=normal_turn` with zero valid actions and disconnected the sim.

## Fix
Server-side rule alignment update:
- allow `DECLARE_REST` after action **only when hand is all wounds** (Slow Recovery path)
- keep existing behavior for non-wound hands (still cannot declare rest after action)
- keep strict `END_TURN` requirement in place (no free end-turn waiver)

### Files
- `packages/core/src/engine/rules/turnStructure.ts`
- `packages/core/src/engine/validators/turnValidators.ts`
- `packages/core/src/engine/__tests__/rest.test.ts`
- `packages/core/src/engine/__tests__/restingValidActions.test.ts`

## Validation
- `bun test packages/core/src/engine/__tests__/rest.test.ts packages/core/src/engine/__tests__/restingValidActions.test.ts`
- `bun run lint`

## Note
I could reproduce the stale disconnect artifact symptom locally when pointed at an older/stale server process. With this patch, engine tests now confirm the dead-end state has a valid escape via Slow Recovery declaration.
