### PR TITLE
feat(client): restore SetupScreen before game initialization

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -121,7 +121,6 @@ export function App() {
       hero={gameConfig.heroIds[0] ?? HERO_ARYTHEA}
       seed={RUNTIME_RUST_CONFIG.seed}
       playerId={gameConfig.playerIds[0]}
-      scenario={gameConfig.scenarioId}
     >
       {gameShell}
     </GameProvider>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -13,6 +13,9 @@ import { TurnNotificationProvider } from "./contexts/TurnNotificationContext";
 import { GameView } from "./components/GameView";
 import { DebugPanel } from "./components/DebugPanel";
 import { ReplayLoadScreen } from "./components/Replay";
+import { SetupScreen } from "./components/Setup";
+import type { GameConfig } from "@mage-knight/shared";
+import { HERO_ARYTHEA } from "@mage-knight/shared";
 
 const MODE_PARAM = "mode" as const;
 const SERVER_URL_PARAM = "serverUrl" as const;
@@ -59,6 +62,8 @@ const RUNTIME_RUST_CONFIG = getRuntimeRustConfig();
 const REPLAY_MODE_REQUESTED = isReplayModeRequested();
 
 export function App() {
+  const [gameConfig, setGameConfig] = useState<GameConfig | null>(null);
+
   // Replay mode state
   const [replayArtifact, setReplayArtifact] = useState<ArtifactData | null>(null);
   const [replayPlayerId, setReplayPlayerId] = useState<string | null>(null);
@@ -105,14 +110,18 @@ export function App() {
     );
   }
 
+  if (!gameConfig) {
+    return <SetupScreen onComplete={setGameConfig} />;
+  }
+
   // Default: connect to Rust mk-server
   return (
     <GameProvider
       serverUrl={RUNTIME_RUST_CONFIG.serverUrl}
-      hero={RUNTIME_RUST_CONFIG.hero}
+      hero={gameConfig.heroIds[0] ?? HERO_ARYTHEA}
       seed={RUNTIME_RUST_CONFIG.seed}
-      playerId={RUNTIME_RUST_CONFIG.playerId}
-      scenario={RUNTIME_RUST_CONFIG.scenario}
+      playerId={gameConfig.playerIds[0]}
+      scenario={gameConfig.scenarioId}
     >
       {gameShell}
     </GameProvider>

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -120,7 +120,7 @@ export function App() {
       serverUrl={RUNTIME_RUST_CONFIG.serverUrl}
       hero={gameConfig.heroIds[0] ?? HERO_ARYTHEA}
       seed={RUNTIME_RUST_CONFIG.seed}
-      playerId={gameConfig.playerIds[0]}
+      playerId={RUNTIME_RUST_CONFIG.playerId}
     >
       {gameShell}
     </GameProvider>


### PR DESCRIPTION
## Summary

The SetupScreen (hero selection + player count) was accidentally dropped when the TS engine was removed in d1bfd499. The components were fully intact but `App.tsx` bypassed them entirely, hardcoding Arythea via URL param.

## Changes

- Restore `SetupScreen` as the entry point before connecting to `mk-server`
- Wire `heroIds[0]` from setup config into `GameProvider`'s `hero` prop
- Drop `scenarioId` from the server call — `mk-server`'s preset list doesn't include engine scenario IDs; omitting it correctly falls back to `FullGame`
- Keep `playerId` from the URL param (not setup config) — server always assigns `player_0` internally, setup screen's `player1` naming caused "waiting for other player's turn"

## Test Plan

- Start `bun run dev:rust` + `mk-server`
- Open app — SetupScreen should appear with hero grid
- Pick a hero, click Start Game — game should initialize and be playable
- `?hero=` URL param still works for dev shortcuts (bypassed by setup screen now, but seed/serverUrl params still respected)