### PR TITLE
Fix client asset base in Bun Docker build

### DIFF
--- a/packages/client/build.ts
+++ b/packages/client/build.ts
@@ -12,6 +12,7 @@ const DIST = join(ROOT, "dist");
 const PUBLIC = join(ROOT, "public");
 const mkBundleAssets = process.env["MK_BUNDLE_ASSETS"];
 const BUNDLE_ASSETS = mkBundleAssets === "1" || mkBundleAssets === "true";
+const ASSETS_BASE_URL = process.env["VITE_ASSETS_BASE_URL"];
 
 async function clean() {
   await rm(DIST, { recursive: true, force: true });
@@ -42,6 +43,13 @@ async function build() {
     minify: true,
     sourcemap: "external",
     splitting: true,
+    define: {
+      "import.meta.env": JSON.stringify({
+        DEV: false,
+        PROD: true,
+        VITE_ASSETS_BASE_URL: ASSETS_BASE_URL,
+      }),
+    },
     // External packages that should not be bundled
     // (none for browser - bundle everything)
   });

--- a/scripts/publish-assets-r2.sh
+++ b/scripts/publish-assets-r2.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ASSETS_DIR="${ASSETS_DIR:-packages/client/public/assets}"
 R2_BUCKET="${R2_BUCKET:-mageknight-assets-prod}"
 R2_PREFIX="${R2_PREFIX:-mageknight/v1/assets}"
+INCLUDE_MUSIC="${INCLUDE_MUSIC:-0}"
 
 if [ ! -d "$ASSETS_DIR" ]; then
   echo "Assets directory not found: $ASSETS_DIR" >&2
@@ -21,10 +22,24 @@ if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
   fi
 fi
 
-total=$(find "$ASSETS_DIR" -type f | wc -l | tr -d ' ')
+find_assets() {
+  if [ "$INCLUDE_MUSIC" = "1" ] || [ "$INCLUDE_MUSIC" = "true" ]; then
+    find "$ASSETS_DIR" -type f -print0
+  else
+    find "$ASSETS_DIR" -path "$ASSETS_DIR/audio/music" -prune -o -type f -print0
+  fi
+}
+
+total=$(find_assets | tr '\0' '\n' | wc -l | tr -d ' ')
+if [ "$INCLUDE_MUSIC" = "1" ] || [ "$INCLUDE_MUSIC" = "true" ]; then
+  echo "Publishing assets from $ASSETS_DIR, including experimental music."
+else
+  echo "Publishing assets from $ASSETS_DIR, excluding experimental music in audio/music."
+fi
+
 count=0
 
-find "$ASSETS_DIR" -type f -print0 | while IFS= read -r -d '' file; do
+find_assets | while IFS= read -r -d '' file; do
   rel=${file#"$ASSETS_DIR"/}
   key="$R2_PREFIX/$rel"
   count=$((count + 1))


### PR DESCRIPTION
## Summary
- inject VITE_ASSETS_BASE_URL into the custom Bun client build so Docker images use the CDN asset pack
- exclude experimental audio/music files from normal R2 asset publishes while keeping sound effects

## Verification
- git diff --check
- bash -n scripts/publish-assets-r2.sh
- VITE_ASSETS_BASE_URL=https://assets.mageknightdigital.app/mageknight/v1/assets bun run --filter @mage-knight/client build
- bun run --filter @mage-knight/client test
- pre-push: cargo clippy, bun run lint, cargo test workspace excluding mk-python
