### PR TITLE
Fix production WebSocket endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
       - name: bun run build (all packages)
         run: bun run build
 
+      - name: check production client server URLs
+        env:
+          VITE_RUST_SERVER_URL: wss://api.mageknightdigital.app/ws
+        run: |
+          bun run --filter @mage-knight/client build
+          bash scripts/check-client-production-bundle.sh
+
       - name: bun test (client)
         run: bun run --filter @mage-knight/client test
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -58,6 +58,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=mk-client
           build-args: |
             VITE_ASSETS_BASE_URL=/assets
+            VITE_RUST_SERVER_URL=wss://api.mageknightdigital.app/ws
           tags: |
             ghcr.io/${{ github.repository_owner }}/mk-client:latest
             ghcr.io/${{ github.repository_owner }}/mk-client:${{ github.sha }}

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -14,7 +14,9 @@ COPY packages/shared/ packages/shared/
 COPY packages/mage-dev/ packages/mage-dev/
 
 ARG VITE_ASSETS_BASE_URL=/assets
+ARG VITE_RUST_SERVER_URL=wss://api.mageknightdigital.app/ws
 ENV VITE_ASSETS_BASE_URL=$VITE_ASSETS_BASE_URL
+ENV VITE_RUST_SERVER_URL=$VITE_RUST_SERVER_URL
 
 RUN bun run --filter @mage-knight/shared build && \
     bun run --filter @mage-knight/client build

--- a/packages/client/__tests__/rustServerUrl.test.ts
+++ b/packages/client/__tests__/rustServerUrl.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { getRuntimeRustServerUrl } from "../src/runtime/rustServerUrl";
+
+function locationFor(url: string): Location {
+  return new URL(url) as unknown as Location;
+}
+
+describe("getRuntimeRustServerUrl", () => {
+  it("uses localhost for local development", () => {
+    expect(
+      getRuntimeRustServerUrl(new URLSearchParams(), locationFor("http://localhost:5173"))
+    ).toBe("ws://localhost:3030/ws");
+  });
+
+  it("uses the api subdomain for deployed play hosts", () => {
+    expect(
+      getRuntimeRustServerUrl(
+        new URLSearchParams(),
+        locationFor("https://play.mageknightdigital.app")
+      )
+    ).toBe("wss://api.mageknightdigital.app/ws");
+  });
+
+  it("keeps query param overrides for explicit testing", () => {
+    expect(
+      getRuntimeRustServerUrl(
+        new URLSearchParams("serverUrl=ws%3A%2F%2Fexample.test%2Fws"),
+        locationFor("https://play.mageknightdigital.app")
+      )
+    ).toBe("ws://example.test/ws");
+  });
+});

--- a/packages/client/build.ts
+++ b/packages/client/build.ts
@@ -13,6 +13,7 @@ const PUBLIC = join(ROOT, "public");
 const mkBundleAssets = process.env["MK_BUNDLE_ASSETS"];
 const BUNDLE_ASSETS = mkBundleAssets === "1" || mkBundleAssets === "true";
 const ASSETS_BASE_URL = process.env["VITE_ASSETS_BASE_URL"];
+const RUST_SERVER_URL = process.env["VITE_RUST_SERVER_URL"];
 
 async function clean() {
   await rm(DIST, { recursive: true, force: true });
@@ -48,6 +49,7 @@ async function build() {
         DEV: false,
         PROD: true,
         VITE_ASSETS_BASE_URL: ASSETS_BASE_URL,
+        VITE_RUST_SERVER_URL: RUST_SERVER_URL,
       }),
     },
     // External packages that should not be bundled

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -14,14 +14,13 @@ import { GameView } from "./components/GameView";
 import { DebugPanel } from "./components/DebugPanel";
 import { ReplayLoadScreen } from "./components/Replay";
 import { SetupScreen } from "./components/Setup";
+import { getRuntimeRustServerUrl } from "./runtime/rustServerUrl";
 import type { GameConfig } from "@mage-knight/shared";
 import { HERO_ARYTHEA } from "@mage-knight/shared";
 
 const MODE_PARAM = "mode" as const;
