### PR TITLE
chore: centralize client asset paths

### DIFF
--- a/packages/client/__tests__/assetUrl.test.ts
+++ b/packages/client/__tests__/assetUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { assetUrl } from "../src/assets/assetPaths";
+
+describe("assetUrl", () => {
+  it("joins a relative path under the default asset root", () => {
+    expect(assetUrl("icons/attack.png")).toBe("/assets/icons/attack.png");
+  });
+
+  it("ignores a leading slash on the path segment", () => {
+    expect(assetUrl("/icons/attack.png")).toBe("/assets/icons/attack.png");
+  });
+
+  it("returns the asset root for an empty path", () => {
+    expect(assetUrl("")).toBe("/assets");
+  });
+});

--- a/packages/client/src/assets/assetPaths.ts
+++ b/packages/client/src/assets/assetPaths.ts
@@ -2,18 +2,30 @@
  * Asset path helpers for game sprites and images
  */
 
-// Base path for all assets
-const ASSETS_BASE = "/assets";
+/** Default web path for static game assets (served as `/assets` in dev and production). */
+const DEFAULT_ASSETS_BASE = "/assets";
+
+/**
+ * Returns an absolute URL path under the game asset root.
+ * Leading slashes on `path` are ignored so `icons/x.png` and `/icons/x.png` resolve the same.
+ * The implementation reserves a single place to swap in a CDN base or version prefix later.
+ */
+export function assetUrl(path: string): string {
+  const trimmed = path.trim();
+  if (!trimmed) return DEFAULT_ASSETS_BASE;
+  const relative = trimmed.replace(/^\/+/, "");
+  return `${DEFAULT_ASSETS_BASE}/${relative}`;
+}
 
 export function getEnemyImageUrl(enemyId: string): string {
   // Enemy IDs use underscores, file names use underscores too
-  return `${ASSETS_BASE}/enemies/${enemyId}.jpg`;
+  return assetUrl(`enemies/${enemyId}.jpg`);
 }
 
 export type EnemyTokenColor = "green" | "grey" | "brown" | "violet" | "red" | "white";
 
 export function getEnemyTokenBackUrl(color: EnemyTokenColor): string {
-  return `${ASSETS_BASE}/enemies/backs/${color}.png`;
+  return assetUrl(`enemies/backs/${color}.png`);
 }
 
 /**
@@ -27,21 +39,21 @@ export function tokenIdToEnemyId(tokenId: string): string {
 }
 
 export function getTileImageUrl(tileId: string): string {
-  return `${ASSETS_BASE}/tiles/${tileId}.png`;
+  return assetUrl(`tiles/${tileId}.png`);
 }
 
 export function getCardSheetUrl(sheet: "basic_actions" | "advanced_actions" | "spells" | "artifacts"): string {
-  return `${ASSETS_BASE}/cards/${sheet}.jpg`;
+  return assetUrl(`cards/${sheet}.jpg`);
 }
 
 export function getCardBackUrl(): string {
-  return `${ASSETS_BASE}/cards/card_back.jpg`;
+  return assetUrl("cards/card_back.jpg");
 }
 
 export function getHeroTokenUrl(heroId: string): string {
   // Note: "_card" files are actually the octagonal portrait tokens for the board
   // "_token" files are smaller circular tokens (naming is backwards in assets)
-  return `${ASSETS_BASE}/heroes/${heroId}_card.png`;
+  return assetUrl(`heroes/${heroId}_card.png`);
 }
 
 /**
@@ -49,7 +61,7 @@ export function getHeroTokenUrl(heroId: string): string {
  * Used when the token is revealed (face-up).
  */
 export function getRuinsTokenFaceUrl(tokenId: string): string {
-  return `${ASSETS_BASE}/sites/ruins/${tokenId}.png`;
+  return assetUrl(`sites/ruins/${tokenId}.png`);
 }
 
 /**
@@ -57,5 +69,5 @@ export function getRuinsTokenFaceUrl(tokenId: string): string {
  * All unrevealed ruins tokens show the same yellow back.
  */
 export function getRuinsTokenBackUrl(): string {
-  return `${ASSETS_BASE}/enemies/backs/yellow.png`;
+  return assetUrl("enemies/backs/yellow.png");
 }

--- a/packages/client/src/components/Combat/AmountPicker.tsx
+++ b/packages/client/src/components/Combat/AmountPicker.tsx
@@ -7,14 +7,17 @@
 
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { AttackType, AttackElement } from "@mage-knight/shared";
+import { assetUrl } from "../../assets/assetPaths";
 import "./AmountPicker.css";
