### PR TITLE
ci: group Dependabot updates and cascade rebase on merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,34 @@ updates:
     directory: "/packages/engine-rs"
     schedule:
       interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/packages/python-sdk"
     schedule:
       interval: "weekly"
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      javascript-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-cascade.yml
+++ b/.github/workflows/dependabot-cascade.yml
@@ -1,0 +1,30 @@
+name: Dependabot Cascade Rebase
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  cascade:
+    name: Rebase open Dependabot PRs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Rebase all open Dependabot PRs
+        run: |
+          gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --author "dependabot[bot]" \
+            --state open \
+            --json number \
+            --jq '.[].number' \
+          | xargs -r -I{} gh pr comment {} \
+            --repo "$GITHUB_REPOSITORY" \
+            --body "@dependabot rebase"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- **Groups**: Dependabot now opens one PR per ecosystem (Rust, JS, Python, Actions) instead of one per package — reduces concurrent PRs from ~15 to ~4
- **Cascade**: When any PR merges to main, a workflow fires and posts `@dependabot rebase` on all remaining open Dependabot PRs — they sequence automatically without manual intervention

## How the cascade works
1. PR A merges → triggers `dependabot-cascade.yml`
2. Workflow finds all open Dependabot PRs and posts `@dependabot rebase`
3. Dependabot rebases each one → triggers `dependabot-auto-merge.yml`
4. Auto-merge is enabled → CI runs → PR B merges → repeat

## Notes
- Groups take effect on the next weekly Dependabot run — existing individual PRs won't be retroactively grouped
- The cascade fires on *any* PR merge to main, not just Dependabot ones, which ensures Dependabot PRs stay current after feature work lands too