### PR TITLE
fix: unify exploration eligibility rules

### DIFF
--- a/packages/core/src/engine/__tests__/explorationRules.test.ts
+++ b/packages/core/src/engine/__tests__/explorationRules.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { CARD_SPACE_BENDING, TERRAIN_PLAINS, hexKey } from "@mage-knight/shared";
+import { addModifier } from "../modifiers/index.js";
+import { createTestGameState, createTestHex, createTestPlayer } from "./testHelpers.js";
+import { getExploreDistance, isPlayerNearExploreEdge } from "../rules/exploration.js";
+import {
+  DURATION_TURN,
+  EFFECT_RULE_OVERRIDE,
+  RULE_SPACE_BENDING_ADJACENCY,
+  SCOPE_SELF,
+  SOURCE_CARD,
+} from "../../types/modifierConstants.js";
+
+describe("exploration rules", () => {
+  it("returns default explore distance of 1", () => {
+    const state = createTestGameState({
+      players: [createTestPlayer({ id: "player1", position: { q: 0, r: 0 } })],
+    });
+
+    expect(getExploreDistance(state, "player1")).toBe(1);
+  });
+
+  it("returns explore distance of 2 when space-bending adjacency is active", () => {
+    let state = createTestGameState({
+      players: [createTestPlayer({ id: "player1", position: { q: 0, r: 0 } })],
+    });
+
+    state = addModifier(state, {
+      source: {
+        type: SOURCE_CARD,
+        cardId: CARD_SPACE_BENDING,
+        playerId: "player1",
+      },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: {
+        type: EFFECT_RULE_OVERRIDE,
+        rule: RULE_SPACE_BENDING_ADJACENCY,
+      },
+      createdAtRound: state.round,
+      createdByPlayerId: "player1",
+    });
+
+    expect(getExploreDistance(state, "player1")).toBe(2);
+  });
+
+  it("uses shared distance rules for edge eligibility", () => {
+    const player = createTestPlayer({
+      id: "player1",
+      position: { q: 0, r: 0 },
+    });
+
+    const hexes = {
+      [hexKey({ q: 0, r: 0 })]: createTestHex(0, 0, TERRAIN_PLAINS),
+      [hexKey({ q: 1, r: -1 })]: createTestHex(1, -1, TERRAIN_PLAINS),
+      [hexKey({ q: 1, r: 0 })]: createTestHex(1, 0, TERRAIN_PLAINS),
+      [hexKey({ q: 0, r: 1 })]: createTestHex(0, 1, TERRAIN_PLAINS),
+      [hexKey({ q: -1, r: 1 })]: createTestHex(-1, 1, TERRAIN_PLAINS),
+      [hexKey({ q: -1, r: 0 })]: createTestHex(-1, 0, TERRAIN_PLAINS),
+      [hexKey({ q: 0, r: -1 })]: createTestHex(0, -1, TERRAIN_PLAINS),
+    };
+
+    const baseState = createTestGameState();
+    let state = createTestGameState({
+      players: [player],
+      map: {
+        ...baseState.map,
+        hexes,
+      },
+    });
+
+    expect(isPlayerNearExploreEdge(state, player)).toBe(false);
+
+    state = addModifier(state, {
+      source: {
+        type: SOURCE_CARD,
+        cardId: CARD_SPACE_BENDING,
+        playerId: "player1",
+      },
+      duration: DURATION_TURN,
+      scope: { type: SCOPE_SELF },
+      effect: {
+        type: EFFECT_RULE_OVERRIDE,
+        rule: RULE_SPACE_BENDING_ADJACENCY,
+      },
+      createdAtRound: state.round,
+      createdByPlayerId: "player1",
+    });
+
+    expect(isPlayerNearExploreEdge(state, state.players[0]!)).toBe(true);
+  });
+});

