### PR TITLE
feat: Full Conquest and Blitz Conquest scenarios

### DIFF
--- a/packages/client/__tests__/skillImagePath.test.ts
+++ b/packages/client/__tests__/skillImagePath.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { skillImagePath } from "../src/utils/skillImagePath";
+
+describe("skillImagePath", () => {
+  it("maps co-op skill ids to scanned asset stems", () => {
+    expect(skillImagePath("norowas_prayer_of_weather")).toBe(
+      "/assets/skills/norowas_calming_the_weather_co-op.jpg"
+    );
+    expect(skillImagePath("wolfhawk_wolfs_howl")).toBe(
+      "/assets/skills/wolfhawk_howl_of_the_pack_co-op.jpg"
+    );
+  });
+
+  it("uses the skill id as the stem when no alias exists", () => {
+    expect(skillImagePath("norowas_motivation")).toBe(
+      "/assets/skills/norowas_motivation.jpg"
+    );
+  });
+});

--- a/packages/client/src/components/Combat/CombatOverlay.css
+++ b/packages/client/src/components/Combat/CombatOverlay.css
@@ -144,7 +144,7 @@
   align-items: center;
   justify-content: center;
   padding: 1rem 2rem;
-  padding-bottom: clamp(200px, 26vh, 280px);
+  padding-bottom: clamp(160px, 22vh, 240px);
   pointer-events: none;
   position: relative;
 }
@@ -165,15 +165,15 @@
    -------------------------------------------------------------------------- */
 .combat-scene__dock {
   position: fixed;
-  left: 50%;
-  bottom: clamp(11rem, 30vh, 17rem);
-  transform: translateX(-50%);
+  right: max(1rem, env(safe-area-inset-right, 0px));
+  top: 54%;
+  transform: translateY(-50%);
   z-index: 210;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 0.55rem;
-  width: min(96vw, 32rem);
+  align-items: stretch;
+  gap: 0.48rem;
+  width: min(18rem, 24vw);
   max-width: 100%;
   pointer-events: none;
 }
@@ -181,7 +181,7 @@
 .combat-scene__dock-actions {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: 0.45rem;
   pointer-events: auto;
 }
