### PR TITLE
Fix pie menu label hit targets

### DIFF
--- a/packages/client/__tests__/pixiHitTesting.test.ts
+++ b/packages/client/__tests__/pixiHitTesting.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import {
+  makeInvisiblePointerHitTarget,
+  makePointerPassthrough,
+} from "../src/components/CardInteraction/pixiHitTesting";
+
+describe("pie menu hit testing", () => {
+  it("makes labels ignore pointer hits so clicks reach the wedge underneath", () => {
+    const label = {
+      eventMode: "static" as const,
+      cursor: "pointer",
+    };
+
+    makePointerPassthrough(label);
+
+    expect(label.eventMode).toBe("none");
+    expect(label.cursor).toBe("default");
+  });
+
+  it("creates an invisible pointer target for text-covered wedge areas", () => {
+    const hitTarget = {
+      eventMode: "none" as const,
+      cursor: "default",
+      alpha: 1,
+    };
+
+    makeInvisiblePointerHitTarget(hitTarget);
+
+    expect(hitTarget.eventMode).toBe("static");
+    expect(hitTarget.cursor).toBe("pointer");
+    expect(hitTarget.alpha).toBeGreaterThan(0);
+    expect(hitTarget.alpha).toBeLessThan(0.01);
+  });
+});

--- a/packages/client/src/components/CardActionMenu/PixiPieMenu.tsx
+++ b/packages/client/src/components/CardActionMenu/PixiPieMenu.tsx
@@ -18,6 +18,10 @@ import { usePixiApp } from "../../contexts/PixiAppContext";
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { cleanupFilters } from "../../utils/pixiFilterCleanup";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
+import {
+  makeInvisiblePointerHitTarget,
+  makePointerPassthrough,
+} from "../CardInteraction/pixiHitTesting";
 
 // ============================================
 // Types
@@ -269,6 +273,7 @@ export function PixiPieMenu({
       });
       label.anchor.set(0.5);
       label.position.set(labelPos.x, labelPos.y - labelOffset);
+      makePointerPassthrough(label);
       wedgeContainer.addChild(label);
 
       // Sublabel
@@ -284,18 +289,37 @@ export function PixiPieMenu({
         });
         sublabel.anchor.set(0.5);
         sublabel.position.set(labelPos.x, labelPos.y + sublabelFontSize * 0.9);
+        makePointerPassthrough(sublabel);
         wedgeContainer.addChild(sublabel);
       }
+
+      const hitTarget = new Graphics();
+      drawWedge(
+        hitTarget,
+        innerRadius,
+        outerRadius,
+        wedge.startAngle,
+        wedge.endAngle,
+        0x000000,
+        0x000000,
+        0
+      );
+      wedgeContainer.addChild(hitTarget);
 
       if (wedge.disabled) {
         wedgeContainer.alpha = 0.5;
       }
 
       // Interactivity
-      shape.eventMode = wedge.disabled ? "none" : "static";
-      shape.cursor = wedge.disabled ? "not-allowed" : "pointer";
+      shape.eventMode = "none";
+      if (wedge.disabled) {
+        hitTarget.eventMode = "none";
+        hitTarget.cursor = "not-allowed";
+      } else {
+        makeInvisiblePointerHitTarget(hitTarget);
+      }
 
