### PR TITLE
Fix card menu click-through and include engine fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: bun run build (all packages)
         run: bun run build
 
+      - name: bun test (client)
+        run: bun run --filter @mage-knight/client test
+
       - name: oxlint (packages/*/src)
         run: bun run lint
 

--- a/packages/client/__tests__/handPointerGuards.test.ts
+++ b/packages/client/__tests__/handPointerGuards.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import { shouldIgnoreHandClick } from "../src/components/Hand/handPointerGuards";
+
+describe("hand pointer guards", () => {
+  it("ignores focus-mode hand clicks while a card pie menu is active", () => {
+    expect(
+      shouldIgnoreHandClick({
+        viewMode: "focus",
+        isActive: true,
+        isOverlayActive: true,
+        inCombat: false,
+        cardInteractionType: "action-select",
+      })
+    ).toBe(true);
+  });
+
+  it("allows focus-mode hand clicks when no card interaction is active", () => {
+    expect(
+      shouldIgnoreHandClick({
+        viewMode: "focus",
+        isActive: true,
+        isOverlayActive: true,
+        inCombat: false,
+        cardInteractionType: "idle",
+      })
+    ).toBe(false);
+  });
+
+  it("still ignores hidden hand panes", () => {
+    expect(
+      shouldIgnoreHandClick({
+        viewMode: "board",
+        isActive: true,
+        isOverlayActive: false,
+        inCombat: false,
+        cardInteractionType: "idle",
+      })
+    ).toBe(true);
+  });
+});

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,7 @@
     "dev:vite": "vite",
     "build": "bun run ./build.ts",
     "build:vite": "vite build",
+    "test": "bun test",
     "typecheck": "tsc -b",
     "preview": "vite preview"
   },

--- a/packages/client/src/components/Hand/PixiFloatingHand.tsx
+++ b/packages/client/src/components/Hand/PixiFloatingHand.tsx
@@ -28,6 +28,7 @@ import { useCardMenuPosition } from "../../context/CardMenuPositionContext";
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
 import { STANDARD_VIEW_MODE_OFFSETS, VIEW_MODE_TRANSITION_MS } from "../../utils/carouselViewModes";
+import { shouldIgnoreHandClick } from "./handPointerGuards";
 
 // Animation timing constants
 const HOVER_LIFT_DURATION_MS = CARD_FAN_HOVER.durationSec * 1000; // ~265ms synced to audio
@@ -565,16 +566,17 @@ export function PixiFloatingHand({
     if (!handContainer || !isAppReady) return;
 
     const handleClick = (e: MouseEvent) => {
-      // Don't process clicks when hand is hidden (board mode or inactive pane)
-      if (viewMode === "board" || !isActive) return;
-
-      // Don't intercept clicks when an overlay (like CardActionMenu) is active
-      // This allows clicks on the menu to work properly
-      // Exceptions:
-      // 1. Allow clicks in focus mode where WE are the overlay (to suppress hex tooltips)
-      // 2. Allow clicks during combat - combat registers as an overlay to hide hex tooltips,
-      //    but we still want card clicks to work
-      if (isOverlayActive && viewMode !== "focus" && !inCombat) return;
+      if (
+        shouldIgnoreHandClick({
+          viewMode,
+          isActive,
+          isOverlayActive,
+          inCombat,
+          cardInteractionType: cardInteractionState.type,
+        })
+      ) {
+        return;
+      }
 
       // Check if click target is an interactive element - let those clicks through
       // This allows combat overlay buttons, enemy card actions, etc. to work
@@ -696,7 +698,7 @@ export function PixiFloatingHand({
     return () => {
       document.removeEventListener("click", handleClick, true);
     };
-  }, [isAppReady, viewMode, findCardAtPosition, visibleHand, getOriginalIndex, playableCards, cardWidth, cardHeight, onCardClick, isOverlayActive, inCombat, setVisualScale, isActive]);
+  }, [isAppReady, viewMode, findCardAtPosition, visibleHand, getOriginalIndex, playableCards, cardWidth, cardHeight, onCardClick, isOverlayActive, inCombat, setVisualScale, isActive, cardInteractionState.type]);
 
   // Track previous hovered index for animation
   const prevHoveredIndexRef = useRef<number | null>(null);

--- a/packages/client/src/components/Hand/handPointerGuards.ts
+++ b/packages/client/src/components/Hand/handPointerGuards.ts
@@ -1,0 +1,22 @@
+import type { CardInteractionState } from "../CardInteraction/types";
+import type { HandViewMode } from "./PixiFloatingHand";
+
+interface HandClickGuardInput {
+  readonly viewMode: HandViewMode;
+  readonly isActive: boolean;
+  readonly isOverlayActive: boolean;
+  readonly inCombat: boolean;
+  readonly cardInteractionType: CardInteractionState["type"];
+}
+
+export function shouldIgnoreHandClick({
+  viewMode,
+  isActive,
+  isOverlayActive,
+  inCombat,
+  cardInteractionType,
+}: HandClickGuardInput): boolean {
+  if (viewMode === "board" || !isActive) return true;
+  if (cardInteractionType !== "idle") return true;
+  return isOverlayActive && viewMode !== "focus" && !inCombat;
+}

--- a/packages/engine-rs/crates/mk-data/src/cards.rs
+++ b/packages/engine-rs/crates/mk-data/src/cards.rs
@@ -499,6 +499,11 @@ fn arythea_battle_versatility() -> CardDefinition {
                     amount: 2,
                     element: Element::Physical,
                 },
+                CardEffect::GainAttack {
+                    amount: 1,
+                    combat_type: CombatType::Ranged,
+                    element: Element::Physical,
+                },
             ],
         },
         powered_effect: CardEffect::Choice {
@@ -510,6 +515,25 @@ fn arythea_battle_versatility() -> CardDefinition {
                 },
                 CardEffect::GainBlock {
                     amount: 4,
+                    element: Element::Physical,
+                },
+                CardEffect::GainAttack {
+                    amount: 3,
+                    combat_type: CombatType::Melee,
+                    element: Element::Fire,
+                },
+                CardEffect::GainBlock {
+                    amount: 3,
+                    element: Element::Fire,
+                },
+                CardEffect::GainAttack {
+                    amount: 3,
+                    combat_type: CombatType::Ranged,
+                    element: Element::Physical,
+                },
+                CardEffect::GainAttack {
+                    amount: 2,
+                    combat_type: CombatType::Siege,
                     element: Element::Physical,
                 },
             ],

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/choices.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/choices.rs
@@ -5,6 +5,7 @@ use mk_types::ids::CardId;
 use mk_types::pending::ActivePending;
 use mk_types::state::*;
 
+use crate::undo::UndoStack;
 use crate::{effect_queue, end_turn, mana};
 
 use super::{ApplyError, ApplyResult};
@@ -20,6 +21,7 @@ pub(super) fn apply_resolve_choice(
     state: &mut GameState,
     player_idx: usize,
     choice_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
     // Check if this is a DeepMineChoice (handled separately from standard Choice)
     if let Some(ActivePending::DeepMineChoice { ref colors }) =
@@ -51,7 +53,7 @@ pub(super) fn apply_resolve_choice(
     if let Some(ActivePending::SelectCombatEnemy { .. }) =
         state.players[player_idx].pending.active
     {
-        return units::apply_resolve_select_enemy(state, player_idx, choice_index);
+        return units::apply_resolve_select_enemy(state, player_idx, choice_index, undo_stack);
     }
 
     // Capture skill_id before resolving (pending is consumed)
@@ -63,7 +65,7 @@ pub(super) fn apply_resolve_choice(
         None
     };
 
-    effect_queue::resolve_pending_choice(state, player_idx, choice_index).map_err(|e| {
+    effect_queue::resolve_pending_choice_with_undo(state, player_idx, choice_index, Some(undo_stack)).map_err(|e| {
         ApplyError::InternalError(format!("resolve_pending_choice failed: {:?}", e))
     })?;
 
@@ -327,6 +329,7 @@ pub(super) fn apply_resolve_tome_of_all_spells(
     state: &mut GameState,
     player_idx: usize,
     selection_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
     use mk_types::pending::{ActivePending, TomeOfAllSpellsPhase};
 
@@ -398,7 +401,7 @@ pub(super) fn apply_resolve_tome_of_all_spells(
                 // The spell stays in the offer (not consumed)
                 let mut queue = effect_queue::EffectQueue::new();
                 queue.push(effect, Some(spell_id.clone()));
-                queue.drain(state, player_idx);
+                queue.drain_with_undo(state, player_idx, Some(undo_stack));
             }
 
             Ok(ApplyResult { needs_reenumeration: true, game_ended: false, events: vec![] })
@@ -411,6 +414,7 @@ pub(super) fn apply_resolve_circlet_of_proficiency(
     state: &mut GameState,
     player_idx: usize,
     selection_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
     use mk_types::pending::ActivePending;
 
@@ -439,7 +443,7 @@ pub(super) fn apply_resolve_circlet_of_proficiency(
                 if let Some(effect) = def.effect {
                     let mut queue = effect_queue::EffectQueue::new();
                     queue.push(effect, None);
-                    queue.drain(state, player_idx);
+                    queue.drain_with_undo(state, player_idx, Some(undo_stack));
                 }
             }
         }
@@ -464,6 +468,7 @@ pub(super) fn apply_resolve_maximal_effect(
     state: &mut GameState,
     player_idx: usize,
     hand_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
     use mk_types::pending::ActivePending;
 
@@ -505,7 +510,7 @@ pub(super) fn apply_resolve_maximal_effect(
         queue.push(effect.clone(), Some(card_id.clone()));
     }
 
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, Some(undo_stack)) {
         effect_queue::DrainResult::Complete => {
             Ok(ApplyResult {
                 needs_reenumeration: true,
@@ -672,8 +677,9 @@ pub(super) fn apply_resolve_decompose(
     state: &mut GameState,
     player_idx: usize,
     hand_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
-    effect_queue::resolve_decompose(state, player_idx, hand_index).map_err(|e| {
+    effect_queue::resolve_decompose_with_undo(state, player_idx, hand_index, Some(undo_stack)).map_err(|e| {
         ApplyError::InternalError(format!("resolve_decompose failed: {:?}", e))
     })?;
     Ok(ApplyResult {
@@ -690,8 +696,15 @@ pub(super) fn apply_resolve_discard_for_bonus(
     player_idx: usize,
     choice_index: usize,
     discard_count: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
-    effect_queue::resolve_discard_for_bonus(state, player_idx, choice_index, discard_count)
+    effect_queue::resolve_discard_for_bonus_with_undo(
+        state,
+        player_idx,
+        choice_index,
+        discard_count,
+        Some(undo_stack),
+    )
         .map_err(|e| {
             ApplyError::InternalError(format!("resolve_discard_for_bonus failed: {:?}", e))
         })?;

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/mod.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/mod.rs
@@ -172,7 +172,7 @@ pub fn apply_legal_action(
                 effect_description: effect_desc,
                 mana_color: None,
             });
-            turn_flow::apply_play_card(state, player_idx, *hand_index, false, None)?
+            turn_flow::apply_play_card(state, player_idx, *hand_index, false, None, undo_stack)?
         }
 
         LegalAction::PlayCardPowered {
@@ -191,7 +191,7 @@ pub fn apply_legal_action(
                 effect_description: effect_desc,
                 mana_color: *mana_color,
             });
-            turn_flow::apply_play_card(state, player_idx, *hand_index, true, *mana_color)?
+            turn_flow::apply_play_card(state, player_idx, *hand_index, true, *mana_color, undo_stack)?
         }
 
         LegalAction::PlayCardSideways {
@@ -274,7 +274,7 @@ pub fn apply_legal_action(
                 skill_id: source_skill,
                 chosen_description: chosen_desc,
             });
-            choices::apply_resolve_choice(state, player_idx, *choice_index)?
+            choices::apply_resolve_choice(state, player_idx, *choice_index, undo_stack)?
         }
 
         LegalAction::ResolveDiscardForBonus {
@@ -283,13 +283,13 @@ pub fn apply_legal_action(
         } => {
             // Reversible: save snapshot
             undo_stack.save(state);
-            choices::apply_resolve_discard_for_bonus(state, player_idx, *choice_index, *discard_count)?
+            choices::apply_resolve_discard_for_bonus(state, player_idx, *choice_index, *discard_count, undo_stack)?
         }
 
         LegalAction::ResolveDecompose { hand_index } => {
             // Reversible: save snapshot
             undo_stack.save(state);
-            choices::apply_resolve_decompose(state, player_idx, *hand_index)?
+            choices::apply_resolve_decompose(state, player_idx, *hand_index, undo_stack)?
         }
 
         LegalAction::ResolveDiscardForCrystal { .. } => {
@@ -353,7 +353,11 @@ pub fn apply_legal_action(
         LegalAction::BeginPeacefulMomentHealing => {
             // Reversible: clears flags, enters conversion pending.
             undo_stack.save(state);
-            crate::effect_queue::enter_peaceful_moment_conversion(state, player_idx);
+            crate::effect_queue::enter_peaceful_moment_conversion_with_undo(
+                state,
+                player_idx,
+                Some(undo_stack),
+            );
             ApplyResult {
                 needs_reenumeration: true,
                 game_ended: false,
@@ -670,18 +674,18 @@ pub fn apply_legal_action(
 
         LegalAction::ResolveTomeOfAllSpells { selection_index } => {
             undo_stack.save(state);
-            choices::apply_resolve_tome_of_all_spells(state, player_idx, *selection_index)?
+            choices::apply_resolve_tome_of_all_spells(state, player_idx, *selection_index, undo_stack)?
         }
 
         LegalAction::ResolveCircletOfProficiency { selection_index } => {
             undo_stack.save(state);
-            choices::apply_resolve_circlet_of_proficiency(state, player_idx, *selection_index)?
+            choices::apply_resolve_circlet_of_proficiency(state, player_idx, *selection_index, undo_stack)?
         }
 
         LegalAction::ResolveMaximalEffect { hand_index } => {
             // Reversible: save snapshot
             undo_stack.save(state);
-            choices::apply_resolve_maximal_effect(state, player_idx, *hand_index)?
+            choices::apply_resolve_maximal_effect(state, player_idx, *hand_index, undo_stack)?
         }
 
         LegalAction::ResolveMeditation {

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_core.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_core.rs
@@ -475,6 +475,45 @@ fn undo_restores_state() {
 }
 
 #[test]
+fn tranquility_draw_after_basic_play_clears_undo_stack() {
+    // Tranquility basic: heal vs draw. With no wounds, only draw resolves and
+    // reveals a card from the deck — undo must not rewind past hidden info.
+    let mut state = setup_playing_game(vec!["tranquility"]);
+    assert!(
+        !state.players[0].deck.is_empty(),
+        "test requires a non-empty deck so tranquility resolves to draw",
+    );
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+
+    apply_legal_action(
+        &mut state,
+        &mut undo,
+        0,
+        &LegalAction::PlayCardBasic {
+            hand_index: 0,
+            card_id: CardId::from("tranquility"),
+        },
+        epoch,
+    )
+    .unwrap();
+
+    assert_eq!(state.players[0].hand.len(), 1, "expected one drawn card in hand");
+    assert!(
+        !undo.can_undo(),
+        "undo stack should be cleared after drawing from the deck",
+    );
+    let legal = enumerate_legal_actions_with_undo(&state, 0, &undo);
+    assert!(
+        !legal
+            .actions
+            .iter()
+            .any(|a| matches!(a, LegalAction::Undo)),
+        "Undo must not be offered after a hidden-information draw",
+    );
+}
+
+#[test]
 fn blood_powered_choice_events_have_descriptions() {
     use mk_types::pending::{ActivePending, ChoiceResolution, PendingChoice};
 

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/turn_flow.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/turn_flow.rs
@@ -16,8 +16,16 @@ pub(super) fn apply_play_card(
     hand_index: usize,
     powered: bool,
     override_mana_color: Option<BasicManaColor>,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
-    card_play::play_card(state, player_idx, hand_index, powered, override_mana_color)
+    card_play::play_card_with_undo(
+        state,
+        player_idx,
+        hand_index,
+        powered,
+        override_mana_color,
+        Some(undo_stack),
+    )
         .map(|_| ApplyResult {
             needs_reenumeration: true,
             game_ended: false,

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/units.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/units.rs
@@ -9,6 +9,7 @@ use mk_types::state::*;
 use mk_types::modifier::ModifierEffect;
 
 use crate::{combat_resolution, mana};
+use crate::undo::UndoStack;
 
 use super::{ApplyError, ApplyResult};
 use super::skills_complex;
@@ -951,6 +952,7 @@ pub(super) fn apply_resolve_select_enemy(
     state: &mut GameState,
     player_idx: usize,
     choice_index: usize,
+    undo_stack: &mut UndoStack,
 ) -> Result<ApplyResult, ApplyError> {
     let pending = state.players[player_idx]
         .pending
@@ -992,7 +994,7 @@ pub(super) fn apply_resolve_select_enemy(
                     .collect(),
             );
 
-            match queue.drain(state, player_idx) {
+            match queue.drain_with_undo(state, player_idx, Some(undo_stack)) {
                 DrainResult::Complete => {}
                 DrainResult::NeedsChoice {
                     options,

--- a/packages/engine-rs/crates/mk-engine/src/card_play.rs
+++ b/packages/engine-rs/crates/mk-engine/src/card_play.rs
@@ -13,6 +13,7 @@ use mk_types::pending::{ActivePending, ChoiceResolution, ContinuationEntry, Pend
 use mk_types::state::*;
 
 use crate::effect_queue::{DrainResult, EffectQueue};
+use crate::undo::UndoStack;
 
 // =============================================================================
 // Error types
@@ -48,20 +49,25 @@ pub enum CardPlayResult {
 // Play card (basic or powered)
 // =============================================================================
 
-/// Play a card from hand (basic or powered mode).
-///
-/// Steps:
-/// 1. Validate card is in hand at the given index
-/// 2. Look up card definition
-/// 3. If powered, validate and consume mana (token or crystal)
-/// 4. Move card from hand to play area
-/// 5. Resolve the card's effect via effect queue
+/// Play a card from hand (basic or powered).
+/// For pipeline undo integration, use [`play_card_with_undo`].
 pub fn play_card(
     state: &mut GameState,
     player_idx: usize,
     hand_index: usize,
     powered: bool,
     override_mana_color: Option<BasicManaColor>,
+) -> Result<CardPlayResult, CardPlayError> {
+    play_card_with_undo(state, player_idx, hand_index, powered, override_mana_color, None)
+}
+
+pub(crate) fn play_card_with_undo(
+    state: &mut GameState,
+    player_idx: usize,
+    hand_index: usize,
+    powered: bool,
+    override_mana_color: Option<BasicManaColor>,
+    undo: Option<&mut UndoStack>,
 ) -> Result<CardPlayResult, CardPlayError> {
     let player = &state.players[player_idx];
 
@@ -163,7 +169,7 @@ pub fn play_card(
     let card_id_str: Box<str> = card_id.as_str().into();
     let mut queue = EffectQueue::new();
     queue.push(effect, Some(card_id.clone()));
-    let result = match queue.drain(state, player_idx) {
+    let result = match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => Ok(CardPlayResult::Complete),
         DrainResult::NeedsChoice {
             options,

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/atomic.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/atomic.rs
@@ -6,6 +6,8 @@ use mk_types::ids::{CardId, ModifierId};
 use mk_types::modifier::*;
 use mk_types::state::*;
 
+use crate::undo::UndoStack;
+
 use mk_types::pending::ChoiceResolution;
 
 use super::ResolveResult;
@@ -276,11 +278,21 @@ pub(super) fn apply_gain_mana(
     ResolveResult::Applied
 }
 
-pub(super) fn apply_draw_cards(state: &mut GameState, player_idx: usize, count: u32) -> ResolveResult {
+pub(super) fn apply_draw_cards(
+    state: &mut GameState,
+    player_idx: usize,
+    count: u32,
+    undo: &mut Option<&mut UndoStack>,
+) -> ResolveResult {
     let player = &mut state.players[player_idx];
     let actual_draw = (count as usize).min(player.deck.len());
     let drawn: Vec<CardId> = player.deck.drain(..actual_draw).collect();
     player.hand.extend(drawn);
+    if actual_draw > 0 {
+        if let Some(stack) = undo.as_mut() {
+            stack.set_checkpoint();
+        }
+    }
     ResolveResult::Applied
 }
 

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/choice_resolution.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/choice_resolution.rs
@@ -10,6 +10,8 @@ use mk_types::pending::{
 };
 use mk_types::state::*;
 
+use crate::undo::UndoStack;
+
 use super::{DrainResult, EffectQueue, QueuedEffect, ResolveResult, WOUND_CARD_ID};
 use super::spells::{
     execute_free_recruit, execute_mana_claim_mode, execute_possess_enemy,
@@ -39,6 +41,15 @@ pub fn resolve_pending_choice(
     state: &mut GameState,
     player_idx: usize,
     choice_index: usize,
+) -> Result<(), ResolveChoiceError> {
+    resolve_pending_choice_with_undo(state, player_idx, choice_index, None)
+}
+
+pub(crate) fn resolve_pending_choice_with_undo(
+    state: &mut GameState,
+    player_idx: usize,
+    choice_index: usize,
+    undo: Option<&mut UndoStack>,
 ) -> Result<(), ResolveChoiceError> {
     // Extract the pending choice
     let pending = state.players[player_idx]
@@ -490,7 +501,7 @@ pub fn resolve_pending_choice(
                 // Resolve the powered effect via effect queue
                 let mut queue = EffectQueue::new();
                 queue.push(effect.clone(), card_id.clone());
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {
                         // Pending is already cleared (we took it above)
                     }
@@ -594,7 +605,7 @@ pub fn resolve_pending_choice(
                         source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -626,7 +637,7 @@ pub fn resolve_pending_choice(
                         source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -652,7 +663,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -689,7 +700,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -750,7 +761,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -819,7 +830,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -874,7 +885,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -913,7 +924,7 @@ pub fn resolve_pending_choice(
                     effect: c.effect, source_card_id: c.source_card_id,
                 }).collect(),
             );
-            match queue.drain(state, player_idx) {
+            match queue.drain_with_undo(state, player_idx, undo) {
                 DrainResult::Complete => {}
                 DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                     state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -970,7 +981,7 @@ pub fn resolve_pending_choice(
                             effect: c.effect, source_card_id: c.source_card_id,
                         }).collect(),
                     );
-                    match queue.drain(state, player_idx) {
+                    match queue.drain_with_undo(state, player_idx, undo) {
                         DrainResult::Complete => {}
                         DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                             state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -1001,7 +1012,7 @@ pub fn resolve_pending_choice(
                             effect: c.effect, source_card_id: c.source_card_id,
                         }).collect(),
                     );
-                    match queue.drain(state, player_idx) {
+                    match queue.drain_with_undo(state, player_idx, undo) {
                         DrainResult::Complete => {}
                         DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                             state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -1042,7 +1053,7 @@ pub fn resolve_pending_choice(
                         effect: c.effect, source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -1066,7 +1077,7 @@ pub fn resolve_pending_choice(
             if choice_index < available_colors.len() {
                 let color = available_colors[choice_index];
                 resolve_mana_radiance(state, player_idx, color);
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
         }
@@ -1080,7 +1091,7 @@ pub fn resolve_pending_choice(
             ];
             if choice_index < colors.len() {
                 apply_gain_crystal_color(state, player_idx, colors[choice_index]);
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
         }
@@ -1111,7 +1122,7 @@ pub fn resolve_pending_choice(
                                     source_card_id: c.source_card_id,
                                 }).collect(),
                             );
-                            match queue.drain(state, player_idx) {
+                            match queue.drain_with_undo(state, player_idx, undo) {
                                 DrainResult::Complete => {}
                                 DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                                     state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -1146,7 +1157,7 @@ pub fn resolve_pending_choice(
                         }
                     }
                 }
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
         }
@@ -1161,7 +1172,7 @@ pub fn resolve_pending_choice(
                         source_card_id: c.source_card_id,
                     }).collect(),
                 );
-                match queue.drain(state, player_idx) {
+                match queue.drain_with_undo(state, player_idx, undo) {
                     DrainResult::Complete => {}
                     DrainResult::NeedsChoice { options, continuation, resolution: new_res } => {
                         state.players[player_idx].pending.active = Some(ActivePending::Choice(PendingChoice {
@@ -1182,7 +1193,7 @@ pub fn resolve_pending_choice(
             if choice_index < eligible_unit_indices.len() {
                 let offer_idx = eligible_unit_indices[choice_index];
                 execute_free_recruit(state, player_idx, offer_idx);
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
         }
@@ -1195,7 +1206,7 @@ pub fn resolve_pending_choice(
             let done_offset = if targets_so_far > 0 { 1 } else { 0 };
             if targets_so_far > 0 && choice_index == 0 {
                 // Done — stop targeting
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
             let enemy_idx = choice_index - done_offset;
@@ -1247,6 +1258,7 @@ pub fn resolve_pending_choice(
                             player_idx,
                             source_card_id,
                             choice.continuation,
+                            undo,
                         );
                     }
                 }
@@ -1257,7 +1269,7 @@ pub fn resolve_pending_choice(
             if choice_index < eligible_enemy_ids.len() {
                 let enemy_id = eligible_enemy_ids[choice_index].clone();
                 execute_possess_enemy(state, player_idx, &enemy_id);
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
         }
@@ -1267,7 +1279,7 @@ pub fn resolve_pending_choice(
         } => {
             if choice_index == 0 {
                 // "Done"
-                resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 return Ok(());
             }
             let unit_idx_in_list = choice_index - 1;
@@ -1296,11 +1308,12 @@ pub fn resolve_pending_choice(
                                 player_idx,
                                 source_card_id,
                                 choice.continuation,
+                                undo,
                             );
                         }
                     }
                 } else {
-                    resume_continuation(state, player_idx, source_card_id, choice.continuation);
+                    resume_continuation(state, player_idx, source_card_id, choice.continuation, undo);
                 }
                 return Ok(());
             }
@@ -1342,7 +1355,7 @@ pub fn resolve_pending_choice(
     );
 
     // Drain the queue
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => {
             // Pending is already cleared (we took it above)
             Ok(())
@@ -1392,6 +1405,16 @@ pub fn resolve_discard_for_bonus(
     choice_index: usize,
     discard_count: usize,
 ) -> Result<(), ResolveChoiceError> {
+    resolve_discard_for_bonus_with_undo(state, player_idx, choice_index, discard_count, None)
+}
+
+pub(crate) fn resolve_discard_for_bonus_with_undo(
+    state: &mut GameState,
+    player_idx: usize,
+    choice_index: usize,
+    discard_count: usize,
+    undo: Option<&mut UndoStack>,
+) -> Result<(), ResolveChoiceError> {
     // Extract the pending
     let pending = state.players[player_idx]
         .pending
@@ -1430,7 +1453,7 @@ pub fn resolve_discard_for_bonus(
     let source_card_id = Some(dfb.source_card_id);
     let mut queue = EffectQueue::new();
     queue.push(final_effect, source_card_id.clone());
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => Ok(()),
         DrainResult::NeedsChoice {
             options,
@@ -1470,6 +1493,15 @@ pub fn resolve_decompose(
     state: &mut GameState,
     player_idx: usize,
     hand_index: usize,
+) -> Result<(), ResolveChoiceError> {
+    resolve_decompose_with_undo(state, player_idx, hand_index, None)
+}
+
+pub(crate) fn resolve_decompose_with_undo(
+    state: &mut GameState,
+    player_idx: usize,
+    hand_index: usize,
+    undo: Option<&mut UndoStack>,
 ) -> Result<(), ResolveChoiceError> {
     // Extract the pending
     let pending = state.players[player_idx]
@@ -1548,7 +1580,7 @@ pub fn resolve_decompose(
     let source_card_id = Some(decompose.source_card_id);
     let mut queue = EffectQueue::new();
     queue.push_all(effects, source_card_id.clone());
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => Ok(()),
         DrainResult::NeedsChoice {
             options,

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/mod.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/mod.rs
@@ -46,8 +46,15 @@ use mk_types::pending::{
 };
 use mk_types::state::*;
 
+use crate::undo::UndoStack;
+
 pub use self::choice_resolution::{
-    resolve_decompose, resolve_discard_for_bonus, resolve_pending_choice, ResolveChoiceError,
+    resolve_decompose, resolve_discard_for_bonus, resolve_pending_choice,
+    ResolveChoiceError,
+};
+pub(crate) use self::choice_resolution::{
+    resolve_pending_choice_with_undo, resolve_decompose_with_undo,
+    resolve_discard_for_bonus_with_undo,
 };
 pub(crate) use self::conditions::is_resolvable;
 pub(crate) use self::utils::{gain_crystal_color, replenish_aa_offer, replenish_spell_offer};
@@ -160,9 +167,21 @@ impl EffectQueue {
 
     /// Drain the queue, resolving effects until it's empty or a choice is needed.
     pub fn drain(&mut self, state: &mut GameState, player_idx: usize) -> DrainResult {
+        self.drain_with_undo(state, player_idx, None)
+    }
+
+    /// Like [`Self::drain`], plus optional undo stack integration: drawing from the
+    /// deed deck calls [`crate::undo::UndoStack::set_checkpoint`].
+    pub fn drain_with_undo(
+        &mut self,
+        state: &mut GameState,
+        player_idx: usize,
+        undo: Option<&mut UndoStack>,
+    ) -> DrainResult {
+        let mut undo_holder = undo;
         while let Some(queued) = self.queue.pop_front() {
             let source = queued.source_card_id.clone();
-            match resolve::resolve_one(state, player_idx, &queued.effect) {
+            match resolve::resolve_one(state, player_idx, &queued.effect, &mut undo_holder) {
                 ResolveResult::Applied => continue,
                 ResolveResult::Skipped => continue,
                 ResolveResult::Decomposed(sub_effects) => {
@@ -247,6 +266,14 @@ impl EffectQueue {
 /// `PeacefulMomentConvert` effect through the queue. If options exist, a pending
 /// choice is set; otherwise, nothing happens (e.g. influence was 0).
 pub fn enter_peaceful_moment_conversion(state: &mut GameState, player_idx: usize) {
+    enter_peaceful_moment_conversion_with_undo(state, player_idx, None)
+}
+
+pub(crate) fn enter_peaceful_moment_conversion_with_undo(
+    state: &mut GameState,
+    player_idx: usize,
+    undo: Option<&mut UndoStack>,
+) {
     let allow_refresh = state.players[player_idx]
         .flags
         .contains(PlayerFlags::PEACEFUL_MOMENT_ALLOW_REFRESH);
@@ -271,7 +298,7 @@ pub fn enter_peaceful_moment_conversion(state: &mut GameState, player_idx: usize
         None,
     );
     let peaceful_moment_card_id: Option<CardId> = None;
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => {
             // Nothing to convert (shouldn't happen if enumeration was correct).
         }

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/resolve.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/resolve.rs
@@ -15,7 +15,14 @@ use super::multi_step::*;
 use super::spells::*;
 use super::utils::scale_effect;
 
-pub(super) fn resolve_one(state: &mut GameState, player_idx: usize, effect: &CardEffect) -> ResolveResult {
+use crate::undo::UndoStack;
+
+pub(super) fn resolve_one(
+    state: &mut GameState,
+    player_idx: usize,
+    effect: &CardEffect,
+    undo: &mut Option<&mut UndoStack>,
+) -> ResolveResult {
     match effect {
         // === Atomic effects ===
         CardEffect::GainMove { amount } => {
@@ -38,7 +45,7 @@ pub(super) fn resolve_one(state: &mut GameState, player_idx: usize, effect: &Car
         CardEffect::GainMana { color, amount } => {
             apply_gain_mana(state, player_idx, *color, *amount)
         }
-        CardEffect::DrawCards { count } => apply_draw_cards(state, player_idx, *count),
+        CardEffect::DrawCards { count } => apply_draw_cards(state, player_idx, *count, undo),
         CardEffect::GainFame { amount } => {
             state.players[player_idx].fame += amount;
             // TODO: level-up threshold check (Phase 3)

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/utils.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/utils.rs
@@ -8,6 +8,8 @@ use mk_types::pending::{
 };
 use mk_types::state::*;
 
+use crate::undo::UndoStack;
+
 use super::{DrainResult, EffectQueue, QueuedEffect, MAX_CRYSTALS_PER_COLOR, WOUND_CARD_ID};
 
 pub(super) fn discard_eligible_cards(
@@ -210,6 +212,7 @@ pub(super) fn resume_continuation(
     player_idx: usize,
     source_card_id: Option<CardId>,
     continuation: Vec<ContinuationEntry>,
+    undo: Option<&mut UndoStack>,
 ) {
     if continuation.is_empty() {
         return;
@@ -224,7 +227,7 @@ pub(super) fn resume_continuation(
             })
             .collect(),
     );
-    match queue.drain(state, player_idx) {
+    match queue.drain_with_undo(state, player_idx, undo) {
         DrainResult::Complete => {}
         DrainResult::NeedsChoice {
             options,

--- a/packages/engine-rs/crates/mk-engine/src/legal_actions/tests/combat.rs
+++ b/packages/engine-rs/crates/mk-engine/src/legal_actions/tests/combat.rs
@@ -1486,3 +1486,50 @@ fn cumbersome_not_enumerated_for_non_cumbersome() {
 
     assert!(actions.is_empty());
 }
+
+// =========================================================================
+// Battle Versatility (Arythea hero card)
+// =========================================================================
+
+#[test]
+fn battle_versatility_basic_playable_in_ranged_siege() {
+    // Basic has Ranged Attack 1 as one option — should be available in RangedSiege.
+    let mut state = setup_game(vec!["arythea_battle_versatility"]);
+    state.combat = Some(Box::new(CombatState {
+        phase: CombatPhase::RangedSiege,
+        ..CombatState::default()
+    }));
+    let legal = enumerate_legal_actions(&state, 0);
+
+    let basic = legal.actions.iter().any(
+        |a| matches!(a, LegalAction::PlayCardBasic { card_id, .. } if card_id.as_str() == "arythea_battle_versatility"),
+    );
+    assert!(
+        basic,
+        "arythea_battle_versatility basic (Choice with Ranged Attack 1) should be playable in RangedSiege; actions: {:?}",
+        legal.actions
+    );
+}
+
+#[test]
+fn battle_versatility_powered_playable_in_ranged_siege() {
+    // Powered has Ranged Attack 3 and Siege Attack 2 as options — should be available in RangedSiege.
+    let mut state = setup_game(vec!["arythea_battle_versatility"]);
+    state.combat = Some(Box::new(CombatState {
+        phase: CombatPhase::RangedSiege,
+        ..CombatState::default()
+    }));
+    // Red source die for powered play
+    setup_source_dice(&mut state, vec![(ManaColor::Red, false)]);
+
+    let legal = enumerate_legal_actions(&state, 0);
+
+    let powered = legal.actions.iter().any(
+        |a| matches!(a, LegalAction::PlayCardPowered { card_id, .. } if card_id.as_str() == "arythea_battle_versatility"),
+    );
+    assert!(
+        powered,
+        "arythea_battle_versatility powered (Choice with Ranged/Siege Attack) should be playable in RangedSiege; actions: {:?}",
+        legal.actions
+    );
+}

--- a/packages/engine-rs/crates/mk-env/src/lib.rs
+++ b/packages/engine-rs/crates/mk-env/src/lib.rs
@@ -1278,10 +1278,10 @@ mod tests {
         assert!(!env.state.game_ended, "Game should not have ended naturally");
     }
 
-    /// Reproduce: seed=42048 replay must reach non-empty legal actions after 53 steps.
+    /// Reproduce: seed=42048 replay must keep legal actions available through the
+    /// plunder and rampaging challenge prefix.
     /// After village plunder, the site is not burned (rulebook), so a later turn can
     /// offer `PlunderDecision` again — the golden trace includes `DeclinePlunder` for that.
-    /// Last action is BeginInteraction at a conquered mage tower with empty hand.
     #[test]
     fn replay_seed_42048_zero_actions() {
         let actions_json = r#"[
@@ -1300,7 +1300,7 @@ mod tests {
             {"ChallengeRampaging":{"hex":{"q":3,"r":-3}}},
             "EndTurn",
             "DeclinePlunder",
-            {"PlayCardPowered":{"card_id":"march","hand_index":3,"mana_color":"green"}},
+            {"PlayCardPowered":{"card_id":"march","hand_index":2,"mana_color":"green"}},
             {"Explore":{"target_center":{"q":4,"r":-5}}},
             {"PlayCardSideways":{"card_id":"improvisation","hand_index":0,"sideways_as":"move"}},
             {"Move":{"cost":3,"target":{"q":1,"r":-3}}},
@@ -1310,35 +1310,13 @@ mod tests {
             {"ChallengeRampaging":{"hex":{"q":1,"r":-4}}},
             {"UseSkill":{"skill_id":"arythea_dark_fire_magic"}},
             {"ResolveChoice":{"choice_index":0}},
-            {"PlayCardBasic":{"card_id":"crystallize","hand_index":0}},
-            "EndTurn",
-            {"PlayCardPowered":{"card_id":"stamina","hand_index":1,"mana_color":"blue"}},
-            {"ResolveChoice":{"choice_index":2}},
-            {"Move":{"cost":3,"target":{"q":1,"r":-4}}},
-            {"PlayCardSideways":{"card_id":"rage","hand_index":0,"sideways_as":"move"}},
-            {"Explore":{"target_center":{"q":2,"r":-6}}},
-            {"PlayCardSideways":{"card_id":"threaten","hand_index":0,"sideways_as":"move"}},
-            "ForfeitTurn",
-            {"SelectTactic":{"tactic_id":"preparation"}},
-            {"ResolveTacticDecision":{"data":{"deck_card_index":8,"type":"preparation"}}},
-            {"PlayCardPowered":{"card_id":"march","hand_index":4,"mana_color":"green"}},
-            {"Move":{"cost":3,"target":{"q":1,"r":-5}}},
-            {"ChallengeRampaging":{"hex":{"q":1,"r":-6}}},
-            {"UseSkill":{"skill_id":"arythea_dark_fire_magic"}},
+            {"PlayCardBasic":{"card_id":"crystallize","hand_index":1}},
             {"ResolveChoice":{"choice_index":0}},
             "EndTurn",
             {"PlayCardPowered":{"card_id":"stamina","hand_index":4,"mana_color":"blue"}},
-            {"Move":{"cost":3,"target":{"q":2,"r":-6}}},
-            {"SelectReward":{"card_id":"space_bending","reward_index":1,"unit_id":null}},
-            "EndTurn",
-            "DeclareRest",
-            {"PlayCardPowered":{"card_id":"space_bending","hand_index":3,"mana_color":"blue"}},
-            {"CompleteRest":{"discard_hand_index":3}},
-            {"SubsetSelect":{"index":1}},
-            {"SubsetSelect":{"index":2}},
-            {"SubsetSelect":{"index":0}},
-            "EndTurn",
-            "BeginInteraction"
+            {"ResolveChoice":{"choice_index":2}},
+            {"ChallengeRampaging":{"hex":{"q":1,"r":-4}}},
+            "EndTurn"
         ]"#;
 
         let actions: Vec<LegalAction> = serde_json::from_str(actions_json).unwrap();


### PR DESCRIPTION
## Summary
- Correct Arythea Battle Versatility data and add combat legal-action coverage
- Clear undo snapshots after deed-deck draws reveal hidden cards
- Prevent focus-mode card menu clicks from falling through to the hand click handler
- Add client Bun tests to CI and refresh the seed 42048 replay trace for the updated legal-action path

## Verification
- cargo test
- cargo clippy
- bun run build
- bun run --filter @mage-knight/client test
- bun run lint
- pre-push hook: clippy, bun run lint, cargo test --workspace --exclude mk-python