### PR TITLE
refactor: extract magic numbers and repeated conversion in goal_tracker

### DIFF
--- a/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
+++ b/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
@@ -15,6 +15,7 @@ import sys
 from typing import Any
 
 from mage_knight_sdk.sim.hero_selection import resolve_hero
+from mage_knight_sdk.sim.rl.goal_tracker import DEFAULT_MAX_GOAL_STEPS
 
 
 class RunningMeanStd:
@@ -218,7 +219,7 @@ def main() -> int:
 
     # Hierarchical RL
     parser.add_argument("--hrl", action="store_true", help="Enable Hierarchical RL (CEO + Worker dual-policy training)")
-    parser.add_argument("--max-goal-steps", type=int, default=30, help="Max steps before a goal times out (default: 30)")
+    parser.add_argument("--max-goal-steps", type=int, default=DEFAULT_MAX_GOAL_STEPS, help=f"Max steps before a goal times out (default: {DEFAULT_MAX_GOAL_STEPS})")
 
     args = parser.parse_args()
     if args.episodes < 1:

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/goal_tracker.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/goal_tracker.py
@@ -29,6 +29,20 @@ NUM_GOAL_TYPES = len(GoalType)
 # Goal encoding dimension: NUM_GOAL_TYPES one-hot + 2 relative target coords
 GOAL_ENCODING_DIM = NUM_GOAL_TYPES + 2
 
+# Default timeout for a single goal before it is marked failed
+DEFAULT_MAX_GOAL_STEPS = 30
+
+# Normalization divisor for relative hex coordinates in goal encoding (typical range -5..5)
+_GOAL_COORD_NORM = 5.0
+
+
+def _to_hex_int(v: float) -> int:
+    """Convert a numpy scalar from the encoded state to an integer hex coordinate.
+
+    Encoded scalars are float32; round() handles sub-pixel drift before casting.
+    """
+    return int(round(float(v)))
+
 
 class GoalStatus(IntEnum):
     ACTIVE = 0
@@ -115,7 +129,7 @@ class GoalTracker:
     One GoalTracker per environment in the VecEnv.
     """
 
-    def __init__(self, max_goal_steps: int = 30) -> None:
+    def __init__(self, max_goal_steps: int = DEFAULT_MAX_GOAL_STEPS) -> None:
         self.max_goal_steps = max_goal_steps
         self.current: GoalState | None = None
         self._step_count = 0
@@ -254,9 +268,8 @@ class GoalTracker:
             if self.current.target_hex is not None:
                 pq, pr = player_pos
                 tq, tr = self.current.target_hex
-                # Normalize relative coords (typical range -5..5)
-                enc[NUM_GOAL_TYPES] = (tq - pq) / 5.0
-                enc[NUM_GOAL_TYPES + 1] = (tr - pr) / 5.0
+                enc[NUM_GOAL_TYPES] = (tq - pq) / _GOAL_COORD_NORM
+                enc[NUM_GOAL_TYPES + 1] = (tr - pr) / _GOAL_COORD_NORM
         return enc
 
     @staticmethod
@@ -336,7 +349,7 @@ class GoalTracker:
             result = []
             for j in range(count):
                 row = scalars[start + j]
-                result.append((int(round(float(row[0]))), int(round(float(row[1])))))
+                result.append((_to_hex_int(row[0]), _to_hex_int(row[1])))
             return result
 
         if goal_type == GoalType.CHALLENGE_RAMPAGING:
@@ -357,8 +370,6 @@ class GoalTracker:
                 for j in range(site_count):
                     row = scalars[start + j]
                     # site_scalars: [is_conquered, is_fortified, rel_q, rel_r, ...]
-                    rel_q = float(row[2])
-                    rel_r = float(row[3])
-                    candidates.append((int(round(rel_q)), int(round(rel_r))))
+                    candidates.append((_to_hex_int(row[2]), _to_hex_int(row[3])))
 
         return candidates


### PR DESCRIPTION
## Summary

Addresses four code review findings in `goal_tracker.py`, all mechanical cleanups with no behaviour change.

- **`DEFAULT_MAX_GOAL_STEPS = 30`** — shared constant between `GoalTracker.__init__` default and `train_rl.py` argparse default; previously the two `30`s were independent and could drift
- **`_GOAL_COORD_NORM = 5.0`** — named constant for the hex coordinate normalization divisor with the existing range comment moved to the constant definition
- **`_to_hex_int(v)`** — helper replacing the three-layer `int(round(float(v)))` pattern used in two separate loops; docstring explains why numpy float32 scalars require all three conversions