### PR TITLE
fix: keep sideways phase legality in rules as single source of truth

### DIFF
--- a/packages/core/src/engine/__tests__/playableCards.test.ts
+++ b/packages/core/src/engine/__tests__/playableCards.test.ts
@@ -18,6 +18,8 @@ import {
   CARD_IMPROVISATION,
   CARD_CRYSTALLIZE,
   CARD_WHIRLWIND,
+  PLAY_SIDEWAYS_AS_MOVE,
+  PLAY_SIDEWAYS_AS_INFLUENCE,
   PLAY_SIDEWAYS_AS_ATTACK,
   PLAY_SIDEWAYS_AS_BLOCK,
   MANA_BLUE,
@@ -675,6 +677,34 @@ describe("getPlayableCardsForCombat", () => {
       // March SHOULD be playable powered with green mana
       expect(marchCard?.canPlayPowered).toBe(true);
       expect(marchCard?.requiredMana).toBe(MANA_GREEN);
+    });
+
+    it("should only advertise move/influence sideways options on normal turn", () => {
+      const player = createTestPlayer({
+        hand: [CARD_RAGE],
+      });
+      const state = createTestGameState({ players: [player] });
+
+      const result = getPlayableCardsForNormalTurn(state, player);
+      const rageCard = result.cards.find((c) => c.cardId === CARD_RAGE);
+
+      expect(rageCard).toBeDefined();
+      expect(rageCard?.sidewaysOptions).toContainEqual({
+        as: PLAY_SIDEWAYS_AS_MOVE,
+        value: 1,
+      });
+      expect(rageCard?.sidewaysOptions).toContainEqual({
+        as: PLAY_SIDEWAYS_AS_INFLUENCE,
+        value: 1,
+      });
+      expect(rageCard?.sidewaysOptions).not.toContainEqual({
+        as: PLAY_SIDEWAYS_AS_ATTACK,
+        value: 1,
+      });
+      expect(rageCard?.sidewaysOptions).not.toContainEqual({
+        as: PLAY_SIDEWAYS_AS_BLOCK,
+        value: 1,
+      });
     });
 
     it("should not advertise Improvisation as basic/powered on normal turn when no other discard exists", () => {

--- a/packages/core/src/engine/rules/sideways.ts
+++ b/packages/core/src/engine/rules/sideways.ts
@@ -44,8 +44,6 @@ export function getAllowedSidewaysChoices(
     return [
       PLAY_SIDEWAYS_AS_MOVE,
       PLAY_SIDEWAYS_AS_INFLUENCE,
-      PLAY_SIDEWAYS_AS_ATTACK,
-      PLAY_SIDEWAYS_AS_BLOCK,
     ];
   }
 

--- a/packages/core/src/engine/validActions/cards/combat.ts
+++ b/packages/core/src/engine/validActions/cards/combat.ts
@@ -10,10 +10,6 @@ import type { CombatState, CombatPhase } from "../../../types/combat.js";
 import type { DeedCard } from "../../../types/cards.js";
 import type { PlayCardOptions, PlayableCard, ManaColor, SidewaysOption } from "@mage-knight/shared";
 import {
-  PLAY_SIDEWAYS_AS_ATTACK,
-  PLAY_SIDEWAYS_AS_BLOCK,
-} from "@mage-knight/shared";
-import {
   COMBAT_PHASE_RANGED_SIEGE,
   COMBAT_PHASE_BLOCK,
   COMBAT_PHASE_ATTACK,
@@ -77,12 +73,12 @@ export function getPlayableCardsForCombat(
         continue;
       }
 
-      let sidewaysOptions: SidewaysOption[] = [];
-      if (combat.phase === COMBAT_PHASE_BLOCK) {
-        sidewaysOptions = [{ as: PLAY_SIDEWAYS_AS_BLOCK, value: sidewaysValue }];
-      } else if (combat.phase === COMBAT_PHASE_ATTACK) {
-        sidewaysOptions = [{ as: PLAY_SIDEWAYS_AS_ATTACK, value: sidewaysValue }];
-      }
+      const sidewaysOptions: SidewaysOption[] = [
+        ...getSidewaysOptionsForValue(sidewaysValue, {
+          inCombat: true,
+          phase: combat.phase,
+        }),
+      ];
 
       if (sidewaysOptions.length === 0) {
         continue;

--- a/packages/core/src/engine/validActions/cards/normalTurn.ts
+++ b/packages/core/src/engine/validActions/cards/normalTurn.ts
@@ -43,7 +43,7 @@ interface CardPlayability {
  * - Move points
  * - Influence points
  * - Healing
- * - Sideways: +1 Move/Influence/Attack/Block (engine allows all sideways choices outside combat)
+ * - Sideways: +1 Move/Influence
  */
 export function getPlayableCardsForNormalTurn(
   state: GameState,

--- a/packages/core/src/engine/validators/sidewaysValidators.ts
+++ b/packages/core/src/engine/validators/sidewaysValidators.ts
@@ -1,7 +1,10 @@
 /**
  * Validators for PLAY_CARD_SIDEWAYS action
  *
- * Any non-Wound card can be played sideways to gain Move 1, Influence 1, Attack 1, or Block 1.
+ * Any non-Wound card can be played sideways, with available gains based on context:
+ * - Outside combat: Move 1 or Influence 1
+ * - Combat Block phase: Block 1
+ * - Combat Attack phase: Attack 1
  * This applies to Basic Actions, Advanced Actions, Spells, Artifacts, etc.
  */
 


### PR DESCRIPTION
## Summary
- make sideways legality outside combat Move/Influence only via shared `rules/sideways`
- remove duplicated combat wound sideways phase branching in valid-actions and route through `getSidewaysOptionsForValue`
- keep validators and valid-actions aligned by consuming the same rules helper
- update and extend sideways tests for out-of-combat rejection and combat-phase allowance

## Validation
- `bun run --filter @mage-knight/core test -- src/engine/__tests__/sidewaysPlay.test.ts src/engine/__tests__/playableCards.test.ts`
  - 49 passed, 0 failed
