### PR TITLE
ci: add Dependabot auto-merge for patch and Actions updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge safe Dependabot updates
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Enable auto-merge for patch and GitHub Actions updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          steps.meta.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a workflow that enables auto-merge on Dependabot PRs once CI passes
- Auto-merges **patch** version bumps (semver patch across Rust, npm, pip)
- Auto-merges **GitHub Actions** version bumps (major bumps are normal/expected for actions)
- Minor and major dependency bumps are left for manual review

## How it works
Uses `dependabot/fetch-metadata` to inspect the update type, then calls `gh pr merge --auto --squash` which enables GitHub's auto-merge feature — the PR only merges once all required CI checks pass, not immediately.

## Test plan
- [ ] Merge this PR
- [ ] Post `@dependabot rebase` on the open patch PRs (#1046, #1054, #1055, #1047) and Actions PRs (#1041, #1042, #1043)
- [ ] Confirm they auto-merge once CI passes