### PR TITLE
feat: cinematic setup screen + village unit guarantee

### DIFF
--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -110,7 +110,11 @@ export function App() {
   }
 
   if (!gameConfig) {
-    return <SetupScreen onComplete={setGameConfig} />;
+    return (
+      <div className="app">
+        <SetupScreen onComplete={setGameConfig} />
+      </div>
+    );
   }
 
   // Default: connect to Rust mk-server

--- a/packages/client/src/assets/assetPaths.ts
+++ b/packages/client/src/assets/assetPaths.ts
@@ -94,8 +94,7 @@ export function getCardBackUrl(): string {
 }
 
 export function getHeroTokenUrl(heroId: string): string {
-  // Note: "_card" files are actually the octagonal portrait tokens for the board
-  // "_token" files are smaller circular tokens (naming is backwards in assets)
+  // Octagonal agon portrait tokens used on the board and setup splash (not circular chips).
   return assetUrl(`heroes/${heroId}_card.png`);
 }
 

--- a/packages/client/src/components/ActivityFeed/ActivityFeed.css
+++ b/packages/client/src/components/ActivityFeed/ActivityFeed.css
@@ -1,44 +1,110 @@
+/**
+ * Chronicle (activity feed): right dock so it never covers the combat phase rail.
+ * Map-room tokens, subdued category tints, not a raw debug console.
+ */
+
 .activity-feed {
+  --feed-ease: var(--ease-out-expo);
+  --feed-radius: 10px;
+  --feed-width: min(19rem, min(42vw, 22rem));
+
   position: fixed;
-  left: 0;
   top: 50%;
+  right: max(0.5rem, env(safe-area-inset-right, 0px));
+  left: auto;
   transform: translateY(-50%);
-  width: 240px;
-  max-height: 50vh;
-  z-index: 250;
-  pointer-events: none;
+  width: var(--feed-width);
+  max-height: min(46vh, 22rem);
+  z-index: 205;
   display: flex;
   flex-direction: column;
-  transition: opacity 0.2s ease;
-  opacity: 0.5;
+  align-items: stretch;
+  pointer-events: none;
+  opacity: 0.88;
+  transition:
+    opacity 0.22s var(--feed-ease),
+    transform 0.28s var(--feed-ease);
 }
 
 .activity-feed:hover {
   opacity: 1;
 }
 
+/* Combat: shorter stack so it stays clear of center battlefield and bottom hand */
+.activity-feed--combat {
+  top: auto;
+  bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+  transform: none;
+  max-height: min(32vh, 15rem);
+  /* Below .combat-scene (200) so fixed combat dock / tray stay visually above */
+  z-index: 198;
+}
+
+@media (min-height: 720px) {
+  .activity-feed--combat {
+    max-height: min(36vh, 17rem);
+  }
+}
+
 .activity-feed__toggle {
-  position: absolute;
-  top: -24px;
-  left: 8px;
-  background: rgba(0, 0, 0, 0.6);
-  color: rgba(255, 255, 255, 0.7);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 4px 4px 0 0;
-  padding: 2px 8px;
-  font-size: 11px;
+  align-self: flex-end;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.35rem;
+  padding: 0.28rem 0.55rem 0.28rem 0.65rem;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: color-mix(in oklch, var(--surface-chrome) 88%, transparent);
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   cursor: pointer;
   pointer-events: auto;
-  font-family: inherit;
+  box-shadow: 0 2px 10px oklch(0.08 0.012 78 / 0.35);
+  transition:
+    background-color 0.2s var(--feed-ease),
+    color 0.2s var(--feed-ease),
+    border-color 0.2s var(--feed-ease),
+    box-shadow 0.2s var(--feed-ease);
 }
 
 .activity-feed__toggle:hover {
-  color: rgba(255, 255, 255, 0.9);
-  background: rgba(0, 0, 0, 0.8);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--surface-hover-lift) 92%, transparent);
+}
+
+.activity-feed__toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.activity-feed__toggle-label {
+  line-height: 1;
+}
+
+.activity-feed__toggle-kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.35rem;
+  padding: 0.12rem 0.28rem;
+  border-radius: 4px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  font-family: inherit;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: var(--surface-canvas);
+  border: 1px solid var(--border-subtle);
 }
 
 .activity-feed--collapsed {
-  opacity: 0.3;
+  opacity: 0.72;
 }
 
 .activity-feed--collapsed .activity-feed__messages {
@@ -46,20 +112,23 @@
 }
 
 .activity-feed__messages {
-  background: rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-left: none;
-  border-radius: 0 6px 6px 0;
-  padding: 6px 0;
-  overflow-y: auto;
-  max-height: 50vh;
   pointer-events: auto;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 0.45rem 0;
+  border-radius: var(--feed-radius);
+  border: 1px solid var(--border-default);
+  background: color-mix(in oklch, var(--surface-canvas) 94%, oklch(0.12 0.012 78));
+  box-shadow:
+    0 12px 36px oklch(0.08 0.012 78 / 0.45),
+    inset 0 1px 0 oklch(0.95 0.01 82 / 0.06);
   scrollbar-width: thin;
-  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+  scrollbar-color: var(--border-strong) transparent;
 }
 
 .activity-feed__messages::-webkit-scrollbar {
-  width: 4px;
+  width: 5px;
 }
 
 .activity-feed__messages::-webkit-scrollbar-track {
@@ -67,83 +136,90 @@
 }
 
 .activity-feed__messages::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 2px;
+  background: var(--border-default);
+  border-radius: 4px;
 }
 
-/* Individual message */
 .activity-feed__msg {
-  padding: 2px 10px;
-  font-size: 11px;
-  line-height: 1.4;
-  color: rgba(255, 255, 255, 0.85);
-  animation: feed-fade-in 0.3s ease;
+  padding: 0.28rem 0.65rem;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+  animation: activity-feed-msg-in 0.32s var(--feed-ease) both;
 }
 
-@keyframes feed-fade-in {
+@keyframes activity-feed-msg-in {
   from {
     opacity: 0;
-    transform: translateY(4px);
+    transform: translateY(6px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
   }
 }
 
-/* Turn boundary separator */
 .activity-feed__msg--boundary {
+  margin-top: 0.35rem;
+  padding-top: 0.5rem;
   text-align: center;
   font-weight: 600;
-  font-size: 10px;
-  letter-spacing: 0.3px;
-  color: rgba(255, 255, 255, 0.5);
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-  margin-top: 4px;
-  padding-top: 5px;
+  font-size: 0.7rem;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border-subtle);
 }
 
-/* Category colors */
+/* Category tints: muted, readable on dark fill */
 .activity-feed__msg--movement {
-  color: #6cb4ee;
+  color: oklch(0.78 0.06 240);
 }
 
 .activity-feed__msg--combat {
-  color: #e86a6a;
+  color: oklch(0.78 0.09 25);
 }
 
 .activity-feed__msg--cards {
-  color: #7dd87d;
+  color: oklch(0.8 0.08 145);
 }
 
 .activity-feed__msg--progression {
-  color: #f0c460;
+  color: oklch(0.82 0.1 85);
 }
 
 .activity-feed__msg--health {
-  color: #e86a6a;
+  color: oklch(0.78 0.09 25);
 }
 
 .activity-feed__msg--units {
-  color: #b88ae8;
+  color: oklch(0.78 0.07 290);
 }
 
 .activity-feed__msg--sites {
-  color: #d4a56a;
+  color: oklch(0.82 0.09 70);
 }
 
-.activity-feed__msg--lifecycle {
-  color: rgba(255, 255, 255, 0.6);
-}
-
+.activity-feed__msg--lifecycle,
 .activity-feed__msg--tactics {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-muted);
 }
 
-/* Empty state */
 .activity-feed__empty {
-  padding: 8px 10px;
-  font-size: 11px;
-  color: rgba(255, 255, 255, 0.3);
+  padding: 0.65rem 0.85rem;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  color: var(--text-faint);
   font-style: italic;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-feed {
+    transition: none;
+  }
+
+  .activity-feed__msg {
+    animation: none;
+  }
 }

--- a/packages/client/src/components/ActivityFeed/ActivityFeed.tsx
+++ b/packages/client/src/components/ActivityFeed/ActivityFeed.tsx
@@ -12,18 +12,22 @@ import "./ActivityFeed.css";
 
 const MAX_MESSAGES = 50;
 
