### PR TITLE
fix(client): preparation card modal and summoned enemy textures

### DIFF
--- a/packages/client/src/components/Combat/PixiEnemyTokens.tsx
+++ b/packages/client/src/components/Combat/PixiEnemyTokens.tsx
@@ -97,6 +97,8 @@ export function PixiEnemyTokens({ enemies, onEnemyClick }: PixiEnemyTokensProps)
 
   // Preload enemy textures
   useEffect(() => {
+    setTexturesLoaded(false);
+
     const loadTextures = async () => {
       const urls = enemies.map((e) => getEnemyImageUrl(e.enemy.enemyId));
       const uniqueUrls = [...new Set(urls)];

--- a/packages/client/src/components/Overlays/PreparationDecision.tsx
+++ b/packages/client/src/components/Overlays/PreparationDecision.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import type { CardId } from "@mage-knight/shared";
 import {
   RESOLVE_TACTIC_DECISION_ACTION,
@@ -5,14 +6,7 @@ import {
 } from "@mage-knight/shared";
 import { useGame } from "../../hooks/useGame";
 import { useMyPlayer } from "../../hooks/useMyPlayer";
-
-// Format card ID for display (convert snake_case to Title Case)
-function formatCardName(cardId: string): string {
-  return cardId
-    .split("_")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
-}
+import { CardSelectionOverlay } from "./CardSelectionOverlay";
 
 export function PreparationDecision() {
   const { state, sendAction } = useGame();
@@ -23,86 +17,41 @@ export function PreparationDecision() {
     state?.validActions?.mode === "pending_tactic_decision"
       ? state.validActions.tacticDecision
       : undefined;
-  if (
-    !pendingDecision ||
-    pendingDecision.type !== TACTIC_DECISION_PREPARATION ||
-    !player
-  ) {
+
+  const isActive =
+    !!pendingDecision &&
+    pendingDecision.type === TACTIC_DECISION_PREPARATION &&
+    !!player;
+
+  const handleSelectCard = useCallback(
+    (selectedCards: readonly CardId[]) => {
+      const cardId = selectedCards[0];
+      if (!cardId) return;
+      sendAction({
+        type: RESOLVE_TACTIC_DECISION_ACTION,
+        decision: {
+          type: TACTIC_DECISION_PREPARATION,
+          cardId,
+        },
+      });
+    },
+    [sendAction]
+  );
+
+  if (!isActive || !pendingDecision) {
     return null;
   }
 
-  // Get deck snapshot from pending decision
   const deckSnapshot: readonly CardId[] = pendingDecision.deckSnapshot ?? [];
 
-  const handleSelectCard = (cardId: CardId) => {
-    sendAction({
-      type: RESOLVE_TACTIC_DECISION_ACTION,
-      decision: {
-        type: TACTIC_DECISION_PREPARATION,
-        cardId,
-      },
-    });
-  };
-
   return (
-    <div className="overlay">
-      <div className="overlay__content choice-selection">
-        <h2 className="choice-selection__title">Preparation</h2>
-        <p style={{ color: "#999", marginBottom: "1rem", textAlign: "center" }}>
-          Choose a card from your deck to add to your hand.
-          The remaining deck will be shuffled.
-        </p>
-
-        {deckSnapshot.length === 0 ? (
-          <p style={{ color: "#999", textAlign: "center" }}>
-            Your deck is empty.
-          </p>
-        ) : (
-          <div
-            style={{
-              display: "flex",
-              flexWrap: "wrap",
-              gap: "0.5rem",
-              justifyContent: "center",
-              marginBottom: "1rem",
-              maxWidth: "600px",
-            }}
-          >
-            {deckSnapshot.map((cardId) => {
-              const isWound = cardId.includes("wound");
-              return (
-                <button
-                  key={cardId}
-                  type="button"
-                  onClick={() => handleSelectCard(cardId)}
-                  style={{
-                    padding: "0.75rem 1rem",
-                    borderRadius: "6px",
-                    background: isWound ? "#8b4513" : "#2c3e50",
-                    color: "#fff",
-                    border: "2px solid transparent",
-                    cursor: "pointer",
-                    fontSize: "0.85rem",
-                    fontWeight: 400,
-                    transition: "all 0.2s ease",
-                  }}
-                  onMouseOver={(e) => {
-                    (e.target as HTMLButtonElement).style.background = "#1a237e";
-                    (e.target as HTMLButtonElement).style.borderColor = "#fff";
-                  }}
-                  onMouseOut={(e) => {
-                    (e.target as HTMLButtonElement).style.background = isWound ? "#8b4513" : "#2c3e50";
-                    (e.target as HTMLButtonElement).style.borderColor = "transparent";
-                  }}
-                >
-                  {formatCardName(cardId)}
-                  {isWound && " (Wound)"}
-                </button>
-              );
-            })}
-          </div>
-        )}
-      </div>
-    </div>
+    <CardSelectionOverlay
+      cards={deckSnapshot}
+      instruction="Preparation: Choose a card from your deck to add to your hand"
+      minSelect={1}
+      maxSelect={1}
+      canSkip={false}
+      onSelect={handleSelectCard}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- **Preparation tactic modal**: Rewrote `PreparationDecision` to use `CardSelectionOverlay` (PixiJS), fixing duplicate React key warning when deck has duplicate cards and rendering actual card images instead of plain text buttons
- **Summoned enemy textures**: Reset `texturesLoaded` state when enemy list changes in `PixiEnemyTokens`, so summoned enemies wait for texture preload before rendering instead of showing empty placeholders

Closes #98

## Test plan
- [ ] Choose Preparation tactic, verify card selection modal shows card images (not text names)
- [ ] Verify no duplicate key warnings in console when deck has multiple copies of a card
- [ ] Fight a Summoner enemy, verify summoned enemies render with correct textures immediately (no blank/delayed load)