-      shape.on("pointerenter", () => {
+      hitTarget.on("pointerenter", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         wedgeContainer.zIndex = 100;
@@ -316,7 +340,7 @@ export function PixiPieMenu({
         drawWedge(shape, innerRadius, outerRadius, wedge.startAngle, wedge.endAngle, wedge.hoverColor, COLORS.STROKE_HOVER, 3);
       });
 
-      shape.on("pointerleave", () => {
+      hitTarget.on("pointerleave", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         wedgeContainer.zIndex = index;
@@ -337,7 +361,7 @@ export function PixiPieMenu({
         drawWedge(shape, innerRadius, outerRadius, wedge.startAngle, wedge.endAngle, wedge.color, strokeColor, 2);
       });
 
-      shape.on("pointerdown", () => {
+      hitTarget.on("pointerdown", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         animManager.animate(`wedge-select-${index}`, wedgeContainer, {
@@ -402,6 +426,7 @@ export function PixiPieMenu({
       centerText.anchor.set(0.5);
       centerText.position.set(0, 0);
       centerText.alpha = 0;
+      makePointerPassthrough(centerText);
       menuContainer.addChild(centerText);
 
       const labelTimeoutId = window.setTimeout(() => {

--- a/packages/client/src/components/CardInteraction/PieMenuRenderer.tsx
+++ b/packages/client/src/components/CardInteraction/PieMenuRenderer.tsx
@@ -15,6 +15,10 @@ import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { UI_COLORS } from "./utils/colorHelpers";
 import { getCardTexture } from "../../utils/pixiTextureLoader";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
+import {
+  makeInvisiblePointerHitTarget,
+  makePointerPassthrough,
+} from "./pixiHitTesting";
 
 // ============================================================================
 // Types
@@ -295,6 +299,7 @@ export function PieMenuRenderer({
       });
       label.anchor.set(0.5);
       label.position.set(labelPos.x, labelPos.y - labelOffset);
+      makePointerPassthrough(label);
       wedgeContainer.addChild(label);
 
       // Sublabel
@@ -310,18 +315,37 @@ export function PieMenuRenderer({
         });
         sublabel.anchor.set(0.5);
         sublabel.position.set(labelPos.x, labelPos.y + sublabelFontSize * 0.9);
+        makePointerPassthrough(sublabel);
         wedgeContainer.addChild(sublabel);
       }
+
+      const hitTarget = new Graphics();
+      drawWedge(
+        hitTarget,
+        innerRadius,
+        outerRadius,
+        wedge.startAngle,
+        wedge.endAngle,
+        0x000000,
+        0x000000,
+        0
+      );
+      wedgeContainer.addChild(hitTarget);
 
       if (wedge.disabled) {
         wedgeContainer.alpha = 0.5;
       }
 
       // Interactivity
-      shape.eventMode = wedge.disabled ? "none" : "static";
-      shape.cursor = wedge.disabled ? "not-allowed" : "pointer";
+      shape.eventMode = "none";
+      if (wedge.disabled) {
+        hitTarget.eventMode = "none";
+        hitTarget.cursor = "not-allowed";
+      } else {
+        makeInvisiblePointerHitTarget(hitTarget);
+      }
 
-      shape.on("pointerenter", () => {
+      hitTarget.on("pointerenter", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         wedgeContainer.zIndex = 100;
@@ -351,7 +375,7 @@ export function PieMenuRenderer({
         );
       });
 
-      shape.on("pointerleave", () => {
+      hitTarget.on("pointerleave", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         wedgeContainer.zIndex = index;
@@ -381,7 +405,7 @@ export function PieMenuRenderer({
         );
       });
 
-      shape.on("pointerdown", () => {
+      hitTarget.on("pointerdown", () => {
         if (wedge.disabled || isDestroyedRef.current) return;
 
         animManager.animate(`wedge-select-${index}`, wedgeContainer, {
@@ -444,6 +468,7 @@ export function PieMenuRenderer({
       cardSprite.position.set(0, 0);
       cardSprite.alpha = 0.3; // Start partially visible for smooth crossfade
       cardSprite.zIndex = 500; // Above wedges
+      makePointerPassthrough(cardSprite);
       menuContainer.addChild(cardSprite);
 
       // Animate card fade in immediately (no delay) to crossfade with hand card
@@ -468,6 +493,7 @@ export function PieMenuRenderer({
       centerText.anchor.set(0.5);
       centerText.position.set(0, 0);
       centerText.alpha = 0;
+      makePointerPassthrough(centerText);
       menuContainer.addChild(centerText);
 
       const labelTimeoutId = window.setTimeout(() => {

--- a/packages/client/src/components/CardInteraction/pixiHitTesting.ts
+++ b/packages/client/src/components/CardInteraction/pixiHitTesting.ts
@@ -1,0 +1,15 @@
+import type { Container } from "pixi.js";
+
+type HitTestableDisplayObject = Pick<Container, "eventMode" | "cursor">;
+type InvisibleHitTarget = Pick<Container, "eventMode" | "cursor" | "alpha">;
+
+export function makePointerPassthrough(displayObject: HitTestableDisplayObject): void {
+  displayObject.eventMode = "none";
+  displayObject.cursor = "default";
+}
+
+export function makeInvisiblePointerHitTarget(displayObject: InvisibleHitTarget): void {
+  displayObject.eventMode = "static";
+  displayObject.cursor = "pointer";
+  displayObject.alpha = 0.001;
+}


### PR DESCRIPTION
## Summary
- route pie-menu pointer events through invisible wedge-shaped hit targets
- make labels and decorative center elements ignore pointer hits
- add focused Bun tests for the hit-testing helpers

## Verification
- clicked the enabled +1 Move label in the in-app browser and confirmed Threaten played sideways, raising Move Points to 1
- bun test packages/client/__tests__/pixiHitTesting.test.ts
- bun run --filter @mage-knight/client build
- bun run lint
- cd packages/engine-rs && cargo test && cargo clippy
- push hook also reran clippy, lint, and cargo test --workspace --exclude mk-python