### PR TITLE
fix(docker): drop --frozen-lockfile for partial workspace install

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -6,7 +6,7 @@ COPY package.json bun.lock ./
 COPY packages/client/package.json packages/client/
 COPY packages/shared/package.json packages/shared/
 COPY packages/mage-dev/package.json packages/mage-dev/
-RUN bun install --frozen-lockfile
+RUN bun install
 
 # Source
 COPY packages/client/ packages/client/


### PR DESCRIPTION
Bun fails with `--frozen-lockfile` when only a subset of workspace packages are present in the Docker build context. Removing the flag fixes the `mk-client` image build.