--- a/packages/core/src/engine/rules/exploration.ts
+++ b/packages/core/src/engine/rules/exploration.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared exploration rules.
+ *
+ * Single source of truth for exploration distance/edge eligibility so
+ * validActions and validators stay in sync.
+ */
+
+import type { GameState } from "../../state/GameState.js";
+import type { Player } from "../../types/player.js";
+import { isNearEdge } from "../explore/index.js";
+import { isRuleActive } from "../modifiers/index.js";
+import { RULE_EXTENDED_EXPLORE, RULE_SPACE_BENDING_ADJACENCY } from "../../types/modifierConstants.js";
+
+/**
+ * Effective exploration distance:
+ * - 1 by default
+ * - 2 when extended explore or space-bending adjacency is active
+ */
+export function getExploreDistance(state: GameState, playerId: string): number {
+  const extendedExplore = isRuleActive(state, playerId, RULE_EXTENDED_EXPLORE);
+  const spaceBending = isRuleActive(state, playerId, RULE_SPACE_BENDING_ADJACENCY);
+  return (extendedExplore || spaceBending) ? 2 : 1;
+}
+
+/**
+ * Whether the player is close enough to map edge to explore with current distance rules.
+ */
+export function isPlayerNearExploreEdge(state: GameState, player: Player): boolean {
+  if (!player.position) {
+    return false;
+  }
+  const exploreDistance = getExploreDistance(state, player.id);
+  return isNearEdge(state, player.position, exploreDistance);
+}
+

--- a/packages/core/src/engine/validActions/exploration.ts
+++ b/packages/core/src/engine/validActions/exploration.ts
@@ -18,7 +18,6 @@ import type { ExploreOptions, ExploreDirection } from "@mage-knight/shared";
 import type { HexDirection, HexCoord } from "@mage-knight/shared";
 import { MAP_SHAPE_WEDGE, MAP_SHAPE_OPEN_3, MAP_SHAPE_OPEN_4, MAP_SHAPE_OPEN_5, hexKey } from "@mage-knight/shared";
 import {
-  isNearEdge,
   TILE_PLACEMENT_OFFSETS,
   getExpansionDirections,
 } from "../explore/index.js";
@@ -28,7 +27,8 @@ import { peekNextTileType } from "../../data/tileDeckSetup.js";
 import { TILE_TYPE_CORE } from "../../data/tileConstants.js";
 import { mustAnnounceEndOfRound } from "./helpers.js";
 import { isRuleActive, getEffectiveExploreCost } from "../modifiers/index.js";
