### PR TITLE
Client: dev port fallback, choice overlay polish, skill image util

### DIFF
--- a/packages/client/dev.ts
+++ b/packages/client/dev.ts
@@ -3,7 +3,9 @@
  * Bun fullstack dev server with HMR
  * Alternative to Vite dev server
  *
- * Usage: bun run dev:bun
+ * Port: defaults to 3000. If busy, tries 3001, 3002, … Prefer
+ * CLIENT_DEV_PORT (SERVER also honors PORT via mk-server — use CLIENT_DEV_PORT
+ * to target only this dev server). From this package: `bun run dev`.
  */
 
 import homepage from "./index.html";
@@ -86,47 +88,96 @@ async function handleArtifactRequest(url: URL): Promise<Response | null> {
 // Dev server
 // ---------------------------------------------------------------------------
 
-const server = Bun.serve({
-  port: 3000,
+const DEFAULT_CLIENT_DEV_PORT = 3000;
+/** How many ports to try (base, base+1, …) when the preferred port is taken. */
+const CLIENT_DEV_PORT_TRIES = 64;
 
-  // Enable HMR and dev features
-  development: {
-    hmr: true,
-    console: true,
-  },
+function parseTcpPort(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === "") return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 && n <= 65535 ? n : undefined;
+}
 
-  routes: {
-    // Serve the app at root
-    "/": homepage,
-  },
+function errnoCode(err: unknown): string | undefined {
+  return typeof err === "object" && err !== null && "code" in err
+    ? String((err as { code?: unknown }).code)
+    : undefined;
+}
 
-  // Handle API routes and static files
-  async fetch(req) {
-    const url = new URL(req.url);
+/** Prefer CLIENT_DEV_PORT. PORT matches mk-server convention but both read it if set in `.env`. */
+const preferredClientDevPort =
+  parseTcpPort(process.env["CLIENT_DEV_PORT"]) ??
+  parseTcpPort(process.env["PORT"]) ??
+  DEFAULT_CLIENT_DEV_PORT;
 
-    // Artifact API for replay viewer
-    const artifactResponse = await handleArtifactRequest(url);
-    if (artifactResponse) return artifactResponse;
+let server: ReturnType<typeof Bun.serve>;
+for (let offset = 0; offset < CLIENT_DEV_PORT_TRIES; offset++) {
+  const port = preferredClientDevPort + offset;
+  if (port > 65535) break;
+  try {
+    server = Bun.serve({
+      port,
 
-    // Serve static files from public folder
-    if (url.pathname.startsWith("/public/")) {
-      const filePath = `./public${url.pathname.slice(7)}`;
-      const file = Bun.file(filePath);
-      if (await file.exists()) {
-        return new Response(file);
-      }
+      // Enable HMR and dev features
+      development: {
+        hmr: true,
+        console: true,
+      },
+
+      routes: {
+        // Serve the app at root
+        "/": homepage,
+      },
+
+      // Handle API routes and static files
+      async fetch(req) {
+        const url = new URL(req.url);
+
+        // Artifact API for replay viewer
+        const artifactResponse = await handleArtifactRequest(url);
+        if (artifactResponse) return artifactResponse;
+
+        // Serve static files from public folder
+        if (url.pathname.startsWith("/public/")) {
+          const filePath = `./public${url.pathname.slice(7)}`;
+          const file = Bun.file(filePath);
+          if (await file.exists()) {
+            return new Response(file);
+          }
+        }
+
+        // Serve files directly from public without /public prefix
+        const publicFile = Bun.file(`./public${url.pathname}`);
+        if (await publicFile.exists()) {
+          return new Response(publicFile);
+        }
+
+        // 404 for unhandled routes
+        return new Response("Not Found", { status: 404 });
+      },
+    });
+    if (offset > 0) {
+      console.warn(
+        `[client dev] port ${preferredClientDevPort} in use; listening on ${port} (set CLIENT_DEV_PORT to pick a port)`,
+      );
     }
-
-    // Serve files directly from public without /public prefix
-    const publicFile = Bun.file(`./public${url.pathname}`);
-    if (await publicFile.exists()) {
-      return new Response(publicFile);
+    break;
+  } catch (err) {
+    if (errnoCode(err) === "EADDRINUSE" && offset < CLIENT_DEV_PORT_TRIES - 1) {
+      continue;
     }
+    throw err;
+  }
+}
 
-    // 404 for unhandled routes
-    return new Response("Not Found", { status: 404 });
-  },
-});
+if (typeof server === "undefined") {
+  throw new Error(
+    `[client dev] no free TCP port in ${preferredClientDevPort}..${Math.min(
+      preferredClientDevPort + CLIENT_DEV_PORT_TRIES - 1,
+      65535,
+    )}; set CLIENT_DEV_PORT`,
+  );
+}
 
 console.log(`
   🚀 Bun dev server running at http://localhost:${server.port}

--- a/packages/client/src/components/Overlays/ChoiceSelection.tsx
+++ b/packages/client/src/components/Overlays/ChoiceSelection.tsx
@@ -1,110 +1,82 @@
-import { useMemo, useCallback } from "react";
+import { useMemo, useCallback, useEffect } from "react";
 import { useGame } from "../../hooks/useGame";
 import { useMyPlayer } from "../../hooks/useMyPlayer";
-import { useCardMenuPosition } from "../../context/CardMenuPositionContext";
 import { useRegisterOverlay } from "../../contexts/OverlayContext";
 import { useCardInteraction } from "../CardInteraction";
 import { extractChoiceOptions, hasAction } from "../../rust/legalActionUtils";
 import { PixiPieMenu, type PixiPieMenuItem } from "../CardActionMenu";
 import "./ChoiceSelection.css";
 
-/**
- * Map effect types to hex colors for PixiJS rendering.
- * Returns { fill, hover } colors for the wedge.
- */
+// Distinct muted palette used when all options share the same semantic color
+// (e.g. "Discard X" × N would all be the same brownish red without this)
+const CHOICE_PALETTE: ReadonlyArray<{ fill: number; hover: number }> = [
+  { fill: 0x4a5568, hover: 0x5d6a7a },
+  { fill: 0x553a4a, hover: 0x684d5e },
+  { fill: 0x3d5a3e, hover: 0x4e7050 },
+  { fill: 0x5a4a28, hover: 0x6e5c38 },
+  { fill: 0x3a3a5a, hover: 0x4a4a6e },
+  { fill: 0x5a3a28, hover: 0x6e4838 },
+];
+
 function getEffectColors(description: string): { fill: number; hover: number } {
   const desc = description.toLowerCase();
 
-  // Check for mana-related effects
-  if (desc.includes("red mana")) {
-    return { fill: 0x6e2d28, hover: 0x8c3c32 };
-  }
-  if (desc.includes("blue mana")) {
-    return { fill: 0x284164, hover: 0x325582 };
-  }
-  if (desc.includes("green mana")) {
-    return { fill: 0x285037, hover: 0x326946 };
-  }
-  if (desc.includes("white mana")) {
-    return { fill: 0x55555a, hover: 0x737378 };
-  }
-  if (desc.includes("gold mana")) {
-    return { fill: 0x645528, hover: 0x826e32 };
-  }
-  if (desc.includes("black mana")) {
-    return { fill: 0x282832, hover: 0x373746 };
-  }
+  if (desc.includes("red mana"))   return { fill: 0x6e2d28, hover: 0x8c3c32 };
+  if (desc.includes("blue mana"))  return { fill: 0x284164, hover: 0x325582 };
+  if (desc.includes("green mana")) return { fill: 0x285037, hover: 0x326946 };
+  if (desc.includes("white mana")) return { fill: 0x55555a, hover: 0x737378 };
+  if (desc.includes("gold mana"))  return { fill: 0x645528, hover: 0x826e32 };
+  if (desc.includes("black mana")) return { fill: 0x282832, hover: 0x373746 };
 
-  // Check for combat effects
   if (desc.includes("attack")) {
-    if (desc.includes("fire")) {
-      return { fill: 0xa04030, hover: 0xc05040 };
-    }
-    if (desc.includes("ice") || desc.includes("cold")) {
-      return { fill: 0x4a7090, hover: 0x5a88a8 };
-    }
+    if (desc.includes("fire"))                    return { fill: 0xa04030, hover: 0xc05040 };
+    if (desc.includes("ice") || desc.includes("cold")) return { fill: 0x4a7090, hover: 0x5a88a8 };
     return { fill: 0x8c5a32, hover: 0xa87040 };
   }
   if (desc.includes("block")) {
-    if (desc.includes("fire")) {
-      return { fill: 0x824637, hover: 0x9a5847 };
-    }
+    if (desc.includes("fire")) return { fill: 0x824637, hover: 0x9a5847 };
     return { fill: 0x2e5a4b, hover: 0x3e7060 };
   }
 
-  // Movement - earthy brown-green
-  if (desc.includes("move")) {
-    return { fill: 0x465537, hover: 0x566848 };
-  }
+  if (desc.includes("move"))      return { fill: 0x465537, hover: 0x566848 };
+  if (desc.includes("influence")) return { fill: 0x55415f, hover: 0x6a5475 };
+  if (desc.includes("heal"))      return { fill: 0x64734b, hover: 0x788860 };
+  if (desc.includes("discard"))   return { fill: 0x5a3232, hover: 0x704040 };
 
-  // Influence - dusty purple
-  if (desc.includes("influence")) {
-    return { fill: 0x55415f, hover: 0x6a5475 };
-  }
-
-  // Healing - moss green
-  if (desc.includes("heal")) {
-    return { fill: 0x64734b, hover: 0x788860 };
-  }
-
-  // Discard - muted red
-  if (desc.includes("discard")) {
-    return { fill: 0x5a3232, hover: 0x704040 };
-  }
-
-  // Default - warm neutral brown
   return { fill: 0x3c3732, hover: 0x4e4842 };
 }
 
-// Format effect description into label + sublabel for pie menu
 function formatEffectLabel(description: string): { label: string; sublabel?: string } {
+  // "Discard X" — put the card name first so each wedge looks unique
+  const discardMatch = description.match(/^Discard (.+)$/i);
+  if (discardMatch?.[1]) {
+    const name = discardMatch[1];
+    return { label: name.charAt(0).toUpperCase() + name.slice(1), sublabel: "Discard" };
+  }
+
   const desc = description.toLowerCase();
 
-  // Mana effects: "Gain X mana"
+  // "Gain X mana" → "X / Mana"
   const manaMatch = desc.match(/gain (\w+) mana/);
-  if (manaMatch && manaMatch[1]) {
+  if (manaMatch?.[1]) {
     const color = manaMatch[1].charAt(0).toUpperCase() + manaMatch[1].slice(1);
     return { label: color, sublabel: "Mana" };
   }
 
-  // Numeric effects: "+N Something"
+  // "+N Something" or "N Something"
   const numMatch = description.match(/^\+?(\d+)\s+(.+)$/);
-  if (numMatch && numMatch[1] && numMatch[2]) {
+  if (numMatch?.[1] && numMatch[2]) {
     return { label: `+${numMatch[1]}`, sublabel: numMatch[2] };
   }
 
   // "Gain N Something"
   const gainMatch = description.match(/^Gain (\d+) (.+)$/i);
-  if (gainMatch && gainMatch[1] && gainMatch[2]) {
+  if (gainMatch?.[1] && gainMatch[2]) {
     return { label: `+${gainMatch[1]}`, sublabel: gainMatch[2] };
   }
 
-  // Short descriptions can just be the label
-  if (description.length <= 12) {
-    return { label: description };
-  }
+  if (description.length <= 12) return { label: description };
 
-  // Fallback: first word as label, rest as sublabel
   const words = description.split(" ");
   if (words.length >= 2) {
     return { label: words[0] ?? description, sublabel: words.slice(1).join(" ") };
@@ -116,61 +88,68 @@ function formatEffectLabel(description: string): { label: string; sublabel?: str
 export function ChoiceSelection() {
   const { state, sendAction, legalActions } = useGame();
   const player = useMyPlayer();
-  const { position: savedPosition } = useCardMenuPosition();
   const { state: cardInteractionState } = useCardInteraction();
 
-  // Derive choices from legalActions — only show when server actually has ResolveChoice actions
   const choiceOptions = useMemo(() => extractChoiceOptions(legalActions), [legalActions]);
   const pendingInfo = player?.pending;
   const hasChoices = choiceOptions.length > 0;
   const canUndo = hasAction(legalActions, "Undo");
   const isInCombat = state?.combat !== null;
 
-  // Don't render if UnifiedCardMenu is handling the interaction
   const unifiedMenuHandling = cardInteractionState.type !== "idle";
 
-  // Register this component as an active overlay to disable background interactions
   useRegisterOverlay(hasChoices && !unifiedMenuHandling);
 
   const handleSelectChoice = useCallback((choiceIndex: number) => {
-    // Find the actual LegalAction to send (guaranteed to be accepted by the server)
     const option = choiceOptions.find(o => o.choiceIndex === choiceIndex);
-    if (option) {
-      sendAction(option.action);
-    }
+    if (option) sendAction(option.action);
   }, [sendAction, choiceOptions]);
 
   const handleUndo = useCallback(() => {
     sendAction("Undo");
   }, [sendAction]);
 
-  // Build pie items from pending.options labels, but only for choice indices that are legal
+  // Auto-confirm when there's only one option and no undo available.
+  // Skip auto-confirm when canUndo: the user might want to go back, and
+  // auto-selecting would immediately re-trigger the same state on undo.
+  const singleChoiceIndex =
+    hasChoices && !unifiedMenuHandling && !canUndo && choiceOptions.length === 1
+      ? (choiceOptions[0]?.choiceIndex ?? null)
+      : null;
+
+  useEffect(() => {
+    if (singleChoiceIndex !== null) {
+      handleSelectChoice(singleChoiceIndex);
+    }
+  }, [singleChoiceIndex, handleSelectChoice]);
+
   const pieItems: PixiPieMenuItem[] = useMemo(() => {
     const pendingOptions = pendingInfo?.options ?? [];
-    return choiceOptions.map((opt) => {
-      // Use the pending option description if available, fall back to index
+    const raw = choiceOptions.map((opt, index) => {
       const description = pendingOptions[opt.choiceIndex] ?? `Option ${opt.choiceIndex + 1}`;
-      const { label, sublabel } = formatEffectLabel(description);
-      const colors = getEffectColors(description);
-      return {
-        id: String(opt.choiceIndex),
-        label,
-        sublabel,
-        color: colors.fill,
-        hoverColor: colors.hover,
-      };
+      return { id: String(opt.choiceIndex), description, index, ...formatEffectLabel(description) };
+    });
+
+    // When all options would get the same semantic color, use the per-index palette
+    // so each wedge is visually distinct (e.g. "Discard X" × 4)
+    const semanticColors = raw.map(r => getEffectColors(r.description));
+    const allSameColor = raw.length > 1 && semanticColors.every(c => c.fill === semanticColors[0]!.fill);
+
+    return raw.map(({ id, label, sublabel, index }) => {
+      const colors = allSameColor
+        ? CHOICE_PALETTE[index % CHOICE_PALETTE.length]!
+        : semanticColors[index]!;
+      return { id, label, sublabel, color: colors.fill, hoverColor: colors.hover };
     });
   }, [choiceOptions, pendingInfo?.options]);
 
   const handlePieSelect = useCallback((id: string) => {
     const index = parseInt(id, 10);
-    if (!isNaN(index)) {
-      handleSelectChoice(index);
-    }
+    if (!isNaN(index)) handleSelectChoice(index);
   }, [handleSelectChoice]);
 
-  // Don't render if no choices or if UnifiedCardMenu is handling it
-  if (!hasChoices || unifiedMenuHandling) {
+  // Don't render if no choices, if UnifiedCardMenu is handling it, or if auto-confirming
+  if (!hasChoices || unifiedMenuHandling || singleChoiceIndex !== null) {
     return null;
   }
 
@@ -179,7 +158,6 @@ export function ChoiceSelection() {
       items={pieItems}
       onSelect={handlePieSelect}
       onCancel={canUndo ? handleUndo : () => {}}
-      position={savedPosition ?? undefined}
       overlayOpacity={isInCombat ? 0.4 : 0.7}
       centerLabel={canUndo ? "Undo" : undefined}
     />

--- a/packages/client/src/components/Overlays/LevelUpRewardSelection.tsx
+++ b/packages/client/src/components/Overlays/LevelUpRewardSelection.tsx
@@ -16,6 +16,7 @@ import {
 } from "../../rust/legalActionUtils";
 import type { LegalAction } from "../../rust/types";
 import { getCardSpriteStyle } from "../../utils/cardAtlas";
+import { skillImagePath } from "../../utils/skillImagePath";
 import "./LevelUpRewardSelection.css";
 
 // Display height for AA card sprites in the level-up modal
@@ -27,11 +28,6 @@ function formatName(id: string): string {
     .split("_")
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
     .join(" ");
-}
-
-// Skill images live at /assets/skills/{skillId}.jpg
-function skillImagePath(skillId: SkillId): string {
-  return `/assets/skills/${skillId}.jpg`;
 }
 
 interface SkillOptionProps {


### PR DESCRIPTION
## Summary
- **Bun `dev.ts`**: If the preferred port is busy, walk up to 64 consecutive ports. Prefer `CLIENT_DEV_PORT`; note that `PORT` is also read by `mk-server`, so use `CLIENT_DEV_PORT` when you want to target only the static/HMR dev server.
- **`ChoiceSelection`**: Visually distinguish pie wedges when every option maps to the same semantic color (e.g. multiple discards). Put the card name first for "Discard X" labels. Auto-submit when there is exactly one legal choice and undo is not available. Drop passing saved card-menu position so the pie stays centered (consistent with `PixiPieMenu` default).
- **`LevelUpRewardSelection`**: Import `skillImagePath` from utils so level-up skills use the same `assetUrl` and co-op stem mapping as the rest of the client.

## Why it felt sloppy
The diff mixed three concerns and `ChoiceSelection` used compressed one-line returns; behavior is still coherent. Lint (`bun run lint`) passes.

## Testing
- `bun run lint`

Made with [Cursor](https://cursor.com)