### PR TITLE
ci: update ruff action for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4.0.0
         with:
           args: check packages/python-sdk scripts --config packages/python-sdk/pyproject.toml
 


### PR DESCRIPTION
## Summary
- Update astral-sh/ruff-action from v3 to v4.0.0 so the Python Lint job runs on Node.js 24.
- Avoid relying on temporary FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workflow environment overrides.

## Verification
- cargo test
- cargo clippy
- bun run lint
- pre-push hook passed: clippy, bun run lint, cargo test --workspace --exclude mk-python