### PR TITLE
Fix live asset loading through app origin

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
           cache-from: type=gha,scope=mk-client
           cache-to: type=gha,mode=max,scope=mk-client
           build-args: |
-            VITE_ASSETS_BASE_URL=https://assets.mageknightdigital.app/mageknight/v1/assets
+            VITE_ASSETS_BASE_URL=/assets
           tags: |
             ghcr.io/${{ github.repository_owner }}/mk-client:latest
             ghcr.io/${{ github.repository_owner }}/mk-client:${{ github.sha }}

--- a/packages/client/Caddyfile
+++ b/packages/client/Caddyfile
@@ -1,7 +1,17 @@
 {$APP_DOMAIN} {
     root * /srv
-    try_files {path} /index.html
-    file_server
+
+    handle_path /assets/* {
+        rewrite * /mageknight/v1/assets{path}
+        reverse_proxy https://assets.mageknightdigital.app {
+            header_up Host assets.mageknightdigital.app
+        }
+    }
+
+    handle {
+        try_files {path} /index.html
+        file_server
+    }
 }
 
 {$API_DOMAIN} {

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -13,7 +13,7 @@ COPY packages/client/ packages/client/
 COPY packages/shared/ packages/shared/
 COPY packages/mage-dev/ packages/mage-dev/
 
-ARG VITE_ASSETS_BASE_URL=https://assets.mageknightdigital.app/mageknight/v1/assets
+ARG VITE_ASSETS_BASE_URL=/assets
 ENV VITE_ASSETS_BASE_URL=$VITE_ASSETS_BASE_URL
 
 RUN bun run --filter @mage-knight/shared build && \

--- a/terraform/modules/cloudflare_site/main.tf
+++ b/terraform/modules/cloudflare_site/main.tf
@@ -23,6 +23,23 @@ resource "cloudflare_r2_custom_domain" "assets" {
   min_tls     = "1.2"
 }
 
+resource "cloudflare_r2_bucket_cors" "assets" {
+  count = var.enable_r2_assets ? 1 : 0
+
+  account_id  = var.cloudflare_account_id
+  bucket_name = cloudflare_r2_bucket.assets[0].name
+
+  rules = [{
+    id = "public-game-assets"
+    allowed = {
+      methods = ["GET", "HEAD"]
+      origins = var.assets_cors_allowed_origins
+      headers = ["*"]
+    }
+    max_age_seconds = 3600
+  }]
+}
+
 resource "cloudflare_dns_record" "play" {
   count = var.create_app_record ? 1 : 0
 

--- a/terraform/modules/cloudflare_site/variables.tf
+++ b/terraform/modules/cloudflare_site/variables.tf
@@ -44,6 +44,12 @@ variable "asset_pack_path" {
   default     = "mageknight/v1/assets"
 }
 
+variable "assets_cors_allowed_origins" {
+  description = "Browser origins allowed to fetch R2-hosted game assets."
+  type        = list(string)
+  default     = ["https://play.mageknightdigital.app"]
+}
+
 variable "play_subdomain" {
   description = "Subdomain for the web app."
   type        = string


### PR DESCRIPTION
## Summary
- serve /assets/* from the app origin by proxying to the R2 asset custom domain
- build the client image with VITE_ASSETS_BASE_URL=/assets so atlas.json loads same-origin
- manage R2 CORS in Terraform as a direct asset-domain fallback

## Verification
- terraform fmt/validate
- git diff --check
- Caddy config validation with caddy:2-alpine
- VITE_ASSETS_BASE_URL=/assets bun run --filter @mage-knight/client build
- bun run --filter @mage-knight/client test
- pre-push: cargo clippy, bun run lint, cargo test workspace excluding mk-python