+
+const icon = (file: string): string => assetUrl(`icons/${file}`);
 
 // Element icon paths
 const ELEMENT_ICONS: Record<AttackElement, string> = {
-  physical: "/assets/icons/attack.png",
-  fire: "/assets/icons/fire_attack.png",
-  ice: "/assets/icons/ice_attack.png",
-  coldFire: "/assets/icons/cold_fire_attack.png",
+  physical: icon("attack.png"),
+  fire: icon("fire_attack.png"),
+  ice: icon("ice_attack.png"),
+  coldFire: icon("cold_fire_attack.png"),
 };
 
 const TYPE_NAMES: Record<AttackType, string> = {
@@ -25,10 +28,10 @@ const TYPE_NAMES: Record<AttackType, string> = {
 
 // Block element icons (use block icon for physical)
 const BLOCK_ICONS: Record<AttackElement, string> = {
-  physical: "/assets/icons/block.png",
-  fire: "/assets/icons/fire_attack.png",
-  ice: "/assets/icons/ice_attack.png",
-  coldFire: "/assets/icons/cold_fire_attack.png",
+  physical: icon("block.png"),
+  fire: icon("fire_attack.png"),
+  ice: icon("ice_attack.png"),
+  coldFire: icon("cold_fire_attack.png"),
 };
 
 interface AmountPickerProps {

--- a/packages/client/src/components/Combat/EnemyDetailPanel.tsx
+++ b/packages/client/src/components/Combat/EnemyDetailPanel.tsx
@@ -13,18 +13,21 @@ import { ABILITY_DESCRIPTIONS, RESISTANCE_DESCRIPTIONS, ENEMIES } from "@mage-kn
 import type { ResistanceType } from "@mage-knight/shared";
 import { GameIcon, type GameIconType } from "../Icons";
 import { getEnemyAttackElements, getEnemyAttacks, groupEnemyAttacks } from "../../utils/enemyAttacks";
+import { assetUrl, getEnemyImageUrl } from "../../assets/assetPaths";
 import "./EnemyDetailPanel.css";
 
 // Icon paths for abilities (fallback for abilities without GameIcon support)
+const icon = (file: string): string => assetUrl(`icons/${file}`);
+
 const ABILITY_ICONS: Record<string, string> = {
-  fortified: "/assets/icons/fortified.png",
-  unfortified: "/assets/icons/unfortified.png",
-  swift: "/assets/icons/swift.png",
-  brutal: "/assets/icons/brutal.png",
-  poison: "/assets/icons/poison.png",
-  paralyze: "/assets/icons/paralyze.png",
-  summon: "/assets/icons/summon.png",
-  cumbersome: "/assets/icons/cumbersome.png",
+  fortified: icon("fortified.png"),
+  unfortified: icon("unfortified.png"),
+  swift: icon("swift.png"),
+  brutal: icon("brutal.png"),
+  poison: icon("poison.png"),
+  paralyze: icon("paralyze.png"),
+  summon: icon("summon.png"),
+  cumbersome: icon("cumbersome.png"),
 };
 
 // Icon paths for resistances
@@ -113,7 +116,7 @@ export function EnemyDetailPanel({ enemy, onClose }: EnemyDetailPanelProps) {
         <div className="enemy-detail-header">
           <div className="enemy-detail-header-content">
             <img
-              src={`/assets/enemies/${enemy.enemyId}.jpg`}
+              src={getEnemyImageUrl(enemy.enemyId)}
               alt={enemy.name}
               className="enemy-detail-portrait"
             />

--- a/packages/client/src/components/Combat/PixiAttackPool.tsx
+++ b/packages/client/src/components/Combat/PixiAttackPool.tsx
@@ -32,6 +32,7 @@ import { useCombatDrag, type DamageChipData } from "../../contexts/CombatDragCon
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
 import { chipRowLayout } from "../../utils/pixiLayout";
+import { assetUrl } from "../../assets/assetPaths";
 
 // ============================================================================
 // Constants
@@ -39,12 +40,14 @@ import { chipRowLayout } from "../../utils/pixiLayout";
 
 const DRAG_THRESHOLD = 8; // pixels before drag starts
 
+const icon = (file: string): string => assetUrl(`icons/${file}`);
+
 // Element icon paths
 const ELEMENT_ICONS: Record<AttackElement, string> = {
-  physical: "/assets/icons/attack.png",
-  fire: "/assets/icons/fire_attack.png",
-  ice: "/assets/icons/ice_attack.png",
-  coldFire: "/assets/icons/cold_fire_attack.png",
+  physical: icon("attack.png"),
+  fire: icon("fire_attack.png"),
+  ice: icon("ice_attack.png"),
+  coldFire: icon("cold_fire_attack.png"),
 };
 
 // Attack type labels

--- a/packages/client/src/components/Combat/PixiBlockPool.tsx
+++ b/packages/client/src/components/Combat/PixiBlockPool.tsx
@@ -30,6 +30,7 @@ import { useCombatDrag, type BlockChipData } from "../../contexts/CombatDragCont
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
 import { chipRowLayout } from "../../utils/pixiLayout";
+import { assetUrl } from "../../assets/assetPaths";
 
 // ============================================================================
 // Constants
@@ -37,12 +38,14 @@ import { chipRowLayout } from "../../utils/pixiLayout";
 
 const DRAG_THRESHOLD = 8; // pixels before drag starts
 
+const icon = (file: string): string => assetUrl(`icons/${file}`);
+
 // Block icon paths
 const BLOCK_ICONS: Record<AttackElement, string> = {
-  physical: "/assets/icons/block.png",
-  fire: "/assets/icons/fire_attack.png",
-  ice: "/assets/icons/ice_attack.png",
-  coldFire: "/assets/icons/cold_fire_attack.png",
+  physical: icon("block.png"),
+  fire: icon("fire_attack.png"),
+  ice: icon("ice_attack.png"),
+  coldFire: icon("cold_fire_attack.png"),
 };
 
 // All block elements in display order

--- a/packages/client/src/components/Combat/PixiCombatOverlay.tsx
+++ b/packages/client/src/components/Combat/PixiCombatOverlay.tsx
@@ -22,10 +22,11 @@ import { useGame } from "../../hooks/useGame";
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { cleanupFilters } from "../../utils/pixiFilterCleanup";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
+import { assetUrl } from "../../assets/assetPaths";
 
 // Site sprite sheet configuration (matches CombatOverlay.tsx)
 const SITES_SHEET = {
-  src: "/assets/sites/sites_sprite_sheet.png",
+  src: assetUrl("sites/sites_sprite_sheet.png"),
   width: 1280,
   height: 1024,
   spriteWidth: 256,

--- a/packages/client/src/components/Combat/PixiEnemyTokens.tsx
+++ b/packages/client/src/components/Combat/PixiEnemyTokens.tsx
@@ -15,11 +15,12 @@
 
 import { useEffect, useRef, useId, useCallback, useState } from "react";
 import { Container, Graphics, Sprite, Texture, Assets } from "pixi.js";
-import type { ClientCombatEnemy, EnemyId } from "@mage-knight/shared";
+import type { ClientCombatEnemy } from "@mage-knight/shared";
 import { usePixiApp } from "../../contexts/PixiAppContext";
 import { useCombatDragOptional } from "../../contexts/CombatDragContext";
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import { PIXI_Z_INDEX } from "../../utils/pixiLayers";
+import { getEnemyImageUrl } from "../../assets/assetPaths";
 
 // Colors
 const COLORS = {
@@ -35,11 +36,6 @@ const COLORS = {
   TARGETED_GLOW: 0xd4a574, // Antique gold
   DROP_HIGHLIGHT: 0xffd700, // Gold for drop target
 };
-
-// Get enemy token image URL
-function getEnemyImageUrl(enemyId: EnemyId): string {
-  return `/assets/enemies/${enemyId}.jpg`;
-}
 
 interface EnemyTokenData {
   enemy: ClientCombatEnemy;

--- a/packages/client/src/components/GameBoard/ManaSourceOverlay.tsx
+++ b/packages/client/src/components/GameBoard/ManaSourceOverlay.tsx
@@ -27,6 +27,7 @@ import {
   BASIC_MANA_COLORS,
 } from "@mage-knight/shared";
 import type { ManaColor, AvailableDie } from "@mage-knight/shared";
+import { assetUrl } from "../../assets/assetPaths";
 import "./ManaSourceOverlay.css";
 
 function getManaIconUrl(color: string): string {
@@ -39,7 +40,7 @@ function getManaIconUrl(color: string): string {
     [MANA_BLACK]: "black",
   };
   const colorName = colorMap[color] || "white";
-  return `/assets/mana_icons/glossy/${colorName}.png`;
+  return assetUrl(`mana_icons/glossy/${colorName}.png`);
 }
 
 // Animation durations must match CSS

--- a/packages/client/src/components/Hand/DeckDiscardIndicator.tsx
+++ b/packages/client/src/components/Hand/DeckDiscardIndicator.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useGameIntro, UI_REVEAL_TIMING } from "../../contexts/GameIntroContext";
+import { assetUrl } from "../../assets/assetPaths";
 import "./DeckDiscardIndicator.css";
 
 interface DeckDiscardIndicatorProps {
@@ -59,7 +60,7 @@ export function DeckDiscardIndicator({ deckCount, discardCount, isHidden }: Deck
     <div className={className}>
       <div className="floating-hand__deck" title={`${deckCount} cards in deck`}>
         <img
-          src="/assets/atlas/cards/card_back.jpg"
+          src={assetUrl("atlas/cards/card_back.jpg")}
           alt="Deck"
           className="floating-hand__deck-image"
         />

--- a/packages/client/src/components/HexTooltip/EnemyTooltipContent.tsx
+++ b/packages/client/src/components/HexTooltip/EnemyTooltipContent.tsx
@@ -15,6 +15,7 @@ import type { ClientHexEnemy, EnemyAbilityType, Element } from "@mage-knight/sha
 import { ENEMIES, ABILITY_DESCRIPTIONS } from "@mage-knight/shared";
 import { GameIcon, type GameIconType } from "../Icons";
 import { getEnemyAttacks, groupEnemyAttacks } from "../../utils/enemyAttacks";
+import { getEnemyTokenBackUrl } from "../../assets/assetPaths";
 
 export interface EnemyTooltipContentProps {
   enemies: readonly ClientHexEnemy[];
@@ -29,13 +30,13 @@ export interface EnemyTooltipContentProps {
 
 // Enemy token back images by color
 const TOKEN_BACK_PATHS: Record<string, string> = {
-  green: "/assets/enemies/backs/green.png",
-  gray: "/assets/enemies/backs/grey.png",
-  grey: "/assets/enemies/backs/grey.png",
-  brown: "/assets/enemies/backs/brown.png",
-  violet: "/assets/enemies/backs/violet.png",
-  red: "/assets/enemies/backs/red.png",
-  white: "/assets/enemies/backs/white.png",
+  green: getEnemyTokenBackUrl("green"),
+  gray: getEnemyTokenBackUrl("grey"),
+  grey: getEnemyTokenBackUrl("grey"),
+  brown: getEnemyTokenBackUrl("brown"),
+  violet: getEnemyTokenBackUrl("violet"),
+  red: getEnemyTokenBackUrl("red"),
+  white: getEnemyTokenBackUrl("white"),
 };
 
 function getAttackIconType(element: Element): GameIconType {

--- a/packages/client/src/components/Icons/GameIcon.tsx
+++ b/packages/client/src/components/Icons/GameIcon.tsx
@@ -13,6 +13,7 @@
  * - Resistances: fire_resist, ice_resist, physical_resist
  */
 
+import { assetUrl } from "../../assets/assetPaths";
 import "./GameIcon.css";
 
 export type GameIconType =
@@ -45,35 +46,37 @@ export type GameIconType =
   | "ice_resist"
   | "physical_resist";
 
+const icon = (file: string): string => assetUrl(`icons/${file}`);
+
 const ICON_PATHS: Record<GameIconType, string> = {
-  attack: "/assets/icons/attack.png",
-  combat: "/assets/icons/combat.png",
-  block: "/assets/icons/block.png",
-  fortified: "/assets/icons/fortified.png",
-  fame: "/assets/icons/fame.png",
-  heal: "/assets/icons/heal.png",
-  spell: "/assets/icons/spell.png",
-  influence: "/assets/icons/influence.png",
-  end_turn: "/assets/icons/end_turn.png",
+  attack: icon("attack.png"),
+  combat: icon("combat.png"),
+  block: icon("block.png"),
+  fortified: icon("fortified.png"),
+  fame: icon("fame.png"),
+  heal: icon("heal.png"),
+  spell: icon("spell.png"),
+  influence: icon("influence.png"),
+  end_turn: icon("end_turn.png"),
   // Enemy abilities
-  swift: "/assets/icons/swift.png",
-  brutal: "/assets/icons/brutal.png",
-  poison: "/assets/icons/poison.png",
-  paralyze: "/assets/icons/paralyze.png",
-  summon: "/assets/icons/summon.png",
-  cumbersome: "/assets/icons/cumbersome.png",
-  unfortified: "/assets/icons/unfortified.png",
-  vampiric: "/assets/icons/heal.png", // TODO: Add dedicated vampiric icon
-  armor: "/assets/icons/armor.png",
-  arcane_immune: "/assets/icons/arcane_immune.png",
+  swift: icon("swift.png"),
+  brutal: icon("brutal.png"),
+  poison: icon("poison.png"),
+  paralyze: icon("paralyze.png"),
+  summon: icon("summon.png"),
+  cumbersome: icon("cumbersome.png"),
+  unfortified: icon("unfortified.png"),
+  vampiric: icon("heal.png"), // TODO: Add dedicated vampiric icon
+  armor: icon("armor.png"),
+  arcane_immune: icon("arcane_immune.png"),
   // Attack elements
-  fire: "/assets/icons/fire_attack.png",
-  ice: "/assets/icons/ice_attack.png",
-  cold_fire: "/assets/icons/cold_fire_attack.png",
+  fire: icon("fire_attack.png"),
+  ice: icon("ice_attack.png"),
+  cold_fire: icon("cold_fire_attack.png"),
   // Resistances
-  fire_resist: "/assets/icons/fire_resist.png",
-  ice_resist: "/assets/icons/ice_resist.png",
-  physical_resist: "/assets/icons/physical_resist.png",
+  fire_resist: icon("fire_resist.png"),
+  ice_resist: icon("ice_resist.png"),
+  physical_resist: icon("physical_resist.png"),
 };
 
 /** Preset sizes for responsive icons */

--- a/packages/client/src/components/Icons/SiteIcon.tsx
+++ b/packages/client/src/components/Icons/SiteIcon.tsx
@@ -1,10 +1,11 @@
 /**
  * SiteIcon - Renders a site icon from individual PNG files
  *
- * All sites use individual cropped images from /assets/sites/
+ * All sites use individual cropped images from the static sites/ folder.
  */
 
 import "./SiteIcon.css";
+import { assetUrl } from "../../assets/assetPaths";
 
 export type SiteIconType =
   | "ancient_ruins"
@@ -29,27 +30,29 @@ export type SiteIconType =
   | "dungeon";
 
 // Map site types to individual image files
+const site = (file: string): string => assetUrl(`sites/${file}`);
+
 const SITE_IMAGE_PATHS: Record<SiteIconType, string> = {
-  ancient_ruins: "/assets/sites/ancient_ruins.png",
-  blue_city: "/assets/sites/city_blue.png",
-  green_city: "/assets/sites/city_green.png",
-  red_city: "/assets/sites/city_red.png",
-  white_city: "/assets/sites/city_white.png",
-  mine: "/assets/sites/crystal_mine.png",
-  deep_mine: "/assets/sites/deep_mine.png",
-  draconum: "/assets/sites/draconum.png",
-  keep: "/assets/sites/keep.png",
-  mage_tower: "/assets/sites/mage_tower.png",
-  maze: "/assets/sites/labyrinth.png",
-  labyrinth: "/assets/sites/labyrinth.png",
-  monastery: "/assets/sites/monastery.png",
-  village: "/assets/sites/village.png",
-  spawning_grounds: "/assets/sites/spawning_grounds.png",
-  magical_glade: "/assets/sites/magic_glade.png",
-  camp: "/assets/sites/refugee_camp.png",
-  monster_den: "/assets/sites/orc_marauder.png",
-  tomb: "/assets/sites/tomb.png",
-  dungeon: "/assets/sites/deep_mine.png",  // Dungeon uses mine/cave image
+  ancient_ruins: site("ancient_ruins.png"),
+  blue_city: site("city_blue.png"),
+  green_city: site("city_green.png"),
+  red_city: site("city_red.png"),
+  white_city: site("city_white.png"),
+  mine: site("crystal_mine.png"),
+  deep_mine: site("deep_mine.png"),
+  draconum: site("draconum.png"),
+  keep: site("keep.png"),
+  mage_tower: site("mage_tower.png"),
+  maze: site("labyrinth.png"),
+  labyrinth: site("labyrinth.png"),
+  monastery: site("monastery.png"),
+  village: site("village.png"),
+  spawning_grounds: site("spawning_grounds.png"),
+  magical_glade: site("magic_glade.png"),
+  camp: site("refugee_camp.png"),
+  monster_den: site("orc_marauder.png"),
+  tomb: site("tomb.png"),
+  dungeon: site("deep_mine.png"), // Dungeon uses mine/cave image
 };
 
 export interface SiteIconProps {

--- a/packages/client/src/components/Setup/HeroCard.tsx
+++ b/packages/client/src/components/Setup/HeroCard.tsx
@@ -5,6 +5,7 @@
 
 import type { HeroId } from "@mage-knight/shared";
 import { HERO_NAMES } from "@mage-knight/shared";
+import { getHeroTokenUrl } from "../../assets/assetPaths";
 import "./SetupScreen.css";
 
 // Player colors for badges (matches existing game UI)
@@ -30,7 +31,7 @@ export function HeroCard({
   playerIndex,
   onClick,
 }: HeroCardProps) {
-  const imagePath = `/assets/heroes/${hero}_card.png`;
+  const imagePath = getHeroTokenUrl(hero);
   const heroName = HERO_NAMES[hero];
 
   return (

--- a/packages/client/src/components/SitePanel/SitePanel.tsx
+++ b/packages/client/src/components/SitePanel/SitePanel.tsx
@@ -27,6 +27,7 @@ import {
   type Element,
 } from "@mage-knight/shared";
 import { useGame } from "../../hooks/useGame";
+import { getEnemyTokenBackUrl } from "../../assets/assetPaths";
 import { SiteIcon, GameIcon, type SiteIconType, type GameIconType } from "../Icons";
 import { getEnemyAttackElements, getEnemyAttacks, groupEnemyAttacks } from "../../utils/enemyAttacks";
 import "./SitePanel.css";
@@ -68,13 +69,13 @@ function getUnitsRecruitableAtSite(
 
 // Token back images by color
 const TOKEN_BACK_PATHS: Record<string, string> = {
-  green: "/assets/enemies/backs/green.png",
-  gray: "/assets/enemies/backs/grey.png",
-  grey: "/assets/enemies/backs/grey.png",
-  brown: "/assets/enemies/backs/brown.png",
-  violet: "/assets/enemies/backs/violet.png",
-  red: "/assets/enemies/backs/red.png",
-  white: "/assets/enemies/backs/white.png",
+  green: getEnemyTokenBackUrl("green"),
+  gray: getEnemyTokenBackUrl("grey"),
+  grey: getEnemyTokenBackUrl("grey"),
+  brown: getEnemyTokenBackUrl("brown"),
+  violet: getEnemyTokenBackUrl("violet"),
+  red: getEnemyTokenBackUrl("red"),
+  white: getEnemyTokenBackUrl("white"),
 };
 
 

--- a/packages/client/src/utils/ambientMusicManager.ts
+++ b/packages/client/src/utils/ambientMusicManager.ts
@@ -6,6 +6,12 @@
  * Both layers can play together with independent volume controls.
  */
 
+import { assetUrl } from "../assets/assetPaths";
+
+function ambientSrc(file: string): string {
+  return assetUrl(`audio/music/${file}`);
+}
+
 export interface AmbientTrack {
   id: string;
   label: string;
@@ -16,32 +22,32 @@ export interface AmbientTrack {
 // Available ambient tracks
 export const AMBIENT_TRACKS: AmbientTrack[] = [
   // Pads - atmospheric drones
-  { id: "pad_04", label: "Pad 04", category: "pad", src: "/assets/audio/music/pad_04.wav" },
+  { id: "pad_04", label: "Pad 04", category: "pad", src: ambientSrc("pad_04.wav") },
   // Strings - orchestral atmosphere
-  { id: "strings_03", label: "Strings 03", category: "strings", src: "/assets/audio/music/strings_03.wav" },
-  { id: "strings_04", label: "Strings 04", category: "strings", src: "/assets/audio/music/strings_04.wav" },
+  { id: "strings_03", label: "Strings 03", category: "strings", src: ambientSrc("strings_03.wav") },
+  { id: "strings_04", label: "Strings 04", category: "strings", src: ambientSrc("strings_04.wav") },
   // Piano - contemplative mood
-  { id: "piano_01", label: "Piano 01", category: "piano", src: "/assets/audio/music/piano_01.wav" },
-  { id: "piano_02", label: "Piano 02", category: "piano", src: "/assets/audio/music/piano_02.wav" },
-  { id: "piano_03", label: "Piano 03", category: "piano", src: "/assets/audio/music/piano_03.wav" },
+  { id: "piano_01", label: "Piano 01", category: "piano", src: ambientSrc("piano_01.wav") },
+  { id: "piano_02", label: "Piano 02", category: "piano", src: ambientSrc("piano_02.wav") },
+  { id: "piano_03", label: "Piano 03", category: "piano", src: ambientSrc("piano_03.wav") },
   // Guitar - ambient guitar
-  { id: "guitar_01", label: "Guitar 01", category: "guitar", src: "/assets/audio/music/guitar_01.wav" },
-  { id: "guitar_02", label: "Guitar 02", category: "guitar", src: "/assets/audio/music/guitar_02.wav" },
-  { id: "guitar_03", label: "Guitar 03", category: "guitar", src: "/assets/audio/music/guitar_03.wav" },
+  { id: "guitar_01", label: "Guitar 01", category: "guitar", src: ambientSrc("guitar_01.wav") },
+  { id: "guitar_02", label: "Guitar 02", category: "guitar", src: ambientSrc("guitar_02.wav") },
+  { id: "guitar_03", label: "Guitar 03", category: "guitar", src: ambientSrc("guitar_03.wav") },
   // Mallets - vibraphone/marimba atmosphere
-  { id: "mallets_02", label: "Mallets 02", category: "mallets", src: "/assets/audio/music/mallets_02.wav" },
+  { id: "mallets_02", label: "Mallets 02", category: "mallets", src: ambientSrc("mallets_02.wav") },
   // Nature - countryside ambience (birds, wind, etc.)
-  { id: "nature_fields_01", label: "Fields 01", category: "nature", src: "/assets/audio/music/nature_fields_01.wav" },
-  { id: "nature_fields_02", label: "Fields 02", category: "nature", src: "/assets/audio/music/nature_fields_02.wav" },
-  { id: "nature_fields_03", label: "Fields 03", category: "nature", src: "/assets/audio/music/nature_fields_03.wav" },
-  { id: "nature_fields_04", label: "Fields 04", category: "nature", src: "/assets/audio/music/nature_fields_04.wav" },
-  { id: "nature_fields_05", label: "Fields 05", category: "nature", src: "/assets/audio/music/nature_fields_05.wav" },
-  { id: "nature_fields_06", label: "Fields 06", category: "nature", src: "/assets/audio/music/nature_fields_06.wav" },
-  { id: "nature_fields_07", label: "Fields 07", category: "nature", src: "/assets/audio/music/nature_fields_07.wav" },
-  { id: "nature_fields_08", label: "Fields 08", category: "nature", src: "/assets/audio/music/nature_fields_08.wav" },
-  { id: "nature_fields_09", label: "Fields 09", category: "nature", src: "/assets/audio/music/nature_fields_09.wav" },
-  { id: "nature_fields_10", label: "Fields 10", category: "nature", src: "/assets/audio/music/nature_fields_10.wav" },
-  { id: "nature_fields_11", label: "Fields 11", category: "nature", src: "/assets/audio/music/nature_fields_11.wav" },
+  { id: "nature_fields_01", label: "Fields 01", category: "nature", src: ambientSrc("nature_fields_01.wav") },
+  { id: "nature_fields_02", label: "Fields 02", category: "nature", src: ambientSrc("nature_fields_02.wav") },
+  { id: "nature_fields_03", label: "Fields 03", category: "nature", src: ambientSrc("nature_fields_03.wav") },
+  { id: "nature_fields_04", label: "Fields 04", category: "nature", src: ambientSrc("nature_fields_04.wav") },
+  { id: "nature_fields_05", label: "Fields 05", category: "nature", src: ambientSrc("nature_fields_05.wav") },
+  { id: "nature_fields_06", label: "Fields 06", category: "nature", src: ambientSrc("nature_fields_06.wav") },
+  { id: "nature_fields_07", label: "Fields 07", category: "nature", src: ambientSrc("nature_fields_07.wav") },
+  { id: "nature_fields_08", label: "Fields 08", category: "nature", src: ambientSrc("nature_fields_08.wav") },
+  { id: "nature_fields_09", label: "Fields 09", category: "nature", src: ambientSrc("nature_fields_09.wav") },
+  { id: "nature_fields_10", label: "Fields 10", category: "nature", src: ambientSrc("nature_fields_10.wav") },
+  { id: "nature_fields_11", label: "Fields 11", category: "nature", src: ambientSrc("nature_fields_11.wav") },
 ];
 
 export type TrackCategory = AmbientTrack["category"];

--- a/packages/client/src/utils/audioManager.ts
+++ b/packages/client/src/utils/audioManager.ts
@@ -4,24 +4,30 @@
  * Supports dynamic sound assignment via debug panel.
  */
 
+import { assetUrl } from "../assets/assetPaths";
+
 export type SoundEvent = "cardHover" | "cardDeal" | "cardPlay";
+
+function soundSrc(file: string): string {
+  return assetUrl(`audio/sounds/${file}`);
+}
 
 // All available sound files (for debug panel)
 export const AVAILABLE_SOUNDS = [
-  { id: "card_hover", label: "Card Slide 1", src: "/assets/audio/sounds/card_hover.wav" },
-  { id: "card_slide_2", label: "Card Slide 2", src: "/assets/audio/sounds/card_slide_2.wav" },
-  { id: "card_playing_0", label: "Card Playing 0", src: "/assets/audio/sounds/card_playing_0.wav" },
-  { id: "card_playing_1", label: "Card Playing 1", src: "/assets/audio/sounds/card_playing_1.wav" },
-  { id: "card_playing_2", label: "Card Playing 2", src: "/assets/audio/sounds/card_playing_2.wav" },
-  { id: "card_playing_3", label: "Card Playing 3", src: "/assets/audio/sounds/card_playing_3.wav" },
-  { id: "card_playing_4", label: "Card Playing 4", src: "/assets/audio/sounds/card_playing_4.wav" },
-  { id: "card_deal_1", label: "Card Deal 1", src: "/assets/audio/sounds/card_deal_1.wav" },
-  { id: "card_deal_2", label: "Card Deal 2", src: "/assets/audio/sounds/card_deal_2.wav" },
-  { id: "card_deal_3", label: "Card Deal 3", src: "/assets/audio/sounds/card_deal_3.wav" },
-  { id: "card_deal_4", label: "Card Deal 4", src: "/assets/audio/sounds/card_deal_4.wav" },
-  { id: "card_deal_5", label: "Card Deal 5", src: "/assets/audio/sounds/card_deal_5.wav" },
-  { id: "card_play", label: "Card Slap 1", src: "/assets/audio/sounds/card_play.wav" },
-  { id: "card_slap_2", label: "Card Slap 2", src: "/assets/audio/sounds/card_slap_2.wav" },
+  { id: "card_hover", label: "Card Slide 1", src: soundSrc("card_hover.wav") },
+  { id: "card_slide_2", label: "Card Slide 2", src: soundSrc("card_slide_2.wav") },
+  { id: "card_playing_0", label: "Card Playing 0", src: soundSrc("card_playing_0.wav") },
+  { id: "card_playing_1", label: "Card Playing 1", src: soundSrc("card_playing_1.wav") },
+  { id: "card_playing_2", label: "Card Playing 2", src: soundSrc("card_playing_2.wav") },
+  { id: "card_playing_3", label: "Card Playing 3", src: soundSrc("card_playing_3.wav") },
+  { id: "card_playing_4", label: "Card Playing 4", src: soundSrc("card_playing_4.wav") },
+  { id: "card_deal_1", label: "Card Deal 1", src: soundSrc("card_deal_1.wav") },
+  { id: "card_deal_2", label: "Card Deal 2", src: soundSrc("card_deal_2.wav") },
+  { id: "card_deal_3", label: "Card Deal 3", src: soundSrc("card_deal_3.wav") },
+  { id: "card_deal_4", label: "Card Deal 4", src: soundSrc("card_deal_4.wav") },
+  { id: "card_deal_5", label: "Card Deal 5", src: soundSrc("card_deal_5.wav") },
+  { id: "card_play", label: "Card Slap 1", src: soundSrc("card_play.wav") },
+  { id: "card_slap_2", label: "Card Slap 2", src: soundSrc("card_slap_2.wav") },
 ] as const;
 
 export type SoundId = typeof AVAILABLE_SOUNDS[number]["id"];

--- a/packages/client/src/utils/cardAtlas.ts
+++ b/packages/client/src/utils/cardAtlas.ts
@@ -1,6 +1,7 @@
 import type { CardId, UnitId, TacticId } from "@mage-knight/shared";
+import { assetUrl } from "../assets/assetPaths";
 
-// Atlas data - matches public/assets/atlas.json
+// Atlas data — layout matches bundled atlas.json (served from the static game asset root)
 interface SheetInfo {
   file: string;
   width: number;
@@ -122,7 +123,7 @@ export interface SpriteData {
  * separately by PixiJS Assets.load() in preloadAllSpriteSheets().
  */
 async function preloadImage(file: string): Promise<void> {
-  const url = `/assets/${file}`;
+  const url = assetUrl(file);
 
   try {
     const img = new Image();
@@ -212,7 +213,7 @@ function computeSpriteStyle(
   const bgHeight = sheet.height * scale;
 
   return {
-    backgroundImage: `url(/assets/${sheet.file})`,
+    backgroundImage: `url(${assetUrl(sheet.file)})`,
     backgroundPosition: `-${bgX}px -${bgY}px`,
     backgroundSize: `${bgWidth}px ${bgHeight}px`,
     width: `${displayWidth}px`,
@@ -331,7 +332,7 @@ function computeIconSpriteStyle(
   const bgHeight = sheet.height * scale;
 
   return {
-    backgroundImage: `url(/assets/${sheet.file})`,
+    backgroundImage: `url(${assetUrl(sheet.file)})`,
     backgroundPosition: `-${bgX}px -${bgY}px`,
     backgroundSize: `${bgWidth}px ${bgHeight}px`,
     width: `${displayWidth}px`,
@@ -365,7 +366,7 @@ function precomputeCrystalStyles(atlasData: RawAtlasData, displayHeight: number)
 export async function loadAtlas(): Promise<void> {
   if (atlasLoaded) return;
 
-  const response = await fetch("/assets/atlas.json");
+  const response = await fetch(assetUrl("atlas.json"));
   const rawData = (await response.json()) as RawAtlasData;
 
   // Cast to AtlasData for card/unit/tactic functions (they only access SheetInfo sheets)
@@ -590,7 +591,7 @@ export function getUnitSpriteData(unitId: UnitId): SpriteData | null {
   const physicalRow = sheet.hasEvenOddLayout ? position.row * 2 : position.row;
 
   return {
-    src: `/assets/${sheet.file}`,
+    src: assetUrl(sheet.file),
     spriteWidth: sheet.cardWidth,
     spriteHeight: fullCardHeight,
     col: position.col,
@@ -619,7 +620,7 @@ export function getTacticSpriteData(tacticId: TacticId): SpriteData | null {
 
   // Tactics sheet doesn't use even/odd layout
   return {
-    src: `/assets/${sheet.file}`,
+    src: assetUrl(sheet.file),
     spriteWidth: sheet.cardWidth,
     spriteHeight: sheet.cardHeight,
     col: position.col,
@@ -655,7 +656,7 @@ export function getCardSpriteData(cardId: CardId): SpriteData | null {
       const physicalRow = sheet.hasEvenOddLayout ? position.row * 2 : position.row;
 
       return {
-        src: `/assets/${sheet.file}`,
+        src: assetUrl(sheet.file),
         spriteWidth: sheet.cardWidth,
         spriteHeight: fullCardHeight,
         col: position.col,

--- a/packages/client/src/utils/pixiTextureLoader.ts
+++ b/packages/client/src/utils/pixiTextureLoader.ts
@@ -19,6 +19,7 @@
 
 import { Texture, Rectangle, Assets } from "pixi.js";
 import type { CardId, UnitId, TacticId } from "@mage-knight/shared";
+import { assetUrl } from "../assets/assetPaths";
 import { getCardSpriteData, getUnitSpriteData, getTacticSpriteData, type SpriteData } from "./cardAtlas";
 
 // ============================================================================
@@ -109,7 +110,7 @@ export async function loadAtlasData(): Promise<AtlasData> {
   if (atlasData) return atlasData;
   if (atlasLoadPromise) return atlasLoadPromise;
 
-  atlasLoadPromise = fetch("/assets/atlas.json")
+  atlasLoadPromise = fetch(assetUrl("atlas.json"))
     .then((res) => res.json())
     .then((data: AtlasData) => {
       atlasData = data;
@@ -156,7 +157,7 @@ export async function getCardTextureFromAtlas(cardId: string): Promise<Texture |
   }
 
   // Load or get base texture
-  const sheetUrl = `/assets/${sheet.file}`;
+  const sheetUrl = assetUrl(sheet.file);
   const loadPromise = (async () => {
     const baseTexture = await Assets.load(sheetUrl);
 
@@ -334,7 +335,7 @@ export async function preloadCardTextures(cardIds: string[]): Promise<void> {
  */
 export async function preloadAllSpriteSheets(): Promise<void> {
   const atlas = await loadAtlasData();
-  const sheetUrls = Object.values(atlas.sheets).map((s) => `/assets/${s.file}`);
+  const sheetUrls = Object.values(atlas.sheets).map((s) => assetUrl(s.file));
   const uniqueUrls = [...new Set(sheetUrls)];
 
   // Load all sheets via PixiJS Assets (this uploads to GPU)

--- a/packages/client/src/utils/skillImagePath.ts
+++ b/packages/client/src/utils/skillImagePath.ts
@@ -1,0 +1,23 @@
+import type { SkillId } from "@mage-knight/shared";
+import { assetUrl } from "../assets/assetPaths";
+
+/**
+ * Skill portraits live under skills/ as `{stem}.jpg` in the static asset tree.
+ * Some scans use a `_co-op` suffix or a different base name than the engine {@link SkillId}.
+ */
+const SKILL_IMAGE_STEM_BY_ID = {
+  arythea_ritual_of_pain: "arythea_ritual_of_pain_co-op",
+  braevalar_natures_vengeance: "braevalar_natures_vengeance_co-op",
+  goldyx_source_opening: "goldyx_source_opening_co-op",
+  krang_mana_enhancement: "krang_mana_enhancement_co-op",
+  tovak_mana_overload: "tovak_mana_overload_co-op",
+  wolfhawk_wolfs_howl: "wolfhawk_howl_of_the_pack_co-op",
+} as const satisfies Record<string, string>;
+
+export function skillImagePath(skillId: SkillId): string {
+  const stem =
+    skillId in SKILL_IMAGE_STEM_BY_ID
+      ? SKILL_IMAGE_STEM_BY_ID[skillId as keyof typeof SKILL_IMAGE_STEM_BY_ID]
+      : skillId;
+  return assetUrl(`skills/${stem}.jpg`);
+}


### PR DESCRIPTION
## Summary

Introduces `assetUrl()` in `packages/client/src/assets/assetPaths.ts` so all client code builds browser URLs under the default static root (**`/assets`**). This is a foundation for future CDN or version-prefixed asset hosting without touching call sites.

## Behavior

- **Runtime behavior is unchanged:** the default base remains `/assets`; no env, localStorage, or deploy config changes.
- Leading slashes on path segments are normalized (`icons/foo` and `/icons/foo` resolve the same).
- Existing helpers (`getEnemyImageUrl`, `getTileImageUrl`, etc.) now delegate to `assetUrl`.

## Tests

- `bun run --filter @mage-knight/client test` — pass (includes new `assetUrl` tests).
- `bun run --filter @mage-knight/client build` — pass.
- `bun run --filter @mage-knight/client typecheck` — currently reports existing workspace/tsconfig issues (Bun globals, etc.), not introduced by this PR.

Made with [Cursor](https://cursor.com)