### PR TITLE
fix: trigger cascade rebase on push to main

### DIFF
--- a/.github/workflows/dependabot-cascade.yml
+++ b/.github/workflows/dependabot-cascade.yml
@@ -1,8 +1,7 @@
 name: Dependabot Cascade Rebase
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches: [main]
 
 permissions:
@@ -12,7 +11,6 @@ jobs:
   cascade:
     name: Rebase open Dependabot PRs
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
 
     steps:
       - name: Rebase all open Dependabot PRs


### PR DESCRIPTION
## Problem
The cascade workflow used `pull_request: closed` as its trigger. GitHub restricts workflows triggered by Dependabot `pull_request` events to a read-only token, so the cascade only fired once (on the human-authored #1058 PR) and silently skipped all subsequent Dependabot auto-merges.

## Fix
Switch trigger to `push` on `main`. Every merge creates a push event — fires reliably for all merges regardless of PR author.