### PR TITLE
fix(rl): fix three training pipeline bugs preventing learning

### DIFF
--- a/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
+++ b/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
@@ -98,6 +98,8 @@ def main() -> int:
     parser.add_argument("--terminal-max-steps-penalty", type=float, default=-0.5, help="Penalty when episode hits max steps")
     parser.add_argument("--terminal-failure-penalty", type=float, default=-1.0, help="Penalty for engine failures")
 
+    parser.add_argument("--fixed-seed", action="store_true", help="Use the same seed for every episode (enables memorization of a single game)")
+
     parser.add_argument("--checkpoint-dir", default=None, help="Run directory for checkpoints + logs (default: auto-generated under training/runs/)")
     parser.add_argument("--checkpoint-every", type=int, default=25, help="Save checkpoint every N episodes")
     parser.add_argument("--no-final-checkpoint", action="store_true", help="Do not save a final checkpoint at the end")
@@ -165,7 +167,8 @@ def main() -> int:
 
     algo = "PPO" if args.ppo else "REINFORCE"
     hero_display = args.hero if args.hero.lower() != "random" else "random (seeded rotation)"
-    print(f"Training episodes={args.episodes} seed={args.seed} max_steps={args.max_steps} algorithm={algo} hero={hero_display}")
+    seed_display = f"{args.seed} (FIXED — same game every episode)" if args.fixed_seed else f"{args.seed} (incrementing)"
+    print(f"Training episodes={args.episodes} seed={seed_display} max_steps={args.max_steps} algorithm={algo} hero={hero_display}")
     print(
         "Rewards: "
         f"fame_delta_scale={args.fame_delta_scale} "
@@ -222,7 +225,7 @@ def _train_native_sequential(
 
     for episode in range(args.episodes):
         global_ep = resume_episode_offset + episode + 1
-        seed = args.seed + resume_episode_offset + episode
+        seed = args.seed if args.fixed_seed else args.seed + resume_episode_offset + episode
         hero = resolve_hero(args.hero, seed)
 
         result, stats = run_native_rl_game(
@@ -311,7 +314,7 @@ def _train_ppo_native(
         batch_fames: list[int] = []
 
         for i in range(batch_size):
-            seed = args.seed + resume_episode_offset + episode_num + i
+            seed = args.seed if args.fixed_seed else args.seed + resume_episode_offset + episode_num + i
             hero = resolve_hero(args.hero, seed)
 
             result, transitions, terminated = run_native_rl_game_ppo(
@@ -376,7 +379,7 @@ def _train_ppo_native(
         # Log each episode in the batch
         for i, stats in enumerate(batch_stats):
             global_ep = resume_episode_offset + episode_num + i + 1
-            seed = args.seed + resume_episode_offset + episode_num + i
+            seed = args.seed if args.fixed_seed else args.seed + resume_episode_offset + episode_num + i
 
             logged_stats = _with_opt(stats, opt_stats)
             _append_metrics_log(

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
@@ -627,13 +627,17 @@ class _EmbeddingActionScoringNetwork(nn.Module):
         hand_embs_masked = hand_embs * hand_mask.unsqueeze(-1).float()
         hand_pool = hand_embs_masked.sum(dim=1) / hand_counts_t.clamp(min=1).unsqueeze(-1).float()  # (N, emb)
 
-        # Mean-pool unit embeddings per env
+        # Mean-pool unit embeddings + per-unit scalars per env
         unit_ids_t = torch.tensor(batch_dict["unit_ids"], dtype=torch.long, device=device)  # (N, max_U)
         unit_counts_t = torch.tensor(batch_dict["unit_counts"], dtype=torch.long, device=device)  # (N,)
+        max_u = unit_ids_t.shape[1]
         unit_embs = self.unit_emb(unit_ids_t)  # (N, max_U, emb)
-        unit_mask = torch.arange(unit_ids_t.shape[1], device=device).unsqueeze(0) < unit_counts_t.unsqueeze(1)
-        unit_embs_masked = unit_embs * unit_mask.unsqueeze(-1).float()
-        unit_pool = unit_embs_masked.sum(dim=1) / unit_counts_t.clamp(min=1).unsqueeze(-1).float()
+        unit_scalars_flat = torch.tensor(batch_dict["unit_scalars"], dtype=torch.float32, device=device)  # (N*max_U, UNIT_SCALAR_DIM)
+        unit_scalars_t = unit_scalars_flat.view(n, max_u, -1)  # (N, max_U, UNIT_SCALAR_DIM)
+        unit_combined = torch.cat([unit_embs, unit_scalars_t], dim=-1)  # (N, max_U, emb+UNIT_SCALAR_DIM)
+        unit_mask = torch.arange(max_u, device=device).unsqueeze(0) < unit_counts_t.unsqueeze(1)
+        unit_masked = unit_combined * unit_mask.unsqueeze(-1).float()
+        unit_pool = unit_masked.sum(dim=1) / unit_counts_t.clamp(min=1).unsqueeze(-1).float()  # (N, emb+UNIT_SCALAR_DIM)
 
         # Mean-pool combat enemy embeddings + scalars
         ce_ids_t = torch.tensor(batch_dict["combat_enemy_ids"], dtype=torch.long, device=device)  # (N, max_CE)

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/vec_env_runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/vec_env_runner.py
@@ -30,6 +30,7 @@ class VecTransition:
     state_ids: np.ndarray              # (3,) int32
     hand_card_ids: np.ndarray          # (H,) int32 (trimmed to actual count)
     unit_ids: np.ndarray               # (U,) int32
+    unit_scalars: np.ndarray           # (U, UNIT_SCALAR_DIM) float32
     combat_enemy_ids: np.ndarray       # (CE,) int32
     combat_enemy_scalars: np.ndarray   # (CE, COMBAT_ENEMY_SCALAR_DIM) float32
     skill_ids: np.ndarray              # (S,) int32
@@ -68,11 +69,15 @@ def _extract_vec_transition(
     ac = int(batch_dict["action_counts"][i])
 
     n = batch_dict["state_scalars"].shape[0]
+    max_u = batch_dict["unit_ids"].shape[1]
     max_ce = batch_dict["combat_enemy_ids"].shape[1]
     max_vs = batch_dict["visible_site_ids"].shape[1]
     max_me = batch_dict["map_enemy_ids"].shape[1]
 
     # Reshape 3D arrays that come as (N*max, dim) → index by env
+    u_scalars_raw = batch_dict["unit_scalars"]
+    u_scalars_3d = u_scalars_raw.reshape(n, max_u, -1)
+
     ce_scalars_raw = batch_dict["combat_enemy_scalars"]
     ce_scalars_3d = ce_scalars_raw.reshape(n, max_ce, -1)
 
@@ -92,6 +97,7 @@ def _extract_vec_transition(
         state_ids=batch_dict["state_ids"][i].copy(),
         hand_card_ids=batch_dict["hand_card_ids"][i, :hc].copy(),
         unit_ids=batch_dict["unit_ids"][i, :uc].copy(),
+        unit_scalars=u_scalars_3d[i, :uc].copy(),
         combat_enemy_ids=batch_dict["combat_enemy_ids"][i, :cec].copy(),
         combat_enemy_scalars=ce_scalars_3d[i, :cec].copy(),
         skill_ids=batch_dict["skill_ids"][i, :sc].copy(),
@@ -115,6 +121,7 @@ def vec_transition_to_transition(vt: VecTransition) -> Transition:
         mode_id=int(vt.state_ids[0]),
         hand_card_ids=vt.hand_card_ids.tolist(),
         unit_ids=vt.unit_ids.tolist(),
+        unit_scalars=vt.unit_scalars.tolist(),
         current_terrain_id=int(vt.state_ids[1]),
         current_site_type_id=int(vt.state_ids[2]),
         combat_enemy_ids=vt.combat_enemy_ids.tolist(),


### PR DESCRIPTION
1. Seed increments every episode even when user expects fixed seed.
   Added --fixed-seed flag to reuse same seed for memorization.

2. forward_batch drops unit_scalars from state encoding, creating a
   dimension mismatch (off by UNIT_SCALAR_DIM=2) vs the state_encoder
   input layer. Fixed to match non-batched path.

3. VecTransition drops unit_scalars field entirely, causing
   vec_transition_to_transition to crash with TypeError.
   Added unit_scalars to VecTransition and its extraction/conversion.

https://claude.ai/code/session_01BSAYGU35PZkGYkNELgNmUD