### PR TITLE
fix(engine): village plunder must not burn the site

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,5 +1,13 @@
 #!/bin/bash
-# Run clippy (matching CI) before push to catch lint errors early.
+# Pre-push checks (see .github/workflows/ci.yml):
+#
+# - "Rust Build, Lint & Test": clippy + the same workspace unit tests CI runs via
+#   `cargo llvm-cov --workspace --exclude mk-python` (root: `bun run test`).
+#   This catches golden replays in mk-env and other cross-crate failures.
+# - "Build & Lint": `bun run lint` (oxlint).
+#
+# Clippy uses `--exclude mk-python` for faster local pushes when PyO3 is not built;
+# CI runs full `cargo clippy --workspace` when engine-rs changes.
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
@@ -10,5 +18,23 @@ cd "$REPO_ROOT/packages/engine-rs" && \
 if [ $? -ne 0 ]; then
     echo ""
     echo "Clippy failed. Fix the errors above before pushing."
+    exit 1
+fi
+
+echo "Running bun run lint..."
+cd "$REPO_ROOT" && bun run lint
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "bun run lint failed. Fix the errors above before pushing."
+    exit 1
+fi
+
+echo "Running bun run test (cargo test workspace, excludes mk-python)..."
+cd "$REPO_ROOT" && bun run test
+
+if [ $? -ne 0 ]; then
+    echo ""
+    echo "bun run test failed. Fix the errors above before pushing."
     exit 1
 fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,7 +254,7 @@ Units (max 8), banners (max 4), kept enemies (max 4) use `ArrayVec` to avoid hea
 
 ### Sites
 - Dungeon/Tomb: `units_allowed=false`, `night_mana_rules=true`, re-enterable
-- Plunder: burns site + rep -1
+- Plunder (village): draw 2, rep −1 (village stays usable; “burned” is monastery-only)
 - Commerce: BuySpell (7 influence), LearnAA (6 influence), BurnMonastery (-3 rep, violet enemy, artifact reward)
 - Conquest rewards: `queue_site_reward` → auto-grant or defer → `promote_site_reward`
 - City-color commerce: Blue (spells), Green (AA from offer or deck), Red (artifact blind draw), White (elite unit + all types)