@@ -189,16 +189,18 @@
 .combat-scene__dock-row {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  justify-content: stretch;
   gap: 0.4rem;
 }
 
 .combat-scene__dock-btn {
-  padding: 0.45rem 1.1rem;
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: none;
+  width: 100%;
+  min-height: 2.6rem;
+  padding: 0.56rem 1.25rem;
+  font-size: 0.82rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
   border-radius: 8px;
   cursor: pointer;
   border: 1px solid var(--border-default);
@@ -236,7 +238,10 @@
 
 .combat-scene__dock-btn--secondary {
   font-size: 0.72rem;
+  min-height: 2rem;
   padding: 0.38rem 0.85rem;
+  text-transform: none;
+  letter-spacing: 0.02em;
   color: var(--text-secondary);
   background: color-mix(in oklch, var(--surface-chrome) 90%, transparent);
 }
@@ -279,10 +284,13 @@
    -------------------------------------------------------------------------- */
 .combat-hud__accumulator {
   position: relative;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: auto auto;
   align-items: center;
-  padding: 0.45rem 1rem;
+  justify-items: center;
+  min-width: 0;
+  width: 100%;
+  padding: 0.52rem 1.15rem 0.5rem;
   background: var(--combat-tray-fill);
   border-radius: 10px;
   border: 1px solid var(--border-default);
@@ -301,18 +309,20 @@
 }
 
 .combat-hud__accumulator-value {
-  font-size: clamp(1.35rem, 3.5vw, 1.85rem);
-  font-weight: 700;
+  font-size: clamp(1.75rem, 3.6vw, 2.4rem);
+  font-weight: 800;
   color: var(--text-primary);
-  line-height: 1;
+  line-height: 0.94;
+  letter-spacing: 0.04em;
 }
 
 .combat-hud__accumulator-label {
-  font-size: clamp(0.62rem, 1.4vw, 0.72rem);
-  font-weight: 600;
+  margin-top: 0.25rem;
+  font-size: clamp(0.64rem, 1.5vw, 0.78rem);
+  font-weight: 750;
   color: var(--text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.11em;
 }
 
 .combat-hud__elements {
@@ -374,9 +384,26 @@
 }
 
 .combat-hud__accumulator--split {
+  display: flex;
   flex-direction: row;
   gap: 0.85rem;
   padding: 0.45rem 0.85rem;
+}
+
+@media (max-width: 1180px) {
+  .combat-scene__dock {
+    left: 50%;
+    right: auto;
+    top: auto;
+    bottom: clamp(8.5rem, 25vh, 12rem);
+    transform: translateX(-50%);
+    width: min(86vw, 24rem);
+    align-items: center;
+  }
+
+  .combat-scene__dock-actions {
+    align-items: center;
+  }
 }
 
 .combat-hud__attack-type {

--- a/packages/client/src/components/Combat/CombatOverlay.tsx
+++ b/packages/client/src/components/Combat/CombatOverlay.tsx
@@ -331,6 +331,10 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
   const { phase, enemies } = combat;
   const { sendAction } = useGame();
   const combatActions = useCombatActions();
+  const [viewportSize, setViewportSize] = useState(() => ({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }));
 
   // Visual effect state - use a counter to force animation restart
   const [activeEffect, setActiveEffect] = useState<EffectType>(null);
@@ -386,6 +390,18 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
   const isAttackPhase = phase === COMBAT_PHASE_ATTACK;
   const isRangedSiegePhase = phase === COMBAT_PHASE_RANGED_SIEGE;
 
+  useEffect(() => {
+    const handleResize = () => {
+      setViewportSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   // Reset damage assignment panel when phase changes
   useEffect(() => {
     setDamageAssignmentEnemy(null);
@@ -393,8 +409,8 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
 
   // Calculate token positions for PixiEnemyCard (must match PixiEnemyTokens layout)
   const enemyCardData = useMemo(() => {
-    const vw = window.innerWidth;
-    const vh = window.innerHeight;
+    const vw = viewportSize.width;
+    const vh = viewportSize.height;
     const tokenSize = Math.min(Math.max(100, Math.min(vw * 0.18, vh * 0.28)), 280);
     const tokenRadius = tokenSize / 2;
 
@@ -470,7 +486,15 @@ function CombatOverlayInner({ combat }: CombatOverlayProps) {
           && combatActions.declaredAttackTargets.includes(enemy.instanceId),
       };
     });
-  }, [enemies, combatActions, isBlockPhase, isDamagePhase, isAttackPhase, isRangedSiegePhase]);
+  }, [
+    enemies,
+    combatActions,
+    isBlockPhase,
+    isDamagePhase,
+    isAttackPhase,
+    isRangedSiegePhase,
+    viewportSize,
+  ]);
 
   // Handle "Take Damage" button on enemy card
   // If units are available, show the DamageAssignmentPanel. Otherwise, send hero damage directly.

--- a/packages/client/src/components/Combat/PixiEnemyCard.tsx
+++ b/packages/client/src/components/Combat/PixiEnemyCard.tsx
@@ -246,7 +246,7 @@ export function PixiEnemyCard({
       container.sortableChildren = true;
 
       container.x = position.x - CARD_WIDTH / 2;
-      container.y = position.y + tokenRadius + 8;
+      container.y = position.y + tokenRadius + 14;
 
       container.layout = {
         ...enemyCardRootLayout(),
@@ -259,7 +259,7 @@ export function PixiEnemyCard({
       const nameContainer = new Container();
       nameContainer.label = "name-section";
       nameContainer.layout = {
-        height: 20,
+        height: 24,
         alignItems: "center",
         justifyContent: "center",
       };
@@ -268,9 +268,12 @@ export function PixiEnemyCard({
         text: enemy.name,
         style: {
           fontFamily: "Arial, sans-serif",
-          fontSize: 14,
+          fontSize: 13,
           fontWeight: "600",
           fill: COLORS.TEXT_PRIMARY,
+          wordWrap: true,
+          wordWrapWidth: CARD_WIDTH,
+          align: "center",
         },
       });
       nameText.layout = {};

--- a/packages/client/src/components/Combat/PixiEnemyTokens.tsx
+++ b/packages/client/src/components/Combat/PixiEnemyTokens.tsx
@@ -288,21 +288,6 @@ export function PixiEnemyTokens({ enemies, onEnemyClick }: PixiEnemyTokensProps)
         tokenContainer.addChild(overlay);
       }
 
-      // Armor indicator (shows armor value below token)
-      if (!enemy.isDefeated) {
-        const armorWidth = 32;
-        const armorHeight = 18;
-        const armorY = radius + 8;
-
-        // Background pill
-        const armorBg = new Graphics();
-        armorBg.roundRect(-armorWidth / 2, armorY, armorWidth, armorHeight, 9);
-        armorBg.fill({ color: COLORS.HEALTH_BG, alpha: 0.9 });
-        armorBg.stroke({ color: COLORS.HEALTH_FILL, width: 1.5 });
-        armorBg.zIndex = 3;
-        tokenContainer.addChild(armorBg);
-      }
-
       // Click handling
       border.eventMode = "static";
       border.cursor = "pointer";

--- a/packages/client/src/components/Combat/PixiPhaseRail.tsx
+++ b/packages/client/src/components/Combat/PixiPhaseRail.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useEffect, useRef, useId, useCallback } from "react";
-import { Container, Graphics, Text } from "pixi.js";
+import { Container, Graphics, Rectangle, Text } from "pixi.js";
 import {
   COMBAT_PHASE_RANGED_SIEGE,
   COMBAT_PHASE_BLOCK,
@@ -55,25 +55,25 @@ const PHASES: { id: CombatPhase; label: string; icon: string; instruction: strin
   {
     id: COMBAT_PHASE_RANGED_SIEGE,
     label: "Ranged",
-    icon: "\u{1F3F9}", // Bow and arrow emoji
+    icon: "R",
     instruction: "Strike from afar before enemies close in",
   },
   {
     id: COMBAT_PHASE_BLOCK,
     label: "Block",
-    icon: "\u{1F6E1}", // Shield emoji
+    icon: "B",
     instruction: "Defend against enemy attacks",
   },
   {
     id: COMBAT_PHASE_ASSIGN_DAMAGE,
     label: "Damage",
-    icon: "\u{1F480}", // Skull emoji
+    icon: "D",
     instruction: "Unblocked enemies deal damage",
   },
   {
     id: COMBAT_PHASE_ATTACK,
     label: "Attack",
-    icon: "\u{2694}", // Crossed swords emoji
+    icon: "A",
     instruction: "Finish off remaining enemies",
   },
 ];
@@ -197,8 +197,9 @@ export function PixiPhaseRail({
       const icon = new Text({
         text: isCompleted ? "\u2713" : phase.icon, // Checkmark for completed
         style: {
-          fontFamily: "Arial, Segoe UI Emoji, sans-serif",
-          fontSize: sizes.iconSize * 0.6,
+          fontFamily: "Arial, sans-serif",
+          fontSize: sizes.iconSize * 0.48,
+          fontWeight: "700",
           fill: isCompleted ? COLORS.LABEL_COMPLETED : isActive ? 0xffffff : COLORS.LABEL_UPCOMING,
           align: "center",
         },
@@ -256,19 +257,6 @@ export function PixiPhaseRail({
         // Scale up active phase
         phaseContainer.scale.set(1.15);
       }
-
-      // Entry animation
-      phaseContainer.alpha = 0;
-      phaseContainer.scale.set(isActive ? 1.15 * 0.8 : 0.8);
-      setTimeout(() => {
-        if (isDestroyedRef.current || !phaseContainer.parent) return;
-        animManager.animate(`phase-entry-${index}`, phaseContainer, {
-          endAlpha: 1,
-          endScale: isActive ? 1.15 : 1,
-          duration: 300,
-          easing: Easing.easeOutBack,
-        });
-      }, 100 + index * 50);
 
       rootContainer.addChild(phaseContainer);
       yOffset += sizes.iconSize + sizes.labelFontSize + sizes.phaseGap;
@@ -340,10 +328,20 @@ export function PixiPhaseRail({
 
     // Button interactivity
     if (canEndPhase) {
-      button.eventMode = "static";
-      button.cursor = "pointer";
+      const hitWidth = isLastPhase ? 112 : sizes.buttonSize + 14;
+      const hitHeight = isLastPhase ? 52 : sizes.buttonSize + 14;
+      buttonContainer.hitArea = new Rectangle(
+        -hitWidth / 2,
+        -hitHeight / 2,
+        hitWidth,
+        hitHeight
+      );
+      buttonContainer.eventMode = "static";
+      buttonContainer.cursor = "pointer";
+      button.eventMode = "none";
+      buttonLabel.eventMode = "none";
 
-      button.on("pointerenter", () => {
+      buttonContainer.on("pointerenter", () => {
         if (isDestroyedRef.current) return;
         drawButton(true);
         animManager.animate("button-hover", buttonContainer, {
@@ -353,7 +351,7 @@ export function PixiPhaseRail({
         });
       });
 
-      button.on("pointerleave", () => {
+      buttonContainer.on("pointerleave", () => {
         if (isDestroyedRef.current) return;
         drawButton(false);
         animManager.animate("button-hover", buttonContainer, {
@@ -363,7 +361,7 @@ export function PixiPhaseRail({
         });
       });
 
-      button.on("pointertap", () => {
+      buttonContainer.on("pointertap", () => {
         if (isDestroyedRef.current) return;
         animManager.animate("button-click", buttonContainer, {
           endScale: 0.95,
@@ -397,20 +395,9 @@ export function PixiPhaseRail({
         pulseButton();
       }
     } else {
-      button.eventMode = "none";
+      buttonContainer.eventMode = "none";
       buttonContainer.alpha = 0.3;
     }
-
-    // Entry animation for button
-    buttonContainer.alpha = 0;
-    setTimeout(() => {
-      if (isDestroyedRef.current || !buttonContainer.parent) return;
-      animManager.animate("button-entry", buttonContainer, {
-        endAlpha: canEndPhase ? 1 : 0.3,
-        duration: 300,
-        easing: Easing.easeOutQuad,
-      });
-    }, 300);
 
     rootContainer.addChild(buttonContainer);
     yOffset += isLastPhase ? 50 : sizes.buttonSize + sizes.sectionGap;

--- a/packages/client/src/components/GameBoard/PixiHexGrid.tsx
+++ b/packages/client/src/components/GameBoard/PixiHexGrid.tsx
@@ -154,6 +154,8 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
 
   // Handler to open the site panel (from right-click on hex)
   const handleOpenSitePanel = useCallback((coord: HexCoord) => {
+    if (isOverlayActive || state?.combat !== null) return;
+
     // Only open if the hex has a site
     const hex = state?.map.hexes[hexKey(coord)];
     if (!hex?.site) return;
@@ -161,7 +163,7 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
     setSitePanelHex(coord);
     setIsSitePanelOpen(true);
     handleHexTooltipLeave();
-  }, [handleHexTooltipLeave, state?.map.hexes]);
+  }, [handleHexTooltipLeave, isOverlayActive, state?.combat, state?.map.hexes]);
 
   // Handler for right-click on hero token (opens site panel for hero's current location)
   const handleHeroRightClick = useCallback(() => {
@@ -240,7 +242,6 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
   const handleGameKeyDown = useCallback((event: KeyboardEvent) => {
     // Don't handle if overlays are active or site panel is open
     if (isOverlayActive || isSitePanelOpen) {
-      handleKeyDown(event);
       return;
     }
 
@@ -333,6 +334,9 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
 
   resetRendererRef.current = resetRenderer;
 
+  // Hide world and background when in combat (so hand overlay shows through transparent canvas)
+  const inCombat = state?.combat !== null;
+
   // Hex interaction handlers
   const { getMoveHighlight, handleHexClick, handleExploreClick } = useHexInteraction({
     validMoveTargets,
@@ -345,10 +349,9 @@ export function PixiHexGrid({ onNavigateToUnitOffer, onNavigateToSpellOffer }: P
     rustMoveActions,
     rustExploreActions,
     rustChallengeActions,
+    isInteractionBlocked: isOverlayActive || inCombat,
   });
 
-  // Hide world and background when in combat (so hand overlay shows through transparent canvas)
-  const inCombat = state?.combat !== null;
   useEffect(() => {
     if (!isInitialized) return;
     const world = worldRef.current;

--- a/packages/client/src/components/GameBoard/hooks/useHexInteraction.ts
+++ b/packages/client/src/components/GameBoard/hooks/useHexInteraction.ts
@@ -22,6 +22,7 @@ interface UseHexInteractionParams {
   rustMoveActions?: Map<string, LegalAction>;
   rustExploreActions?: Map<string, LegalAction>;
   rustChallengeActions?: Map<string, LegalAction>;
+  isInteractionBlocked?: boolean;
 }
 
 interface UseHexInteractionReturn {
@@ -41,6 +42,7 @@ export function useHexInteraction({
   rustMoveActions,
   rustExploreActions,
   rustChallengeActions,
+  isInteractionBlocked = false,
 }: UseHexInteractionParams): UseHexInteractionReturn {
   // Movement highlight getter
   const getMoveHighlight = useCallback(
@@ -89,6 +91,8 @@ export function useHexInteraction({
   // Handle hex click for movement or challenge
   const handleHexClick = useCallback(
     (coord: HexCoord) => {
+      if (isInteractionBlocked) return;
+
       // Block interaction if not player's turn
       if (!isMyTurn) return;
 
@@ -131,12 +135,24 @@ export function useHexInteraction({
         }
       }
     },
-    [isMyTurn, playerPosition, validMoveTargets, reachableHexes, challengeTargetHexes, sendAction, rustMoveActions, rustChallengeActions]
+    [
+      isInteractionBlocked,
+      isMyTurn,
+      playerPosition,
+      validMoveTargets,
+      reachableHexes,
+      challengeTargetHexes,
+      sendAction,
+      rustMoveActions,
+      rustChallengeActions,
+    ]
   );
 
   // Handle explore click
   const handleExploreClick = useCallback(
     (target: ExploreTarget) => {
+      if (isInteractionBlocked) return;
+
       // Block interaction if not player's turn
       if (!isMyTurn) return;
 
@@ -144,7 +160,7 @@ export function useHexInteraction({
       const action = rustExploreActions?.get(key);
       if (action) sendAction(action);
     },
-    [isMyTurn, sendAction, rustExploreActions]
+    [isInteractionBlocked, isMyTurn, sendAction, rustExploreActions]
   );
 
   return {

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -108,6 +108,14 @@ body {
   pointer-events: auto; /* PixiJS phase rail and other combat UI needs canvas events */
 }
 
+/* Non-combat chrome should not accept hover/click while the combat layer is active. */
+.app--combat .top-bar,
+.app--combat .end-turn-seal,
+.app--combat .turn-actions,
+.app--combat .replay-controls {
+  pointer-events: none;
+}
+
 /* Boost hand z-index during combat so it's above the combat overlay */
 .app--combat .floating-hand {
   z-index: 150;

--- a/packages/client/src/utils/skillImagePath.ts
+++ b/packages/client/src/utils/skillImagePath.ts
@@ -10,6 +10,7 @@ const SKILL_IMAGE_STEM_BY_ID = {
   braevalar_natures_vengeance: "braevalar_natures_vengeance_co-op",
   goldyx_source_opening: "goldyx_source_opening_co-op",
   krang_mana_enhancement: "krang_mana_enhancement_co-op",
+  norowas_prayer_of_weather: "norowas_calming_the_weather_co-op",
   tovak_mana_overload: "tovak_mana_overload_co-op",
   wolfhawk_wolfs_howl: "wolfhawk_howl_of_the_pack_co-op",
 } as const satisfies Record<string, string>;

--- a/packages/engine-rs/crates/mk-data/src/scenarios.rs
+++ b/packages/engine-rs/crates/mk-data/src/scenarios.rs
@@ -150,20 +150,108 @@ pub fn first_reconnaissance_4p() -> ScenarioConfig {
     }
 }
 
-/// Full Conquest — standard scenario (stub).
+fn full_conquest_scoring() -> ScenarioScoringConfig {
+    ScenarioScoringConfig {
+        base_score_mode: BaseScoreMode::IndividualFame,
+        achievements: AchievementsConfig {
+            enabled: true,
+            mode: AchievementMode::Competitive,
+            overrides: BTreeMap::new(),
+        },
+        modules: vec![ScoringModuleConfig::CityConquest(
+            CityConquestModuleConfig {
+                leader_points: 7,
+                participant_points: 4,
+                title_name: "Greatest City Conqueror".to_string(),
+                title_bonus: 5,
+                title_tied_bonus: 2,
+            },
+        )],
+    }
+}
+
+/// Full Conquest — 2-player variant.
 ///
-/// Map: Open 5 shape. 6 rounds (3 day + 3 night).
-/// Conquer the city to win. All expansions enabled.
-pub fn full_conquest() -> ScenarioConfig {
+/// Map: Wedge, 8 countryside + 1 non-city core + 2 city tiles. 6 rounds (3 day + 3 night).
+/// Cities are level 4. Game ends when all cities are conquered.
+pub fn full_conquest_2p() -> ScenarioConfig {
     ScenarioConfig {
         countryside_tile_count: 8,
-        core_tile_count: 4,
-        city_tile_count: 1,
+        core_tile_count: 1,
+        city_tile_count: 2,
+        map_shape: MapShape::Wedge,
+        day_rounds: 3,
+        night_rounds: 3,
+        total_rounds: 6,
+        min_players: 2,
+        max_players: 2,
+        starting_fame: 0,
+        starting_reputation: 0,
+        skills_enabled: true,
+        elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
+        pvp_enabled: true,
+        spells_available: true,
+        advanced_actions_available: true,
+        enabled_expansions: vec![],
+        fame_per_tile_explored: 0,
+        cities_can_be_entered: true,
+        default_city_level: 4,
+        tactic_removal_mode: TacticRemovalMode::RemoveTwo,
+        dummy_tactic_order: DummyTacticOrder::None,
+        end_trigger: ScenarioEndTrigger::CityConquered,
+        scoring_config: Some(full_conquest_scoring()),
+    }
+}
+
+/// Full Conquest — 3-player variant.
+///
+/// Map: Wedge, 9 countryside + 2 non-city core + 3 city tiles. 6 rounds (3 day + 3 night).
+/// Cities are level 4. Game ends when all cities are conquered.
+pub fn full_conquest_3p() -> ScenarioConfig {
+    ScenarioConfig {
+        countryside_tile_count: 9,
+        core_tile_count: 2,
+        city_tile_count: 3,
+        map_shape: MapShape::Wedge,
+        day_rounds: 3,
+        night_rounds: 3,
+        total_rounds: 6,
+        min_players: 3,
+        max_players: 3,
+        starting_fame: 0,
+        starting_reputation: 0,
+        skills_enabled: true,
+        elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
+        pvp_enabled: true,
+        spells_available: true,
+        advanced_actions_available: true,
+        enabled_expansions: vec![],
+        fame_per_tile_explored: 0,
+        cities_can_be_entered: true,
+        default_city_level: 4,
+        tactic_removal_mode: TacticRemovalMode::RemoveOne,
+        dummy_tactic_order: DummyTacticOrder::None,
+        end_trigger: ScenarioEndTrigger::CityConquered,
+        scoring_config: Some(full_conquest_scoring()),
+    }
+}
+
+/// Full Conquest — 4-player variant.
+///
+/// Map: Fully Open, 11 countryside + 3 non-city core + 4 city tiles. 6 rounds (3 day + 3 night).
+/// Cities are level 4. Game ends when all cities are conquered.
+pub fn full_conquest_4p() -> ScenarioConfig {
+    ScenarioConfig {
+        countryside_tile_count: 11,
+        core_tile_count: 3,
+        city_tile_count: 4,
         map_shape: MapShape::Open5,
         day_rounds: 3,
         night_rounds: 3,
         total_rounds: 6,
-        min_players: 1,
+        min_players: 4,
         max_players: 4,
         starting_fame: 0,
         starting_reputation: 0,
@@ -173,34 +261,14 @@ pub fn full_conquest() -> ScenarioConfig {
         pvp_enabled: true,
         spells_available: true,
         advanced_actions_available: true,
-        enabled_expansions: vec![
-            ExpansionId::LostLegion,
-            ExpansionId::Krang,
-            ExpansionId::ShadesOfTezla,
-        ],
+        enabled_expansions: vec![],
         fame_per_tile_explored: 0,
         cities_can_be_entered: true,
-        default_city_level: 5,
-        tactic_removal_mode: TacticRemovalMode::AllUsed,
-        dummy_tactic_order: DummyTacticOrder::AfterHumans,
+        default_city_level: 4,
+        tactic_removal_mode: TacticRemovalMode::None,
+        dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityConquered,
-        scoring_config: Some(ScenarioScoringConfig {
-            base_score_mode: BaseScoreMode::IndividualFame,
-            achievements: AchievementsConfig {
-                enabled: true,
-                mode: AchievementMode::Competitive,
-                overrides: BTreeMap::new(),
-            },
-            modules: vec![ScoringModuleConfig::CityConquest(
-                CityConquestModuleConfig {
-                    leader_points: 7,
-                    participant_points: 4,
-                    title_name: "Greatest City Conqueror".to_string(),
-                    title_bonus: 5,
-                    title_tied_bonus: 2,
-                },
-            )],
-        }),
+        scoring_config: Some(full_conquest_scoring()),
     }
 }
 
@@ -211,7 +279,9 @@ pub fn get_scenario(id: &str) -> Option<ScenarioConfig> {
         "first_reconnaissance_2p" => Some(first_reconnaissance_2p()),
         "first_reconnaissance_3p" => Some(first_reconnaissance_3p()),
         "first_reconnaissance_4p" => Some(first_reconnaissance_4p()),
-        "full_conquest" => Some(full_conquest()),
+        "full_conquest_2p" => Some(full_conquest_2p()),
+        "full_conquest_3p" => Some(full_conquest_3p()),
+        "full_conquest_4p" => Some(full_conquest_4p()),
         _ => None,
     }
 }
@@ -268,23 +338,52 @@ mod tests {
     }
 
     #[test]
-    fn full_conquest_config() {
-        let config = full_conquest();
-        assert_eq!(config.map_shape, MapShape::Open5);
+    fn full_conquest_2p_config() {
+        let config = full_conquest_2p();
+        assert_eq!(config.map_shape, MapShape::Wedge);
+        assert_eq!(config.countryside_tile_count, 8);
+        assert_eq!(config.core_tile_count, 1);
+        assert_eq!(config.city_tile_count, 2);
+        assert_eq!(config.total_rounds, 6);
+        assert_eq!(config.default_city_level, 4);
+        assert_eq!(config.min_players, 2);
+        assert_eq!(config.max_players, 2);
         assert!(config.skills_enabled);
         assert!(config.elite_units_enabled);
         assert!(config.pvp_enabled);
         assert!(config.cities_can_be_entered);
-        assert_eq!(config.default_city_level, 5);
         assert_eq!(config.end_trigger, ScenarioEndTrigger::CityConquered);
-        assert_eq!(config.enabled_expansions.len(), 3);
-
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::RemoveTwo);
+        assert_eq!(config.dummy_tactic_order, DummyTacticOrder::None);
         let scoring = config.scoring_config.as_ref().unwrap();
-        assert_eq!(
-            scoring.achievements.mode,
-            AchievementMode::Competitive
-        );
+        assert_eq!(scoring.achievements.mode, AchievementMode::Competitive);
         assert_eq!(scoring.modules.len(), 1);
+    }
+
+    #[test]
+    fn full_conquest_3p_config() {
+        let config = full_conquest_3p();
+        assert_eq!(config.map_shape, MapShape::Wedge);
+        assert_eq!(config.countryside_tile_count, 9);
+        assert_eq!(config.core_tile_count, 2);
+        assert_eq!(config.city_tile_count, 3);
+        assert_eq!(config.default_city_level, 4);
+        assert_eq!(config.min_players, 3);
+        assert_eq!(config.max_players, 3);
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::RemoveOne);
+    }
+
+    #[test]
+    fn full_conquest_4p_config() {
+        let config = full_conquest_4p();
+        assert_eq!(config.map_shape, MapShape::Open5);
+        assert_eq!(config.countryside_tile_count, 11);
+        assert_eq!(config.core_tile_count, 3);
+        assert_eq!(config.city_tile_count, 4);
+        assert_eq!(config.default_city_level, 4);
+        assert_eq!(config.min_players, 4);
+        assert_eq!(config.max_players, 4);
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::None);
     }
 
     #[test]
@@ -293,7 +392,9 @@ mod tests {
         assert!(get_scenario("first_reconnaissance_2p").is_some());
         assert!(get_scenario("first_reconnaissance_3p").is_some());
         assert!(get_scenario("first_reconnaissance_4p").is_some());
-        assert!(get_scenario("full_conquest").is_some());
+        assert!(get_scenario("full_conquest_2p").is_some());
+        assert!(get_scenario("full_conquest_3p").is_some());
+        assert!(get_scenario("full_conquest_4p").is_some());
         assert!(get_scenario("nonexistent_scenario").is_none());
     }
 }

--- a/packages/engine-rs/crates/mk-data/src/scenarios.rs
+++ b/packages/engine-rs/crates/mk-data/src/scenarios.rs
@@ -33,6 +33,9 @@ pub fn first_reconnaissance() -> ScenarioConfig {
         fame_per_tile_explored: 1,
         cities_can_be_entered: false,
         default_city_level: 1,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::AllUsed,
         dummy_tactic_order: DummyTacticOrder::AfterHumans,
         end_trigger: ScenarioEndTrigger::CityRevealed,
@@ -75,6 +78,9 @@ pub fn first_reconnaissance_2p() -> ScenarioConfig {
         fame_per_tile_explored: 1,
         cities_can_be_entered: false,
         default_city_level: 1,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::RemoveTwo,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityRevealed,
@@ -109,6 +115,9 @@ pub fn first_reconnaissance_3p() -> ScenarioConfig {
         fame_per_tile_explored: 1,
         cities_can_be_entered: false,
         default_city_level: 1,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::RemoveOne,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityRevealed,
@@ -143,6 +152,9 @@ pub fn first_reconnaissance_4p() -> ScenarioConfig {
         fame_per_tile_explored: 1,
         cities_can_be_entered: false,
         default_city_level: 1,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::None,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityRevealed,
@@ -197,6 +209,9 @@ pub fn full_conquest_2p() -> ScenarioConfig {
         fame_per_tile_explored: 0,
         cities_can_be_entered: true,
         default_city_level: 4,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::RemoveTwo,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityConquered,
@@ -231,6 +246,9 @@ pub fn full_conquest_3p() -> ScenarioConfig {
         fame_per_tile_explored: 0,
         cities_can_be_entered: true,
         default_city_level: 4,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::RemoveOne,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityConquered,
@@ -265,10 +283,145 @@ pub fn full_conquest_4p() -> ScenarioConfig {
         fame_per_tile_explored: 0,
         cities_can_be_entered: true,
         default_city_level: 4,
+        fame_per_level_crossed: 0,
+        extra_source_dice: 0,
+        extra_unit_offer_slots: 0,
         tactic_removal_mode: TacticRemovalMode::None,
         dummy_tactic_order: DummyTacticOrder::None,
         end_trigger: ScenarioEndTrigger::CityConquered,
         scoring_config: Some(full_conquest_scoring()),
+    }
+}
+
+fn blitz_conquest_scoring() -> ScenarioScoringConfig {
+    ScenarioScoringConfig {
+        base_score_mode: BaseScoreMode::IndividualFame,
+        achievements: AchievementsConfig {
+            enabled: true,
+            mode: AchievementMode::Competitive,
+            overrides: BTreeMap::new(),
+        },
+        modules: vec![ScoringModuleConfig::CityConquest(
+            CityConquestModuleConfig {
+                leader_points: 7,
+                participant_points: 4,
+                title_name: "Greatest City Conqueror".to_string(),
+                title_bonus: 5,
+                title_tied_bonus: 2,
+            },
+        )],
+    }
+}
+
+/// Blitz Conquest — 2-player variant.
+///
+/// Map: Wedge, 6 countryside + 1 non-city core + 2 city tiles. 4 rounds (2 day + 2 night).
+/// Cities are level 3. Starts with 1 Fame, +2 Reputation, extra Source die and Unit offer slot.
+pub fn blitz_conquest_2p() -> ScenarioConfig {
+    ScenarioConfig {
+        countryside_tile_count: 6,
+        core_tile_count: 1,
+        city_tile_count: 2,
+        map_shape: MapShape::Wedge,
+        day_rounds: 2,
+        night_rounds: 2,
+        total_rounds: 4,
+        min_players: 2,
+        max_players: 2,
+        starting_fame: 1,
+        starting_reputation: 2,
+        skills_enabled: true,
+        elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
+        pvp_enabled: true,
+        spells_available: true,
+        advanced_actions_available: true,
+        enabled_expansions: vec![],
+        fame_per_tile_explored: 0,
+        cities_can_be_entered: true,
+        default_city_level: 3,
+        fame_per_level_crossed: 1,
+        extra_source_dice: 1,
+        extra_unit_offer_slots: 1,
+        tactic_removal_mode: TacticRemovalMode::RemoveTwo,
+        dummy_tactic_order: DummyTacticOrder::None,
+        end_trigger: ScenarioEndTrigger::CityConquered,
+        scoring_config: Some(blitz_conquest_scoring()),
+    }
+}
+
+/// Blitz Conquest — 3-player variant.
+///
+/// Map: Wedge, 7 countryside + 2 non-city core + 3 city tiles. 4 rounds (2 day + 2 night).
+/// Cities are level 3. Starts with 1 Fame, +2 Reputation, extra Source die and Unit offer slot.
+pub fn blitz_conquest_3p() -> ScenarioConfig {
+    ScenarioConfig {
+        countryside_tile_count: 7,
+        core_tile_count: 2,
+        city_tile_count: 3,
+        map_shape: MapShape::Wedge,
+        day_rounds: 2,
+        night_rounds: 2,
+        total_rounds: 4,
+        min_players: 3,
+        max_players: 3,
+        starting_fame: 1,
+        starting_reputation: 2,
+        skills_enabled: true,
+        elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
+        pvp_enabled: true,
+        spells_available: true,
+        advanced_actions_available: true,
+        enabled_expansions: vec![],
+        fame_per_tile_explored: 0,
+        cities_can_be_entered: true,
+        default_city_level: 3,
+        fame_per_level_crossed: 1,
+        extra_source_dice: 1,
+        extra_unit_offer_slots: 1,
+        tactic_removal_mode: TacticRemovalMode::RemoveOne,
+        dummy_tactic_order: DummyTacticOrder::None,
+        end_trigger: ScenarioEndTrigger::CityConquered,
+        scoring_config: Some(blitz_conquest_scoring()),
+    }
+}
+
+/// Blitz Conquest — 4-player variant.
+///
+/// Map: Open4 (limited to 4 columns), 9 countryside + 3 non-city core + 4 city tiles.
+/// 4 rounds (2 day + 2 night). Cities are level 3. Starts with 1 Fame, +2 Reputation,
+/// extra Source die and Unit offer slot.
+pub fn blitz_conquest_4p() -> ScenarioConfig {
+    ScenarioConfig {
+        countryside_tile_count: 9,
+        core_tile_count: 3,
+        city_tile_count: 4,
+        map_shape: MapShape::Open4,
+        day_rounds: 2,
+        night_rounds: 2,
+        total_rounds: 4,
+        min_players: 4,
+        max_players: 4,
+        starting_fame: 1,
+        starting_reputation: 2,
+        skills_enabled: true,
+        elite_units_enabled: true,
+        guarantee_village_unit_in_offer: false,
+        pvp_enabled: true,
+        spells_available: true,
+        advanced_actions_available: true,
+        enabled_expansions: vec![],
+        fame_per_tile_explored: 0,
+        cities_can_be_entered: true,
+        default_city_level: 3,
+        fame_per_level_crossed: 1,
+        extra_source_dice: 1,
+        extra_unit_offer_slots: 1,
+        tactic_removal_mode: TacticRemovalMode::None,
+        dummy_tactic_order: DummyTacticOrder::None,
+        end_trigger: ScenarioEndTrigger::CityConquered,
+        scoring_config: Some(blitz_conquest_scoring()),
     }
 }
 
@@ -282,6 +435,9 @@ pub fn get_scenario(id: &str) -> Option<ScenarioConfig> {
         "full_conquest_2p" => Some(full_conquest_2p()),
         "full_conquest_3p" => Some(full_conquest_3p()),
         "full_conquest_4p" => Some(full_conquest_4p()),
+        "blitz_conquest_2p" => Some(blitz_conquest_2p()),
+        "blitz_conquest_3p" => Some(blitz_conquest_3p()),
+        "blitz_conquest_4p" => Some(blitz_conquest_4p()),
         _ => None,
     }
 }

--- a/packages/engine-rs/crates/mk-data/src/scenarios.rs
+++ b/packages/engine-rs/crates/mk-data/src/scenarios.rs
@@ -551,6 +551,82 @@ mod tests {
         assert!(get_scenario("full_conquest_2p").is_some());
         assert!(get_scenario("full_conquest_3p").is_some());
         assert!(get_scenario("full_conquest_4p").is_some());
+        assert!(get_scenario("blitz_conquest_2p").is_some());
+        assert!(get_scenario("blitz_conquest_3p").is_some());
+        assert!(get_scenario("blitz_conquest_4p").is_some());
         assert!(get_scenario("nonexistent_scenario").is_none());
+    }
+
+    #[test]
+    fn blitz_conquest_2p_config() {
+        let config = blitz_conquest_2p();
+        assert_eq!(config.map_shape, MapShape::Wedge);
+        assert_eq!(config.countryside_tile_count, 6);
+        assert_eq!(config.core_tile_count, 1);
+        assert_eq!(config.city_tile_count, 2);
+        assert_eq!(config.total_rounds, 4);
+        assert_eq!(config.default_city_level, 3);
+        assert_eq!(config.min_players, 2);
+        assert_eq!(config.max_players, 2);
+        assert_eq!(config.starting_fame, 1);
+        assert_eq!(config.starting_reputation, 2);
+        assert_eq!(config.fame_per_level_crossed, 1);
+        assert_eq!(config.extra_source_dice, 1);
+        assert_eq!(config.extra_unit_offer_slots, 1);
+        assert_eq!(config.end_trigger, ScenarioEndTrigger::CityConquered);
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::RemoveTwo);
+    }
+
+    #[test]
+    fn blitz_conquest_3p_config() {
+        let config = blitz_conquest_3p();
+        assert_eq!(config.map_shape, MapShape::Wedge);
+        assert_eq!(config.countryside_tile_count, 7);
+        assert_eq!(config.core_tile_count, 2);
+        assert_eq!(config.city_tile_count, 3);
+        assert_eq!(config.default_city_level, 3);
+        assert_eq!(config.min_players, 3);
+        assert_eq!(config.max_players, 3);
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::RemoveOne);
+        assert_eq!(config.fame_per_level_crossed, 1);
+    }
+
+    #[test]
+    fn blitz_conquest_4p_config() {
+        let config = blitz_conquest_4p();
+        assert_eq!(config.map_shape, MapShape::Open4);
+        assert_eq!(config.countryside_tile_count, 9);
+        assert_eq!(config.core_tile_count, 3);
+        assert_eq!(config.city_tile_count, 4);
+        assert_eq!(config.default_city_level, 3);
+        assert_eq!(config.min_players, 4);
+        assert_eq!(config.max_players, 4);
+        assert_eq!(config.tactic_removal_mode, TacticRemovalMode::None);
+        assert_eq!(config.fame_per_level_crossed, 1);
+    }
+
+    #[test]
+    fn blitz_conquest_scoring_module_present() {
+        let config = blitz_conquest_2p();
+        let scoring = config.scoring_config.as_ref().unwrap();
+        assert_eq!(scoring.achievements.mode, AchievementMode::Competitive);
+        assert_eq!(scoring.modules.len(), 1);
+        if let ScoringModuleConfig::CityConquest(ref m) = scoring.modules[0] {
+            assert_eq!(m.leader_points, 7);
+            assert_eq!(m.participant_points, 4);
+            assert_eq!(m.title_bonus, 5);
+        } else {
+            panic!("expected CityConquest scoring module");
+        }
+    }
+
+    #[test]
+    fn existing_scenarios_have_zero_blitz_fields() {
+        for id in ["first_reconnaissance", "first_reconnaissance_2p", "full_conquest_2p"] {
+            let config = get_scenario(id).unwrap();
+            assert_eq!(config.fame_per_level_crossed, 0, "{id}: fame_per_level_crossed should be 0");
+            assert_eq!(config.extra_source_dice, 0, "{id}: extra_source_dice should be 0");
+            assert_eq!(config.extra_unit_offer_slots, 0, "{id}: extra_unit_offer_slots should be 0");
+        }
     }
 }

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/combat_end.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/combat_end.rs
@@ -140,6 +140,28 @@ pub(super) fn end_combat(state: &mut GameState, player_idx: usize) {
             }
         }
 
+        // CityConquered scenario end: triggered when ALL cities are now conquered
+        if !state.scenario_end_triggered
+            && state.scenario_config.end_trigger == ScenarioEndTrigger::CityConquered
+            && conquered_site_type == Some(SiteType::City)
+        {
+            let conquered_city_count = state
+                .map
+                .hexes
+                .values()
+                .filter(|h| {
+                    h.site
+                        .as_ref()
+                        .map(|s| s.site_type == SiteType::City && s.is_conquered)
+                        .unwrap_or(false)
+                })
+                .count() as u32;
+            if conquered_city_count >= state.scenario_config.city_tile_count {
+                state.scenario_end_triggered = true;
+                state.final_turns_remaining = Some(state.players.len() as u32);
+            }
+        }
+
         // BurnMonastery victory: if combat_context == BurnMonastery and all enemies defeated
         if combat.combat_context == CombatContext::BurnMonastery && all_defeated {
             if let Some(hex_coord) = combat.combat_hex_coord {

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_sites.rs
@@ -5511,3 +5511,94 @@ fn fortified_assault_rampaging_enemy_not_required_for_conquest() {
         "Player should stay at site after successful assault (rampaging enemy not required)"
     );
 }
+
+// =========================================================================
+// CityConquered scenario end trigger
+// =========================================================================
+
+fn setup_city_combat(state: &mut GameState, coord: HexCoord) {
+    state.combat = Some(Box::new(CombatState {
+        phase: CombatPhase::Attack,
+        enemies: vec![CombatEnemy {
+            instance_id: CombatInstanceId::from("enemy_0"),
+            enemy_id: EnemyId::from("diggers"),
+            is_blocked: false,
+            is_defeated: true,
+            damage_assigned: false,
+            is_required_for_conquest: true,
+            summoned_by_instance_id: None,
+            is_summoner_hidden: false,
+            attacks_blocked: vec![false],
+            attacks_damage_assigned: vec![false],
+            attacks_cancelled: vec![false],
+        }],
+        combat_hex_coord: Some(coord),
+        is_at_fortified_site: true,
+        ..CombatState::default()
+    }));
+}
+
+#[test]
+fn city_conquest_triggers_scenario_end_when_last_city() {
+    let mut state = setup_playing_game(vec!["march"]);
+    state.scenario_config.end_trigger = ScenarioEndTrigger::CityConquered;
+    state.scenario_config.city_tile_count = 1;
+    let coord = place_player_on_site(&mut state, SiteType::City);
+    setup_city_combat(&mut state, coord);
+
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+    apply_legal_action(&mut state, &mut undo, 0, &LegalAction::EndCombatPhase, epoch).unwrap();
+
+    assert!(state.scenario_end_triggered);
+    assert_eq!(state.final_turns_remaining, Some(1));
+}
+
+#[test]
+fn city_conquest_no_trigger_when_cities_remain() {
+    let mut state = setup_playing_game(vec!["march"]);
+    state.scenario_config.end_trigger = ScenarioEndTrigger::CityConquered;
+    state.scenario_config.city_tile_count = 2;
+    let coord = place_player_on_site(&mut state, SiteType::City);
+    setup_city_combat(&mut state, coord);
+
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+    apply_legal_action(&mut state, &mut undo, 0, &LegalAction::EndCombatPhase, epoch).unwrap();
+
+    assert!(!state.scenario_end_triggered);
+    assert!(state.final_turns_remaining.is_none());
+}
+
+#[test]
+fn city_conquest_no_trigger_for_non_city_sites() {
+    let mut state = setup_playing_game(vec!["march"]);
+    state.scenario_config.end_trigger = ScenarioEndTrigger::CityConquered;
+    state.scenario_config.city_tile_count = 1;
+    // Conquer a dungeon, not a city
+    let coord = place_player_on_site(&mut state, SiteType::Dungeon);
+    state.combat = Some(Box::new(CombatState {
+        phase: CombatPhase::Attack,
+        enemies: vec![CombatEnemy {
+            instance_id: CombatInstanceId::from("enemy_0"),
+            enemy_id: EnemyId::from("diggers"),
+            is_blocked: false,
+            is_defeated: true,
+            damage_assigned: false,
+            is_required_for_conquest: true,
+            summoned_by_instance_id: None,
+            is_summoner_hidden: false,
+            attacks_blocked: vec![false],
+            attacks_damage_assigned: vec![false],
+            attacks_cancelled: vec![false],
+        }],
+        combat_hex_coord: Some(coord),
+        ..CombatState::default()
+    }));
+
+    let mut undo = UndoStack::new();
+    let epoch = state.action_epoch;
+    apply_legal_action(&mut state, &mut undo, 0, &LegalAction::EndCombatPhase, epoch).unwrap();
+
+    assert!(!state.scenario_end_triggered);
+}

--- a/packages/engine-rs/crates/mk-engine/src/end_turn.rs
+++ b/packages/engine-rs/crates/mk-engine/src/end_turn.rs
@@ -467,47 +467,58 @@ pub fn forfeit_turn(state: &mut GameState, player_idx: usize) -> Result<EndTurnR
 /// For even levels (2, 4, 6, 8, 10), draws hero skills and queues level-up rewards
 /// as deferred pending entries.
 fn process_level_ups(state: &mut GameState, player_idx: usize) {
-    let old_level = state.players[player_idx].level;
-    let new_level = get_level_from_fame(state.players[player_idx].fame);
+    let bonus_per_line = state.scenario_config.fame_per_level_crossed;
+    loop {
+        let old_level = state.players[player_idx].level;
+        let new_level = get_level_from_fame(state.players[player_idx].fame);
 
-    if new_level <= old_level {
-        return;
-    }
-
-    // Use the final level's stats
-    let stats = get_level_stats(new_level);
-    let player = &mut state.players[player_idx];
-    player.level = new_level;
-    player.armor = stats.armor;
-    player.hand_limit = stats.hand_limit;
-    player.command_tokens = stats.command_slots;
-
-    // Queue skill choices for each even level crossed
-    let mut rewards: Vec<PendingLevelUpReward> = Vec::new();
-    for level in (old_level + 1)..=new_level {
-        if is_skill_level_up(level) {
-            // Shuffle remaining_hero_skills, draw min(2, len)
-            let player = &mut state.players[player_idx];
-            state.rng.shuffle(&mut player.remaining_hero_skills);
-            let draw_count = player.remaining_hero_skills.len().min(MAX_DRAWN_SKILLS);
-            let mut drawn: ArrayVec<SkillId, MAX_DRAWN_SKILLS> = ArrayVec::new();
-            for _ in 0..draw_count {
-                drawn.push(player.remaining_hero_skills.pop().unwrap());
-            }
-            rewards.push(PendingLevelUpReward {
-                level: level as u8,
-                drawn_skills: drawn,
-                phase: mk_types::pending::LevelUpRewardPhase::SelectSkill,
-            });
+        if new_level <= old_level {
+            break;
         }
-    }
 
-    // Add as deferred pending — promoted to active when end_turn flow processes them
-    if !rewards.is_empty() {
-        state.players[player_idx]
-            .pending
-            .deferred
-            .push(DeferredPending::LevelUpRewards(rewards));
+        let lines_crossed = new_level - old_level;
+
+        // Use the final level's stats
+        let stats = get_level_stats(new_level);
+        let player = &mut state.players[player_idx];
+        player.level = new_level;
+        player.armor = stats.armor;
+        player.hand_limit = stats.hand_limit;
+        player.command_tokens = stats.command_slots;
+
+        // Queue skill choices for each even level crossed
+        let mut rewards: Vec<PendingLevelUpReward> = Vec::new();
+        for level in (old_level + 1)..=new_level {
+            if is_skill_level_up(level) {
+                let player = &mut state.players[player_idx];
+                state.rng.shuffle(&mut player.remaining_hero_skills);
+                let draw_count = player.remaining_hero_skills.len().min(MAX_DRAWN_SKILLS);
+                let mut drawn: ArrayVec<SkillId, MAX_DRAWN_SKILLS> = ArrayVec::new();
+                for _ in 0..draw_count {
+                    drawn.push(player.remaining_hero_skills.pop().unwrap());
+                }
+                rewards.push(PendingLevelUpReward {
+                    level: level as u8,
+                    drawn_skills: drawn,
+                    phase: mk_types::pending::LevelUpRewardPhase::SelectSkill,
+                });
+            }
+        }
+
+        // Add as deferred pending — promoted to active when end_turn flow processes them
+        if !rewards.is_empty() {
+            state.players[player_idx]
+                .pending
+                .deferred
+                .push(DeferredPending::LevelUpRewards(rewards));
+        }
+
+        // Blitz: grant bonus fame per line crossed, then loop to catch cascading level-ups
+        if bonus_per_line > 0 {
+            state.players[player_idx].fame += bonus_per_line * lines_crossed;
+        } else {
+            break;
+        }
     }
 }
 
@@ -1179,7 +1190,7 @@ pub(crate) fn end_round(state: &mut GameState) {
 
     // 2. Reset mana source (reroll all dice for new time of day)
     let player_count = state.players.len() as u32;
-    state.source = create_mana_source(player_count, state.time_of_day, &mut state.rng);
+    state.source = create_mana_source(player_count, state.scenario_config.extra_source_dice, state.time_of_day, &mut state.rng);
 
     // 3. Dummy offer gains (solo mode — before offer refresh)
     if let Some(ref mut dummy) = state.dummy_player {

--- a/packages/engine-rs/crates/mk-engine/src/end_turn.rs
+++ b/packages/engine-rs/crates/mk-engine/src/end_turn.rs
@@ -1840,6 +1840,52 @@ mod tests {
     }
 
     #[test]
+    fn blitz_fame_per_level_crossed_grants_bonus_on_level_up() {
+        // Level thresholds: L2=3, L3=8. Start at fame=6 (L2), level=1.
+        // Level-up: crosses L2 (lines_crossed=1) → bonus +1 fame → fame=7.
+        // 7 < 8, so no further crossing. Final: level=2, fame=7.
+        let mut state = setup_playing_game(vec!["march"]);
+        state.scenario_config.fame_per_level_crossed = 1;
+        state.players[0].fame = 6;
+        state.players[0].level = 1;
+
+        process_level_ups_pub(&mut state, 0);
+
+        assert_eq!(state.players[0].level, 2);
+        assert_eq!(state.players[0].fame, 7);
+    }
+
+    #[test]
+    fn blitz_fame_per_level_crossed_cascades() {
+        // Level thresholds: L2=3, L3=8, L4=14. Start at fame=13 (L3), level=1.
+        // Iteration 1: crosses L2+L3 (lines_crossed=2) → bonus +2 → fame=15.
+        // Iteration 2: 15 >= L4=14, crosses L4 (lines_crossed=1) → bonus +1 → fame=16.
+        // Iteration 3: get_level_from_fame(16)=4 == level=4 → break.
+        let mut state = setup_playing_game(vec!["march"]);
+        state.scenario_config.fame_per_level_crossed = 1;
+        state.players[0].fame = 13;
+        state.players[0].level = 1;
+
+        process_level_ups_pub(&mut state, 0);
+
+        assert_eq!(state.players[0].level, 4);
+        assert_eq!(state.players[0].fame, 16);
+    }
+
+    #[test]
+    fn blitz_zero_bonus_does_not_grant_extra_fame() {
+        let mut state = setup_playing_game(vec!["march"]);
+        state.scenario_config.fame_per_level_crossed = 0;
+        state.players[0].fame = 6;
+        state.players[0].level = 1;
+
+        process_level_ups_pub(&mut state, 0);
+
+        assert_eq!(state.players[0].level, 2);
+        assert_eq!(state.players[0].fame, 6); // No bonus
+    }
+
+    #[test]
     fn end_turn_no_level_down() {
         let mut state = setup_playing_game(vec!["march"]);
         state.players[0].fame = 3; // Level 2

--- a/packages/engine-rs/crates/mk-engine/src/setup.rs
+++ b/packages/engine-rs/crates/mk-engine/src/setup.rs
@@ -74,10 +74,11 @@ pub fn create_ruins_token_piles(rng: &mut RngState) -> RuinsTokenPiles {
 /// Black dice start depleted during daytime.
 pub fn create_mana_source(
     player_count: u32,
+    extra_dice: u32,
     time_of_day: TimeOfDay,
     rng: &mut RngState,
 ) -> ManaSource {
-    let dice_count = (player_count + 2) as usize;
+    let dice_count = (player_count + 2 + extra_dice) as usize;
     let min_basic = dice_count.div_ceil(2); // ceil(dice_count / 2)
 
     // Initial roll
@@ -306,7 +307,7 @@ pub fn create_solo_game(seed: u32, hero: Hero) -> GameState {
     );
 
     // Create mana source
-    let source = create_mana_source(1, TimeOfDay::Day, &mut rng);
+    let source = create_mana_source(1, scenario_config.extra_source_dice, TimeOfDay::Day, &mut rng);
 
     // Create enemy token piles
     let enemy_tokens = create_enemy_token_piles(&mut rng);
@@ -315,7 +316,7 @@ pub fn create_solo_game(seed: u32, hero: Hero) -> GameState {
     let (aa_deck, aa_offer) = create_aa_deck_and_offer(&mut rng);
     let (spell_deck, spell_offer) = create_spell_deck_and_offer(&mut rng);
     let (unit_deck, elite_unit_deck, unit_offer) =
-        create_unit_deck_and_offer(&mut rng, 1, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
+        create_unit_deck_and_offer(&mut rng, 1 + scenario_config.extra_unit_offer_slots as usize, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
 
     // Create dummy player for solo mode
     let dummy_hero = dummy_player::select_dummy_hero(&[hero], &mut rng);
@@ -453,8 +454,8 @@ pub fn create_multiplayer_game(
         players.push(player);
     }
 
-    // Create mana source (player_count + 2 dice)
-    let source = create_mana_source(player_count as u32, TimeOfDay::Day, &mut rng);
+    // Create mana source (player_count + 2 + extra_source_dice dice)
+    let source = create_mana_source(player_count as u32, scenario_config.extra_source_dice, TimeOfDay::Day, &mut rng);
 
     // Create enemy token piles
     let enemy_tokens = create_enemy_token_piles(&mut rng);
@@ -463,7 +464,7 @@ pub fn create_multiplayer_game(
     let (aa_deck, aa_offer) = create_aa_deck_and_offer(&mut rng);
     let (spell_deck, spell_offer) = create_spell_deck_and_offer(&mut rng);
     let (unit_deck, elite_unit_deck, unit_offer) =
-        create_unit_deck_and_offer(&mut rng, player_count, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
+        create_unit_deck_and_offer(&mut rng, player_count + scenario_config.extra_unit_offer_slots as usize, scenario_config.elite_units_enabled, scenario_config.guarantee_village_unit_in_offer);
 
     // Day tactics
     let available_tactics: Vec<TacticId> =

--- a/packages/engine-rs/crates/mk-types/src/state.rs
+++ b/packages/engine-rs/crates/mk-types/src/state.rs
@@ -742,6 +742,12 @@ pub struct ScenarioConfig {
     pub fame_per_tile_explored: u32,
     pub cities_can_be_entered: bool,
     pub default_city_level: u32,
+    /// Extra fame granted each time the player crosses a fame track line (Blitz scenarios).
+    pub fame_per_level_crossed: u32,
+    /// Extra dice added to the Mana Source beyond the standard player_count + 2 (Blitz scenarios).
+    pub extra_source_dice: u32,
+    /// Extra slots added to the Unit offer beyond the standard player_count + 2 (Blitz scenarios).
+    pub extra_unit_offer_slots: u32,
     // Tactic handling
     pub tactic_removal_mode: TacticRemovalMode,
     pub dummy_tactic_order: DummyTacticOrder,

--- a/packages/shared/src/hero.ts
+++ b/packages/shared/src/hero.ts
@@ -70,3 +70,47 @@ export const HERO_NAMES: Record<HeroId, string> = {
   [HERO_KRANG]: "Krang",
   [HERO_BRAEVALAR]: "Braevalar",
 };
+
+/** Flavor/lore text for hero detail surfaces. */
+export interface HeroLore {
+  title: string;
+  flavorText: string;
+}
+
+export const HERO_LORE = {
+  [HERO_ARYTHEA]: {
+    title: "Arythea, the Blood Cultist",
+    flavorText:
+      "While the origins of The Breaking are shrouded in mystery, it is spoken in hushed whispers and knowing glances that it may have been the Blood Cultists who were responsible for the cataclysm and resulting chaos that ensued. Evidence exists that the Cultists were finally successful in their ancient quest to awaken the dark god Amara who repaid his followers by unleashing his might upon the land. Believed to be the strongest of the known Mage Knights, Arythea has emerged from the chaos more powerful than ever and she has gone forth spreading Amara's bloody gospel as she crushes her foes under her spiked heel. Under her leadership, the Blood Cultists have slipped the bonds of their former masters in the Dark Crusade and have become a power unto themselves; feared by many and respected by all. No one knows where Arythea will strike next but one thing is certain, the bloody god Amara has directed her to participate in the Council of the Void's plans and will be pleased with her conquests and the proliferation of his teachings.",
+  },
+  [HERO_TOVAK]: {
+    title: "Tovak Wyrmstalker, Head of the Order of the Ninth Circle",
+    flavorText:
+      "The strongest presence left within the Order of the Ninth Circle, Tovak Wyrmstalker is less a leader of this new faction and more a force of nature to be respected and followed. Originally the Order of the Ninth Circle sold their swords in service to other factions, but under the strong hand of Tovak Wyrmstalker they have become a force unto themselves. The more established factions in the Land are certainly beginning to take notice of the Order's actions. The Mage Spawn that comprise the Order of the Ninth Circle are held together loosely by their common disdain for the self-proclaimed superiority that the other factions profess, and Tovak Wyrmstalker seeks nothing less than the total defeat of the other factions and their lofty aspirations of supremacy. After the sudden demise of the two previous heads of the Order, Tovak Wyrmstalker has embraced his new role as shepherd to the Order's cause and will not rest until all Mage Spawn are free to determine their own paths. That the Council of the Void's current plans are to conquer lands that oppress his people is all the better.",
+  },
+  [HERO_GOLDYX]: {
+    title: "Goldyx, Mightiest of the Draconum",
+    flavorText:
+      "From the day they are hatched until the day they are killed, Draconum seek only two things; combat and evolution. As they wander the land, Draconum look for worthy opponents strong enough to challenge their brutally honed martial abilities with only one goal in mind; personal augmentation. Draconum have never been closely tied to any one faction and since The Breaking they are even more likely to distrust others, even their own kind. After undergoing the \"Surge\", the most powerful of Draconum evolutions, Goldyx has arisen as the mightiest of his kind. He seeks personal wealth and power and The Council of the Void has promised both beyond anything he had previously dreamed of. That his own brethren may get in his way in his current assignment only makes him more interested in the riches that lie ahead and the foes that are worthy of his attentions.",
+  },
+  [HERO_NOROWAS]: {
+    title: "Norowas, Greatest of the Elf-Lords",
+    flavorText:
+      "Like all great Elven soldiers, Norowas spent centuries mastering the combat arts of both spell and sword. Prior to The Breaking, Norowas had bartered his influence with the Elvish Free Armies to consolidate a position on the High Elven Council, an organization dedicated to bringing their own brand of order to the realm by any means necessary. Norowas embraces these philosophies wholeheartedly and is not above utilizing destructive tactics to achieve his goals. His recent contact with the Council of the Void has steeled his determination that now is the time and the Council of the Void has the means for him to venture forth and bring an end to the chaos he sees throughout the land, without mercy or hesitation.",
+  },
+  [HERO_WOLFHAWK]: {
+    title: "Wolfhawk",
+    flavorText:
+      "Orphaned as a child, Wolfhawk was raised by the greatest Amazon warriors of the Cainus Mons forests. She proved to have an exceptional talent for swordsmanship, joining Queen Corella's army at a young age. Her heroic deeds during the Battle of Nepharus Mons did not go unnoticed and soon she was promoted to Corella's personal guard. During the next few years, Wolfhawk became one of the queen's closest and most trusted companions. When Wolfhawk later became oathsworn to the mysterious Solonavi, some said it was on the orders of the queen herself. Whatever the reason, Wolfhawk began to set out alone on secret missions under the cover of night. She would go on months at a time, sometimes years. It was no wonder when no one questioned it when she disappeared during The Breaking. It was assumed she had died on one of her dangerous journeys. But now, she has returned as one of the Mage Knights. Deadlier and swifter than ever, her swords scythe through anyone getting in her way. What convinced the most loyal servant to abandon her queen and leave her oath to the Solonavi behind? We can only guess; Wolfhawk remains as silent, focused and solitary as she ever was.",
+  },
+  [HERO_KRANG]: {
+    title: "Krang",
+    flavorText:
+      "Krang remembers little about the time before the breaking. Only flashes of memories, images, words here and there, and feelings of confusion and pain. There was the time he was a chaos shaman; the memory of the magestone dust entering his lungs still lingered. There were the words of the council of the void imploring him to give up those ways. Individually, the words were forgotten but collectively the argument was convincing, wasn't it? The painful memories of his purging certainly remain. He was fortunate however, as otherwise the breaking would have destroyed him. Very fortunate. In the years that followed, he was taught other magics by the best the council had to offer. The most was made of his powerful Orcish frame as his blunt but effective martial skills were perfected. Now he has been sent forth to bring order to the lands of the Atlantean Empire. He has turned his back on his Orcish brethren. His true nature has been disguised from locals with help from the council, masters of deceit and trickery. For the first time in years, he has a certainty within him. This he is sure about. This he can do.",
+  },
+  [HERO_BRAEVALAR]: {
+    title: "Braevalar",
+    flavorText:
+      "Braevalar was a storm druid, a part of the Elementalists faction that is motivated by anger for those who ravage the land as much as by the desire to protect it. Disillusioned by the Elementalists' reluctance to take the fight to their enemies, Braevalar looked for another way. His search ended one night when a voice spoke to him from the darkness of the forest. It told him there was indeed another way for those with the will to do whatever it takes to defeat their enemies; the way of the Council of the Void. Although the training was hard, Braevalar never lacked determination. His cunning and knowledge of how to use the terrain around him were great assets, as were his powers over the natural world. Somewhere along the way, however, he lost sight of the importance of protecting nature and now his motivations are... unclear. He serves the Council.",
+  },
+} as const satisfies Record<HeroId, HeroLore>;


### PR DESCRIPTION
## Summary

- **Fix(client): polish combat dock and skill image alias** — combat UI refinements (phase rail letter icons, overlay layout, PixiEnemyTokens removal, hex interaction improvements) and hero lore/flavor text added to shared package
- **Full Conquest (2p/3p/4p)**: Replace broken single-config stub with three correct per-player-count variants matching the rulebook (city level 4, Wedge/Open5 maps, correct tile counts, tactic removal modes). Wire `CityConquered` scenario end trigger in `combat_end.rs` to fire when **all** cities are conquered, giving each player one last turn.
- **Blitz Conquest (2p/3p/4p)**: Add three new scenario variants (4 rounds, city level 3, starting fame 1, reputation +2). Add three new `ScenarioConfig` fields — `fame_per_level_crossed`, `extra_source_dice`, `extra_unit_offer_slots` — and wire them into setup (source dice, unit offer size) and `process_level_ups` (cascading fame bonus on line crossings).

All values sourced directly from the official rulebook (Mage Knight Ultimate Edition, Scenario Book pp. 19–20).

## Test plan

- [ ] All existing engine tests pass (`cargo test` — 2380+ tests, no failures)
- [ ] Clippy clean, lint clean
- [ ] `get_scenario("full_conquest_2p/3p/4p")` returns correct configs (city level 4, correct tile counts)
- [ ] `get_scenario("blitz_conquest_2p/3p/4p")` returns correct configs (city level 3, fame/rep bonuses, extra dice/unit)
- [ ] `CityConquered` end trigger fires only after **all** cities conquered (not the first)
- [ ] `fame_per_level_crossed` cascades correctly when bonus fame triggers additional level-ups