### PR TITLE
Keep live WebSocket connection warm

### DIFF
--- a/packages/client/src/rust/RustGameConnection.ts
+++ b/packages/client/src/rust/RustGameConnection.ts
@@ -2,8 +2,8 @@
  * WebSocket client for the Rust mk-server.
  *
  * Protocol:
- *   Client -> Server: { type: "new_game", hero, seed } | { type: "action", action, epoch } | { type: "undo" }
- *   Server -> Client: { type: "state_update", state, events, legal_actions, epoch } | { type: "error", message }
+ *   Client -> Server: { type: "new_game", hero, seed } | { type: "action", action, epoch } | { type: "ping" } | { type: "undo" }
+ *   Server -> Client: { type: "state_update", state, events, legal_actions, epoch } | { type: "error", message } | { type: "pong" }
  */
 
 import type { LegalAction, ServerMessage } from "./types";
@@ -19,12 +19,14 @@ export interface RustGameConnectionOptions {
 
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 500;
+const HEARTBEAT_INTERVAL_MS = 25_000;
 
 export class RustGameConnection {
   private ws: WebSocket | null = null;
   private options: RustGameConnectionOptions;
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
   private pendingNewGame: { hero: string; seed?: number; scenario?: string } | null = null;
 
   constructor(options: RustGameConnectionOptions) {
@@ -38,6 +40,7 @@ export class RustGameConnection {
     this.ws.onopen = () => {
       this.reconnectAttempts = 0;
       this.options.onStatusChange("connected");
+      this.startHeartbeat();
       // Send pending new_game if we have one
       if (this.pendingNewGame) {
         this.sendRaw({
@@ -59,6 +62,7 @@ export class RustGameConnection {
     };
 
     this.ws.onclose = () => {
+      this.stopHeartbeat();
       this.ws = null;
       this.tryReconnect();
     };
@@ -73,6 +77,7 @@ export class RustGameConnection {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    this.stopHeartbeat();
     if (this.ws) {
       this.ws.onclose = null; // prevent reconnect
       this.ws.close();
@@ -99,6 +104,20 @@ export class RustGameConnection {
   private sendRaw(msg: unknown): void {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg));
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      this.sendRaw({ type: "ping" });
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
     }
   }
 

--- a/packages/client/src/rust/types.ts
+++ b/packages/client/src/rust/types.ts
@@ -150,9 +150,11 @@ export function isAction(action: LegalAction, type: string): boolean {
 export type ClientMessage =
   | { type: "new_game"; hero: string; seed?: number }
   | { type: "action"; action: LegalAction; epoch: number }
+  | { type: "ping" }
   | { type: "undo" };
 
 /** Messages the server sends to the client. */
 export type ServerMessage =
   | { type: "state_update"; state: Record<string, unknown>; events: unknown[]; legal_actions: LegalAction[]; epoch: number }
-  | { type: "error"; message: string };
+  | { type: "error"; message: string }
+  | { type: "pong" };

--- a/packages/engine-rs/tools/mk-server/src/main.rs
+++ b/packages/engine-rs/tools/mk-server/src/main.rs
@@ -55,6 +55,7 @@ enum ClientMessage {
         action: LegalAction,
         epoch: u64,
     },
+    Ping,
     Undo,
 }
 
@@ -117,6 +118,7 @@ enum ServerMessage {
     Error {
         message: String,
     },
+    Pong,
 }
 
 // =============================================================================
@@ -266,6 +268,8 @@ async fn handle_socket(mut socket: WebSocket) {
                 },
             },
 
+            ClientMessage::Ping => ServerMessage::Pong,
+
             ClientMessage::Undo => match session.as_mut() {
                 None => ServerMessage::Error {
                     message: "No active game. Send new_game first.".into(),
@@ -345,6 +349,16 @@ mod tests {
         match msg {
             ClientMessage::NewGame { seed, .. } => assert_eq!(seed, Some(12345)),
             _ => panic!("expected new_game"),
+        }
+    }
+
+    #[test]
+    fn ping_message_deserializes() {
+        let msg: ClientMessage = serde_json::from_str(r#"{"type":"ping"}"#).unwrap();
+
+        match msg {
+            ClientMessage::Ping => {}
+            _ => panic!("expected ping"),
         }
     }
 


### PR DESCRIPTION
## Summary
- add an app-level WebSocket ping/pong heartbeat
- send client pings every 25s while connected to keep Cloudflare/Caddy/server connection active
- stop the heartbeat on close/disconnect so reconnect timers do not leak
- add server support and a regression test for ping messages

## Verification
- cargo test -p mk-server
- bun run --filter @mage-knight/client test
- bun run --filter @mage-knight/client build
- bun run lint
- pre-push: cargo clippy, bun run lint, cargo test workspace