--- a/packages/client/src/components/Overlays/PlunderDecisionOverlay.tsx
+++ b/packages/client/src/components/Overlays/PlunderDecisionOverlay.tsx
@@ -27,7 +27,8 @@ export function PlunderDecisionOverlay() {
       <div className="overlay__content choice-selection">
         <h2 className="choice-selection__title">Plunder Site</h2>
         <p style={{ color: "#999", marginBottom: "1rem", textAlign: "center" }}>
-          Plundering burns the site and costs 1 reputation.
+          Plundering draws two cards and costs 1 reputation. The village remains
+          usable for recruiting and healing.
         </p>
         <div
           className="choice-selection__options"

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/mod.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/mod.rs
@@ -399,7 +399,7 @@ pub fn apply_legal_action(
         }
 
         LegalAction::PlunderSite => {
-            // Irreversible: burns site + reputation loss
+            // Irreversible: reputation loss + card draw (village not destroyed)
             undo_stack.set_checkpoint();
             sites::apply_plunder_site(state, player_idx)?
         }

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/sites.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/sites.rs
@@ -385,12 +385,12 @@ pub(super) fn apply_plunder_site(
         .get_mut(&hex_key)
         .ok_or_else(|| ApplyError::InternalError("PlunderSite: hex not found".into()))?;
 
-    let site = hex
-        .site
-        .as_mut()
-        .ok_or_else(|| ApplyError::InternalError("PlunderSite: no site on hex".into()))?;
+    if hex.site.is_none() {
+        return Err(ApplyError::InternalError("PlunderSite: no site on hex".into()));
+    }
 
-    site.is_burned = true;
+    // Village plunder (rulebook): draw 2 cards and −1 reputation only.
+    // "Burned" / destroyed is monastery-only (Burn Monastery combat), not plunder.
 
     // Reputation loss (capped at -7)
     let player = &mut state.players[player_idx];

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
@@ -435,6 +435,28 @@ fn plunder_village_leaves_unit_recruitment_available() {
 }
 
 #[test]
+fn plunder_site_errors_when_hex_has_no_site() {
+    let mut state = setup_playing_game(vec!["march"]);
+    let coord = place_player_on_site(&mut state, SiteType::Village);
+    state.players[0].pending.active = Some(ActivePending::PlunderDecision);
+    state.map.hexes.get_mut(&coord.key()).unwrap().site = None;
+
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+    let result = apply_legal_action(
+        &mut state,
+        &mut undo,
+        0,
+        &LegalAction::PlunderSite,
+        epoch,
+    );
+    assert!(
+        result.is_err(),
+        "PlunderSite internal guard should fail when hex has no site"
+    );
+}
+
+#[test]
 fn plunder_draws_fewer_if_deck_small() {
     let mut state = setup_playing_game(vec!["march"]);
     place_player_on_site(&mut state, SiteType::Village);

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
@@ -6,7 +6,7 @@ use super::*;
 
 use arrayvec::ArrayVec;
 use mk_types::hex::HexCoord;
-use mk_types::ids::{CombatInstanceId, EnemyId};
+use mk_types::ids::{CombatInstanceId, EnemyId, UnitId};
 use mk_types::state::CombatEnemy;
 
 /// Helper: place player on a hex with a specific site.
@@ -383,7 +383,7 @@ fn plunder_decision_offered_at_unconquered_village() {
 }
 
 #[test]
-fn plunder_burns_site_and_rep_hit() {
+fn plunder_village_draws_cards_and_rep_hit_without_burning_site() {
     let mut state = setup_playing_game(vec!["march"]);
     let coord = place_player_on_site(&mut state, SiteType::Village);
     state.players[0].pending.active = Some(ActivePending::PlunderDecision);
@@ -397,13 +397,41 @@ fn plunder_burns_site_and_rep_hit() {
     apply_legal_action(&mut state, &mut undo, 0, &LegalAction::PlunderSite, epoch).unwrap();
 
     let site = state.map.hexes.get(&coord.key()).unwrap().site.as_ref().unwrap();
-    assert!(site.is_burned, "Site should be burned");
+    assert!(
+        !site.is_burned,
+        "plundering a village must not mark the site burned (monastery-only)"
+    );
     assert_eq!(state.players[0].reputation, rep_before - 1, "Reputation -1");
     assert!(state.players[0].flags.contains(PlayerFlags::HAS_PLUNDERED_THIS_TURN));
     assert!(!state.players[0].pending.has_active(), "Pending should be cleared");
     // Should have drawn 2 cards
     assert_eq!(state.players[0].hand.len(), hand_before + 2, "Should draw 2 cards");
     assert!(state.players[0].deck.is_empty(), "Deck should be empty after draw");
+}
+
+#[test]
+fn plunder_village_leaves_unit_recruitment_available() {
+    let mut state = setup_playing_game(vec!["march"]);
+    let _coord = place_player_on_site(&mut state, SiteType::Village);
+    state.players[0].pending.active = Some(ActivePending::PlunderDecision);
+    state.players[0].deck = vec![CardId::from("rage"), CardId::from("swiftness")];
+    state.offers.units = vec![
+        UnitId::from("peasants"),
+        UnitId::from("foresters"),
+        UnitId::from("herbalist"),
+    ];
+    state.players[0].influence_points = 20;
+
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+    apply_legal_action(&mut state, &mut undo, 0, &LegalAction::PlunderSite, epoch).unwrap();
+
+    state.players[0].flags.insert(PlayerFlags::IS_INTERACTING);
+    let actions = enumerate_legal_actions_with_undo(&state, 0, &UndoStack::new());
+    assert!(
+        actions.actions.iter().any(|a| matches!(a, LegalAction::RecruitUnit { .. })),
+        "recruitment must remain available at a plundered village"
+    );
 }
 
 #[test]

--- a/packages/engine-rs/crates/mk-env/src/lib.rs
+++ b/packages/engine-rs/crates/mk-env/src/lib.rs
@@ -1278,7 +1278,9 @@ mod tests {
         assert!(!env.state.game_ended, "Game should not have ended naturally");
     }
 
-    /// Reproduce: seed=42048 with 53 LegalActions yields 0 legal actions.
+    /// Reproduce: seed=42048 replay must reach non-empty legal actions after 53 steps.
+    /// After village plunder, the site is not burned (rulebook), so a later turn can
+    /// offer `PlunderDecision` again — the golden trace includes `DeclinePlunder` for that.
     /// Last action is BeginInteraction at a conquered mage tower with empty hand.
     #[test]
     fn replay_seed_42048_zero_actions() {
@@ -1297,6 +1299,7 @@ mod tests {
             "PlunderSite",
             {"ChallengeRampaging":{"hex":{"q":3,"r":-3}}},
             "EndTurn",
+            "DeclinePlunder",
             {"PlayCardPowered":{"card_id":"march","hand_index":3,"mana_color":"green"}},
             {"Explore":{"target_center":{"q":4,"r":-5}}},
             {"PlayCardSideways":{"card_id":"improvisation","hand_index":0,"sideways_as":"move"}},


### PR DESCRIPTION
## Summary
Village plunder (rulebook: draw two cards, −1 reputation) was incorrectly setting `Site.is_burned`, which blocked recruitment and healing—the same flag reserved for **destroyed monasteries** after Burn Monastery.

## Changes
- Remove setting `is_burned` from `apply_plunder_site`
- Regression tests: village stays unburned after plunder; `RecruitUnit` actions still enumerated when interacting after plunder
- Align plunder overlay copy and `CLAUDE.md` site note with `docs/reference/sites.md`
- **CI parity:** `.githooks/pre-push` now runs `bun run test` (same workspace test set as CI’s Rust job `cargo llvm-cov --workspace --exclude mk-python`), so `mk-env` golden replays fail locally instead of only on CI
- **mk-env:** update `replay_seed_42048` trace with `DeclinePlunder` when the village can offer plunder again after plunder no longer burns the site

## Verification
- `bun run test`
- `bun run lint`
- `cargo clippy` (pre-push)

Made with [Cursor](https://cursor.com)