-import { RULE_EXTENDED_EXPLORE, RULE_SPACE_BENDING_ADJACENCY, RULE_NO_EXPLORATION } from "../../types/modifierConstants.js";
+import { RULE_NO_EXPLORATION } from "../../types/modifierConstants.js";
+import { getExploreDistance, isPlayerNearExploreEdge } from "../rules/exploration.js";
 
 /**
  * Get valid explore options for a player.
@@ -88,14 +88,12 @@ export function getValidExploreOptions(
   }
 
   // Determine explore distance (1 = normal adjacency, 2 = extended via Scouts ability or Space Bending)
-  const extendedExplore = isRuleActive(state, player.id, RULE_EXTENDED_EXPLORE);
-  const spaceBending = isRuleActive(state, player.id, RULE_SPACE_BENDING_ADJACENCY);
-  const exploreDistance = (extendedExplore || spaceBending) ? 2 : 1;
+  const exploreDistance = getExploreDistance(state, player.id);
 
   // Must be near the edge of the revealed map
   // Standard: must be on an edge hex (adjacent to unrevealed hex)
   // Extended: can be within 2 hexes of unrevealed hex
-  if (!isNearEdge(state, player.position, exploreDistance)) {
+  if (!isPlayerNearExploreEdge(state, player)) {
     return undefined;
   }
 

--- a/packages/core/src/engine/validators/exploreValidators.ts
+++ b/packages/core/src/engine/validators/exploreValidators.ts
@@ -19,7 +19,6 @@ import {
   COLUMN_LIMIT_EXCEEDED,
 } from "./validationCodes.js";
 import {
-  isEdgeHex,
   getExpansionDirections,
   TILE_PLACEMENT_OFFSETS,
 } from "../explore/index.js";
@@ -28,6 +27,8 @@ import { getValidExploreOptions } from "../validActions/exploration.js";
 import { peekNextTileType } from "../../data/tileDeckSetup.js";
 import { TILE_TYPE_CORE } from "../../data/tileConstants.js";
 import { getPlayerById } from "../helpers/playerHelpers.js";
+import { getEffectiveExploreCost } from "../modifiers/index.js";
+import { isPlayerNearExploreEdge } from "../rules/exploration.js";
 
 /**
  * Extract explore direction from action (type guard helper)
@@ -68,7 +69,7 @@ export function validateOnEdgeHex(
     return invalid(NOT_ON_MAP, "Player is not on the map");
   }
 
-  if (!isEdgeHex(state, player.position)) {
+  if (!isPlayerNearExploreEdge(state, player)) {
     return invalid(NOT_ON_EDGE, "Must be on edge of revealed map to explore");
   }
 
@@ -177,9 +178,7 @@ export function validateExploreMoveCost(
     return invalid(PLAYER_NOT_FOUND, "Player not found");
   }
 
-  // SIMPLE: Always costs 2 for now
-  // FUTURE: Cost equals terrain cost if exploring from dangerous space
-  const cost = 2;
+  const cost = getEffectiveExploreCost(state, playerId);
 
   if (player.movePoints < cost) {
     return invalid(

--- a/packages/python-sdk/src/mage_knight_sdk/viewer/static/index.html
+++ b/packages/python-sdk/src/mage_knight_sdk/viewer/static/index.html
@@ -224,6 +224,54 @@
       white-space: pre-wrap;
       word-break: break-all;
     }
+    .json-tree {
+      font-family: ui-monospace, "SF Mono", "Cascadia Code", Consolas, monospace;
+      font-size: 12px;
+      line-height: 1.4;
+      color: #a9b1d6;
+      user-select: text;
+    }
+    .json-line {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      min-height: 18px;
+    }
+    .json-line .json-children {
+      flex-basis: 100%;
+      padding-left: 16px;
+      border-left: 1px solid #363b54;
+      margin-left: 6px;
+    }
+    .json-line.collapsed .json-children { display: none; }
+    .json-line.collapsed .json-open-expanded { display: none; }
+    .json-line.collapsed .json-close { display: none; }
+    .json-line .json-preview { display: none; }
+    .json-line.collapsed .json-preview { display: inline; }
+    .json-toggle {
+      display: inline-block;
+      width: 16px;
+      cursor: pointer;
+      color: #565f89;
+      flex-shrink: 0;
+    }
+    .json-line.collapsed .json-toggle::before { content: '▶'; }
+    .json-line:not(.collapsed) .json-toggle::before { content: '▼'; }
+    .json-head {
+      cursor: pointer;
+      display: inline-flex;
+      align-items: baseline;
+      flex-wrap: wrap;
+    }
+    .json-head:hover .json-toggle { color: #7aa2f7; }
+    .json-key { color: #9ece6a; margin-right: 4px; }
+    .json-colon { color: #565f89; margin-right: 4px; }
+    .json-brace { color: #7aa2f7; }
+    .json-value-string { color: #e0af68; }
+    .json-value-number { color: #bb9af7; }
+    .json-value-boolean { color: #7aa2f7; }
+    .json-value-null { color: #565f89; }
+    .json-preview { color: #565f89; font-style: italic; }
   </style>
 </head>
 <body>
@@ -317,6 +365,44 @@
       const div = document.createElement('div');
       div.textContent = s;
       return div.innerHTML;
+    }
+
+    function jsonTreeHtml(value, key) {
+      const keyPart = key !== undefined ? `<span class="json-key">${escapeHtml(JSON.stringify(key))}</span><span class="json-colon">:</span> ` : '';
+      if (value === null) {
+        return `<div class="json-line json-primitive">${keyPart}<span class="json-value-null">null</span></div>`;
+      }
+      if (typeof value === 'boolean') {
+        return `<div class="json-line json-primitive">${keyPart}<span class="json-value-boolean">${value}</span></div>`;
+      }
+      if (typeof value === 'number') {
+        return `<div class="json-line json-primitive">${keyPart}<span class="json-value-number">${value}</span></div>`;
+      }
+      if (typeof value === 'string') {
+        return `<div class="json-line json-primitive">${keyPart}<span class="json-value-string">${escapeHtml(JSON.stringify(value))}</span></div>`;
+      }
+      if (Array.isArray(value)) {
+        const len = value.length;
+        const children = value.map((v, i) => jsonTreeHtml(v, i)).join('');
+        return `<div class="json-line json-array">
+          <span class="json-head"><span class="json-toggle"></span>${keyPart}<span class="json-open-expanded json-brace">[</span><span class="json-preview"> ${len} item${len !== 1 ? 's' : ''} </span></span>
+          <span class="json-children">${children}<span class="json-line"><span class="json-brace">]</span></span></span>
+        </div>`;
+      }
+      if (typeof value === 'object') {
+        const keys = Object.keys(value);
+        const children = keys.map(k => jsonTreeHtml(value[k], k)).join('');
+        const preview = ` ${keys.length} key${keys.length !== 1 ? 's' : ''} `;
+        return `<div class="json-line json-object">
+          <span class="json-head"><span class="json-toggle"></span>${keyPart}<span class="json-open-expanded json-brace">{</span><span class="json-preview">${escapeHtml(preview)}</span></span>
+          <span class="json-children">${children}<span class="json-line"><span class="json-brace">}</span></span></span>
+        </div>`;
+      }
+      return '';
+    }
+
+    function jsonTreeToHtml(value) {
+      return `<div class="json-tree">${jsonTreeHtml(value)}</div>`;
     }
 
     function getCachedEntry(index) {
@@ -517,7 +603,7 @@
               body.querySelectorAll('.state-modal-tab-content').forEach((panel, i) => {
                 const msg = updates[i];
                 const data = getDisplayData(msg, showFull);
-                panel.querySelector('pre').textContent = JSON.stringify(data, null, 2);
+                panel.innerHTML = jsonTreeToHtml(data);
               });
             }
 
@@ -536,9 +622,8 @@
             }).join('');
             const initialData = updates.map((msg, i) => getDisplayData(msg, false));
             const contentsHtml = updates.map((msg, i) => {
-              const json = escapeHtml(JSON.stringify(initialData[i], null, 2));
               const active = i === selectedIndex ? ' active' : '';
-              return `<div class="state-modal-tab-content${active}" data-index="${i}" role="tabpanel"><pre>${json}</pre></div>`;
+              return `<div class="state-modal-tab-content${active}" data-index="${i}" role="tabpanel">${jsonTreeToHtml(initialData[i])}</div>`;
             }).join('');
             body.innerHTML = `<div class="state-modal-tabs" role="tablist">${tabsHtml}</div>${contentsHtml}`;
 
@@ -558,7 +643,7 @@
             });
           } else {
             const payload = data.payload ?? data.state ?? data;
-            body.innerHTML = '<pre>' + escapeHtml(JSON.stringify(payload, null, 2)) + '</pre>';
+            body.innerHTML = jsonTreeToHtml(payload);
           }
         })
         .catch(err => {
@@ -575,6 +660,13 @@
     document.getElementById('state-modal-close').addEventListener('click', closeStateModal);
     document.getElementById('state-modal-overlay').addEventListener('click', (e) => {
       if (e.target === e.currentTarget) closeStateModal();
+      const head = e.target.closest('.json-head');
+      if (head) {
+        const line = head.closest('.json-line');
+        if (line && (line.classList.contains('json-object') || line.classList.contains('json-array'))) {
+          line.classList.toggle('collapsed');
+        }
+      }
     });
     document.addEventListener('keydown', (e) => {
       if (stateModalOpen && e.key === 'Escape') closeStateModal();


### PR DESCRIPTION
## Summary
- extract shared exploration rule helpers into `rules/exploration.ts`
- use shared helpers in both `validActions/exploration.ts` and `validators/exploreValidators.ts`
- align explore move-cost validation with `getEffectiveExploreCost`
- add regression coverage for the distance-2 edge eligibility mismatch and rule-level tests

## Why
The simulator hit an invariant where `EXPLORE` was advertised valid but rejected by server validation (`Must be on edge of revealed map to explore`). This came from duplicated edge-distance logic diverging between valid-actions and validators.

## Validation
- `bun run build`
- `bun run lint`
- `bun run test`