-const SERVER_URL_PARAM = "serverUrl" as const;
 const PLAYER_ID_PARAM = "playerId" as const;
 const MODE_REPLAY = "replay" as const;
-const DEFAULT_RUST_SERVER_URL = "ws://localhost:3030/ws" as const;
 const HERO_PARAM = "hero" as const;
 const SEED_PARAM = "seed" as const;
 const SCENARIO_PARAM = "scenario" as const;
@@ -43,7 +42,7 @@ function getRuntimeRustConfig(): RuntimeRustConfig {
   const urlParams = new URLSearchParams(window.location.search);
 
   const hero = urlParams.get(HERO_PARAM) ?? "arythea";
-  const serverUrl = urlParams.get(SERVER_URL_PARAM) ?? DEFAULT_RUST_SERVER_URL;
+  const serverUrl = getRuntimeRustServerUrl(urlParams);
   const playerId = urlParams.get(PLAYER_ID_PARAM) ?? undefined;
   const seedParam = urlParams.get(SEED_PARAM);
   const seed = seedParam ? parseInt(seedParam, 10) : undefined;

--- a/packages/client/src/runtime/rustServerUrl.ts
+++ b/packages/client/src/runtime/rustServerUrl.ts
@@ -1,0 +1,32 @@
+type RuntimeImportMeta = ImportMeta & {
+  env?: {
+    VITE_RUST_SERVER_URL?: string;
+  };
+};
+
+function isLocalHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+function getDefaultRustServerUrl(location: Location): string {
+  if (isLocalHostname(location.hostname)) {
+    return `ws://${location.hostname}:3030/ws`;
+  }
+
+  const websocketProtocol = location.protocol === "https:" ? "wss:" : "ws:";
+  const apiHostname = location.hostname.startsWith("play.")
+    ? `api.${location.hostname.slice("play.".length)}`
+    : location.hostname;
+
+  return `${websocketProtocol}//${apiHostname}/ws`;
+}
+
+export function getRuntimeRustServerUrl(searchParams: URLSearchParams, location: Location = window.location): string {
+  const queryOverride = searchParams.get("serverUrl");
+  if (queryOverride) return queryOverride;
+
+  const envOverride = (import.meta as RuntimeImportMeta).env?.VITE_RUST_SERVER_URL?.trim();
+  if (envOverride) return envOverride;
+
+  return getDefaultRustServerUrl(location);
+}

--- a/scripts/check-client-production-bundle.sh
+++ b/scripts/check-client-production-bundle.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bundle_dir="${1:-packages/client/dist}"
+
+if [ ! -d "$bundle_dir" ]; then
+  echo "Client bundle directory not found: $bundle_dir" >&2
+  exit 1
+fi
+
+bundle_files=$(find "$bundle_dir" -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' \))
+
+if grep -E 'ws://localhost|wss://localhost|http://localhost|127\.0\.0\.1:3030' $bundle_files >/dev/null; then
+  echo "Production client bundle contains localhost server references." >&2
+  grep -n -E 'ws://localhost|wss://localhost|http://localhost|127\.0\.0\.1:3030' $bundle_files >&2
+  exit 1
+fi
+
+if ! grep 'wss://api.mageknightdigital.app/ws' $bundle_files >/dev/null; then
+  echo "Production client bundle does not contain the expected API WebSocket URL." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- derive the production WebSocket default as wss://api.mageknightdigital.app/ws instead of baking localhost into deployed bundles
- keep local dev on ws://localhost:3030/ws and preserve the ?serverUrl override for testing
- pass VITE_RUST_SERVER_URL through Docker builds and add a CI bundle guard that fails if production assets reference localhost

## Verification
- bun run --filter @mage-knight/client test
- VITE_ASSETS_BASE_URL=/assets VITE_RUST_SERVER_URL=wss://api.mageknightdigital.app/ws bun run --filter @mage-knight/client build
- bash scripts/check-client-production-bundle.sh
- pre-push: cargo clippy, bun run lint, cargo test workspace