### PR TITLE
feat(client): warm map-room shell with OKLCH design tokens

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,247 @@
+---
+name: Mage Knight Client
+description: Warm map-room shell via `:root` OKLCH tokens (`--surface-*`, `--text-*`, `--border-*`, `--accent*`) plus restrained parchment overlays; tactical clarity first.
+colors:
+  surface-ground: "oklch(0.21 0.012 78)"
+  surface-canvas: "oklch(0.17 0.011 80)"
+  surface-raised: "oklch(0.265 0.013 77)"
+  surface-chrome: "oklch(0.195 0.012 79)"
+  surface-hover-lift: "oklch(0.22 0.013 76)"
+  text-primary-soft: "oklch(0.93 0.008 82)"
+  text-muted-mid: "oklch(0.72 0.012 78)"
+  text-muted-low: "oklch(0.58 0.014 76)"
+  parchment-border-earth: "#5c4a3a"
+  parchment-heading-gold: "#e8c476"
+  parchment-body-cream: "#f0e6d2"
+  combat-antique-gold: "#d4a574"
+  combat-night-shell: "#1a1d2e"
+  stat-level-amethyst: "#9b59b6"
+  stat-fame-gold: "#f1c40f"
+  stat-armor-slate: "#95a5a6"
+  stat-influence-sky: "#3498db"
+  accent-selection-ember: "oklch(0.74 0.085 72)"
+  telemetry-teal-debug: "#4ecdc4"
+  hero-token-ruby-glow: "#ff4444"
+  setup-deep-oklch: "oklch(0.14 0.022 58)"
+  setup-gold-oklch: "oklch(0.78 0.11 82)"
+typography:
+  display:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "clamp(1.85rem, 4.5vw, 2.65rem)"
+    fontWeight: 700
+    lineHeight: 1.12
+    letterSpacing: "0.14em"
+  headline-section:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "1.5rem"
+    fontWeight: 600
+    lineHeight: 1.25
+    letterSpacing: "normal"
+  title-card:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 600
+    lineHeight: 1.3
+    letterSpacing: "normal"
+  body-reading:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "1rem"
+    fontWeight: 400
+    lineHeight: 1.5
+    letterSpacing: "normal"
+  label-dense-cap:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "0.85rem"
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: "normal"
+  caption-stat-micro:
+    fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif"
+    fontSize: "0.65rem"
+    fontWeight: 500
+    lineHeight: 1.2
+    letterSpacing: "normal"
+rounded:
+  sm: "6px"
+  md: "8px"
+  lg: "12px"
+spacing:
+  xs: "4px"
+  sm: "8px"
+  md: "16px"
+  lg: "24px"
+  xl: "32px"
+components:
+  panel-chrome-base:
+    backgroundColor: "{colors.surface-raised}"
+    textColor: "{colors.text-primary-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  overlay-sheet-base:
+    backgroundColor: "{colors.surface-raised}"
+    textColor: "{colors.text-primary-soft}"
+    rounded: "{rounded.lg}"
+    padding: "{spacing.xl}"
+  reward-option-card-rest:
+    backgroundColor: "{colors.surface-canvas}"
+    textColor: "{colors.text-primary-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  reward-option-card-active:
+    backgroundColor: "{colors.surface-hover-lift}"
+    textColor: "{colors.text-primary-soft}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  chrome-top-strip:
+    backgroundColor: "{colors.surface-chrome}"
+    textColor: "{colors.text-primary-soft}"
+    rounded: "{rounded.sm}"
+    height: "36px"
+    padding: "{spacing.sm} {spacing.md}"
+---
+
+# Design System: Mage Knight Client
+
+## Overview
+
+**Creative North Star: "The Quiet Map Room"**
+
+The client reads as **two coordinated families** rather than one flat token bundle. **Play chrome** (shell, hex cradle, panels, modal sheets, top bar, player bubbles) is authored as **warm low-chroma neutrals** in OKLCH on `:root` (`--surface-ground` → `--surface-raised`, `--surface-chrome`) so the perimeter feels like a **map table under soft light**, not cold violet midnight UI. Dedicated flows (setup, parchment-style rewards and level-ups, combat CSS notes and Pixi atmosphere) deliberately adopt **muted brass, earth borders, antiqued parchment cream text** so menu moments stay grounded without flashy fantasy chrome.
+
+PRODUCT.md asks for clarity before spectacle and rejects dominant mystical cliché plus heroic bombast. The structural stack is intentionally **matte and legibility-first**; parchment and combat lanes remain episodic warmth. Going forward the goal is to **narrow drift**: reuse the shared `:root` tokens in new HUD before introducing screen-local hex.
+
+The system rejects **looks-over-scanability** chrome: dense stat rows, multi-panel combat, solo cognitive load demand consistent hit targets and readable captions over flair.
+
+**Key Characteristics:**
+- **`--surface-canvas` / `--surface-ground` / `--surface-raised`** tier the Pixi hex board and card-like panels with a warm neutral spine.
+- **Parchment-earth** overlays provide warm episodic containment without implying mystic gimmickery.
+- **System UI sans** everywhere today: fast, predictable, slightly generic unless weight and letter-spacing cues mark titles.
+- **Stat accent colors** intentionally flat and categorical (purple level icon legacy, teal only in debug-heavy replay tooling).
+- **Motion** converges on **`--ease-out-expo`** for top bar intro (replacing historical overshoot easing) toward PRODUCT alignment.
+
+## Colors
+
+The palette separates **warm structural chrome** (shared `:root` surfaces, borders, text ramp) from **warm narrative shells** combat and parchment flows already use.
+
+### Primary (CSS custom properties)
+
+- **`--surface-ground`**: dominant app background wash (`body`); low-noise perimeter around the canvas.
+- **`--surface-canvas`**: hex-grid container backdrop; darkest functional surface for tactical focus.
+- **`--surface-raised`**: default `.panel` and `.overlay__content` interior fill.
+
+These three anchors are authoritative for any new HUD element that wraps live game state unless a flow explicitly adopts the parchment or combat palettes below.
+
+### Secondary
+
+- **Antique Combat Gold** (#d4a574) and **Night Shell Indigo** (#1a1d2e): anchored in `CombatOverlay.css` commentary and mana chrome gradients; aligns CSS UI with Pixi-rendered battlefield atmosphere. Use for combat-adjacent affordances that must read clearly against illustrated backdrops rather than rewriting artwork.
+
+### Tertiary
+
+- **`--accent`** (selection lane, OKLCH): reward grids and affirmative interactive emphasis (hover/active borders); keep dosage low on large fills.
+
+### Neutral
+
+- **`--text-primary`**, **`--text-secondary`**, **`--text-muted`**, **`--text-faint`**: progressive de-emphasis on dark surfaces (audit pairs as surfaces evolve; target WCAG AA on core strings).
+- **`--surface-chrome`**: condensed top HUD strip (`TopBar`); opaque matte bar (no violet translucency stack).
+- **`--surface-hover-lift`**: hovered elevated cards on dark canvases without jumping to parchment.
+
+### Parchment Overlay Family
+
+- **Parchment Border Earth** (#5c4a3a), **Heading Gold** (#e8c476), **Body Cream** (#f0e6d2): `LevelUpRewardSelection.css`-style overlays; restrained warmth, tactile frames, faint inner highlights rather than gemstone glow.
+
+### Named Rules
+
+**The Two-Family Rule.** When adding a panel, declare whether it belongs to **map-room chrome** (`--surface-*` ladder) or **parchment session** overlays. Avoid inventing a third decorative stack per feature.
+
+**The Stat Color Semantics Rule.** Reuse categorical stat hues (`stat-level-amethyst`, `stat-fame-gold`, `stat-armor-slate`, `stat-influence-sky`) wherever matching hero identity labels to reinforce recognition; do not recolor arbitrarily per screen.
+
+**The OKLCH Setup Lane Rule.** `.setup-screen` uses nested OKLCH custom properties documented in-component; migrating those tokens onto `:root` is preferred long-term while keeping authored OKLCH as canonical for that lane (frontmatter exposes representative strings `setup-deep-oklch`, `setup-gold-oklch` alongside hex neighbors for tooling that demands sRGB literals).
+
+## Typography
+
+**Display Font:** System UI stack (same as BODY; no bespoke display face yet).
+
+**Body Font:** system-ui / -apple-system / BlinkMacSystemFont / Segoe UI / sans-serif.
+
+**Label / mono:** No monospace system defined; captions reuse sans at micro sizes.
+
+**Character:** Practical, tabletop-tool plainspoken. Hierarchy is carved with **weight, letter-spacing**, and localized **uppercase cues** rather than ornate display typography.
+
+### Hierarchy
+
+- **Display** (700, clamp(1.85rem … 2.65rem), ~1.12 line height, tracked wide uppercase context on setup titles): ceremonial entry banners only where flow already established.
+- **Headline Section** (600, `1.5rem`, compact): overlay titles (`reward-selection`, similar).
+- **Title Card / Row** (`1rem`, 600): list leaders and affirmative actions embedded in overlays.
+- **Body Reading** (400, `1rem`, relaxed line-height): explanatory copy targeting ≤75ch widths where prose appears.
+- **Label Dense Cap** (~`0.85rem`, 600, capitalize transforms on hero identity lines): condensed HUD labels (top bar).
+- **Caption Stat Micro** (~`0.65rem`, 500): inline numeric companions in multiplayer roster chips.
+
+### Named Rules
+
+**The System Spine Rule.** Until a purposeful display face is introduced, retain the single stack everywhere; differentiation is spacing and weight rather than pairing.
+
+**The Legibility Spine Rule.** Never set long instructional copy smaller than Body Reading tokens; PRODUCT solo clarity depends on deliberate reading comfort.
+
+## Elevation
+
+Depth is conveyed mostly through **opaque surface tiering**, **thin neutral borders**, and **selective tonal lifts** (`--surface-hover-lift`, parchment inner highlights). True shadow stacks appear on parchment containers and richer interactive cards (`box-shadow` plus subtle inset rims on gold-forward affordances).
+
+The global `.overlay` stacking context uses **`--scrim-overlay`** (warm-tinted scrim, not pure `#000`) to pull focus inward; overlays do not blur the live board unnecessarily (blur-based glass stacks are discouraged per PRODUCT restraint).
+
+Shadow vocabulary is **split**: combat documentation enumerates illustrative fantasy-earth metals for Pixi cohesion; HUD chrome mostly stays matte.
+
+### Shadow Vocabulary
+
+- **Parchment Tray Shadow** (~`0 8px 32px rgba(0,0,0,0.6)` + inset hairline warmth): tactile framed reward panels (`LevelUpRewardSelection.css`).
+- **Active Player Bloom** (~`0 0 10px rgba(241,196,15,0.35)` atop gold border `#f1c40f`): unmistakable solo-turn signal in player bubbles.
+
+## Components
+
+HUD and overlay primitives predominate; game-specific widgets (hands, carousel tracks) visually extend these tokens.
+
+### Buttons / Selectable Tiles
+
+- **Reward option cards**: `rounded.md`, `--surface-canvas` fill at rest, `--border-on-raised` border. Hover lifts background to `--surface-hover-lift`, border shifts to **`--accent`**, slight negative translate upward for tactile acknowledgment (budget motion conscientiously toward WCAG prefers-reduced-motion over time).
+
+### Panels / Containers
+
+- **Standard `.panel`** (global): `rounded.md`, `--surface-raised` fill, uniform `spacing.md`.
+- **`.overlay__content`**: enlarged corner radius (`rounded.lg`), expanded padding (`spacing.xl`) for readability.
+
+### Top Bar HUD
+
+- **Height** ~36px, **opaque `--surface-chrome`** bar bridging board and OS chrome; faint bottom hairline (`--border-subtle`) divides context.
+- **Stat icons**: flat categorical hues (purple level / armor slate / fame gold / blues) echo player chips for cross-surface reinforcement.
+
+### Player Roster Chips
+
+- **Passive**: softened translucent pill using `color-mix` on `--surface-chrome`, subdued `border-subtle` stroke.
+- **Active**: thickened gold ring + restrained outer emphasis emphasizing turn ownership without triumphant orchestral embellishment elsewhere.
+
+### Signature Overlays / Flows
+
+- **Setup Surface**: Implements OKLCH gradient stack with `--ease-out-expo` easing for interactive pulses; aligns with DOCUMENTED intent to converge overlays toward map-table cohesion.
+- **Combat Scene**: Transparency-first layout with Pixi painting atmosphere; localized gradient chips echo night palette `#1a1d2e` region.
+
+## Do's and Don'ts
+
+Ground every decision in PRODUCT.md clauses on clarity, subdued atmosphere, mystical/bombastic rejection, scanability mandates, WCAG AA forward posture, reduced motion empathy.
+
+### Do:
+
+- **Do** reuse the **`--surface-ground` → `--surface-canvas` → `--surface-raised`** tier ladder for new HUD unless a flow participates in parchment or combat palettes intentionally.
+- **Do** cite **OKLCH setup tokens** or promote them upward when refactoring rather than cloning approximate hex anew.
+- **Do** anchor combat-adjacent gold accents around **Antique Combat Gold** (#d4a574 family) documented alongside Pixi's illustrated layers.
+- **Do** preserve **readable flat hierarchy** inside dense flows (solo cognitive load mandate).
+- **Do** consolidate radii (`6px`, `8px`, `12px`) as the default scale before inventing orphan radii.
+- **Do** plan audio direction **ambient grounded map energy** complementary to subdued UI contrasts ( INTERFACE NOT THE HERO ).
+- **Do** implement future motion on **exponential ease-out curves** resembling setup's `--ease-out-expo`.
+
+### Don't:
+
+- **Don't** let **Dominant mystical fantasy cliché** (heavy rune shimmer, incense fog decorative noise) occlude authoritative engine-driven state readability.
+- **Don't** soundtrack or visually stage **Epic heroic bombast**: overwrought triumphant framing contradicts restrained crunch-forward mood.
+- **Don't** bury legibility under ornamental stacks that cause players to mistrust moves or LOS clarity (explicit PRODUCT anti-pattern on looks-over-scanability).
+- **Don't** sprinkle **neon candy accent rainbows** arbitrarily; limit categorical color to semantic stat roles (+ intentional debug telemetry hues like teal in replay tooling isolated from default play overlays).
+- **Don't** enlarge **glassmorphism + heavy blur layering** casually; tonal scrims suffice today.
+- **Don't** widen **thin side-stripe brand gimmicks (`border-left > 1px colored`)** purely for sparkle; impeccable shared prohibition.

--- a/packages/client/src/components/DebugPanel/DebugPanel.css
+++ b/packages/client/src/components/DebugPanel/DebugPanel.css
@@ -30,7 +30,7 @@
   right: 1rem;
   width: 350px;
   max-height: 80vh;
-  background: #1a1a2e;
+  background: var(--surface-ground);
   border: 2px solid #3498db;
   border-radius: 8px;
   z-index: 9999;
@@ -419,7 +419,7 @@
   padding: 0.25rem;
   border-radius: 3px;
   border: 1px solid #444;
-  background: #1a1a2e;
+  background: var(--surface-ground);
   color: #ddd;
   font-size: 0.7rem;
 }

--- a/packages/client/src/components/Overlays/ChoiceSelection.css
+++ b/packages/client/src/components/Overlays/ChoiceSelection.css
@@ -17,17 +17,17 @@
 }
 
 .choice-selection__option {
-  background: #0f0f23;
-  border: 2px solid #333;
+  background: var(--surface-canvas);
+  border: 2px solid var(--border-on-raised);
   border-radius: 8px;
   padding: 1rem;
   cursor: pointer;
   transition: all 0.15s;
   text-align: left;
-  color: #eee;
+  color: var(--text-primary);
 }
 
 .choice-selection__option:hover {
-  border-color: #4fc3f7;
-  background: #1a1a3e;
+  border-color: var(--accent);
+  background: var(--surface-hover-lift);
 }

--- a/packages/client/src/components/Overlays/RestCompletionOverlay.tsx
+++ b/packages/client/src/components/Overlays/RestCompletionOverlay.tsx
@@ -96,9 +96,9 @@ export function RestCompletionOverlay() {
               style={{
                 padding: "0.75rem 1.5rem",
                 borderRadius: "6px",
-                background: "#1a1a3e",
-                color: "#ddd",
-                border: "2px solid #333",
+                background: "var(--surface-hover-lift)",
+                color: "var(--text-secondary)",
+                border: "2px solid var(--border-on-raised)",
                 cursor: "pointer",
                 fontSize: "1rem",
               }}

--- a/packages/client/src/components/Overlays/RewardSelection.css
+++ b/packages/client/src/components/Overlays/RewardSelection.css
@@ -11,14 +11,14 @@
 
 .reward-selection__description {
   font-size: 1rem;
-  color: #aaa;
+  color: var(--text-muted);
   text-align: center;
   margin-bottom: 1rem;
 }
 
 .reward-selection__remaining {
   font-size: 0.875rem;
-  color: #888;
+  color: var(--text-faint);
   text-align: center;
   margin-bottom: 1.5rem;
 }
@@ -33,19 +33,19 @@
 }
 
 .reward-selection__card {
-  background: #0f0f23;
-  border: 2px solid #333;
+  background: var(--surface-canvas);
+  border: 2px solid var(--border-on-raised);
   border-radius: 8px;
   padding: 1rem;
   cursor: pointer;
   transition: all 0.15s;
   text-align: center;
-  color: #eee;
+  color: var(--text-primary);
 }
 
 .reward-selection__card:hover {
-  border-color: #f39c12;
-  background: #1a1a3e;
+  border-color: var(--accent);
+  background: var(--surface-hover-lift);
   transform: translateY(-2px);
 }
 
@@ -56,8 +56,8 @@
 }
 
 .reward-selection__card--selected {
-  border-color: #f39c12;
-  background: #1a1a3e;
+  border-color: var(--accent);
+  background: var(--surface-hover-lift);
 }
 
 .reward-selection__card-name {

--- a/packages/client/src/components/PlayerList/PlayerEntry.css
+++ b/packages/client/src/components/PlayerList/PlayerEntry.css
@@ -8,8 +8,8 @@
   gap: 0.4rem;
   padding: 0.35rem 0.5rem;
   border-radius: 6px;
-  background: rgba(10, 10, 25, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: color-mix(in oklch, var(--surface-chrome) 60%, transparent);
+  border: 1px solid var(--border-subtle);
   transition: all 0.2s ease;
   position: relative;
 }
@@ -17,7 +17,7 @@
 /* Active player - golden glow */
 .player-entry--active {
   border: 2px solid #f1c40f;
-  box-shadow: 0 0 12px rgba(241, 196, 15, 0.6);
+  box-shadow: 0 0 10px rgba(241, 196, 15, 0.35);
   background: rgba(241, 196, 15, 0.1);
 }
 
@@ -34,7 +34,7 @@
 .player-entry__hero {
   font-size: 0.75rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
   text-transform: capitalize;
   max-width: 80px;
   overflow: hidden;
@@ -56,7 +56,7 @@
 
 .player-entry__value {
   font-size: 0.65rem;
-  color: #ddd;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 

--- a/packages/client/src/components/Replay/ReplayLoadScreen.css
+++ b/packages/client/src/components/Replay/ReplayLoadScreen.css
@@ -5,8 +5,8 @@
   justify-content: center;
   min-height: 100vh;
   padding: 2rem;
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-  color: #eee;
+  background: linear-gradient(135deg, var(--surface-ground) 0%, var(--surface-raised) 100%);
+  color: var(--text-primary);
 }
 
 .replay-load-screen__title {
@@ -64,9 +64,9 @@
   gap: 0.75rem;
   width: 100%;
   padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.05);
+  background: color-mix(in oklch, var(--text-primary) 5%, transparent);
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  border: 1px solid var(--border-subtle);
 }
 
 .replay-load-screen__meta-row {
@@ -77,7 +77,7 @@
 
 .replay-load-screen__meta-label {
   font-weight: 600;
-  color: #aaa;
+  color: var(--text-muted);
   font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -85,7 +85,7 @@
 
 .replay-load-screen__meta-value {
   font-family: monospace;
-  color: #eee;
+  color: var(--text-primary);
 }
 
 .replay-load-screen__player-select {
@@ -98,8 +98,8 @@
 .replay-load-screen__select {
   padding: 0.4rem 0.75rem;
   font-size: 0.95rem;
-  background: #1a1a2e;
-  color: #eee;
+  background: var(--surface-ground);
+  color: var(--text-primary);
   border: 2px solid #4ecdc4;
   border-radius: 8px;
   outline: none;
@@ -112,7 +112,7 @@
   background: linear-gradient(135deg, #4ecdc4 0%, #44b3ab 100%);
   border: none;
   border-radius: 12px;
-  color: #1a1a2e;
+  color: var(--surface-ground);
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 4px 16px rgba(78, 205, 196, 0.4);
@@ -137,9 +137,9 @@
   flex: 1;
   padding: 0.6rem 0.75rem;
   font-size: 0.9rem;
-  background: #1a1a2e;
-  color: #eee;
-  border: 2px solid rgba(255, 255, 255, 0.2);
+  background: var(--surface-ground);
+  color: var(--text-primary);
+  border: 2px solid var(--border-default);
   border-radius: 8px;
   outline: none;
   cursor: pointer;
@@ -156,7 +156,7 @@
   font-size: 0.95rem;
   font-weight: 600;
   background: #4ecdc4;
-  color: #1a1a2e;
+  color: var(--surface-ground);
   border: none;
   border-radius: 8px;
   cursor: pointer;

--- a/packages/client/src/components/SaveLoadControls.css
+++ b/packages/client/src/components/SaveLoadControls.css
@@ -11,14 +11,14 @@
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  background: #0f0f23;
+  background: var(--surface-canvas);
   border-radius: 4px;
   padding: 0.25rem 0.5rem;
 }
 
 .save-slot__label {
   font-size: 0.625rem;
-  color: #888;
+  color: var(--text-faint);
   min-width: 80px;
   text-align: center;
 }

--- a/packages/client/src/components/TopBar/HotkeyHelp.css
+++ b/packages/client/src/components/TopBar/HotkeyHelp.css
@@ -3,7 +3,7 @@
 .hotkey-help__overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.75);
+  background: var(--scrim-soft);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -21,8 +21,8 @@
 }
 
 .hotkey-help__modal {
-  background: linear-gradient(145deg, #1a1a2e, #16213e);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: linear-gradient(145deg, var(--surface-ground), var(--surface-raised));
+  border: 1px solid var(--border-subtle);
   border-radius: 12px;
   width: 90%;
   max-width: 500px;

--- a/packages/client/src/components/TopBar/TopBar.css
+++ b/packages/client/src/components/TopBar/TopBar.css
@@ -20,8 +20,8 @@
   justify-content: space-between;
   height: 36px;
   padding: 0 1rem;
-  background: rgba(10, 10, 25, 0.9);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--surface-chrome);
+  border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
   /* GPU acceleration - promote entire bar to compositor layer for smooth animation */
   will-change: transform, opacity;
@@ -35,7 +35,7 @@
 
 /* Animate in during ui-settle */
 .top-bar--intro-reveal {
-  animation: topbar-slide-down 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: topbar-slide-down 0.4s var(--ease-out-expo) forwards;
 }
 
 .top-bar__section {
@@ -66,7 +66,7 @@
 .top-bar__hero-name {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
   text-transform: capitalize;
 }
 
@@ -109,20 +109,20 @@
 
 .top-bar__stat--move .top-bar__value,
 .top-bar__stat--influence .top-bar__value {
-  color: #fff;
+  color: var(--text-primary);
   font-weight: 600;
 }
 
 .top-bar__divider {
   width: 1px;
   height: 20px;
-  background: rgba(255, 255, 255, 0.2);
+  background: var(--border-default);
   margin: 0 0.25rem;
 }
 
 .top-bar__value {
   font-size: 0.8rem;
-  color: #ddd;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
@@ -135,7 +135,7 @@
 
 .top-bar__mana-group--tokens {
   padding-left: 0.5rem;
-  border-left: 1px solid rgba(255, 255, 255, 0.2);
+  border-left: 1px solid var(--border-default);
 }
 
 .top-bar__crystal {
@@ -147,29 +147,29 @@
   border-radius: 4px;
   font-size: 0.75rem;
   font-weight: 700;
-  color: #fff;
+  color: var(--text-primary);
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
 }
 
 .top-bar__crystal--red {
   background: linear-gradient(135deg, #e74c3c, #c0392b);
-  box-shadow: 0 0 4px rgba(231, 76, 60, 0.5);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .top-bar__crystal--blue {
   background: linear-gradient(135deg, #3498db, #2980b9);
-  box-shadow: 0 0 4px rgba(52, 152, 219, 0.5);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .top-bar__crystal--green {
   background: linear-gradient(135deg, #2ecc71, #27ae60);
-  box-shadow: 0 0 4px rgba(46, 204, 113, 0.5);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
 }
 
 .top-bar__crystal--white {
   background: linear-gradient(135deg, #ecf0f1, #bdc3c7);
-  box-shadow: 0 0 4px rgba(236, 240, 241, 0.5);
-  color: #333;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+  color: oklch(0.32 0.012 78);
 }
 
 /* Mana tokens */
@@ -193,7 +193,7 @@
 }
 
 .top-bar__token--white {
-  background: radial-gradient(circle at 30% 30%, #fff, #bdc3c7);
+  background: radial-gradient(circle at 30% 30%, oklch(0.98 0.004 82), #bdc3c7);
 }
 
 .top-bar__token--gold {
@@ -213,7 +213,7 @@
 
 .top-bar__round-label {
   font-size: 0.7rem;
-  color: #888;
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.03em;
 }
@@ -221,7 +221,7 @@
 .top-bar__round-value {
   font-size: 0.85rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .top-bar__time {
@@ -236,14 +236,14 @@
 
 .top-bar__time--day {
   background: linear-gradient(135deg, #f39c12, #e67e22);
-  color: #fff;
-  box-shadow: 0 0 8px rgba(243, 156, 18, 0.5);
+  color: var(--text-primary);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
 }
 
 .top-bar__time--night {
   background: linear-gradient(135deg, #2c3e50, #1a252f);
   color: #bdc3c7;
-  box-shadow: 0 0 8px rgba(44, 62, 80, 0.5);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
 /* Help button */
@@ -254,25 +254,28 @@
   width: 24px;
   height: 24px;
   border-radius: 50%;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.05);
-  color: #888;
+  border: 1px solid var(--border-default);
+  background: color-mix(in oklch, var(--text-primary) 6%, transparent);
+  color: var(--text-faint);
   font-size: 0.85rem;
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background 0.15s var(--ease-out-expo),
+    border-color 0.15s var(--ease-out-expo),
+    color 0.15s var(--ease-out-expo);
 }
 
 .top-bar__help-btn:hover {
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.3);
-  color: #fff;
+  background: color-mix(in oklch, var(--text-primary) 10%, transparent);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
 }
 
 /* Stolen mana section (Mana Steal tactic) */
 .top-bar__mana-group--stolen {
   padding-left: 0.5rem;
-  border-left: 1px solid rgba(255, 193, 7, 0.4);
+  border-left: 1px solid color-mix(in oklch, var(--accent) 45%, transparent);
 }
 
 /* Stolen token styling - pulsing amber border to indicate "special" status */
@@ -287,7 +290,7 @@
   position: absolute;
   inset: -3px;
   border-radius: 50%;
-  border: 1.5px dashed rgba(255, 193, 7, 0.7);
+  border: 1.5px dashed color-mix(in oklch, var(--accent) 72%, transparent);
   animation: stolen-border-spin 8s linear infinite;
 }
 
@@ -296,13 +299,12 @@
   0%, 100% {
     box-shadow:
       0 0 3px rgba(0, 0, 0, 0.3),
-      0 0 4px rgba(255, 193, 7, 0.3);
+      0 0 0 1px color-mix(in oklch, var(--accent) 35%, transparent);
   }
   50% {
     box-shadow:
       0 0 3px rgba(0, 0, 0, 0.3),
-      0 0 8px rgba(255, 193, 7, 0.6),
-      0 0 12px rgba(255, 193, 7, 0.3);
+      0 0 0 2px color-mix(in oklch, var(--accent) 55%, transparent);
   }
 }
 

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -2,6 +2,34 @@
    Global Reset & Base Styles
    ============================================ */
 
+:root {
+  /* Map-room shell: warm low-chroma neutrals (OKLCH) */
+  --surface-ground: oklch(0.21 0.012 78);
+  --surface-canvas: oklch(0.17 0.011 80);
+  --surface-raised: oklch(0.265 0.013 77);
+  --surface-chrome: oklch(0.195 0.012 79);
+  --surface-hover-lift: oklch(0.22 0.013 76);
+
+  --scrim-overlay: oklch(0.12 0.012 78 / 0.86);
+  --scrim-soft: oklch(0.12 0.012 78 / 0.76);
+  --scrim-combat: oklch(0.1 0.011 78 / 0.92);
+
+  --text-primary: oklch(0.93 0.008 82);
+  --text-secondary: oklch(0.86 0.01 80);
+  --text-muted: oklch(0.72 0.012 78);
+  --text-faint: oklch(0.58 0.014 76);
+
+  --border-subtle: oklch(0.92 0.006 82 / 0.12);
+  --border-default: oklch(0.92 0.008 82 / 0.22);
+  --border-strong: oklch(0.92 0.01 82 / 0.3);
+  --border-on-raised: oklch(0.38 0.012 76);
+
+  --accent: oklch(0.74 0.085 72);
+  --accent-muted: oklch(0.74 0.05 72 / 0.35);
+
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+}
+
 * {
   box-sizing: border-box;
   margin: 0;
@@ -10,8 +38,8 @@
 
 body {
   font-family: system-ui, -apple-system, sans-serif;
-  background: #1a1a2e;
-  color: #eee;
+  background: var(--surface-ground);
+  color: var(--text-primary);
   min-height: 100vh;
 }
 
@@ -111,7 +139,7 @@ body {
   justify-content: center;
   min-height: 100vh;
   font-size: 1.25rem;
-  color: #888;
+  color: var(--text-faint);
 }
 
 /* ============================================
@@ -119,7 +147,7 @@ body {
    ============================================ */
 
 .panel {
-  background: #16213e;
+  background: var(--surface-raised);
   border-radius: 8px;
   padding: 1rem;
 }
@@ -131,7 +159,7 @@ body {
 .overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.85);
+  background: var(--scrim-overlay);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -139,7 +167,7 @@ body {
 }
 
 .overlay__content {
-  background: #16213e;
+  background: var(--surface-raised);
   border-radius: 12px;
   padding: 2rem;
   max-width: 90vw;
@@ -152,7 +180,7 @@ body {
    ============================================ */
 
 .hex-grid {
-  background: #0f0f23;
+  background: var(--surface-canvas);
   border-radius: 8px;
 }
 
@@ -167,7 +195,7 @@ body {
 .combat-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.9);
+  background: var(--scrim-combat);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/client/src/utils/pixiTextureLoader.ts
+++ b/packages/client/src/utils/pixiTextureLoader.ts
@@ -61,6 +61,9 @@ const loadingTextures = new Map<string, Promise<Texture>>();
 let placeholderTexture: Texture | null = null;
 let placeholderCanvas: HTMLCanvasElement | null = null;
 
+/** sRGB aligned with `index.css` `--surface-ground` for shared placeholder tiles. */
+const SURFACE_GROUND_PLACEHOLDER_HEX = "#1b1a17";
+
 // Atlas data cache (for PixiCardCanvas which uses atlas.json directly)
 let atlasData: AtlasData | null = null;
 let atlasLoadPromise: Promise<AtlasData> | null = null;
@@ -81,7 +84,7 @@ export function getPlaceholderTexture(): Texture {
     const ctx = placeholderCanvas.getContext("2d");
     if (ctx) {
       // Dark background
-      ctx.fillStyle = "#1a1a2e";
+      ctx.fillStyle = SURFACE_GROUND_PLACEHOLDER_HEX;
       ctx.fillRect(0, 0, 200, 300);
       // Border
       ctx.strokeStyle = "#333";


### PR DESCRIPTION
## Summary

Replaces the cold violet midnight play chrome with a **restrained warm neutral** stack (map-room / tabletop legibility), using **OKLCH** on `:root` and wiring the shell, top bar, and common overlays to shared tokens.

## What changed

- **New CSS variables** in `packages/client/src/styles/index.css`: `--surface-*`, `--text-*`, `--border-*`, `--accent*`, scrims (`--scrim-overlay`, `--scrim-soft`, `--scrim-combat`), `--ease-out-expo`, `--border-on-raised`.
- **Global primitives**: `body`, hex grid, panels, overlay backdrop + content, combat overlay scrim, loading text.
- **Top bar**: opaque chrome, shared text/border ramp, calmer crystal/day chip shadows, stolen-mana pulse without heavy glow; intro easing uses expo.
- **Overlays / HUD**: reward + choice selection, save/load chips, hotkey help, replay load screen, debug panel, player roster chips; RestCompletion cancel button uses CSS vars.
- **Choice hover**: uses shared `--accent` (was cyan) for consistency with reward tiles.
- **Pixi placeholder**: `SURFACE_GROUND_PLACEHOLDER_HEX` aligned with new ground tone.
- **DESIGN.md**: added with updated frontmatter and prose matching the token ladder (was untracked locally).

## Not in this PR

- `PRODUCT.md` and `.impeccable/` remain untracked locally and were not included.

## Verification

- `bun run build` (client in graph)
- `bun run lint`
- Pre-push hook: clippy + cargo test workspace (excludes mk-python)

Made with [Cursor](https://cursor.com)