+const CHRONICLE_PANEL_ID = "activity-feed-chronicle" as const;
+const CHRONICLE_TOGGLE_LABEL = "Chronicle" as const;
+const CHRONICLE_EMPTY = "Nothing to report yet." as const;
+
 export function ActivityFeed() {
   const { state, events } = useGame();
   const [collapsed, setCollapsed] = useState(false);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
 
-  // Build players list for narration from state
+  const inCombat = state?.combat != null;
+
   const players: NarrationPlayer[] = useMemo(() => {
     if (!state) return [];
     return state.players.map((p) => ({ id: p.id, hero: p.hero }));
   }, [state]);
 
-  // Derive messages from events — pure computation, no effect needed
   const messages: ActivityMessage[] = useMemo(() => {
     if (events.length === 0 || players.length === 0) return [];
     const result: ActivityMessage[] = [];
@@ -36,17 +40,14 @@ export function ActivityFeed() {
     return result.slice(-MAX_MESSAGES);
   }, [events, players]);
 
-  // Auto-scroll to bottom when messages change
   useEffect(() => {
     const el = messagesContainerRef.current;
     if (!el) return;
-    // Use rAF to ensure DOM has rendered new content before scrolling
     requestAnimationFrame(() => {
       el.scrollTop = el.scrollHeight;
     });
   }, [messages]);
 
-  // Keyboard shortcut: L to toggle
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (
@@ -68,19 +69,37 @@ export function ActivityFeed() {
 
   const feedClass = [
     "activity-feed",
+    inCombat && "activity-feed--combat",
     collapsed && "activity-feed--collapsed",
   ]
     .filter(Boolean)
     .join(" ");
 
   return (
-    <div className={feedClass}>
-      <button className="activity-feed__toggle" onClick={toggle}>
-        Log [L]
+    <aside className={feedClass} aria-label="Game chronicle">
+      <button
+        type="button"
+        className="activity-feed__toggle"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-controls={CHRONICLE_PANEL_ID}
+        title="Toggle chronicle (keyboard L)"
+      >
+        <span className="activity-feed__toggle-label">{CHRONICLE_TOGGLE_LABEL}</span>
+        <kbd className="activity-feed__toggle-kbd" aria-hidden="true">
+          L
+        </kbd>
       </button>
-      <div className="activity-feed__messages" ref={messagesContainerRef}>
+      <div
+        id={CHRONICLE_PANEL_ID}
+        className="activity-feed__messages"
+        ref={messagesContainerRef}
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+      >
         {messages.length === 0 ? (
-          <div className="activity-feed__empty">No events yet</div>
+          <div className="activity-feed__empty">{CHRONICLE_EMPTY}</div>
         ) : (
           messages.map((msg, i) => {
             const classes = [
@@ -98,6 +117,6 @@ export function ActivityFeed() {
           })
         )}
       </div>
-    </div>
+    </aside>
   );
 }

--- a/packages/client/src/components/Combat/CombatOverlay.css
+++ b/packages/client/src/components/Combat/CombatOverlay.css
@@ -1,43 +1,28 @@
 /* ============================================================================
-   MAGE KNIGHT COMBAT THEME
-   Color palette aligned with PixiJS background atmosphere
+   Combat scene (HTML layer over Pixi combat backdrop)
 
-   Day palette: warm brown #3d3528 → #1a1610
-   Night palette: deep blue-purple #1a1d2e → #0a0a12
-
-   Combat accent colors (fantasy/earthy):
-   - Attack/Combat: Bronze #b87333, Copper #a06030, Rust #8b4513
-   - Block/Defense: Verdigris #2e6b5a, Forest #1a4d3e
-   - Targeting: Antique Gold #d4a574, #c9a86c
-   - Success: Moss #8b9a6b
-   - Warning: Burnt Sienna #a65d3f
-   - Fire: Deep Crimson #a04030
-   - Ice: Steel Blue #4a7090
-   - ColdFire: Dusty Purple #6a4a8a
+   Map-room tokens on :root, antique gold accents aligned with DESIGN.md
+   combat lane. No raw #000/#fff fills, no decorative backdrop blur.
    ============================================================================ */
 
-/* Combat Scene - full screen combat arena
- * z-index 200: must be above the PixiJS canvas (.hex-grid = 150 during combat)
- * so that action buttons (Attack, Confirm Targets, etc.) are clickable.
- * pointer-events: none lets clicks pass through to the canvas for hand cards. */
 .combat-scene {
+  --combat-ease: var(--ease-out-expo);
+  --combat-tray-fill: color-mix(in oklch, var(--surface-canvas) 92%, oklch(0.12 0.018 270));
+  --combat-tray-edge: color-mix(in oklch, var(--border-default) 70%, oklch(0.72 0.07 72));
+  --combat-antique: oklch(0.78 0.08 72);
+  --combat-attack-edge: color-mix(in oklch, oklch(0.58 0.12 55) 55%, var(--border-default));
+  --combat-block-edge: color-mix(in oklch, oklch(0.52 0.08 165) 50%, var(--border-default));
+
   position: fixed;
   inset: 0;
   z-index: 200;
   display: flex;
   flex-direction: column;
   pointer-events: none;
-
-  /* Background now rendered by PixiCombatOverlay */
   background: transparent;
-
-  /* Flash effect on combat start */
-  animation: combat-flash 0.4s ease-out;
+  animation: combat-flash 0.4s var(--combat-ease);
 }
 
-/* Site backdrop now rendered by PixiCombatOverlay.tsx */
-
-/* Main layout - phase rail overlaid on left, battle area full width */
 .combat-scene__layout {
   flex: 1;
   display: flex;
@@ -51,38 +36,44 @@
   pointer-events: auto;
 }
 
-/* Phase rail now rendered by PixiPhaseRail.tsx */
-
-/* Mana Source - positioned top right corner */
-.combat-scene__mana-source {
+/* --------------------------------------------------------------------------
+   Top tray: personal mana + shared dice, single horizontal rhythm (no stack)
+   -------------------------------------------------------------------------- */
+.combat-scene__top-tray {
   position: fixed;
-  top: 0.75rem;
-  right: 1rem;
-  pointer-events: auto;
-  z-index: 200;
+  top: calc(36px + 0.35rem);
+  right: max(0.5rem, env(safe-area-inset-right, 0px));
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  z-index: 210;
+  pointer-events: none;
 }
 
-/* Override mana source styles for combat */
+.combat-scene__top-tray > * {
+  pointer-events: auto;
+}
+
+.combat-scene__mana-resources:empty {
+  display: none;
+}
+
 .combat-scene__mana-source .mana-source-overlay {
   position: static !important;
   top: auto !important;
   right: auto !important;
-  /* Force visible - override intro animation states */
   opacity: 1 !important;
   transform: none !important;
   pointer-events: auto !important;
-  /* Match PixiJS night palette with antique gold accent */
-  background: linear-gradient(
-    135deg,
-    rgba(26, 29, 46, 0.95) 0%,
-    rgba(20, 22, 35, 0.95) 100%
-  );
-  border: 1px solid rgba(212, 165, 116, 0.35);
+  background: var(--combat-tray-fill);
+  border: 1px solid var(--combat-tray-edge);
   border-radius: 8px;
-  padding: 0.4rem 0.6rem;
+  padding: 0.4rem 0.55rem;
   box-shadow:
-    0 4px 20px rgba(0, 0, 0, 0.6),
-    inset 0 1px 0 rgba(212, 165, 116, 0.1);
+    0 6px 24px oklch(0.08 0.012 78 / 0.45),
+    inset 0 1px 0 oklch(0.95 0.01 82 / 0.06);
 }
 
 .combat-scene__mana-source .mana-source-overlay__dice {
@@ -92,7 +83,6 @@
 .combat-scene__mana-source .mana-source-overlay__die {
   width: clamp(1.8rem, 3vw, 2.5rem);
   height: clamp(1.8rem, 3vw, 2.5rem);
-  /* Force visible */
   opacity: 1 !important;
   animation: none !important;
 }
@@ -100,20 +90,53 @@
 .combat-scene__mana-source .mana-source-overlay__label {
   font-size: 0.5rem;
   margin-bottom: 0.25rem;
+  color: var(--text-muted);
+}
+
+/* Undo: left rail, clear of phase rail + top chrome */
+.combat-scene__undo {
+  position: fixed;
+  top: calc(36px + 0.35rem);
+  left: max(0.5rem, env(safe-area-inset-left, 0px));
+  z-index: 210;
+  padding: 0.35rem 0.65rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--surface-chrome) 92%, transparent);
+  border: 1px solid var(--border-default);
+  border-radius: 6px;
+  cursor: pointer;
+  pointer-events: auto;
+  box-shadow: 0 4px 16px oklch(0.08 0.012 78 / 0.35);
+  transition:
+    color 0.18s var(--combat-ease),
+    border-color 0.18s var(--combat-ease),
+    background-color 0.18s var(--combat-ease);
+}
+
+.combat-scene__undo:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+  background: color-mix(in oklch, var(--surface-hover-lift) 94%, transparent);
+}
+
+.combat-scene__undo:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 @keyframes combat-flash {
   0% {
-    background: rgba(212, 165, 116, 0.25);
+    background: color-mix(in oklch, var(--combat-antique) 22%, transparent);
   }
   100% {
     background: transparent;
   }
 }
 
-/* Screen effects (damage/block/attack flashes) now rendered by PixiScreenEffects.tsx */
-
-/* Battlefield - full width, enemies centered */
 .combat-scene__battlefield {
   flex: 1;
   display: flex;
@@ -121,7 +144,6 @@
   align-items: center;
   justify-content: center;
   padding: 1rem 2rem;
-  /* Leave space at bottom for hand cards */
   padding-bottom: clamp(200px, 26vh, 280px);
   pointer-events: none;
   position: relative;
@@ -131,32 +153,6 @@
   pointer-events: auto;
 }
 
-/* Undo button - top right of battle area */
-.combat-scene__undo {
-  position: absolute;
-  top: 1rem;
-  right: 1rem;
-  padding: 0.5rem 1rem;
-  font-size: 0.75rem;
-  font-weight: 600;
-  color: #aaa;
-  background: rgba(0, 0, 0, 0.6);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  border-radius: 4px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  z-index: 10;
-}
-
-.combat-scene__undo:hover {
-  color: #fff;
-  background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.3);
-}
-
-/* Enemies container */
 .combat-scene__enemies {
   display: flex;
   gap: 2rem;
@@ -164,191 +160,271 @@
   flex-wrap: wrap;
 }
 
-/* Accumulator HUD - fixed position above hand cards */
-.combat-hud__accumulator {
+/* --------------------------------------------------------------------------
+   Bottom dock: accumulator + CTAs stack once (no overlapping fixed layers)
+   -------------------------------------------------------------------------- */
+.combat-scene__dock {
   position: fixed;
-  bottom: clamp(190px, 26vh, 290px);
   left: 50%;
+  bottom: clamp(11rem, 30vh, 17rem);
   transform: translateX(-50%);
+  z-index: 210;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0.5rem 1.25rem;
-  /* Match PixiJS night palette */
-  background: linear-gradient(
-    135deg,
-    rgba(26, 29, 46, 0.92) 0%,
-    rgba(15, 15, 25, 0.95) 100%
-  );
+  gap: 0.55rem;
+  width: min(96vw, 32rem);
+  max-width: 100%;
+  pointer-events: none;
+}
+
+.combat-scene__dock-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.45rem;
+  pointer-events: auto;
+}
+
+.combat-scene__dock-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+.combat-scene__dock-btn {
+  padding: 0.45rem 1.1rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: none;
   border-radius: 8px;
-  border: 2px solid;
-  z-index: 150; /* Above hand cards */
-  backdrop-filter: blur(4px);
+  cursor: pointer;
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  background: color-mix(in oklch, var(--surface-raised) 94%, oklch(0.12 0.015 78));
+  box-shadow: 0 4px 14px oklch(0.08 0.012 78 / 0.35);
+  transition:
+    background-color 0.18s var(--combat-ease),
+    border-color 0.18s var(--combat-ease),
+    box-shadow 0.18s var(--combat-ease),
+    transform 0.18s var(--combat-ease);
+}
+
+.combat-scene__dock-btn:hover {
+  border-color: var(--combat-tray-edge);
+  background: color-mix(in oklch, var(--surface-hover-lift) 95%, transparent);
+}
+
+.combat-scene__dock-btn:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.combat-scene__dock-btn--primary {
+  border-color: var(--combat-attack-edge);
+  background: color-mix(in oklch, oklch(0.32 0.06 55) 88%, var(--surface-canvas));
+  box-shadow:
+    0 4px 18px oklch(0.12 0.04 55 / 0.35),
+    inset 0 1px 0 oklch(0.92 0.04 72 / 0.08);
+}
+
+.combat-scene__dock-btn--primary:hover {
+  border-color: color-mix(in oklch, var(--combat-antique) 45%, var(--border-strong));
+}
+
+.combat-scene__dock-btn--secondary {
+  font-size: 0.72rem;
+  padding: 0.38rem 0.85rem;
+  color: var(--text-secondary);
+  background: color-mix(in oklch, var(--surface-chrome) 90%, transparent);
+}
+
+.combat-scene__dock-btn--accent {
+  border-color: color-mix(in oklch, oklch(0.62 0.12 72) 40%, var(--border-default));
+  background: color-mix(in oklch, oklch(0.28 0.04 72) 85%, var(--surface-canvas));
+}
+
+.combat-scene__dock-btn--pulse {
+  animation: combat-dock-pulse 2.4s var(--combat-ease) infinite;
+}
+
+@keyframes combat-dock-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 4px 14px oklch(0.08 0.012 78 / 0.35),
+      0 0 0 0 oklch(0.72 0.08 72 / 0);
+  }
+  50% {
+    box-shadow:
+      0 6px 22px oklch(0.1 0.03 55 / 0.4),
+      0 0 0 3px oklch(0.72 0.08 72 / 0.18);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .combat-scene {
+    animation: none;
+  }
+
+  .combat-scene__dock-btn--pulse {
+    animation: none;
+  }
+}
+
+/* --------------------------------------------------------------------------
+   Attack / block accumulator (inside dock; not position:fixed)
+   -------------------------------------------------------------------------- */
+.combat-hud__accumulator {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.45rem 1rem;
+  background: var(--combat-tray-fill);
+  border-radius: 10px;
+  border: 1px solid var(--border-default);
+  box-shadow:
+    0 8px 28px oklch(0.08 0.012 78 / 0.4),
+    inset 0 1px 0 oklch(0.95 0.01 82 / 0.05);
+  pointer-events: auto;
 }
 
 .combat-hud__accumulator--attack {
-  /* Bronze/copper attack accent */
-  border-color: rgba(184, 115, 51, 0.7);
-  box-shadow:
-    0 0 20px rgba(184, 115, 51, 0.25),
-    inset 0 1px 0 rgba(184, 115, 51, 0.15);
+  border-color: var(--combat-attack-edge);
 }
 
 .combat-hud__accumulator--block {
-  /* Verdigris/teal block accent */
-  border-color: rgba(46, 107, 90, 0.7);
-  box-shadow:
-    0 0 20px rgba(46, 107, 90, 0.25),
-    inset 0 1px 0 rgba(46, 107, 90, 0.15);
+  border-color: var(--combat-block-edge);
 }
 
 .combat-hud__accumulator-value {
-  font-size: clamp(1.5rem, 4vw, 2rem);
+  font-size: clamp(1.35rem, 3.5vw, 1.85rem);
   font-weight: 700;
-  color: #fff;
+  color: var(--text-primary);
   line-height: 1;
 }
 
 .combat-hud__accumulator-label {
-  font-size: clamp(0.6rem, 1.5vw, 0.75rem);
+  font-size: clamp(0.62rem, 1.4vw, 0.72rem);
   font-weight: 600;
-  color: #888;
+  color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
 }
 
-/* Elemental breakdown display */
 .combat-hud__elements {
   display: flex;
-  gap: 0.5rem;
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  gap: 0.45rem;
+  margin-top: 0.45rem;
+  padding-top: 0.45rem;
+  border-top: 1px solid var(--border-subtle);
 }
 
 .combat-hud__element {
   display: flex;
   align-items: center;
   gap: 0.2rem;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 600;
-  padding: 0.2rem 0.4rem;
-  border-radius: 3px;
-  background: rgba(255, 255, 255, 0.1);
+  padding: 0.2rem 0.45rem;
+  border-radius: 6px;
+  background: color-mix(in oklch, var(--surface-chrome) 75%, transparent);
 }
 
 .combat-hud__element--physical {
-  color: #a0a5aa;
-  background: rgba(120, 125, 130, 0.15);
+  color: var(--text-secondary);
 }
 
 .combat-hud__element--fire {
-  /* Deep crimson, not bright orange */
-  color: #c06040;
-  background: rgba(160, 64, 48, 0.2);
+  color: oklch(0.72 0.1 25);
+  background: color-mix(in oklch, oklch(0.35 0.08 25) 35%, transparent);
 }
 
 .combat-hud__element--ice {
-  /* Steel blue, muted */
-  color: #6090b0;
-  background: rgba(74, 112, 144, 0.2);
+  color: oklch(0.72 0.08 240);
+  background: color-mix(in oklch, oklch(0.32 0.06 240) 35%, transparent);
 }
 
 .combat-hud__element--coldFire {
-  /* Dusty purple */
-  color: #8a6aaa;
-  background: rgba(106, 74, 138, 0.2);
+  color: oklch(0.7 0.09 290);
+  background: color-mix(in oklch, oklch(0.3 0.07 290) 35%, transparent);
 }
 
 .combat-hud__element--halved {
-  opacity: 0.7;
+  opacity: 0.72;
   text-decoration: line-through;
-  text-decoration-color: rgba(255, 255, 255, 0.5);
+  text-decoration-color: var(--border-strong);
 }
 
 .combat-hud__halved-note {
-  font-size: 0.7rem;
-  /* Burnt sienna warning */
-  color: #c08050;
-  margin-left: 0.2rem;
+  font-size: 0.65rem;
+  color: oklch(0.72 0.1 55);
+  margin-left: 0.15rem;
   text-decoration: none !important;
 }
 
 .combat-hud__resistance-warning {
-  margin-top: 0.5rem;
-  font-size: 0.65rem;
-  /* Burnt sienna warning */
-  color: #c08050;
+  margin-top: 0.4rem;
+  font-size: 0.62rem;
+  color: oklch(0.72 0.1 55);
   text-align: center;
 }
 
-/* Split Ranged/Siege display */
 .combat-hud__accumulator--split {
   flex-direction: row;
-  gap: 1rem;
-  padding: 0.5rem 1rem;
+  gap: 0.85rem;
+  padding: 0.45rem 0.85rem;
 }
 
 .combat-hud__attack-type {
   display: flex;
   flex-direction: column;
   align-items: center;
-  min-width: 50px;
+  min-width: 52px;
 }
 
-.combat-hud__attack-type--warning .combat-hud__accumulator-value {
-  /* Burnt sienna warning */
-  color: #c06040;
-}
-
+.combat-hud__attack-type--warning .combat-hud__accumulator-value,
 .combat-hud__attack-type--warning .combat-hud__accumulator-label {
-  color: #c06040;
+  color: oklch(0.7 0.14 25);
 }
 
 .combat-hud__attack-divider {
   width: 1px;
   align-self: stretch;
-  background: rgba(212, 165, 116, 0.2);
+  background: var(--border-subtle);
 }
 
 .combat-hud__siege-hint {
   font-size: 0.55rem;
-  /* Burnt sienna warning */
-  color: #c06040;
-  margin-top: 0.15rem;
+  color: oklch(0.68 0.12 25);
+  margin-top: 0.12rem;
   white-space: nowrap;
 }
 
-/* ============================================================================
-   Combat Mana Resources Display
-   ============================================================================ */
-
-.combat-scene__mana-resources {
-  position: fixed;
-  top: 0.75rem;
-  right: 8rem; /* To the left of mana source dice */
-  pointer-events: auto;
-  z-index: 200;
+.combat-hud__progress-separator {
+  font-size: 0.8em;
+  color: color-mix(in oklch, var(--combat-antique) 55%, var(--text-muted));
+  margin: 0 0.12em;
 }
 
+/* --------------------------------------------------------------------------
+   Combat mana (personal tray, pairs with dice in top tray)
+   -------------------------------------------------------------------------- */
 .combat-mana {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.4rem 0.6rem;
-  /* Match PixiJS night palette */
-  background: linear-gradient(
-    135deg,
-    rgba(26, 29, 46, 0.95) 0%,
-    rgba(20, 22, 35, 0.95) 100%
-  );
-  /* Dusty purple accent for mana */
-  border: 1px solid rgba(106, 74, 138, 0.4);
+  gap: 0.2rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--combat-tray-fill);
+  border: 1px solid var(--combat-tray-edge);
   border-radius: 8px;
   box-shadow:
-    0 4px 20px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(106, 74, 138, 0.1);
+    0 6px 22px oklch(0.08 0.012 78 / 0.4),
+    inset 0 1px 0 oklch(0.95 0.01 82 / 0.05);
 }
 
 .combat-mana__label {
@@ -356,12 +432,12 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-muted);
 }
 
 .combat-mana__content {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.45rem;
   align-items: center;
 }
 
@@ -372,11 +448,10 @@
 }
 
 .combat-mana__group--tokens {
-  padding-left: 0.4rem;
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
+  padding-left: 0.35rem;
+  border-left: 1px solid var(--border-subtle);
 }
 
