### PR TITLE
fix: eliminate shell injection in copyToClipboard

### DIFF
--- a/packages/mage-dev/src/lib/worktrees.ts
+++ b/packages/mage-dev/src/lib/worktrees.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "node:child_process";
+import { execSync, spawn, spawnSync } from "node:child_process";
 import {
   createWriteStream,
   existsSync,
@@ -129,7 +129,7 @@ export function getWorktrees(): Worktree[] {
 
 export function copyToClipboard(text: string): boolean {
   try {
-    execSync(`echo ${JSON.stringify(text)} | pbcopy`, { stdio: "pipe" });
+    spawnSync("pbcopy", [], { input: text, stdio: "pipe" });
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary

Fixes CodeQL alert #27 (`js/shell-command-injection-from-environment`) in `packages/mage-dev/src/lib/worktrees.ts`.

### Root cause

```ts
execSync(`echo ${JSON.stringify(text)} | pbcopy`, { stdio: "pipe" });
```

`JSON.stringify` is not shell-safe. It escapes for JSON encoding, not for bash — `$(cmd)` and backtick substitutions are still expanded inside double-quoted strings. Any caller-controlled content in `text` (e.g. a branch name or generated command containing `$(...)`) would be executed by the shell.

### Fix

```ts
spawnSync("pbcopy", [], { input: text, stdio: "pipe" });
```

`spawnSync` with `input` pipes the string directly to `pbcopy`'s stdin with no shell involved — no quoting, no interpolation, no injection surface.