### PR TITLE
Harden client keyboard shortcuts

### DIFF
--- a/packages/client/__tests__/hotkeys.test.ts
+++ b/packages/client/__tests__/hotkeys.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { matchesHotkey } from "../src/utils/hotkeys";
+
+function keyEvent(key: string, code: string): KeyboardEvent {
+  return { key, code } as KeyboardEvent;
+}
+
+describe("matchesHotkey", () => {
+  it("matches printable key values", () => {
+    expect(matchesHotkey(keyEvent("4", ""), ["4"])).toBe(true);
+    expect(matchesHotkey(keyEvent("Q", ""), ["q"])).toBe(true);
+  });
+
+  it("matches physical key codes when key is unreliable", () => {
+    expect(matchesHotkey(keyEvent("Unidentified", "Digit4"), ["4"], ["Digit4"])).toBe(true);
+    expect(matchesHotkey(keyEvent("Unidentified", "Numpad4"), ["4"], ["Numpad4"])).toBe(true);
+    expect(matchesHotkey(keyEvent("Unidentified", "KeyQ"), ["q"], ["KeyQ"])).toBe(true);
+  });
+});

--- a/packages/client/src/components/Hand/PlayerHand.tsx
+++ b/packages/client/src/components/Hand/PlayerHand.tsx
@@ -12,6 +12,7 @@ import { useIsMyTurn } from "../../hooks/useIsMyTurn";
 import { useCardInteraction } from "../CardInteraction";
 import { useRegisterOverlay } from "../../contexts/OverlayContext";
 import { groupCardActions, extractTacticOptions, extractUnitActions } from "../../rust/legalActionUtils";
+import { isEditableHotkeyTarget, matchesHotkey } from "../../utils/hotkeys";
 
 // Menu state types
 type MenuState =
@@ -123,22 +124,24 @@ export function PlayerHand({ onOfferViewChange }: PlayerHandProps = {}) {
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Ignore if user is typing in an input
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (isEditableHotkeyTarget(e.target)) {
         return;
       }
 
-      const key = e.key.toLowerCase();
-
       // View mode keys: 1=focus, 2=ready, 3=board (map), 4=offer
-      if (key === "1") {
+      if (matchesHotkey(e, ["1"], ["Digit1", "Numpad1"])) {
         setHandView("focus");
-      } else if (key === "2") {
+      } else if (matchesHotkey(e, ["2"], ["Digit2", "Numpad2"])) {
         setHandView("ready");
-      } else if (key === "3") {
+      } else if (matchesHotkey(e, ["3"], ["Digit3", "Numpad3"])) {
         setHandView("board");
-      } else if (key === "4") {
+      } else if (matchesHotkey(e, ["4"], ["Digit4", "Numpad4"])) {
         setHandView("offer");
-      } else if (key === "q" || key === "w" || key === "e") {
+      } else if (
+        matchesHotkey(e, ["q"], ["KeyQ"]) ||
+        matchesHotkey(e, ["w"], ["KeyW"]) ||
+        matchesHotkey(e, ["e"], ["KeyE"])
+      ) {
         // Q/W/E carousel navigation - only when NOT in offer view
         // (Offer view has its own Q/W/E handling for Units/Spells/AAs)
         setHandView(current => {
@@ -147,15 +150,15 @@ export function PlayerHand({ onOfferViewChange }: PlayerHandProps = {}) {
             return current;
           }
 
-          if (key === "q") {
+          if (matchesHotkey(e, ["q"], ["KeyQ"])) {
             // Tactics pane - only if tactic selection is needed
             if (needsTacticSelection) {
               setCarouselPane("tactics");
             }
-          } else if (key === "w") {
+          } else if (matchesHotkey(e, ["w"], ["KeyW"])) {
             // Cards pane
             setCarouselPane("cards");
-          } else if (key === "e") {
+          } else if (matchesHotkey(e, ["e"], ["KeyE"])) {
             // Units pane
             setCarouselPane("units");
           }

--- a/packages/client/src/components/OfferView/PixiOfferView.tsx
+++ b/packages/client/src/components/OfferView/PixiOfferView.tsx
@@ -18,6 +18,7 @@ import { usePixiApp } from "../../contexts/PixiAppContext";
 import { useGame } from "../../hooks/useGame";
 import { useMyPlayer } from "../../hooks/useMyPlayer";
 import { getOfferCardTexture } from "../../utils/pixiTextureLoader";
+import { isEditableHotkeyTarget, matchesHotkey } from "../../utils/hotkeys";
 import { AnimationManager, Easing } from "../GameBoard/pixi/animations";
 import {
   UNITS,
@@ -660,19 +661,21 @@ export function PixiOfferView({ isVisible, onClose, initialTab = "units" }: Pixi
     if (!isVisible) return;
 
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) {
+      if (isEditableHotkeyTarget(e.target)) {
         return;
       }
 
-      const key = e.key.toLowerCase();
-
-      if (key === "q") {
+      if (matchesHotkey(e, ["q"], ["KeyQ"])) {
         switchPane("units");
-      } else if (key === "w") {
+      } else if (matchesHotkey(e, ["w"], ["KeyW"])) {
         switchPane("spells");
-      } else if (key === "e") {
+      } else if (matchesHotkey(e, ["e"], ["KeyE"])) {
         switchPane("advancedActions");
-      } else if (key === "2" || key === "s" || key === "escape") {
+      } else if (
+        matchesHotkey(e, ["2"], ["Digit2", "Numpad2"]) ||
+        matchesHotkey(e, ["s"], ["KeyS"]) ||
+        matchesHotkey(e, ["escape"], ["Escape"])
+      ) {
         onCloseRef.current();
       }
     };

--- a/packages/client/src/utils/hotkeys.ts
+++ b/packages/client/src/utils/hotkeys.ts
@@ -1,0 +1,17 @@
+export function isEditableHotkeyTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    (target instanceof HTMLElement && target.isContentEditable);
+}
+
+export function matchesHotkey(
+  event: KeyboardEvent,
+  keys: readonly string[],
+  codes: readonly string[] = [],
+): boolean {
+  const key = event.key.toLowerCase();
+  const code = event.code;
+
+  return keys.includes(key) || codes.includes(code);
+}


### PR DESCRIPTION
## Summary
- add a small shared hotkey matcher that accepts both KeyboardEvent.key and KeyboardEvent.code
- use it for hand view hotkeys 1/2/3/4 and Q/W/E pane navigation
- use it for offer view Q/W/E and close shortcuts
- ignore select/contenteditable targets in addition to inputs/textareas

## Verification
- bun run --filter @mage-knight/client test
- bun run --filter @mage-knight/client build
- bun run lint
- pre-push: cargo clippy, bun run lint, cargo test workspace