-/* Crystals - compact squares with count */
 .combat-mana__crystal {
   display: flex;
   align-items: center;
@@ -384,219 +459,71 @@
   width: 20px;
   height: 20px;
   border-radius: 4px;
-  font-size: 0.7rem;
+  font-size: 0.68rem;
   font-weight: 700;
-  color: #fff;
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+  color: var(--text-primary);
+  border: 1px solid color-mix(in oklch, currentColor 25%, var(--border-default));
 }
 
 .combat-mana__crystal--red {
-  /* Deep ruby red, more fantasy */
-  background: linear-gradient(135deg, #a04040, #802828);
-  box-shadow: 0 0 6px rgba(160, 64, 64, 0.5);
+  background: color-mix(in oklch, oklch(0.42 0.14 25) 90%, var(--surface-canvas));
 }
 
 .combat-mana__crystal--blue {
-  /* Steel blue, muted */
-  background: linear-gradient(135deg, #4a7090, #3a5a70);
-  box-shadow: 0 0 6px rgba(74, 112, 144, 0.5);
+  background: color-mix(in oklch, oklch(0.42 0.1 250) 90%, var(--surface-canvas));
 }
 
 .combat-mana__crystal--green {
-  /* Forest/verdigris green */
-  background: linear-gradient(135deg, #3a8060, #2a6048);
-  box-shadow: 0 0 6px rgba(58, 128, 96, 0.5);
+  background: color-mix(in oklch, oklch(0.42 0.1 145) 90%, var(--surface-canvas));
 }
 
 .combat-mana__crystal--white {
-  /* Ivory/parchment white */
-  background: linear-gradient(135deg, #e8e0d0, #c8c0b0);
-  box-shadow: 0 0 6px rgba(232, 224, 208, 0.5);
-  color: #3a3020;
+  background: color-mix(in oklch, oklch(0.88 0.02 82) 92%, var(--surface-canvas));
+  color: oklch(0.28 0.02 78);
 }
 
-/* Clickable crystals - convert to mana token */
 .combat-mana__crystal--clickable {
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition: transform 0.16s var(--combat-ease), box-shadow 0.16s var(--combat-ease);
 }
 
 .combat-mana__crystal--clickable:hover {
-  transform: scale(1.15);
-  box-shadow: 0 0 10px rgba(255, 255, 255, 0.5);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px oklch(0.08 0.012 78 / 0.35);
 }
 
 .combat-mana__crystal--clickable:active {
-  transform: scale(0.95);
+  transform: translateY(0);
 }
 
-/* Tokens - small colored circles */
 .combat-mana__token {
   width: 14px;
   height: 14px;
   border-radius: 50%;
-  box-shadow:
-    0 0 3px rgba(0, 0, 0, 0.4),
-    inset 0 1px 2px rgba(255, 255, 255, 0.2);
+  border: 1px solid color-mix(in oklch, var(--border-default) 60%, transparent);
+  box-shadow: inset 0 1px 2px oklch(0.95 0.01 82 / 0.12);
 }
 
 .combat-mana__token--red {
-  background: radial-gradient(circle at 30% 30%, #c06060, #802828);
+  background: radial-gradient(circle at 32% 28%, oklch(0.55 0.16 25), oklch(0.32 0.1 25));
 }
 
 .combat-mana__token--blue {
-  background: radial-gradient(circle at 30% 30%, #6090b0, #3a5a70);
+  background: radial-gradient(circle at 32% 28%, oklch(0.55 0.1 250), oklch(0.32 0.07 250));
 }
 
 .combat-mana__token--green {
-  background: radial-gradient(circle at 30% 30%, #50a080, #2a6048);
+  background: radial-gradient(circle at 32% 28%, oklch(0.52 0.11 145), oklch(0.32 0.08 145));
 }
 
 .combat-mana__token--white {
-  background: radial-gradient(circle at 30% 30%, #f0e8d8, #c8c0b0);
+  background: radial-gradient(circle at 32% 28%, oklch(0.9 0.02 82), oklch(0.72 0.02 82));
 }
 
 .combat-mana__token--gold {
-  /* Antique gold matching PixiJS dust palette */
-  background: radial-gradient(circle at 30% 30%, #d4a574, #a08050);
+  background: radial-gradient(circle at 32% 28%, oklch(0.78 0.1 72), oklch(0.55 0.08 72));
 }
 
 .combat-mana__token--black {
-  background: radial-gradient(circle at 30% 30%, #505560, #252830);
+  background: radial-gradient(circle at 32% 28%, oklch(0.42 0.02 78), oklch(0.22 0.015 78));
 }
-
-/* ============================================================================
-   Initiate Attack Buttons (pre-target-selection)
-   ============================================================================ */
-
-.combat-scene__initiate-attacks {
-  position: fixed;
-  bottom: clamp(190px, 26vh, 290px);
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 0.5rem;
-  z-index: 160;
-  pointer-events: auto;
-}
-
-.combat-scene__initiate-attack-btn {
-  padding: 0.6rem 1.5rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  color: #fff;
-  background: linear-gradient(135deg, #a06030, #8b4513);
-  border: 2px solid rgba(184, 115, 51, 0.8);
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-}
-
-.combat-scene__initiate-attack-btn:hover {
-  background: linear-gradient(135deg, #b87040, #9b5523);
-  box-shadow:
-    0 4px 20px rgba(184, 115, 51, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
-}
-
-.combat-scene__initiate-attack-btn--convert {
-  font-size: 0.7rem;
-  padding: 0.4rem 1rem;
-  background: linear-gradient(135deg, #4a5060, #3a3a48);
-  border-color: rgba(160, 165, 180, 0.5);
-}
-
-.combat-scene__initiate-attack-btn--convert:hover {
-  background: linear-gradient(135deg, #5a6070, #4a4a58);
-  border-color: rgba(160, 165, 180, 0.7);
-}
-
-/* ============================================================================
-   Target-First Combat Action Buttons
-   ============================================================================ */
-
-/* Shared base for all target-first action buttons */
-.combat-scene__declare-targets,
-.combat-scene__finalize-attack,
-.combat-scene__finalize-block {
-  position: fixed;
-  bottom: clamp(190px, 26vh, 290px);
-  left: 50%;
-  transform: translateX(-50%);
-  padding: 0.6rem 1.5rem;
-  font-size: 0.85rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.15s ease;
-  z-index: 160;
-  pointer-events: auto;
-  box-shadow:
-    0 4px 16px rgba(0, 0, 0, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
-}
-
-/* Declare Targets - bronze/attack accent */
-.combat-scene__declare-targets {
-  color: #fff;
-  background: linear-gradient(135deg, #a06030, #8b4513);
-  border: 2px solid rgba(184, 115, 51, 0.8);
-}
-
-.combat-scene__declare-targets:hover {
-  background: linear-gradient(135deg, #b87040, #9b5523);
-  box-shadow:
-    0 4px 20px rgba(184, 115, 51, 0.4),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
-}
-
-/* Finalize Attack - bronze/copper accent */
-.combat-scene__finalize-attack {
-  color: #fff;
-  background: linear-gradient(135deg, #b87333, #a06030);
-  border: 2px solid rgba(184, 115, 51, 0.9);
-  animation: combat-btn-pulse 2s ease-in-out infinite;
-}
-
-.combat-scene__finalize-attack:hover {
-  background: linear-gradient(135deg, #c88343, #b07040);
-  box-shadow:
-    0 4px 20px rgba(184, 115, 51, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
-}
-
-/* Finalize Block - verdigris/defense accent */
-.combat-scene__finalize-block {
-  color: #fff;
-  background: linear-gradient(135deg, #2e6b5a, #1a4d3e);
-  border: 2px solid rgba(46, 107, 90, 0.9);
-  animation: combat-btn-pulse 2s ease-in-out infinite;
-}
-
-.combat-scene__finalize-block:hover {
-  background: linear-gradient(135deg, #3e7b6a, #2a5d4e);
-  box-shadow:
-    0 4px 20px rgba(46, 107, 90, 0.5),
-    inset 0 1px 0 rgba(255, 255, 255, 0.15);
-}
-
-@keyframes combat-btn-pulse {
-  0%, 100% { box-shadow: 0 4px 16px rgba(0, 0, 0, 0.5), inset 0 1px 0 rgba(255, 255, 255, 0.1); }
-  50% { box-shadow: 0 4px 24px rgba(255, 255, 255, 0.15), inset 0 1px 0 rgba(255, 255, 255, 0.15); }
-}
-
-
-/* Attack progress separator in accumulator */
-.combat-hud__progress-separator {
-  font-size: 0.8em;
-  color: rgba(212, 165, 116, 0.6);
-  margin: 0 0.15em;
-}
-

--- a/packages/client/src/components/Combat/CombatOverlay.tsx
+++ b/packages/client/src/components/Combat/CombatOverlay.tsx
@@ -499,6 +499,25 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
       {/* PixiJS Screen Effects - damage/block/attack flashes */}
       <PixiScreenEffects activeEffect={activeEffect} effectKey={effectKey} />
 
+      <div className="combat-scene__top-tray" aria-label="Combat mana and dice">
+        <div className="combat-scene__mana-resources">
+          <CombatManaDisplay />
+        </div>
+        <div className="combat-scene__mana-source">
+          <ManaSourceOverlay />
+        </div>
+      </div>
+
+      {combatActions.canUndo && combatActions.undoAction && (
+        <button
+          className="combat-scene__undo"
+          onClick={() => sendAction(combatActions.undoAction!)}
+          type="button"
+        >
+          Undo
+        </button>
+      )}
+
       {/* PixiJS Phase Rail - renders to canvas */}
       <PixiPhaseRail
         currentPhase={phase}
@@ -529,41 +548,20 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
       {/* Main layout: battle area */}
       <div className="combat-scene__layout">
         <div className="combat-scene__battlefield">
-          {/* Undo button */}
-          {combatActions.canUndo && combatActions.undoAction && (
-            <button
-              className="combat-scene__undo"
-              onClick={() => sendAction(combatActions.undoAction!)}
-              type="button"
-            >
-              Undo
-            </button>
-          )}
-
-          {/* Mana Source */}
-          <div className="combat-scene__mana-source">
-            <ManaSourceOverlay />
-          </div>
-
-          {/* Player's mana tokens/crystals */}
-          <div className="combat-scene__mana-resources">
-            <CombatManaDisplay />
-          </div>
-
           {/* Enemies - layout placeholder for positioning */}
           <div className="combat-scene__enemies" />
         </div>
       </div>
 
-      {/* === Action buttons — outside layout to avoid z-index stacking context === */}
-
-      {/* Convert Move to Attack buttons */}
+      <div className="combat-scene__dock" aria-label="Combat status and actions">
+        <AccumulatorDisplay />
+        <div className="combat-scene__dock-actions">
           {combatActions.convertMoveToAttack.length > 0 && !combatActions.isSelectingTargets && (
-            <div className="combat-scene__initiate-attacks">
+            <div className="combat-scene__dock-row combat-scene__dock-row--wrap">
               {combatActions.convertMoveToAttack.map((opt, i) => (
                 <button
                   key={`convert-move-${i}`}
-                  className="combat-scene__initiate-attack-btn combat-scene__initiate-attack-btn--convert"
+                  className="combat-scene__dock-btn combat-scene__dock-btn--secondary"
                   onClick={() => sendAction(opt.action)}
                   type="button"
                 >
@@ -573,60 +571,55 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
             </div>
           )}
 
-          {/* Subset Confirm button (target selection active) */}
           {combatActions.isSelectingTargets && combatActions.subsetConfirmAction && (
             <button
-              className="combat-scene__declare-targets"
+              className="combat-scene__dock-btn combat-scene__dock-btn--primary"
               onClick={() => sendAction(combatActions.subsetConfirmAction!)}
               type="button"
             >
-              Confirm Targets
+              Confirm targets
             </button>
           )}
 
-{/* Resolve Attack button (targets declared, attack sufficient) */}
           {combatActions.resolveAttackAction && (
             <button
-              className="combat-scene__declare-targets"
+              className="combat-scene__dock-btn combat-scene__dock-btn--primary combat-scene__dock-btn--pulse"
               onClick={() => {
                 triggerEffect("attack");
                 sendAction(combatActions.resolveAttackAction!);
               }}
               type="button"
             >
-              Resolve Attack
+              Resolve attack
             </button>
           )}
 
-          {/* Convert Influence to Block buttons */}
           {combatActions.convertInfluenceToBlock.length > 0 && (
-            <div className="combat-scene__convert-influence">
+            <div className="combat-scene__dock-row combat-scene__dock-row--wrap">
               {combatActions.convertInfluenceToBlock.map((opt, i) => (
                 <button
                   key={`convert-inf-${i}`}
-                  className="combat-scene__convert-influence-btn"
+                  className="combat-scene__dock-btn combat-scene__dock-btn--secondary"
                   onClick={() => sendAction(opt.action)}
                   type="button"
                 >
-                  Convert {opt.influencePoints} Influence \u2192 Block
+                  Convert {opt.influencePoints} influence \u2192 block
                 </button>
               ))}
             </div>
           )}
 
-          {/* Heroes Assault action */}
           {combatActions.payHeroesAssaultAction && (
             <button
-              className="combat-scene__heroes-assault-btn"
+              className="combat-scene__dock-btn combat-scene__dock-btn--accent"
               onClick={() => sendAction(combatActions.payHeroesAssaultAction!)}
               type="button"
             >
               Pay Heroes Assault
             </button>
           )}
-
-      {/* Accumulated power display */}
-      <AccumulatorDisplay />
+        </div>
+      </div>
 
       {/* Enemy Detail Panel - full rulebook details */}
       {selectedEnemy && (

--- a/packages/client/src/components/GameView.tsx
+++ b/packages/client/src/components/GameView.tsx
@@ -135,7 +135,7 @@ export function GameView() {
             onNavigateToUnitOffer={handleNavigateToUnitOffer}
             onNavigateToSpellOffer={handleNavigateToSpellOffer}
           />
-          <ManaSourceOverlay />
+          {!inCombat && <ManaSourceOverlay />}
         </div>
       </main>
 

--- a/packages/client/src/components/Setup/HeroCard.tsx
+++ b/packages/client/src/components/Setup/HeroCard.tsx
@@ -1,8 +1,8 @@
 /**
- * Hero card component for setup screen.
- * Displays a hero portrait with selection state.
+ * Hero strip tile for setup (octagonal agon portrait).
  */
 
+import type { CSSProperties } from "react";
 import type { HeroId } from "@mage-knight/shared";
 import { HERO_NAMES } from "@mage-knight/shared";
 import { getHeroTokenUrl } from "../../assets/assetPaths";
@@ -14,21 +14,27 @@ const PLAYER_COLORS = ["#8b4513", "#1a4d3e", "#7c5e10", "#2c4a6e"];
 interface HeroCardProps {
   /** Hero to display */
   hero: HeroId;
+  /** Compact agon tile for bottom filmstrip */
+  strip?: boolean;
   /** Whether this hero is currently selected by the active player slot */
   selected: boolean;
   /** Whether this hero is disabled (already selected by another player) */
   disabled: boolean;
   /** If selected, which player index (0-based) for the badge color */
   playerIndex?: number;
+  /** Hover preview on strip (updates spotlight hero) */
+  onHover?: () => void;
   /** Click handler */
   onClick: () => void;
 }
 
 export function HeroCard({
   hero,
+  strip = false,
   selected,
   disabled,
   playerIndex,
+  onHover,
   onClick,
 }: HeroCardProps) {
   const imagePath = getHeroTokenUrl(hero);
@@ -37,31 +43,35 @@ export function HeroCard({
   return (
     <button
       type="button"
-      className={`hero-card ${selected ? "hero-card--selected" : ""} ${disabled ? "hero-card--disabled" : ""}`}
+      className={`hero-card ${strip ? "hero-card--strip" : ""} ${selected ? "hero-card--selected" : ""} ${disabled ? "hero-card--disabled" : ""}`}
       onClick={disabled ? undefined : onClick}
+      onMouseEnter={strip && onHover && !disabled ? onHover : undefined}
       disabled={disabled}
-      style={{
-        borderColor:
-          selected && playerIndex !== undefined
-            ? PLAYER_COLORS[playerIndex]
-            : undefined,
-      }}
+      style={
+        selected && playerIndex !== undefined
+          ? ({
+              "--hero-seat-ring": PLAYER_COLORS[playerIndex],
+            } as CSSProperties)
+          : undefined
+      }
     >
-      <img
-        src={imagePath}
-        alt={heroName}
-        className="hero-card__image"
-        decoding="async"
-        draggable={false}
-      />
-      <div className="hero-card__name">{heroName}</div>
+      <span className="hero-card__figure">
+        <img
+          src={imagePath}
+          alt=""
+          className="hero-card__image"
+          decoding="async"
+          draggable={false}
+        />
+      </span>
+      <span className="hero-card__name">{heroName}</span>
       {playerIndex !== undefined && (
-        <div
+        <span
           className="hero-card__player-badge"
           style={{ backgroundColor: PLAYER_COLORS[playerIndex] }}
         >
           P{playerIndex + 1}
-        </div>
+        </span>
       )}
     </button>
   );

--- a/packages/client/src/components/Setup/HeroSelectionGrid.tsx
+++ b/packages/client/src/components/Setup/HeroSelectionGrid.tsx
@@ -1,11 +1,16 @@
 /**
- * Hero selection grid for game setup.
- * Displays available heroes and tracks which players have selected which heroes.
+ * Hero selection: Divinity-style full-stage spotlight + bottom filmstrip.
+ * Uses octagonal agon portraits (`*_card.png`), not circular crops.
  */
 
+import { useCallback, useEffect, useState } from "react";
 import type { HeroId } from "@mage-knight/shared";
+import { HERO_NAMES } from "@mage-knight/shared";
+import { getHeroTokenUrl } from "../../assets/assetPaths";
 import { HeroCard } from "./HeroCard";
 import "./SetupScreen.css";
+
+const SETUP_HERO_ROSTER_ARIA_LABEL = "Choose a hero from the roster strip" as const;
 
 interface HeroSelectionGridProps {
   /** Heroes available for selection */
@@ -24,53 +29,105 @@ export function HeroSelectionGrid({
   onSelectHero,
   currentPlayerIndex,
 }: HeroSelectionGridProps) {
-  /**
-   * Check if a hero is available for selection by the current player.
-   * A hero is available if:
-   * 1. It's not selected by any player, OR
-   * 2. It's selected by the current player (they can re-select it)
-   */
-  const isHeroAvailable = (hero: HeroId): boolean => {
-    const selectedIndex = selectedHeroes.indexOf(hero);
-    return selectedIndex === -1 || selectedIndex === currentPlayerIndex;
-  };
+  const isHeroAvailable = useCallback(
+    (hero: HeroId): boolean => {
+      const selectedIndex = selectedHeroes.indexOf(hero);
+      return selectedIndex === -1 || selectedIndex === currentPlayerIndex;
+    },
+    [currentPlayerIndex, selectedHeroes]
+  );
 
-  /**
-   * Get which player index has selected a given hero.
-   * Returns undefined if hero is not selected.
-   */
-  const getPlayerIndexForHero = (hero: HeroId): number | undefined => {
-    const index = selectedHeroes.indexOf(hero);
-    return index >= 0 ? index : undefined;
-  };
+  const getPlayerIndexForHero = useCallback(
+    (hero: HeroId): number | undefined => {
+      const index = selectedHeroes.indexOf(hero);
+      return index >= 0 ? index : undefined;
+    },
+    [selectedHeroes]
+  );
 
-  // Check if all players have selected
-  const allSelected = selectedHeroes.every((h) => h !== null);
+  const [spotlightHero, setSpotlightHero] = useState<HeroId>(
+    () => availableHeroes[0]!
+  );
+
+  useEffect(() => {
+    const assigned = selectedHeroes[currentPlayerIndex];
+    if (assigned != null) {
+      setSpotlightHero(assigned);
+      return;
+    }
+    const firstFree = availableHeroes.find((h) => isHeroAvailable(h));
+    setSpotlightHero(firstFree ?? availableHeroes[0]!);
+  }, [
+    availableHeroes,
+    currentPlayerIndex,
+    isHeroAvailable,
+    selectedHeroes,
+  ]);
+
+  const handleStripHover = useCallback(
+    (hero: HeroId) => {
+      if (isHeroAvailable(hero)) {
+        setSpotlightHero(hero);
+      }
+    },
+    [isHeroAvailable]
+  );
+
+  const splashUrl = getHeroTokenUrl(spotlightHero);
+  const splashName = HERO_NAMES[spotlightHero];
+  const selectedByIndex = getPlayerIndexForHero(spotlightHero);
+  const heroState = selectedByIndex === undefined ? "Available" : null;
 
   return (
-    <div className="hero-selection-grid">
-      <h2 className="setup-section-title">
-        {allSelected
-          ? "Warband ready"
-          : `Mage Knight ${currentPlayerIndex + 1}: choose your hero`}
-      </h2>
-      <div className="hero-grid">
-        {availableHeroes.map((hero) => {
-          const playerIndex = getPlayerIndexForHero(hero);
-          const isSelected = selectedHeroes[currentPlayerIndex] === hero;
-          const isDisabled = !isHeroAvailable(hero);
+    <div
+      className="setup-hero-stage"
+      role="region"
+      aria-label={SETUP_HERO_ROSTER_ARIA_LABEL}
+    >
+      <div
+        key={spotlightHero}
+        className="setup-hero-splash-bg"
+        style={{ backgroundImage: `url(${splashUrl})` }}
+        aria-hidden
+      />
+      <div className="setup-hero-splash-scrim" aria-hidden />
+      <div className="setup-hero-splash-vignette" aria-hidden />
 
-          return (
-            <HeroCard
-              key={hero}
-              hero={hero}
-              selected={isSelected}
-              disabled={isDisabled}
-              playerIndex={playerIndex}
-              onClick={() => onSelectHero(currentPlayerIndex, hero)}
-            />
-          );
-        })}
+      <div className="setup-hero-stage-inner">
+        <div key={spotlightHero} className="setup-hero-splash-main">
+          <img
+            src={splashUrl}
+            alt=""
+            className="setup-hero-splash-token"
+            decoding="async"
+            draggable={false}
+          />
+          <p className="setup-hero-splash-name">{splashName}</p>
+          {heroState ? (
+            <p className="setup-hero-splash-state">{heroState}</p>
+          ) : null}
+        </div>
+
+        <div className="setup-hero-strip" role="presentation">
+          {availableHeroes.map((hero) => {
+            const playerIndex = getPlayerIndexForHero(hero);
+            const isSelected = selectedHeroes[currentPlayerIndex] === hero;
+            const isDisabled = !isHeroAvailable(hero);
+
+            return (
+              <HeroCard
+                key={hero}
+                hero={hero}
+                strip
+                selected={isSelected}
+                disabled={isDisabled}
+                playerIndex={playerIndex}
+                onHover={() => handleStripHover(hero)}
+                onClick={() => onSelectHero(currentPlayerIndex, hero)}
+              />
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/packages/client/src/components/Setup/PlayerCountSelector.tsx
+++ b/packages/client/src/components/Setup/PlayerCountSelector.tsx
@@ -1,9 +1,11 @@
 /**
  * Player count selector for game setup.
- * Displays 1-4 buttons to choose the number of players.
+ * Displays 1-4 controls to choose the number of players.
  */
 
 import "./SetupScreen.css";
+
+const SETUP_PLAYERS_GROUP_ARIA = "Number of players" as const;
 
 interface PlayerCountSelectorProps {
   /** Currently selected player count */
@@ -28,16 +30,20 @@ export function PlayerCountSelector({
   );
 
   return (
-    <div className="player-count-selector">
-      <h2 className="setup-section-title">Mage Knights</h2>
-      <p className="setup-section-hint">How many players at the table?</p>
-      <div className="count-buttons">
+    <div
+      className="setup-players"
+      role="group"
+      aria-label={SETUP_PLAYERS_GROUP_ARIA}
+    >
+      <span className="setup-players__label">Players</span>
+      <div className="setup-players__rail">
         {counts.map((count) => (
           <button
             key={count}
             type="button"
-            className={`count-button ${count === selectedCount ? "count-button--selected" : ""}`}
+            className={`setup-players__btn ${count === selectedCount ? "setup-players__btn--on" : ""}`}
             onClick={() => onSelectCount(count)}
+            aria-pressed={count === selectedCount}
           >
             {count}
           </button>

--- a/packages/client/src/components/Setup/SetupScreen.css
+++ b/packages/client/src/components/Setup/SetupScreen.css
@@ -21,6 +21,7 @@
   --setup-pad-inline: clamp(0.45rem, 2.2vw, 1.15rem);
   --setup-pad-block-start: clamp(0.45rem, 1.6vmin, 0.95rem);
   --setup-pad-block-end: clamp(0.4rem, 1.4vmin, 0.75rem);
+  --setup-hud-space: 3.7rem;
 
   position: relative;
   isolation: isolate;
@@ -68,103 +69,113 @@
 /* --- HUD --- */
 
 .setup-screen__hud {
-  position: relative;
-  z-index: 1;
-  flex-shrink: 0;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.65rem 1rem;
-  padding: 0.25rem clamp(0.3rem, 1vw, 0.65rem) 0;
+  position: absolute;
+  inset: var(--setup-pad-block-start) var(--setup-pad-inline) auto;
+  z-index: 5;
+  min-height: var(--setup-hud-space);
+  padding: 0;
+  pointer-events: none;
 }
 
 .setup-screen__brand {
+  position: absolute;
+  top: 0.3rem;
+  left: clamp(0.55rem, 1.6vw, 1.35rem);
   display: flex;
-  flex-direction: column;
-  gap: 0.22rem;
-  min-width: min(100%, 12rem);
-}
-
-.setup-screen__scenario {
-  margin: 0;
-  max-width: 36ch;
-  font-size: 0.66rem;
-  font-weight: 800;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--setup-muted);
+  align-items: center;
+  pointer-events: auto;
 }
 
 .setup-screen__party {
-  flex: 1 1 auto;
-  display: flex;
-  justify-content: flex-end;
+  position: absolute;
+  top: 0.1rem;
+  right: clamp(0.55rem, 1.6vw, 1.35rem);
+  display: inline-flex;
   align-items: center;
-  gap: clamp(0.55rem, 1.7vw, 1rem);
-  min-width: min(100%, 20rem);
+  gap: 0.55rem;
+  pointer-events: auto;
+}
+
+.setup-screen__back {
+  min-width: 4.8rem;
+  padding: 0.52rem 0.78rem 0.48rem;
+  border: 1px solid oklch(0.38 0.04 66 / 0.5);
+  border-radius: 4px;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: oklch(0.78 0.035 78 / 0.86);
+  cursor: pointer;
+  background:
+    linear-gradient(180deg, oklch(0.15 0.022 56 / 0.76), oklch(0.08 0.016 55 / 0.82));
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.045),
+    0 8px 18px oklch(0.04 0.016 58 / 0.26);
+}
+
+.setup-screen__back:hover {
+  color: var(--setup-cream);
+  border-color: oklch(0.58 0.07 76 / 0.62);
 }
 
 .setup-screen__seats {
   display: flex;
   justify-content: center;
-  gap: 0.3rem;
+  gap: 0.18rem;
+  width: 4.05rem;
+  padding: 0.28rem 0.32rem;
+  border: 1px solid oklch(0.38 0.035 60 / 0.45);
+  border-radius: 999px;
+  background:
+    linear-gradient(180deg, oklch(0.15 0.022 56 / 0.76), oklch(0.08 0.016 55 / 0.82));
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.045),
+    0 8px 18px oklch(0.04 0.016 58 / 0.26);
 }
 
 .setup-seat-chip {
-  min-width: 5.15rem;
-  max-width: 7.2rem;
+  position: relative;
+  width: 0.72rem;
+  height: 0.72rem;
   display: flex;
   align-items: center;
-  gap: 0.32rem;
-  padding: 0.28rem 0.42rem;
-  border: 1px solid oklch(0.34 0.034 60 / 0.6);
-  border-radius: 6px;
-  color: var(--setup-faint);
-  background: oklch(0.1 0.02 56 / 0.68);
-  box-shadow: inset 0 1px 0 oklch(0.95 0.02 82 / 0.035);
+  justify-content: center;
+  border: 1px solid oklch(0.35 0.03 62 / 0.45);
+  border-radius: 999px;
+  background:
+    radial-gradient(circle at 45% 35%, oklch(0.3 0.036 64 / 0.45), oklch(0.08 0.016 56 / 0.65));
+  opacity: 0.42;
+  transition:
+    opacity 0.22s var(--ease-out-expo),
+    border-color 0.22s var(--ease-out-expo),
+    background 0.22s var(--ease-out-expo),
+    box-shadow 0.22s var(--ease-out-expo);
+}
+
+.setup-seat-chip__mark {
+  width: 0.28rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: oklch(0.52 0.04 72 / 0.5);
+}
+
+.setup-seat-chip--enabled {
+  opacity: 1;
+  border-color: oklch(0.49 0.052 70 / 0.58);
 }
 
 .setup-seat-chip--active {
-  color: var(--setup-cream);
   border-color: oklch(0.72 0.095 78 / 0.72);
   background:
-    linear-gradient(180deg, oklch(0.23 0.035 58 / 0.9), oklch(0.14 0.023 56 / 0.94));
+    radial-gradient(circle at 45% 35%, oklch(0.76 0.1 78 / 0.9), oklch(0.37 0.06 58 / 0.78));
   box-shadow:
-    inset 0 1px 0 oklch(0.95 0.03 82 / 0.08),
-    0 0 0 1px oklch(0.08 0.02 58 / 0.45),
-    0 0 20px oklch(0.62 0.08 78 / 0.14);
+    inset 0 1px 0 oklch(0.95 0.03 82 / 0.18),
+    0 0 14px oklch(0.62 0.08 78 / 0.24);
 }
 
-.setup-seat-chip--filled:not(.setup-seat-chip--active) {
-  color: var(--setup-muted);
-  border-color: oklch(0.48 0.06 72 / 0.52);
-}
-
-.setup-seat-chip__label {
-  flex: 0 0 auto;
-  width: 1.2rem;
-  height: 1.2rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 999px;
-  font-size: 0.56rem;
-  font-weight: 900;
-  letter-spacing: 0.02em;
-  color: oklch(0.1 0.02 58);
-  background: var(--setup-gold-dim);
-}
-
-.setup-seat-chip__value {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 0.6rem;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+.setup-seat-chip--filled:not(.setup-seat-chip--active) .setup-seat-chip__mark {
+  background: oklch(0.68 0.08 78 / 0.72);
 }
 
 .setup-screen__seat {
@@ -176,30 +187,216 @@
   color: var(--setup-faint);
 }
 
+/* --- Table setup: seats first, scenario second --- */
+
+.setup-table {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  grid-template-areas:
+    "header settings"
+    "slots settings"
+    "footer settings";
+  gap: clamp(0.9rem, 2vw, 1.4rem);
+  width: min(100%, 74rem);
+  margin: 0 auto;
+  padding: clamp(1rem, 3.4vmin, 2.2rem) clamp(0.3rem, 1.2vw, 0.8rem)
+    clamp(0.4rem, 1vmin, 0.8rem);
+}
+
+.setup-table::before {
+  content: "";
+  position: absolute;
+  inset: -8% -12%;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    radial-gradient(ellipse 45% 44% at 30% 42%, oklch(0.42 0.06 58 / 0.14), transparent 65%),
+    radial-gradient(ellipse 42% 42% at 82% 34%, oklch(0.54 0.06 82 / 0.08), transparent 64%);
+}
+
+.setup-table__header {
+  grid-area: header;
+  align-self: end;
+  padding-left: clamp(0.15rem, 0.7vw, 0.45rem);
+}
+
+.setup-table__eyebrow {
+  margin: 0 0 0.45rem;
+  font-size: 0.62rem;
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: oklch(0.68 0.035 76 / 0.78);
+}
+
+.setup-table__title {
+  margin: 0;
+  font-size: clamp(1.65rem, 4.4vmin, 2.8rem);
+  line-height: 1;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--setup-cream);
+  text-shadow: 0 2px 20px oklch(0.04 0.016 58 / 0.85);
+}
+
+.setup-table__slots {
+  grid-area: slots;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(12rem, 1fr));
+  gap: clamp(0.55rem, 1.4vw, 0.9rem);
+  align-self: stretch;
+}
+
+.setup-table-seat {
+  position: relative;
+  min-height: clamp(8.5rem, 24vmin, 14rem);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  justify-items: center;
+  align-items: center;
+  padding: clamp(0.85rem, 2vmin, 1.15rem);
+  border: 1px solid oklch(0.34 0.03 62 / 0.46);
+  border-radius: 6px;
+  color: oklch(0.58 0.025 72 / 0.72);
+  cursor: pointer;
+  background:
+    linear-gradient(180deg, oklch(0.18 0.023 58 / 0.66), oklch(0.09 0.018 56 / 0.78)),
+    radial-gradient(ellipse 80% 64% at 50% 36%, oklch(0.56 0.055 76 / 0.08), transparent 68%);
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.045),
+    0 14px 34px oklch(0.04 0.016 58 / 0.24);
+  transition:
+    color 0.22s var(--ease-out-expo),
+    border-color 0.22s var(--ease-out-expo),
+    background 0.22s var(--ease-out-expo),
+    transform 0.22s var(--ease-out-expo);
+}
+
+.setup-table-seat:hover {
+  color: var(--setup-cream);
+  border-color: oklch(0.55 0.06 72 / 0.62);
+  transform: translateY(-1px);
+}
+
+.setup-table-seat--open {
+  color: var(--setup-muted);
+  border-color: oklch(0.55 0.065 74 / 0.58);
+  background:
+    linear-gradient(180deg, oklch(0.22 0.028 58 / 0.72), oklch(0.11 0.02 56 / 0.84)),
+    radial-gradient(ellipse 88% 70% at 50% 38%, oklch(0.72 0.08 76 / 0.12), transparent 68%);
+}
+
+.setup-table-seat__number {
+  font-size: 0.6rem;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.setup-table-seat__name {
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: clamp(1.15rem, 3vmin, 1.75rem);
+  font-weight: 700;
+  color: currentColor;
+}
+
+.setup-table-seat__state {
+  min-width: 5rem;
+  padding: 0.38rem 0.7rem;
+  border-top: 1px solid oklch(0.62 0.06 72 / 0.22);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: oklch(0.66 0.035 76 / 0.78);
+}
+
+.setup-table__settings {
+  grid-area: settings;
+  align-self: stretch;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  min-height: 0;
+  padding: clamp(0.8rem, 2vmin, 1.1rem);
+  border: 1px solid oklch(0.36 0.034 62 / 0.5);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, oklch(0.17 0.022 56 / 0.72), oklch(0.08 0.016 55 / 0.86));
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.045),
+    0 16px 38px oklch(0.04 0.016 58 / 0.28);
+}
+
+.setup-table-setting {
+  display: grid;
+  gap: 0.28rem;
+  padding: 0.95rem 0.25rem;
+  border-bottom: 1px solid oklch(0.58 0.04 70 / 0.16);
+}
+
+.setup-table-setting:last-child {
+  border-bottom: 0;
+}
+
+.setup-table-setting__label {
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: oklch(0.56 0.026 72 / 0.78);
+}
+
+.setup-table-setting__value {
+  font-size: clamp(1rem, 2.2vmin, 1.28rem);
+  line-height: 1.2;
+  font-weight: 800;
+  color: var(--setup-cream);
+}
+
+.setup-table-setting--muted .setup-table-setting__value {
+  color: var(--setup-muted);
+}
+
+.setup-table__footer {
+  grid-area: footer;
+  align-self: start;
+}
+
 /* Leather-and-copper player rail */
 
 .setup-players {
   display: inline-flex;
   flex-direction: row;
-  align-items: flex-end;
-  gap: 0.45rem;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .setup-players__label {
-  align-self: center;
-  font-size: 0.56rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: oklch(0.48 0.03 68);
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .setup-players__rail {
   display: inline-flex;
   align-items: center;
   gap: 1px;
-  padding: 4px;
-  border-radius: 6px;
+  padding: 3px;
+  border-radius: 5px;
   background: linear-gradient(
     180deg,
     oklch(0.2 0.028 56 / 0.92) 0%,
@@ -208,7 +405,7 @@
   box-shadow:
     0 1px 0 oklch(0.95 0.02 82 / 0.06),
     inset 0 2px 5px oklch(0.04 0.015 58 / 0.65),
-    0 6px 18px oklch(0.05 0.02 58 / 0.45);
+    0 8px 22px oklch(0.05 0.02 58 / 0.45);
   border: 1px solid oklch(0.38 0.035 60 / 0.55);
 }
 
@@ -346,6 +543,8 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  box-sizing: border-box;
+  padding-top: var(--setup-hud-space);
 }
 
 .setup-hero-splash-main {
@@ -697,13 +896,8 @@
 }
 
 @media (max-height: 560px) {
-  .setup-screen__hud {
-    min-height: auto;
-    padding-block: 0.45rem;
-  }
-
-  .setup-screen__scenario {
-    font-size: 0.58rem;
+  .setup-screen {
+    --setup-hud-space: 3.1rem;
   }
 
   .setup-players__btn {
@@ -727,32 +921,52 @@
 
 @media (max-width: 780px) {
   .setup-screen {
+    --setup-hud-space: 7.4rem;
+
     overflow-y: auto;
   }
 
-  .setup-screen__hud {
-    align-items: stretch;
+  .setup-table {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto auto;
+    grid-template-areas:
+      "header"
+      "slots"
+      "settings"
+      "footer";
+    width: 100%;
+    min-height: auto;
+    padding-top: 0.5rem;
   }
 
-  .setup-screen__brand,
-  .setup-screen__party {
-    flex: 1 1 12rem;
+  .setup-table__slots {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-table-seat {
+    min-height: 6.8rem;
+  }
+
+  .setup-table__settings {
+    min-height: auto;
+  }
+
+  .setup-screen__brand {
+    top: 0;
+    left: 0;
   }
 
   .setup-screen__party {
+    top: 1.9rem;
+    left: 0;
+    right: auto;
     flex-wrap: wrap;
     justify-content: flex-start;
+    max-width: calc(100% - 0.9rem);
   }
 
   .setup-screen__seats {
-    flex-basis: 100%;
     justify-content: flex-start;
-    overflow-x: auto;
-    padding-bottom: 0.15rem;
-  }
-
-  .setup-seat-chip {
-    min-width: 7rem;
   }
 
   .setup-players {

--- a/packages/client/src/components/Setup/SetupScreen.css
+++ b/packages/client/src/components/Setup/SetupScreen.css
@@ -1,312 +1,689 @@
 /**
- * Setup screen: parchment / map-table aesthetic aligned with level-up and combat overlays.
+ * Setup screen: war-council / map-table prelude. Warm brass, umber depth, tactile tokens.
+ * One full-viewport stage (no nested framed panels); ornament stays on surfaces and light.
  */
 
 .setup-screen {
-  --setup-deep: oklch(0.14 0.022 58);
-  --setup-mid: oklch(0.18 0.028 55);
-  --setup-raised: oklch(0.22 0.032 54);
-  --setup-border: oklch(0.42 0.038 62);
-  --setup-border-bright: oklch(0.58 0.065 72);
+  --setup-void: oklch(0.1 0.022 58);
+  --setup-deep: oklch(0.13 0.024 56);
+  --setup-mid: oklch(0.17 0.028 55);
+  --setup-wash: oklch(0.2 0.03 54);
   --setup-gold: oklch(0.78 0.11 82);
-  --setup-gold-soft: oklch(0.68 0.085 78);
+  --setup-gold-dim: oklch(0.62 0.085 78);
+  --setup-ember: oklch(0.72 0.09 58);
+  --setup-cream: oklch(0.93 0.02 82);
   --setup-text: oklch(0.94 0.018 82);
   --setup-muted: oklch(0.72 0.028 72);
-  --setup-faint: oklch(0.58 0.03 68);
-  --setup-bronze: oklch(0.52 0.1 58);
+  --setup-faint: oklch(0.52 0.028 68);
+  --setup-copper: oklch(0.48 0.095 58);
+  --setup-copper-lit: oklch(0.55 0.1 60);
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --setup-pad-inline: clamp(0.45rem, 2.2vw, 1.15rem);
+  --setup-pad-block-start: clamp(0.45rem, 1.6vmin, 0.95rem);
+  --setup-pad-block-end: clamp(0.4rem, 1.4vmin, 0.75rem);
 
+  position: relative;
+  isolation: isolate;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
-  padding: clamp(1.25rem, 4vw, 2.75rem);
-  background:
-    radial-gradient(
-      ellipse 120% 80% at 50% 20%,
-      oklch(0.24 0.04 58) 0%,
-      transparent 55%
-    ),
-    linear-gradient(165deg, var(--setup-deep) 0%, var(--setup-mid) 45%, var(--setup-deep) 100%);
+  overflow: hidden;
+  padding: var(--setup-pad-block-start) var(--setup-pad-inline)
+    var(--setup-pad-block-end);
   color: var(--setup-text);
+  background-color: var(--setup-void);
+  background-image:
+    radial-gradient(ellipse 85% 65% at 50% 108%, oklch(0.06 0.02 58 / 0.88) 0%, transparent 58%),
+    radial-gradient(ellipse 120% 75% at 50% -8%, oklch(0.28 0.045 62 / 0.22) 0%, transparent 42%),
+    radial-gradient(ellipse 70% 48% at 50% 38%, oklch(0.24 0.038 58 / 0.18) 0%, transparent 55%),
+    linear-gradient(168deg, var(--setup-deep) 0%, var(--setup-mid) 46%, oklch(0.11 0.021 56) 100%);
 }
 
-.setup-screen__header {
-  text-align: center;
-  margin-bottom: clamp(1.25rem, 3vw, 2rem);
-  max-width: 42rem;
-}
-
-.setup-screen__title {
-  margin: 0;
-  font-size: clamp(1.85rem, 4.5vw, 2.65rem);
-  font-weight: 700;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--setup-gold);
-  text-shadow:
-    0 2px 10px oklch(0.08 0.02 58 / 0.85),
-    0 0 28px oklch(0.78 0.11 82 / 0.12);
-}
-
-.setup-screen__title::after {
-  content: "";
-  display: block;
-  width: min(220px, 55%);
-  height: 2px;
-  margin: 0.85rem auto 0;
-  background: linear-gradient(
-    90deg,
-    transparent,
-    oklch(0.48 0.045 62) 25%,
-    var(--setup-border-bright) 50%,
-    oklch(0.48 0.045 62) 75%,
-    transparent
-  );
-}
-
-.setup-screen__scenario {
-  margin: 0.85rem 0 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--setup-muted);
-}
-
-.setup-screen__panel {
-  width: min(920px, 100%);
-  padding: clamp(1.5rem, 3vw, 2.35rem) clamp(1.25rem, 3vw, 2.5rem);
-  background: linear-gradient(
-    172deg,
-    oklch(0.22 0.028 54 / 0.96) 0%,
-    oklch(0.17 0.024 52 / 0.98) 100%
-  );
-  border: 3px solid var(--setup-border);
-  border-radius: 10px;
-  box-shadow:
-    0 16px 48px oklch(0.06 0.015 58 / 0.65),
-    inset 0 1px 0 oklch(0.95 0.02 82 / 0.06);
-  position: relative;
-}
-
-.setup-screen__panel::before {
+.setup-screen::before {
   content: "";
   position: absolute;
   inset: 0;
-  border-radius: 7px;
-  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.045'/%3E%3C/svg%3E");
+  z-index: 0;
   pointer-events: none;
+  opacity: 0.55;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.055'/%3E%3C/svg%3E");
 }
 
-.setup-screen__content {
+.setup-screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 72% 58% at 50% 44%,
+    transparent 0%,
+    transparent 38%,
+    oklch(0.07 0.018 58 / 0.72) 100%
+  );
+}
+
+/* --- HUD --- */
+
+.setup-screen__hud {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.65rem 1rem;
+  padding: 0.25rem clamp(0.3rem, 1vw, 0.65rem) 0;
+}
+
+.setup-screen__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.22rem;
+  min-width: min(100%, 12rem);
+}
+
+.setup-screen__scenario {
+  margin: 0;
+  max-width: 36ch;
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--setup-muted);
+}
+
+.setup-screen__party {
+  flex: 1 1 auto;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: clamp(0.55rem, 1.7vw, 1rem);
+  min-width: min(100%, 20rem);
+}
+
+.setup-screen__seats {
+  display: flex;
+  justify-content: center;
+  gap: 0.3rem;
+}
+
+.setup-seat-chip {
+  min-width: 5.15rem;
+  max-width: 7.2rem;
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+  padding: 0.28rem 0.42rem;
+  border: 1px solid oklch(0.34 0.034 60 / 0.6);
+  border-radius: 6px;
+  color: var(--setup-faint);
+  background: oklch(0.1 0.02 56 / 0.68);
+  box-shadow: inset 0 1px 0 oklch(0.95 0.02 82 / 0.035);
+}
+
+.setup-seat-chip--active {
+  color: var(--setup-cream);
+  border-color: oklch(0.72 0.095 78 / 0.72);
+  background:
+    linear-gradient(180deg, oklch(0.23 0.035 58 / 0.9), oklch(0.14 0.023 56 / 0.94));
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.03 82 / 0.08),
+    0 0 0 1px oklch(0.08 0.02 58 / 0.45),
+    0 0 20px oklch(0.62 0.08 78 / 0.14);
+}
+
+.setup-seat-chip--filled:not(.setup-seat-chip--active) {
+  color: var(--setup-muted);
+  border-color: oklch(0.48 0.06 72 / 0.52);
+}
+
+.setup-seat-chip__label {
+  flex: 0 0 auto;
+  width: 1.2rem;
+  height: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  font-size: 0.56rem;
+  font-weight: 900;
+  letter-spacing: 0.02em;
+  color: oklch(0.1 0.02 58);
+  background: var(--setup-gold-dim);
+}
+
+.setup-seat-chip__value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.6rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.setup-screen__seat {
+  margin: 0;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--setup-faint);
+}
+
+/* Leather-and-copper player rail */
+
+.setup-players {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 0.45rem;
+}
+
+.setup-players__label {
+  align-self: center;
+  font-size: 0.56rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: oklch(0.48 0.03 68);
+}
+
+.setup-players__rail {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  padding: 4px;
+  border-radius: 6px;
+  background: linear-gradient(
+    180deg,
+    oklch(0.2 0.028 56 / 0.92) 0%,
+    oklch(0.11 0.02 55 / 0.96) 100%
+  );
+  box-shadow:
+    0 1px 0 oklch(0.95 0.02 82 / 0.06),
+    inset 0 2px 5px oklch(0.04 0.015 58 / 0.65),
+    0 6px 18px oklch(0.05 0.02 58 / 0.45);
+  border: 1px solid oklch(0.38 0.035 60 / 0.55);
+}
+
+.setup-players__btn {
+  position: relative;
+  min-width: 2rem;
+  height: 2rem;
+  padding: 0 0.32rem;
+  border: 1px solid oklch(0.32 0.03 58 / 0.5);
+  border-radius: 4px;
+  font-size: 0.88rem;
+  font-weight: 800;
+  font-variant-numeric: tabular-nums;
+  color: var(--setup-muted);
+  cursor: pointer;
+  background: linear-gradient(
+    165deg,
+    oklch(0.22 0.03 56 / 0.55) 0%,
+    oklch(0.14 0.022 55 / 0.75) 100%
+  );
+  box-shadow: inset 0 1px 0 oklch(0.95 0.02 82 / 0.05);
+  transition:
+    color 0.2s var(--ease-out-expo),
+    border-color 0.2s var(--ease-out-expo),
+    box-shadow 0.2s var(--ease-out-expo),
+    background 0.2s var(--ease-out-expo);
+}
+
+.setup-players__btn:hover:not(.setup-players__btn--on) {
+  color: var(--setup-cream);
+  border-color: oklch(0.48 0.05 62 / 0.55);
+  background: linear-gradient(
+    165deg,
+    oklch(0.28 0.034 58 / 0.65) 0%,
+    oklch(0.16 0.025 56 / 0.85) 100%
+  );
+}
+
+.setup-players__btn--on {
+  color: oklch(0.1 0.02 58);
+  border-color: oklch(0.62 0.1 72 / 0.65);
+  background: linear-gradient(
+    165deg,
+    var(--setup-copper-lit) 0%,
+    var(--setup-copper) 100%
+  );
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.03 82 / 0.22),
+    0 0 0 1px oklch(0.08 0.02 58 / 0.35),
+    0 4px 12px oklch(0.06 0.025 55 / 0.45);
+}
+
+.setup-players__btn:focus-visible {
+  outline: 2px solid var(--setup-gold-dim);
+  outline-offset: 2px;
+}
+
+/* --- Roster: full-stage agon spotlight (DOS2-style) + filmstrip --- */
+
+.setup-screen__roster {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+  min-height: 0;
+  width: calc(100% + 2 * var(--setup-pad-inline));
+  margin-inline: calc(-1 * var(--setup-pad-inline));
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.setup-hero-stage {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
+}
+
+.setup-hero-splash-bg {
+  position: absolute;
+  inset: -12%;
+  z-index: 0;
+  pointer-events: none;
+  background-size: cover;
+  background-position: center 38%;
+  background-repeat: no-repeat;
+  filter: blur(36px) saturate(1.2) brightness(0.38);
+  transform: scale(1.08);
+  animation: setup-hero-bg-bloom 0.52s var(--ease-out-expo) both;
+}
+
+@keyframes setup-hero-bg-bloom {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.setup-hero-splash-scrim {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    oklch(0.08 0.02 58 / 0.55) 0%,
+    oklch(0.1 0.022 58 / 0.35) 38%,
+    oklch(0.11 0.022 56 / 0.72) 100%
+  );
+}
+
+.setup-hero-splash-vignette {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  pointer-events: none;
+  background: radial-gradient(
+    ellipse 72% 70% at 50% 42%,
+    transparent 22%,
+    oklch(0.06 0.018 58 / 0.88) 100%
+  );
+}
+
+.setup-hero-stage-inner {
+  position: relative;
+  z-index: 3;
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: clamp(1.35rem, 3vw, 2rem);
-  position: relative;
-  z-index: 1;
 }
 
-.setup-section-title {
-  font-size: 1.08rem;
-  font-weight: 600;
-  margin: 0 0 0.35rem;
-  color: var(--setup-text);
-  text-align: center;
-  letter-spacing: 0.06em;
-  text-shadow: 0 1px 3px oklch(0.08 0.02 58 / 0.55);
-}
-
-.setup-section-hint {
-  margin: 0 0 1rem;
-  font-size: 0.88rem;
-  font-style: italic;
-  color: var(--setup-muted);
-  text-align: center;
-}
-
-.player-count-selector {
-  text-align: center;
-  padding-bottom: 0.25rem;
-  border-bottom: 1px solid oklch(0.38 0.032 60 / 0.65);
-}
-
-.count-buttons {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  justify-content: center;
-}
-
-.count-button {
-  min-width: 3.25rem;
-  height: 3.25rem;
-  padding: 0 0.85rem;
-  font-size: 1.25rem;
-  font-weight: 700;
-  font-variant-numeric: tabular-nums;
-  border: 2px solid var(--setup-border-bright);
-  border-radius: 8px;
-  background: oklch(0.16 0.022 55 / 0.85);
-  color: var(--setup-gold-soft);
-  cursor: pointer;
-  transition:
-    background-color 0.22s var(--ease-out-expo),
-    border-color 0.22s var(--ease-out-expo),
-    color 0.22s var(--ease-out-expo),
-    box-shadow 0.22s var(--ease-out-expo);
-}
-
-.count-button:hover:not(.count-button--selected) {
-  border-color: var(--setup-gold-soft);
-  background: oklch(0.26 0.035 58 / 0.65);
-  box-shadow: 0 0 0 1px oklch(0.78 0.11 82 / 0.12);
-}
-
-.count-button--selected {
-  background: var(--setup-bronze);
-  border-color: var(--setup-gold);
-  color: oklch(0.12 0.02 58);
-  box-shadow:
-    0 4px 14px oklch(0.08 0.03 55 / 0.55),
-    inset 0 1px 0 oklch(0.92 0.03 82 / 0.22);
-}
-
-.hero-selection-grid {
-  width: 100%;
-}
-
-.hero-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(168px, 1fr));
-  gap: 1.15rem;
-  justify-items: center;
-  max-width: 52rem;
-  margin: 0 auto;
-}
-
-.hero-card {
-  position: relative;
+.setup-hero-splash-main {
+  flex: 1;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 0.7rem 0.65rem 0.65rem;
-  border: 2px solid var(--setup-border);
-  border-radius: 10px;
+  justify-content: center;
+  gap: clamp(0.35rem, 1.5vmin, 0.85rem);
+  padding: 0 0.5rem;
+}
+
+.setup-hero-splash-token {
+  width: auto;
+  height: min(36vh, min(38vw, 340px));
+  max-height: 36vh;
+  max-width: min(86vw, 460px);
+  object-fit: contain;
+  filter: drop-shadow(0 28px 48px oklch(0.05 0.02 58 / 0.75))
+    drop-shadow(0 4px 0 oklch(0.08 0.02 58 / 0.55));
+  animation: setup-hero-token-rise 0.48s var(--ease-out-expo) both;
+}
+
+.setup-hero-splash-name {
+  margin: 0;
+  font-size: clamp(1.65rem, 5vmin, 2.8rem);
+  font-weight: 800;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--setup-cream);
+  text-shadow:
+    0 2px 16px oklch(0.05 0.02 58 / 0.9),
+    0 0 40px oklch(0.55 0.08 72 / 0.15);
+  animation: setup-hero-name-reveal 0.42s var(--ease-out-expo) 0.08s both;
+}
+
+.setup-hero-splash-state {
+  margin: -0.25rem 0 0;
+  min-height: 1rem;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--setup-gold-dim);
+  animation: setup-hero-name-reveal 0.36s var(--ease-out-expo) 0.14s both;
+}
+
+@keyframes setup-hero-token-rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.94);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes setup-hero-name-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Bottom filmstrip: all agon tiles in one row */
+.setup-hero-strip {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: center;
+  align-items: flex-end;
+  gap: clamp(0.35rem, 1.15vw, 0.82rem);
+  padding: clamp(0.6rem, 2vmin, 0.95rem) clamp(0.45rem, 2vw, 1.25rem)
+    clamp(0.35rem, 1.2vmin, 0.6rem);
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  scroll-snap-type: x proximity;
+  scroll-padding-inline: 1rem;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-color: var(--setup-copper-lit) oklch(0.1 0.02 58 / 0.4);
   background: linear-gradient(
-    180deg,
-    oklch(0.2 0.026 54 / 0.92) 0%,
-    oklch(0.14 0.02 52 / 0.94) 100%
+    0deg,
+    oklch(0.06 0.018 58 / 0.92) 0%,
+    oklch(0.1 0.02 58 / 0.45) 55%,
+    transparent 100%
   );
+}
+
+/* Strip agon tile */
+.hero-card {
+  --hero-seat-ring: var(--setup-ember);
+
+  position: relative;
+  flex: 0 0 auto;
+  scroll-snap-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.3rem;
+  width: auto;
+  min-width: clamp(4.55rem, 7vw, 5.65rem);
+  max-width: 5.85rem;
+  padding: 0.36rem 0.32rem 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
   cursor: pointer;
-  width: 100%;
-  max-width: 188px;
+  background: transparent;
   transition:
-    border-color 0.24s var(--ease-out-expo),
-    box-shadow 0.24s var(--ease-out-expo),
-    transform 0.24s var(--ease-out-expo);
+    transform 0.24s var(--ease-out-expo),
+    box-shadow 0.28s var(--ease-out-expo),
+    background-color 0.22s var(--ease-out-expo),
+    border-color 0.22s var(--ease-out-expo);
 }
 
-.hero-card:hover:not(.hero-card--disabled) {
-  transform: translateY(-4px);
-  border-color: var(--setup-border-bright);
-  box-shadow:
-    0 12px 28px oklch(0.06 0.02 58 / 0.55),
-    0 0 0 1px oklch(0.78 0.11 82 / 0.12);
+.hero-card--strip {
+  min-width: clamp(4.55rem, 7vw, 5.65rem);
+  max-width: 5.85rem;
 }
 
-.hero-card:focus-visible {
-  outline: 2px solid var(--setup-gold-soft);
-  outline-offset: 3px;
-}
-
-.hero-card--selected {
-  box-shadow:
-    0 0 0 1px oklch(0.78 0.11 82 / 0.35),
-    0 10px 26px oklch(0.06 0.02 58 / 0.45);
-}
-
-.hero-card--disabled {
-  opacity: 0.38;
-  cursor: not-allowed;
+.hero-card__figure {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: clamp(3.85rem, 12vmin, 5.25rem);
+  transition:
+    transform 0.24s var(--ease-out-expo),
+    filter 0.24s var(--ease-out-expo);
 }
 
 .hero-card__image {
-  width: 100%;
-  max-width: 156px;
-  height: auto;
-  border-radius: 6px;
-  margin-bottom: 0.45rem;
-  border: 1px solid oklch(0.32 0.028 58 / 0.85);
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: 100%;
+  object-fit: contain;
+  filter: drop-shadow(0 6px 12px oklch(0.05 0.02 58 / 0.5));
+  transition:
+    transform 0.24s var(--ease-out-expo),
+    filter 0.24s var(--ease-out-expo);
 }
 
 .hero-card__name {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--setup-text);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--setup-gold-dim);
   text-align: center;
+  line-height: 1.15;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    color 0.2s var(--ease-out-expo),
+    letter-spacing 0.24s var(--ease-out-expo);
+}
+
+.hero-card:hover:not(.hero-card--disabled) {
+  background: oklch(0.18 0.025 58 / 0.35);
+  border-color: oklch(0.54 0.06 68 / 0.35);
+  transform: translateY(-3px);
+}
+
+.hero-card:hover:not(.hero-card--disabled) .hero-card__figure {
+  transform: scale(1.06);
+}
+
+.hero-card:hover:not(.hero-card--disabled) .hero-card__image {
+  filter: drop-shadow(0 10px 20px oklch(0.05 0.02 58 / 0.62))
+    drop-shadow(0 0 18px oklch(0.55 0.08 72 / 0.12));
+}
+
+.hero-card:hover:not(.hero-card--disabled) .hero-card__name {
+  letter-spacing: 0.095em;
+  color: var(--setup-cream);
+}
+
+.hero-card:active:not(.hero-card--disabled) {
+  transform: translateY(-1px) scale(0.98);
+  transition-duration: 0.08s;
+}
+
+.hero-card:active:not(.hero-card--disabled) .hero-card__figure {
+  transform: scale(1.02);
+}
+
+.hero-card:focus-visible {
+  outline: 2px solid var(--setup-gold-dim);
+  outline-offset: 2px;
+}
+
+.hero-card--selected {
+  background: oklch(0.22 0.03 58 / 0.55);
+  border-color: oklch(0.74 0.095 78 / 0.68);
+  box-shadow:
+    0 0 0 2px var(--hero-seat-ring),
+    0 0 24px oklch(0.55 0.08 62 / 0.2);
+  animation: hero-strip-select-settle 0.45s var(--ease-out-expo) both;
+}
+
+@keyframes hero-strip-select-settle {
+  0% {
+    box-shadow:
+      0 0 0 0 oklch(0.95 0.03 82 / 0),
+      0 0 0 0 oklch(0.55 0.08 62 / 0);
+  }
+
+  45% {
+    box-shadow:
+      0 0 0 3px oklch(0.95 0.03 82 / 0.12),
+      0 0 32px oklch(0.62 0.1 72 / 0.28);
+  }
+
+  100% {
+    box-shadow:
+      0 0 0 2px var(--hero-seat-ring),
+      0 0 24px oklch(0.55 0.08 62 / 0.2);
+  }
+}
+
+.hero-card--selected .hero-card__name {
+  color: var(--setup-cream);
+}
+
+.hero-card--disabled {
+  opacity: 0.44;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.hero-card--disabled .hero-card__image {
+  filter: saturate(0.45) brightness(0.85) drop-shadow(0 4px 8px oklch(0.05 0.02 58 / 0.35));
 }
 
 .hero-card__player-badge {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 2rem;
-  height: 2rem;
+  top: 2px;
+  right: 2px;
+  width: 1.45rem;
+  height: 1.45rem;
   border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.72rem;
-  font-weight: 700;
+  font-size: 0.52rem;
+  font-weight: 800;
   letter-spacing: 0.02em;
-  color: oklch(0.96 0.015 82);
-  text-shadow: 0 1px 2px oklch(0.08 0.02 58 / 0.75);
-  box-shadow: 0 2px 10px oklch(0.06 0.02 58 / 0.55);
-  border: 1px solid oklch(0.95 0.02 82 / 0.35);
+  color: oklch(0.97 0.015 82);
+  text-shadow: 0 1px 2px oklch(0.08 0.02 58 / 0.8);
+  box-shadow: 0 2px 6px oklch(0.06 0.02 58 / 0.45);
+  border: 1px solid oklch(0.95 0.02 82 / 0.2);
 }
 
-.start-game-button {
-  align-self: center;
-  padding: 0.85rem 2.4rem;
-  font-size: 1.05rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
+/* --- Commit: forged primary --- */
+
+.setup-screen__footer {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  padding-top: clamp(0.5rem, 1.6vmin, 0.85rem);
+}
+
+.setup-screen__begin {
+  width: 100%;
+  max-width: 26rem;
+  margin-inline: auto;
+  display: block;
+  padding: clamp(0.72rem, 2vmin, 0.95rem) 1.75rem;
+  font-size: clamp(0.78rem, 2.1vmin, 0.98rem);
+  font-weight: 800;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
+  color: oklch(0.12 0.02 58);
+  cursor: pointer;
+  border: 1px solid oklch(0.58 0.09 72 / 0.65);
+  border-radius: 8px;
   background: linear-gradient(
     180deg,
-    oklch(0.48 0.09 58) 0%,
-    oklch(0.4 0.085 56) 100%
+    oklch(0.62 0.11 78) 0%,
+    var(--setup-copper-lit) 38%,
+    var(--setup-copper) 100%
   );
-  border: 2px solid var(--setup-border-bright);
-  border-radius: 8px;
-  color: oklch(0.96 0.02 82);
-  cursor: pointer;
+  text-shadow: 0 1px 0 oklch(0.95 0.02 82 / 0.22);
+  box-shadow:
+    0 2px 0 oklch(0.08 0.02 58 / 0.55),
+    0 10px 28px oklch(0.06 0.025 55 / 0.5),
+    inset 0 2px 0 oklch(0.95 0.03 82 / 0.28);
   transition:
-    filter 0.22s var(--ease-out-expo),
-    box-shadow 0.22s var(--ease-out-expo),
-    transform 0.22s var(--ease-out-expo);
-  box-shadow:
-    0 6px 20px oklch(0.08 0.03 55 / 0.45),
-    inset 0 1px 0 oklch(0.92 0.03 82 / 0.18);
-  margin-top: 0.35rem;
+    filter 0.2s var(--ease-out-expo),
+    box-shadow 0.2s var(--ease-out-expo),
+    transform 0.2s var(--ease-out-expo),
+    opacity 0.2s var(--ease-out-expo);
 }
 
-.start-game-button:hover:not(:disabled) {
+.setup-screen__begin:hover:not(:disabled) {
   filter: brightness(1.06);
-  transform: translateY(-2px);
+  transform: translateY(-1px);
   box-shadow:
-    0 10px 28px oklch(0.08 0.03 55 / 0.5),
-    inset 0 1px 0 oklch(0.92 0.03 82 / 0.22);
+    0 2px 0 oklch(0.08 0.02 58 / 0.55),
+    0 14px 34px oklch(0.06 0.025 55 / 0.55),
+    inset 0 2px 0 oklch(0.95 0.03 82 / 0.32);
 }
 
-.start-game-button:disabled {
-  opacity: 0.42;
+.setup-screen__begin:active:not(:disabled) {
+  transform: translateY(1px);
+  box-shadow:
+    0 1px 0 oklch(0.08 0.02 58 / 0.55),
+    0 4px 14px oklch(0.06 0.025 55 / 0.4),
+    inset 0 2px 4px oklch(0.08 0.02 58 / 0.35);
+}
+
+.setup-screen__begin:disabled {
   cursor: not-allowed;
+  opacity: 0.48;
+  color: oklch(0.42 0.025 62);
+  text-shadow: none;
+  border-color: oklch(0.32 0.025 58 / 0.55);
+  background: linear-gradient(
+    180deg,
+    oklch(0.22 0.025 58 / 0.85) 0%,
+    oklch(0.14 0.02 56 / 0.92) 100%
+  );
+  box-shadow:
+    inset 0 2px 6px oklch(0.05 0.015 58 / 0.5),
+    0 1px 0 oklch(0.95 0.02 82 / 0.04);
   transform: none;
-  filter: grayscale(0.25);
 }
 
 .loading-screen {
@@ -319,25 +696,103 @@
   font-size: 1.5rem;
 }
 
-@media (max-width: 600px) {
-  .hero-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.85rem;
+@media (max-height: 560px) {
+  .setup-screen__hud {
+    min-height: auto;
+    padding-block: 0.45rem;
   }
 
-  .hero-card {
-    max-width: none;
-    padding: 0.55rem;
+  .setup-screen__scenario {
+    font-size: 0.58rem;
   }
 
-  .hero-card__image {
-    max-width: 120px;
+  .setup-players__btn {
+    min-width: 2.1rem;
+    height: 2.1rem;
+    font-size: 0.92rem;
   }
 
-  .start-game-button {
-    width: 100%;
-    max-width: 20rem;
-    padding: 0.75rem 1.5rem;
-    font-size: 0.98rem;
+  .setup-hero-splash-state {
+    display: none;
+  }
+
+  .setup-hero-splash-token {
+    height: min(31vh, min(40vw, 270px));
+  }
+
+  .setup-hero-splash-name {
+    font-size: clamp(1.1rem, 4vmin, 1.85rem);
+  }
+}
+
+@media (max-width: 780px) {
+  .setup-screen {
+    overflow-y: auto;
+  }
+
+  .setup-screen__hud {
+    align-items: stretch;
+  }
+
+  .setup-screen__brand,
+  .setup-screen__party {
+    flex: 1 1 12rem;
+  }
+
+  .setup-screen__party {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+
+  .setup-screen__seats {
+    flex-basis: 100%;
+    justify-content: flex-start;
+    overflow-x: auto;
+    padding-bottom: 0.15rem;
+  }
+
+  .setup-seat-chip {
+    min-width: 7rem;
+  }
+
+  .setup-players {
+    align-items: flex-end;
+  }
+
+  .setup-hero-strip {
+    justify-content: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .setup-hero-splash-bg,
+  .setup-hero-splash-token,
+  .setup-hero-splash-name,
+  .setup-hero-splash-state {
+    animation: none;
+  }
+
+  .hero-card--selected {
+    animation: none;
+  }
+
+  .hero-card,
+  .setup-screen__begin,
+  .setup-players__btn {
+    transition-duration: 0.01ms;
+  }
+
+  .hero-card:hover:not(.hero-card--disabled),
+  .hero-card:active:not(.hero-card--disabled),
+  .setup-screen__begin:hover:not(:disabled) {
+    transform: none;
+  }
+
+  .hero-card:hover:not(.hero-card--disabled) .hero-card__figure {
+    transform: none;
+  }
+
+  .hero-card:hover:not(.hero-card--disabled) .hero-card__name {
+    letter-spacing: 0.08em;
   }
 }

--- a/packages/client/src/components/Setup/SetupScreen.tsx
+++ b/packages/client/src/components/Setup/SetupScreen.tsx
@@ -11,13 +11,19 @@ import {
   SCENARIO_DISPLAY_NAMES,
   SCENARIO_FIRST_RECONNAISSANCE,
 } from "@mage-knight/shared";
-import { PlayerCountSelector } from "./PlayerCountSelector";
 import { HeroSelectionGrid } from "./HeroSelectionGrid";
 import "./SetupScreen.css";
 
 const SETUP_BEGIN_ARIA_READY = "Begin scenario" as const;
 const SETUP_BEGIN_ARIA_PENDING =
   "Begin scenario, locked until every player seat has a hero" as const;
+const SETUP_MAX_PLAYERS = 4;
+type SetupStep = "table" | "heroes";
+
+function getSlotState(index: number, isEnabled: boolean): "Host" | "Seat" | "Closed" {
+  if (!isEnabled) return "Closed";
+  return index === 0 ? "Host" : "Seat";
+}
 
 interface SetupScreenProps {
   /** Callback when setup is complete and game should start */
@@ -25,6 +31,8 @@ interface SetupScreenProps {
 }
 
 export function SetupScreen({ onComplete }: SetupScreenProps) {
+  const [setupStep, setSetupStep] = useState<SetupStep>("table");
+
   // Player count (1-4)
   const [playerCount, setPlayerCount] = useState(1);
 
@@ -35,11 +43,13 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
 
   /**
    * Handle player count change.
-   * Resets hero selections when count changes.
+   * Preserves selections for seats that remain active.
    */
   const handlePlayerCountChange = useCallback((count: number) => {
     setPlayerCount(count);
-    setSelectedHeroes(Array(count).fill(null));
+    setSelectedHeroes((prev) =>
+      Array.from({ length: count }, (_, index) => prev[index] ?? null)
+    );
   }, []);
 
   /**
@@ -95,63 +105,146 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
   const activeSeatIndex =
     currentPlayerIndex >= 0 ? currentPlayerIndex : playerCount - 1;
 
+  const renderSeatSockets = () => (
+    <div className="setup-screen__seats" aria-label="Player seats">
+      {Array.from({ length: SETUP_MAX_PLAYERS }, (_, index) => {
+        const hero = selectedHeroes[index] ?? null;
+        const isEnabled = index < playerCount;
+        const isActive =
+          isEnabled && !allSelected && index === activeSeatIndex;
+        const heroName = hero ? HERO_NAMES[hero] : "Open";
+        const seatLabel = isEnabled
+          ? `Player ${index + 1}: ${heroName}`
+          : `Player ${index + 1}: inactive`;
+
+        return (
+          <div
+            key={`seat-${index + 1}`}
+            className={`setup-seat-chip ${
+              isEnabled ? "setup-seat-chip--enabled" : ""
+            } ${isActive ? "setup-seat-chip--active" : ""} ${
+              hero ? "setup-seat-chip--filled" : ""
+            }`}
+            aria-current={isActive ? "step" : undefined}
+            aria-label={seatLabel}
+          >
+            <span className="setup-seat-chip__mark" aria-hidden="true" />
+          </div>
+        );
+      })}
+    </div>
+  );
+
   return (
     <div className="setup-screen">
-      <header className="setup-screen__hud">
-        <div className="setup-screen__brand">
-          <p className="setup-screen__scenario">{scenarioTitle}</p>
-        </div>
+      {setupStep === "table" ? (
+        <main className="setup-table" aria-label="Table setup">
+          <div className="setup-table__header">
+            <p className="setup-table__eyebrow">Scenario setup</p>
+            <h1 className="setup-table__title">Prepare the table</h1>
+          </div>
 
-        <div className="setup-screen__party">
-          <PlayerCountSelector
-            selectedCount={playerCount}
-            onSelectCount={handlePlayerCountChange}
-          />
-
-          <div className="setup-screen__seats" aria-label="Player seats">
-            {selectedHeroes.map((hero, index) => {
-              const isActive = !allSelected && index === activeSeatIndex;
+          <section className="setup-table__slots" aria-label="Player slots">
+            {Array.from({ length: SETUP_MAX_PLAYERS }, (_, index) => {
+              const isEnabled = index < playerCount;
+              const hero = selectedHeroes[index] ?? null;
               const heroName = hero ? HERO_NAMES[hero] : "Open";
+              const slotState = getSlotState(index, isEnabled);
 
               return (
-                <div
-                  key={`seat-${index + 1}`}
-                  className={`setup-seat-chip ${isActive ? "setup-seat-chip--active" : ""} ${
-                    hero ? "setup-seat-chip--filled" : ""
+                <button
+                  key={`table-seat-${index + 1}`}
+                  type="button"
+                  className={`setup-table-seat ${
+                    isEnabled ? "setup-table-seat--open" : ""
                   }`}
-                  aria-current={isActive ? "step" : undefined}
+                  onClick={() => handlePlayerCountChange(index + 1)}
+                  aria-pressed={isEnabled}
                 >
-                  <span className="setup-seat-chip__label">P{index + 1}</span>
-                  <span className="setup-seat-chip__value">{heroName}</span>
-                </div>
+                  <span className="setup-table-seat__number">
+                    P{index + 1}
+                  </span>
+                  <span className="setup-table-seat__name">
+                    {isEnabled ? heroName : "Closed"}
+                  </span>
+                  <span className="setup-table-seat__state">{slotState}</span>
+                </button>
               );
             })}
-          </div>
-        </div>
-      </header>
+          </section>
 
-      <main className="setup-screen__roster">
-        <HeroSelectionGrid
-          availableHeroes={ALL_HEROES}
-          selectedHeroes={selectedHeroes}
-          onSelectHero={handleSelectHero}
-          currentPlayerIndex={activeSeatIndex}
-        />
-      </main>
+          <section
+            className="setup-table__settings"
+            aria-label="Scenario settings"
+          >
+            <div className="setup-table-setting">
+              <span className="setup-table-setting__label">Scenario</span>
+              <strong className="setup-table-setting__value">
+                {scenarioTitle}
+              </strong>
+            </div>
+            <div className="setup-table-setting">
+              <span className="setup-table-setting__label">Seats</span>
+              <strong className="setup-table-setting__value">
+                {playerCount}
+              </strong>
+            </div>
+            <div className="setup-table-setting setup-table-setting--muted">
+              <span className="setup-table-setting__label">Variants</span>
+              <strong className="setup-table-setting__value">Standard</strong>
+            </div>
+          </section>
 
-      <footer className="setup-screen__footer">
-        <button
-          type="button"
-          className="setup-screen__begin"
-          disabled={!allSelected}
-          onClick={handleStartGame}
-          aria-label={
-            allSelected ? SETUP_BEGIN_ARIA_READY : SETUP_BEGIN_ARIA_PENDING
-          }
-        >
-          Begin scenario
-        </button>
-      </footer>
+          <footer className="setup-table__footer">
+            <button
+              type="button"
+              className="setup-screen__begin setup-screen__begin--ready"
+              onClick={() => setSetupStep("heroes")}
+            >
+              Choose heroes
+            </button>
+          </footer>
+        </main>
+      ) : (
+        <>
+          <header className="setup-screen__hud">
+            <div className="setup-screen__brand">
+              <button
+                type="button"
+                className="setup-screen__back"
+                onClick={() => setSetupStep("table")}
+              >
+                Table
+              </button>
+            </div>
+
+            <div className="setup-screen__party">{renderSeatSockets()}</div>
+          </header>
+
+          <main className="setup-screen__roster">
+            <HeroSelectionGrid
+              availableHeroes={ALL_HEROES}
+              selectedHeroes={selectedHeroes}
+              onSelectHero={handleSelectHero}
+              currentPlayerIndex={activeSeatIndex}
+            />
+          </main>
+
+          <footer className="setup-screen__footer">
+            <button
+              type="button"
+              className="setup-screen__begin"
+              disabled={!allSelected}
+              onClick={handleStartGame}
+              aria-label={
+                allSelected ? SETUP_BEGIN_ARIA_READY : SETUP_BEGIN_ARIA_PENDING
+              }
+            >
+              Begin scenario
+            </button>
+          </footer>
+        </>
+      )}
     </div>
   );
 }

--- a/packages/client/src/components/Setup/SetupScreen.tsx
+++ b/packages/client/src/components/Setup/SetupScreen.tsx
@@ -7,12 +7,17 @@ import { useState, useCallback } from "react";
 import type { GameConfig, HeroId } from "@mage-knight/shared";
 import {
   ALL_HEROES,
+  HERO_NAMES,
   SCENARIO_DISPLAY_NAMES,
   SCENARIO_FIRST_RECONNAISSANCE,
 } from "@mage-knight/shared";
 import { PlayerCountSelector } from "./PlayerCountSelector";
 import { HeroSelectionGrid } from "./HeroSelectionGrid";
 import "./SetupScreen.css";
+
+const SETUP_BEGIN_ARIA_READY = "Begin scenario" as const;
+const SETUP_BEGIN_ARIA_PENDING =
+  "Begin scenario, locked until every player seat has a hero" as const;
 
 interface SetupScreenProps {
   /** Callback when setup is complete and game should start */
@@ -87,39 +92,66 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
   const scenarioTitle =
     SCENARIO_DISPLAY_NAMES[SCENARIO_FIRST_RECONNAISSANCE];
 
+  const activeSeatIndex =
+    currentPlayerIndex >= 0 ? currentPlayerIndex : playerCount - 1;
+
   return (
     <div className="setup-screen">
-      <header className="setup-screen__header">
-        <h1 className="setup-screen__title">Mage Knight</h1>
-        <p className="setup-screen__scenario">{scenarioTitle}</p>
-      </header>
+      <header className="setup-screen__hud">
+        <div className="setup-screen__brand">
+          <p className="setup-screen__scenario">{scenarioTitle}</p>
+        </div>
 
-      <div className="setup-screen__panel">
-        <div className="setup-screen__content">
+        <div className="setup-screen__party">
           <PlayerCountSelector
             selectedCount={playerCount}
             onSelectCount={handlePlayerCountChange}
           />
 
-          <HeroSelectionGrid
-            availableHeroes={ALL_HEROES}
-            selectedHeroes={selectedHeroes}
-            onSelectHero={handleSelectHero}
-            currentPlayerIndex={
-              currentPlayerIndex >= 0 ? currentPlayerIndex : playerCount - 1
-            }
-          />
+          <div className="setup-screen__seats" aria-label="Player seats">
+            {selectedHeroes.map((hero, index) => {
+              const isActive = !allSelected && index === activeSeatIndex;
+              const heroName = hero ? HERO_NAMES[hero] : "Open";
 
-          <button
-            type="button"
-            className="start-game-button"
-            disabled={!allSelected}
-            onClick={handleStartGame}
-          >
-            Begin scenario
-          </button>
+              return (
+                <div
+                  key={`seat-${index + 1}`}
+                  className={`setup-seat-chip ${isActive ? "setup-seat-chip--active" : ""} ${
+                    hero ? "setup-seat-chip--filled" : ""
+                  }`}
+                  aria-current={isActive ? "step" : undefined}
+                >
+                  <span className="setup-seat-chip__label">P{index + 1}</span>
+                  <span className="setup-seat-chip__value">{heroName}</span>
+                </div>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      </header>
+
+      <main className="setup-screen__roster">
+        <HeroSelectionGrid
+          availableHeroes={ALL_HEROES}
+          selectedHeroes={selectedHeroes}
+          onSelectHero={handleSelectHero}
+          currentPlayerIndex={activeSeatIndex}
+        />
+      </main>
+
+      <footer className="setup-screen__footer">
+        <button
+          type="button"
+          className="setup-screen__begin"
+          disabled={!allSelected}
+          onClick={handleStartGame}
+          aria-label={
+            allSelected ? SETUP_BEGIN_ARIA_READY : SETUP_BEGIN_ARIA_PENDING
+          }
+        >
+          Begin scenario
+        </button>
+      </footer>
     </div>
   );
 }

--- a/packages/engine-rs/crates/mk-data/src/scenarios.rs
+++ b/packages/engine-rs/crates/mk-data/src/scenarios.rs
@@ -25,6 +25,7 @@ pub fn first_reconnaissance() -> ScenarioConfig {
         starting_reputation: 0,
         skills_enabled: false,
         elite_units_enabled: false,
+        guarantee_village_unit_in_offer: true,
         pvp_enabled: false,
         spells_available: true,
         advanced_actions_available: true,
@@ -66,6 +67,7 @@ pub fn first_reconnaissance_2p() -> ScenarioConfig {
         starting_reputation: 0,
         skills_enabled: false,
         elite_units_enabled: false,
+        guarantee_village_unit_in_offer: true,
         pvp_enabled: false,
         spells_available: true,
         advanced_actions_available: true,
@@ -99,6 +101,7 @@ pub fn first_reconnaissance_3p() -> ScenarioConfig {
         starting_reputation: 0,
         skills_enabled: false,
         elite_units_enabled: false,
+        guarantee_village_unit_in_offer: true,
         pvp_enabled: false,
         spells_available: true,
         advanced_actions_available: true,
@@ -132,6 +135,7 @@ pub fn first_reconnaissance_4p() -> ScenarioConfig {
         starting_reputation: 0,
         skills_enabled: false,
         elite_units_enabled: false,
+        guarantee_village_unit_in_offer: true,
         pvp_enabled: false,
         spells_available: true,
         advanced_actions_available: true,
@@ -165,6 +169,7 @@ pub fn full_conquest() -> ScenarioConfig {
         starting_reputation: 0,
         skills_enabled: true,
         elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
         pvp_enabled: true,
         spells_available: true,
         advanced_actions_available: true,
@@ -231,6 +236,7 @@ mod tests {
         assert_eq!(config.starting_reputation, 0);
         assert!(!config.skills_enabled);
         assert!(!config.elite_units_enabled);
+        assert!(config.guarantee_village_unit_in_offer);
         assert!(!config.pvp_enabled);
         assert!(config.spells_available);
         assert!(config.advanced_actions_available);

--- a/packages/engine-rs/crates/mk-data/src/unit_offers.rs
+++ b/packages/engine-rs/crates/mk-data/src/unit_offers.rs
@@ -6,17 +6,26 @@
 use mk_types::ids::UnitId;
 use mk_types::rng::RngState;
 
+use mk_types::enums::RecruitSite;
+
 use crate::units::{all_elite_unit_ids, all_regular_unit_ids, get_unit, is_elite_unit};
+
+fn is_village_recruitable(id: &str) -> bool {
+    get_unit(id).is_some_and(|u| u.recruit_sites.contains(&RecruitSite::Village))
+}
 
 /// Create the unit decks (regular + elite) and initial offer.
 ///
 /// Pool: `copies` instances of each unit type, shuffled.
 /// Initial offer: drawn from regular deck only (no Core tiles at game start).
+/// If `guarantee_village_unit` is true and the drawn offer contains no village-recruitable
+/// unit, the first such unit in the remaining deck is swapped into offer[0].
 /// Returns `(regular_deck, elite_deck, offer)`.
 pub fn create_unit_deck_and_offer(
     rng: &mut RngState,
     player_count: usize,
     elite_units_enabled: bool,
+    guarantee_village_unit: bool,
 ) -> (Vec<UnitId>, Vec<UnitId>, Vec<UnitId>) {
     // Build regular pool
     let mut regular_pool: Vec<UnitId> = Vec::new();
@@ -42,7 +51,17 @@ pub fn create_unit_deck_and_offer(
 
     // Initial offer from regular deck only
     let offer_size = (player_count + 2).min(regular_pool.len());
-    let offer: Vec<UnitId> = regular_pool.drain(..offer_size).collect();
+    let mut offer: Vec<UnitId> = regular_pool.drain(..offer_size).collect();
+
+    // Guarantee at least one village-recruitable unit in the offer
+    if guarantee_village_unit && !offer.iter().any(|u| is_village_recruitable(u.as_str())) {
+        if let Some(pos) = regular_pool.iter().position(|u| is_village_recruitable(u.as_str())) {
+            let village_unit = regular_pool.remove(pos);
+            let displaced = std::mem::replace(&mut offer[0], village_unit);
+            regular_pool.insert(0, displaced);
+        }
+    }
+
     (regular_pool, elite_pool, offer)
 }
 
@@ -127,7 +146,7 @@ mod tests {
     #[test]
     fn create_unit_deck_offer_sizes() {
         let mut rng = RngState::new(42);
-        let (deck, elite_deck, offer) = create_unit_deck_and_offer(&mut rng, 1, false);
+        let (deck, elite_deck, offer) = create_unit_deck_and_offer(&mut rng, 1, false, false);
         // Solo: offer = 1 + 2 = 3
         assert_eq!(offer.len(), 3);
         // Elite deck empty when disabled
@@ -143,7 +162,7 @@ mod tests {
     #[test]
     fn create_with_elite_enabled() {
         let mut rng = RngState::new(42);
-        let (regular_deck, elite_deck, offer) = create_unit_deck_and_offer(&mut rng, 1, true);
+        let (regular_deck, elite_deck, offer) = create_unit_deck_and_offer(&mut rng, 1, true, false);
         // Offer still drawn from regular only
         assert_eq!(offer.len(), 3);
         for unit in &offer {
@@ -166,9 +185,9 @@ mod tests {
     #[test]
     fn create_deterministic() {
         let mut rng1 = RngState::new(99);
-        let (deck1, elite1, offer1) = create_unit_deck_and_offer(&mut rng1, 1, true);
+        let (deck1, elite1, offer1) = create_unit_deck_and_offer(&mut rng1, 1, true, false);
         let mut rng2 = RngState::new(99);
-        let (deck2, elite2, offer2) = create_unit_deck_and_offer(&mut rng2, 1, true);
+        let (deck2, elite2, offer2) = create_unit_deck_and_offer(&mut rng2, 1, true, false);
         assert_eq!(offer1, offer2);
         assert_eq!(deck1, deck2);
         assert_eq!(elite1, elite2);
@@ -282,5 +301,51 @@ mod tests {
         // Check decks got returns
         assert!(regular_deck.iter().any(|u| u.as_str() == "peasants"));
         assert!(elite_deck.iter().any(|u| u.as_str() == "fire_mages"));
+    }
+
+    #[test]
+    fn guarantee_village_unit_always_present_across_seeds() {
+        // With guarantee_village_unit=true, every seed must produce an offer
+        // containing at least one village-recruitable unit.
+        for seed in 0u32..200 {
+            let mut rng = RngState::new(seed);
+            let (_, _, offer) = create_unit_deck_and_offer(&mut rng, 1, false, true);
+            assert!(
+                offer.iter().any(|u| is_village_recruitable(u.as_str())),
+                "seed {seed}: offer contained no village-recruitable unit: {:?}",
+                offer.iter().map(|u| u.as_str()).collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn guarantee_false_can_produce_no_village_unit_in_offer() {
+        // Without the guarantee, some seeds produce offers with zero village units.
+        // Confirm at least one such seed exists in our range (sanity check).
+        let found_non_village_offer = (0u32..500).any(|seed| {
+            let mut rng = RngState::new(seed);
+            let (_, _, offer) = create_unit_deck_and_offer(&mut rng, 1, false, false);
+            !offer.iter().any(|u| is_village_recruitable(u.as_str()))
+        });
+        assert!(
+            found_non_village_offer,
+            "expected at least one seed to produce an all-non-village offer when flag=false"
+        );
+    }
+
+    #[test]
+    fn guarantee_preserves_total_card_count() {
+        // Swapping must not create or destroy cards.
+        for seed in 0u32..50 {
+            let mut rng_a = RngState::new(seed);
+            let (deck_a, elite_a, offer_a) = create_unit_deck_and_offer(&mut rng_a, 1, false, true);
+            let mut rng_b = RngState::new(seed);
+            let (deck_b, elite_b, offer_b) = create_unit_deck_and_offer(&mut rng_b, 1, false, false);
+            assert_eq!(
+                deck_a.len() + offer_a.len() + elite_a.len(),
+                deck_b.len() + offer_b.len() + elite_b.len(),
+                "seed {seed}: card count changed after guarantee swap"
+            );
+        }
     }
 }

--- a/packages/engine-rs/crates/mk-engine/src/setup.rs
+++ b/packages/engine-rs/crates/mk-engine/src/setup.rs
@@ -315,7 +315,7 @@ pub fn create_solo_game(seed: u32, hero: Hero) -> GameState {
     let (aa_deck, aa_offer) = create_aa_deck_and_offer(&mut rng);
     let (spell_deck, spell_offer) = create_spell_deck_and_offer(&mut rng);
     let (unit_deck, elite_unit_deck, unit_offer) =
-        create_unit_deck_and_offer(&mut rng, 1, scenario_config.elite_units_enabled);
+        create_unit_deck_and_offer(&mut rng, 1, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
 
     // Create dummy player for solo mode
     let dummy_hero = dummy_player::select_dummy_hero(&[hero], &mut rng);
@@ -463,7 +463,7 @@ pub fn create_multiplayer_game(
     let (aa_deck, aa_offer) = create_aa_deck_and_offer(&mut rng);
     let (spell_deck, spell_offer) = create_spell_deck_and_offer(&mut rng);
     let (unit_deck, elite_unit_deck, unit_offer) =
-        create_unit_deck_and_offer(&mut rng, player_count, scenario_config.elite_units_enabled);
+        create_unit_deck_and_offer(&mut rng, player_count, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
 
     // Day tactics
     let available_tactics: Vec<TacticId> =

--- a/packages/engine-rs/crates/mk-types/src/state.rs
+++ b/packages/engine-rs/crates/mk-types/src/state.rs
@@ -734,6 +734,7 @@ pub struct ScenarioConfig {
     // Special rules
     pub skills_enabled: bool,
     pub elite_units_enabled: bool,
+    pub guarantee_village_unit_in_offer: bool,
     pub pvp_enabled: bool,
     pub spells_available: bool,
     pub advanced_actions_available: bool,

--- a/packages/shared/src/events/narrateEvent.ts
+++ b/packages/shared/src/events/narrateEvent.ts
@@ -152,7 +152,7 @@ export function narrateEvent(
     case "TURN_STARTED": {
       const name = heroNameByIndex(players, event.playerIndex);
       return {
-        text: `--- ${name}'s Turn ---`,
+        text: `${name}'s turn`,
         category: EVENT_CATEGORY.LIFECYCLE,
         isTurnBoundary: true,
       };

--- a/packages/shared/src/events/narrateRustEvent.ts
+++ b/packages/shared/src/events/narrateRustEvent.ts
@@ -255,12 +255,8 @@ export function narrateRustEvent(
 
     case "gameStarted": {
       const hero = event["hero"] as string | undefined;
-      const seed = event["seed"] as number | undefined;
-      const heroLabel = hero ? capitalize(hero) : "Hero";
-      return msg(
-        `Game started — ${heroLabel}${seed != null ? ` (seed ${seed})` : ""}`,
-        EVENT_CATEGORY.LIFECYCLE,
-      );
+      const heroLabel = hero ? capitalize(hero) : "the mage-knight";
+      return msg(`The tale opens with ${heroLabel}.`, EVENT_CATEGORY.LIFECYCLE);
     }
 
     case "turnStarted": {
@@ -268,12 +264,14 @@ export function narrateRustEvent(
       const round = event["round"] as number | undefined;
       const tod = field(event, "time_of_day", "timeOfDay") as string | undefined;
       const todLabel = tod ? formatTimeOfDay(tod) : "";
-      return msg(
-        `--- ${name}'s Turn${round != null ? ` (Round ${round}${todLabel ? `, ${todLabel}` : ""})` : ""} ---`,
-        EVENT_CATEGORY.LIFECYCLE,
-        pid,
-        true,
-      );
+      const when =
+        round != null
+          ? todLabel
+            ? `Round ${round}, ${todLabel}`
+            : `Round ${round}`
+          : todLabel || "";
+      const text = when ? `${when}: ${name}'s turn` : `${name}'s turn`;
+      return msg(text, EVENT_CATEGORY.LIFECYCLE, pid, true);
     }
 
     case "turnEnded": {


### PR DESCRIPTION
## Summary

- **Setup screen table step** — new first step before hero selection lets the host configure seats (click to enable/disable players 1–4) with a scenario settings panel; a "Table" back button returns from hero picker without losing selections
- **Activity feed right dock** — moved from left edge to right side so it never overlaps the combat phase rail; in combat mode it pins to bottom-right at a lower z-index to stay out of the way
- **ManaSourceOverlay hidden in combat** — reduces clutter during fight resolution
- **Narrative polish** — turn boundaries shortened to `Round N, Day: Name's turn`; game-start message rewritten to flavour text
- **Engine: guarantee village-recruitable unit in First Recon offer** — adds `guarantee_village_unit_in_offer: bool` to `ScenarioConfig`; when true, if the initial shuffle yields only non-village units (e.g. Illusionists, Guardian Golems) the first village-recruitable unit in the deck swaps into the offer; enabled for all First Reconnaissance variants

## Test plan

- [ ] Launch a solo First Reconnaissance game across several seeds and confirm at least one of Peasants / Foresters / Herbalist / Scouts / Thugs / Utem Crossbowmen / Utem Guardsmen appears in the unit offer
- [ ] Setup screen: verify clicking a seat slot enables/disables the player; hero selections for remaining active seats are preserved on count change
- [ ] Back button from hero step returns to table step without resetting selections
- [ ] Activity feed appears on the right side during normal play and pins bottom-right during combat
- [ ] ManaSource overlay is hidden while in combat
- [ ] `cargo test && cargo clippy` passes (enforced by pre-push hook)