### PR TITLE
feat: scenario picker + local hotseat multiplayer

### DIFF
--- a/packages/client/__tests__/hotseatSetup.test.tsx
+++ b/packages/client/__tests__/hotseatSetup.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import {
+  GAME_LAUNCH_MODE_HOTSEAT,
+  GAME_SEAT_CONTROLLER_LOCAL,
+  SCENARIO_BLITZ_CONQUEST_3P,
+  SCENARIO_FULL_CONQUEST_2P,
+  SCENARIO_FULL_CONQUEST_4P,
+} from "@mage-knight/shared";
+import {
+  createGameConfigForSetup,
+  getSetupScenarioLaunchConfig,
+} from "../src/components/Setup/SetupScreen";
+import { HotseatPassScreen } from "../src/components/HotseatPassScreen";
+
+describe("hotseat setup", () => {
+  it("emits hotseat config with stable engine player ids", () => {
+    const config = createGameConfigForSetup(
+      2,
+      ["arythea", "tovak"],
+      { scenarioId: SCENARIO_FULL_CONQUEST_2P }
+    );
+
+    expect(config).not.toBeNull();
+    expect(config?.launchMode).toBe(GAME_LAUNCH_MODE_HOTSEAT);
+    expect(config?.playerIds).toEqual(["player_0", "player_1"]);
+    expect(config?.seats).toEqual([
+      {
+        playerId: "player_0",
+        heroId: "arythea",
+        controller: GAME_SEAT_CONTROLLER_LOCAL,
+      },
+      {
+        playerId: "player_1",
+        heroId: "tovak",
+        controller: GAME_SEAT_CONTROLLER_LOCAL,
+      },
+    ]);
+  });
+
+  it("maps conquest scenarios to explicit player-count variants", () => {
+    expect(getSetupScenarioLaunchConfig("full_conquest", 2)?.scenarioId).toBe(
+      SCENARIO_FULL_CONQUEST_2P
+    );
+    expect(getSetupScenarioLaunchConfig("full_conquest", 4)?.scenarioId).toBe(
+      SCENARIO_FULL_CONQUEST_4P
+    );
+    expect(getSetupScenarioLaunchConfig("blitz_conquest", 3)?.scenarioId).toBe(
+      SCENARIO_BLITZ_CONQUEST_3P
+    );
+  });
+
+  it("renders the hotseat pass screen for the next active player", () => {
+    const html = renderToStaticMarkup(
+      <HotseatPassScreen playerId="player_1" hero="tovak" onContinue={() => {}} />
+    );
+
+    expect(html).toContain("Pass to Tovak");
+    expect(html).toContain("Reveal turn");
+  });
+});

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -16,21 +16,18 @@ import { ReplayLoadScreen } from "./components/Replay";
 import { SetupScreen } from "./components/Setup";
 import { getRuntimeRustServerUrl } from "./runtime/rustServerUrl";
 import type { GameConfig } from "@mage-knight/shared";
-import { HERO_ARYTHEA } from "@mage-knight/shared";
 
 const MODE_PARAM = "mode" as const;
 const PLAYER_ID_PARAM = "playerId" as const;
 const MODE_REPLAY = "replay" as const;
 const HERO_PARAM = "hero" as const;
 const SEED_PARAM = "seed" as const;
-const SCENARIO_PARAM = "scenario" as const;
 
 interface RuntimeRustConfig {
   serverUrl: string;
   hero: string;
   seed?: number;
   playerId?: string;
-  scenario?: string;
 }
 
 function isReplayModeRequested(): boolean {
@@ -46,14 +43,12 @@ function getRuntimeRustConfig(): RuntimeRustConfig {
   const playerId = urlParams.get(PLAYER_ID_PARAM) ?? undefined;
   const seedParam = urlParams.get(SEED_PARAM);
   const seed = seedParam ? parseInt(seedParam, 10) : undefined;
-  const scenario = urlParams.get(SCENARIO_PARAM) ?? undefined;
 
   return {
     serverUrl,
     hero,
     seed: seed && !isNaN(seed) ? seed : undefined,
     playerId,
-    scenario,
   };
 }
 
@@ -121,7 +116,7 @@ export function App() {
   return (
     <GameProvider
       serverUrl={RUNTIME_RUST_CONFIG.serverUrl}
-      hero={gameConfig.heroIds[0] ?? HERO_ARYTHEA}
+      gameConfig={gameConfig}
       seed={RUNTIME_RUST_CONFIG.seed}
       playerId={RUNTIME_RUST_CONFIG.playerId}
     >

--- a/packages/client/src/components/HotseatPassScreen.css
+++ b/packages/client/src/components/HotseatPassScreen.css
@@ -1,0 +1,82 @@
+.hotseat-pass {
+  position: fixed;
+  inset: 0;
+  z-index: 10000;
+  display: grid;
+  place-items: center;
+  padding: clamp(1rem, 4vw, 2rem);
+  color: var(--text-primary);
+  background:
+    radial-gradient(ellipse 52% 42% at 50% 44%, oklch(0.24 0.018 78 / 0.72), transparent 68%),
+    var(--scrim-overlay);
+}
+
+.hotseat-pass__panel {
+  width: min(100%, 26rem);
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.4rem;
+  border: 1px solid var(--border-on-raised);
+  border-radius: 8px;
+  background: var(--surface-raised);
+  box-shadow:
+    inset 0 1px 0 oklch(0.94 0.008 82 / 0.06),
+    0 24px 60px oklch(0.08 0.012 78 / 0.52);
+}
+
+.hotseat-pass__eyebrow,
+.hotseat-pass__seat {
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.hotseat-pass__title {
+  margin: 0;
+  font-size: 1.45rem;
+  line-height: 1.18;
+  font-weight: 750;
+  color: var(--text-primary);
+}
+
+.hotseat-pass__copy {
+  max-width: 56ch;
+  margin: 0;
+  font-size: 0.96rem;
+  line-height: 1.45;
+  color: var(--text-secondary);
+}
+
+.hotseat-pass__seat {
+  width: fit-content;
+  padding: 0.42rem 0.62rem;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--surface-canvas);
+}
+
+.hotseat-pass__button {
+  justify-self: start;
+  min-height: 2.6rem;
+  padding: 0 1rem;
+  border: 1px solid oklch(0.62 0.085 78 / 0.72);
+  border-radius: 6px;
+  color: oklch(0.16 0.012 78);
+  cursor: pointer;
+  background: var(--accent);
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.hotseat-pass__button:hover {
+  filter: brightness(1.04);
+}
+
+.hotseat-pass__button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}

--- a/packages/client/src/components/HotseatPassScreen.tsx
+++ b/packages/client/src/components/HotseatPassScreen.tsx
@@ -1,0 +1,37 @@
+import { HERO_NAMES, type HeroId } from "@mage-knight/shared";
+import "./HotseatPassScreen.css";
+
+interface HotseatPassScreenProps {
+  readonly playerId: string;
+  readonly hero?: HeroId;
+  readonly onContinue: () => void;
+}
+
+export function HotseatPassScreen({
+  playerId,
+  hero,
+  onContinue,
+}: HotseatPassScreenProps) {
+  const heroName = hero ? HERO_NAMES[hero] : "Next player";
+  const seatLabel = playerId.replace("_", " ");
+
+  return (
+    <div className="hotseat-pass" role="dialog" aria-modal="true" aria-labelledby="hotseat-pass-title">
+      <div className="hotseat-pass__panel">
+        <p className="hotseat-pass__eyebrow">Hotseat handoff</p>
+        <h2 id="hotseat-pass-title" className="hotseat-pass__title">
+          Pass to {heroName}
+        </h2>
+        <p className="hotseat-pass__copy">
+          Private cards stay covered until the next player is ready.
+        </p>
+        <div className="hotseat-pass__seat" aria-label={`Active seat ${seatLabel}`}>
+          {seatLabel}
+        </div>
+        <button type="button" className="hotseat-pass__button" onClick={onContinue} autoFocus>
+          Reveal turn
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/client/src/components/Setup/SetupScreen.css
+++ b/packages/client/src/components/Setup/SetupScreen.css
@@ -195,14 +195,14 @@
   flex: 1;
   min-height: 0;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(16rem, 22rem);
+  grid-template-columns: minmax(0, 1fr) minmax(22rem, 30rem);
   grid-template-rows: auto minmax(0, 1fr) auto;
   grid-template-areas:
     "header settings"
     "slots settings"
     "footer settings";
   gap: clamp(0.9rem, 2vw, 1.4rem);
-  width: min(100%, 74rem);
+  width: min(100%, 82rem);
   margin: 0 auto;
   padding: clamp(1rem, 3.4vmin, 2.2rem) clamp(0.3rem, 1.2vw, 0.8rem)
     clamp(0.4rem, 1vmin, 0.8rem);
@@ -253,6 +253,37 @@
   align-self: stretch;
 }
 
+.setup-scenario-browser {
+  grid-area: slots;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(0.55rem, 1.4vw, 0.85rem);
+  padding: clamp(0.72rem, 1.8vmin, 1rem);
+  border: 1px solid oklch(0.34 0.03 62 / 0.46);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, oklch(0.17 0.022 56 / 0.72), oklch(0.08 0.016 55 / 0.86));
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.045),
+    0 16px 38px oklch(0.04 0.016 58 / 0.24);
+}
+
+.setup-scenario-browser__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.1rem 0.15rem 0.35rem;
+  border-bottom: 1px solid oklch(0.58 0.04 70 / 0.16);
+}
+
+.setup-scenario-browser__header strong {
+  font-size: 0.76rem;
+  font-weight: 800;
+  color: var(--setup-muted);
+}
+
 .setup-table-seat {
   position: relative;
   min-height: clamp(8.5rem, 24vmin, 14rem);
@@ -284,12 +315,26 @@
   transform: translateY(-1px);
 }
 
+.setup-table-seat:disabled {
+  cursor: not-allowed;
+  transform: none;
+}
+
 .setup-table-seat--open {
   color: var(--setup-muted);
   border-color: oklch(0.55 0.065 74 / 0.58);
   background:
     linear-gradient(180deg, oklch(0.22 0.028 58 / 0.72), oklch(0.11 0.02 56 / 0.84)),
     radial-gradient(ellipse 88% 70% at 50% 38%, oklch(0.72 0.08 76 / 0.12), transparent 68%);
+}
+
+.setup-table-seat--unavailable {
+  opacity: 0.5;
+}
+
+.setup-table-seat--unavailable:hover {
+  color: oklch(0.58 0.025 72 / 0.72);
+  border-color: oklch(0.34 0.03 62 / 0.46);
 }
 
 .setup-table-seat__number {
@@ -322,10 +367,10 @@
 
 .setup-table__settings {
   grid-area: settings;
-  align-self: stretch;
+  align-self: start;
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: clamp(0.65rem, 1.4vmin, 0.9rem);
   min-height: 0;
   padding: clamp(0.8rem, 2vmin, 1.1rem);
   border: 1px solid oklch(0.36 0.034 62 / 0.5);
@@ -337,15 +382,11 @@
     0 16px 38px oklch(0.04 0.016 58 / 0.28);
 }
 
-.setup-table-setting {
+.setup-table__scenario-heading {
   display: grid;
-  gap: 0.28rem;
-  padding: 0.95rem 0.25rem;
+  gap: 0.32rem;
+  padding: 0.1rem 0.18rem 0.25rem;
   border-bottom: 1px solid oklch(0.58 0.04 70 / 0.16);
-}
-
-.setup-table-setting:last-child {
-  border-bottom: 0;
 }
 
 .setup-table-setting__label {
@@ -363,8 +404,230 @@
   color: var(--setup-cream);
 }
 
-.setup-table-setting--muted .setup-table-setting__value {
+.setup-table__scenario-note {
+  max-width: 44ch;
+  font-size: 0.82rem;
+  line-height: 1.42;
   color: var(--setup-muted);
+}
+
+.setup-scenario-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.24rem;
+  padding: 0.2rem;
+  border: 1px solid oklch(0.35 0.032 62 / 0.42);
+  border-radius: 6px;
+  background: oklch(0.11 0.018 56 / 0.72);
+}
+
+.setup-scenario-tab {
+  min-width: 0;
+  padding: 0.52rem 0.44rem;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: oklch(0.64 0.028 72 / 0.82);
+  cursor: pointer;
+  background: transparent;
+  font-size: 0.58rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition:
+    color 0.18s var(--ease-out-expo),
+    border-color 0.18s var(--ease-out-expo),
+    background-color 0.18s var(--ease-out-expo);
+}
+
+.setup-scenario-tab:hover {
+  color: var(--setup-cream);
+}
+
+.setup-scenario-tab:focus-visible {
+  outline: 2px solid var(--setup-gold-dim);
+  outline-offset: 2px;
+}
+
+.setup-scenario-tab--selected {
+  color: var(--setup-cream);
+  border-color: oklch(0.55 0.06 72 / 0.48);
+  background: oklch(0.22 0.028 58 / 0.72);
+}
+
+.setup-scenario-list {
+  display: grid;
+  gap: 0.48rem;
+  overflow: auto;
+  padding-right: 0.12rem;
+  scrollbar-color: var(--setup-copper-lit) oklch(0.1 0.02 58 / 0.4);
+}
+
+.setup-scenario-list--catalog {
+  min-height: 0;
+  align-content: start;
+}
+
+.setup-scenario-option {
+  position: relative;
+  display: grid;
+  gap: 0.34rem;
+  width: 100%;
+  padding: 0.76rem 0.82rem;
+  border: 1px solid oklch(0.35 0.032 62 / 0.5);
+  border-radius: 6px;
+  color: var(--setup-muted);
+  text-align: left;
+  cursor: pointer;
+  background:
+    linear-gradient(180deg, oklch(0.18 0.023 58 / 0.58), oklch(0.1 0.018 56 / 0.78)),
+    radial-gradient(ellipse 90% 80% at 0% 0%, oklch(0.5 0.05 70 / 0.08), transparent 68%);
+  box-shadow: inset 0 1px 0 oklch(0.95 0.02 82 / 0.04);
+  transition:
+    color 0.2s var(--ease-out-expo),
+    border-color 0.2s var(--ease-out-expo),
+    background 0.2s var(--ease-out-expo),
+    box-shadow 0.2s var(--ease-out-expo),
+    transform 0.2s var(--ease-out-expo);
+}
+
+.setup-scenario-option:hover {
+  color: var(--setup-cream);
+  border-color: oklch(0.52 0.06 72 / 0.62);
+  transform: translateY(-1px);
+}
+
+.setup-scenario-option:focus-visible {
+  outline: 2px solid var(--setup-gold-dim);
+  outline-offset: 2px;
+}
+
+.setup-scenario-option--selected {
+  color: var(--setup-cream);
+  border-color: oklch(0.7 0.095 78 / 0.72);
+  background:
+    linear-gradient(180deg, oklch(0.24 0.033 58 / 0.82), oklch(0.12 0.021 56 / 0.9)),
+    radial-gradient(ellipse 92% 80% at 12% 0%, oklch(0.68 0.085 78 / 0.14), transparent 70%);
+  box-shadow:
+    inset 0 1px 0 oklch(0.95 0.02 82 / 0.08),
+    0 10px 24px oklch(0.05 0.02 58 / 0.26);
+}
+
+.setup-scenario-option__topline,
+.setup-scenario-option__facts {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.setup-scenario-option__eyebrow,
+.setup-scenario-option__players,
+.setup-scenario-option__facts {
+  font-size: 0.56rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+}
+
+.setup-scenario-option__eyebrow {
+  color: var(--setup-gold-dim);
+}
+
+.setup-scenario-option__players {
+  color: oklch(0.62 0.034 76 / 0.82);
+}
+
+.setup-scenario-option__title {
+  font-size: 1rem;
+  line-height: 1.18;
+  font-weight: 800;
+  color: currentColor;
+}
+
+.setup-scenario-option__summary {
+  max-width: 48ch;
+  font-size: 0.78rem;
+  line-height: 1.38;
+  color: oklch(0.72 0.028 72 / 0.84);
+}
+
+.setup-scenario-option__facts {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  color: oklch(0.58 0.03 72 / 0.84);
+}
+
+.setup-table__table-facts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.55rem;
+  margin-top: 0;
+}
+
+.setup-table-fact {
+  display: grid;
+  gap: 0.24rem;
+  padding: 0.74rem 0.78rem;
+  border: 1px solid oklch(0.35 0.032 62 / 0.42);
+  border-radius: 6px;
+  background: oklch(0.12 0.019 56 / 0.62);
+}
+
+.setup-seat-selector {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.74rem 0.78rem;
+  border: 1px solid oklch(0.35 0.032 62 / 0.42);
+  border-radius: 6px;
+  background: oklch(0.12 0.019 56 / 0.62);
+}
+
+.setup-seat-selector__buttons {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
+}
+
+.setup-seat-selector__button {
+  min-height: 2.35rem;
+  border: 1px solid oklch(0.33 0.03 62 / 0.58);
+  border-radius: 4px;
+  color: oklch(0.66 0.03 74 / 0.78);
+  cursor: pointer;
+  background: oklch(0.16 0.022 56 / 0.74);
+  font-size: 0.7rem;
+  font-weight: 850;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  transition:
+    color 0.18s var(--ease-out-expo),
+    border-color 0.18s var(--ease-out-expo),
+    background-color 0.18s var(--ease-out-expo);
+}
+
+.setup-seat-selector__button:hover:not(:disabled) {
+  color: var(--setup-cream);
+  border-color: oklch(0.52 0.06 72 / 0.62);
+}
+
+.setup-seat-selector__button--open {
+  color: oklch(0.1 0.02 58);
+  border-color: oklch(0.62 0.1 72 / 0.65);
+  background: linear-gradient(
+    165deg,
+    var(--setup-copper-lit) 0%,
+    var(--setup-copper) 100%
+  );
+}
+
+.setup-seat-selector__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.38;
+}
+
+.setup-seat-selector__button:focus-visible {
+  outline: 2px solid var(--setup-gold-dim);
+  outline-offset: 2px;
 }
 
 .setup-table__footer {
@@ -951,6 +1214,10 @@
     min-height: auto;
   }
 
+  .setup-scenario-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .setup-screen__brand {
     top: 0;
     left: 0;
@@ -992,13 +1259,16 @@
 
   .hero-card,
   .setup-screen__begin,
-  .setup-players__btn {
+  .setup-players__btn,
+  .setup-scenario-option,
+  .setup-scenario-tab {
     transition-duration: 0.01ms;
   }
 
   .hero-card:hover:not(.hero-card--disabled),
   .hero-card:active:not(.hero-card--disabled),
-  .setup-screen__begin:hover:not(:disabled) {
+  .setup-screen__begin:hover:not(:disabled),
+  .setup-scenario-option:hover {
     transform: none;
   }
 

--- a/packages/client/src/components/Setup/SetupScreen.tsx
+++ b/packages/client/src/components/Setup/SetupScreen.tsx
@@ -7,9 +7,18 @@ import { useState, useCallback } from "react";
 import type { GameConfig, HeroId } from "@mage-knight/shared";
 import {
   ALL_HEROES,
+  GAME_LAUNCH_MODE_HOTSEAT,
+  GAME_LAUNCH_MODE_SOLO,
+  GAME_SEAT_CONTROLLER_LOCAL,
   HERO_NAMES,
+  SCENARIO_BLITZ_CONQUEST_2P,
+  SCENARIO_BLITZ_CONQUEST_3P,
+  SCENARIO_BLITZ_CONQUEST_4P,
   SCENARIO_DISPLAY_NAMES,
   SCENARIO_FIRST_RECONNAISSANCE,
+  SCENARIO_FULL_CONQUEST_2P,
+  SCENARIO_FULL_CONQUEST_3P,
+  SCENARIO_FULL_CONQUEST_4P,
 } from "@mage-knight/shared";
 import { HeroSelectionGrid } from "./HeroSelectionGrid";
 import "./SetupScreen.css";
@@ -18,11 +27,231 @@ const SETUP_BEGIN_ARIA_READY = "Begin scenario" as const;
 const SETUP_BEGIN_ARIA_PENDING =
   "Begin scenario, locked until every player seat has a hero" as const;
 const SETUP_MAX_PLAYERS = 4;
+const SETUP_PLAYER_ID_PREFIX = "player_" as const;
+const SETUP_SCENARIO_STANDARD = "standard" as const;
+const SETUP_SCENARIO_FULL_CONQUEST = "full_conquest" as const;
+const SETUP_SCENARIO_BLITZ_CONQUEST = "blitz_conquest" as const;
+const SETUP_SCENARIO_RECON_EXPLORE = "recon_explore" as const;
+const SETUP_SCENARIO_EXPLORATION = "exploration" as const;
+const SETUP_SCENARIO_EXPLORATION_TINY = "exploration_tiny" as const;
+const SETUP_CATEGORY_ALL = "all" as const;
+const SETUP_CATEGORY_LEARNING = "learning" as const;
+const SETUP_CATEGORY_CONQUEST = "conquest" as const;
+const SETUP_CATEGORY_DRILLS = "drills" as const;
 type SetupStep = "table" | "heroes";
+export type SetupScenarioKey =
+  | typeof SETUP_SCENARIO_STANDARD
+  | typeof SETUP_SCENARIO_FULL_CONQUEST
+  | typeof SETUP_SCENARIO_BLITZ_CONQUEST
+  | typeof SETUP_SCENARIO_RECON_EXPLORE
+  | typeof SETUP_SCENARIO_EXPLORATION
+  | typeof SETUP_SCENARIO_EXPLORATION_TINY;
+type SetupScenarioCategory =
+  | typeof SETUP_CATEGORY_LEARNING
+  | typeof SETUP_CATEGORY_CONQUEST
+  | typeof SETUP_CATEGORY_DRILLS;
+type SetupScenarioFilter =
+  | typeof SETUP_CATEGORY_ALL
+  | SetupScenarioCategory;
+type SetupPlayerCount = 1 | 2 | 3 | 4;
 
-function getSlotState(index: number, isEnabled: boolean): "Host" | "Seat" | "Closed" {
-  if (!isEnabled) return "Closed";
-  return index === 0 ? "Host" : "Seat";
+export interface SetupScenarioLaunchConfig {
+  readonly scenarioId: GameConfig["scenarioId"];
+  readonly serverScenario?: string;
+}
+
+interface SetupScenarioOption {
+  readonly key: SetupScenarioKey;
+  readonly category: SetupScenarioCategory;
+  readonly title: string;
+  readonly statusLabel: string;
+  readonly summary: string;
+  readonly detail: string;
+  readonly launchConfig?: SetupScenarioLaunchConfig;
+  readonly launchVariants?: Partial<Record<SetupPlayerCount, SetupScenarioLaunchConfig>>;
+  readonly minPlayers: number;
+  readonly maxPlayers: number;
+  readonly rounds: string;
+  readonly objective: string;
+}
+
+const SETUP_SCENARIO_CATEGORIES: readonly {
+  readonly key: SetupScenarioFilter;
+  readonly label: string;
+}[] = [
+  { key: SETUP_CATEGORY_ALL, label: "All" },
+  { key: SETUP_CATEGORY_LEARNING, label: "Learning" },
+  { key: SETUP_CATEGORY_CONQUEST, label: "Conquest" },
+  { key: SETUP_CATEGORY_DRILLS, label: "Drills" },
+] as const;
+
+const SETUP_SCENARIOS: readonly SetupScenarioOption[] = [
+  {
+    key: SETUP_SCENARIO_STANDARD,
+    category: SETUP_CATEGORY_LEARNING,
+    title: SCENARIO_DISPLAY_NAMES[SCENARIO_FIRST_RECONNAISSANCE],
+    statusLabel: "Launchable",
+    summary: "Standard solo start with the Rust rules engine in charge.",
+    detail: "City reveal objective, four rounds, dummy tactic timing.",
+    launchConfig: {
+      scenarioId: SCENARIO_FIRST_RECONNAISSANCE,
+    },
+    minPlayers: 1,
+    maxPlayers: 1,
+    rounds: "4 rounds",
+    objective: "Reveal a city",
+  },
+  {
+    key: SETUP_SCENARIO_FULL_CONQUEST,
+    category: SETUP_CATEGORY_CONQUEST,
+    title: "Full Conquest",
+    statusLabel: "Launchable",
+    summary: "Full table conquest for 2-4 local hotseat players.",
+    detail: "Choose a local seat for each hero. The pass screen covers private hands between turns.",
+    launchVariants: {
+      2: { scenarioId: SCENARIO_FULL_CONQUEST_2P },
+      3: { scenarioId: SCENARIO_FULL_CONQUEST_3P },
+      4: { scenarioId: SCENARIO_FULL_CONQUEST_4P },
+    },
+    minPlayers: 2,
+    maxPlayers: 4,
+    rounds: "6 rounds",
+    objective: "Conquer all cities",
+  },
+  {
+    key: SETUP_SCENARIO_BLITZ_CONQUEST,
+    category: SETUP_CATEGORY_CONQUEST,
+    title: "Blitz Conquest",
+    statusLabel: "Launchable",
+    summary: "Shorter conquest arc with hotter fame and source pacing.",
+    detail: "A faster 2-4 player hotseat conquest with the same local handoff privacy.",
+    launchVariants: {
+      2: { scenarioId: SCENARIO_BLITZ_CONQUEST_2P },
+      3: { scenarioId: SCENARIO_BLITZ_CONQUEST_3P },
+      4: { scenarioId: SCENARIO_BLITZ_CONQUEST_4P },
+    },
+    minPlayers: 2,
+    maxPlayers: 4,
+    rounds: "4 rounds",
+    objective: "Conquer all cities",
+  },
+  {
+    key: SETUP_SCENARIO_RECON_EXPLORE,
+    category: SETUP_CATEGORY_DRILLS,
+    title: "Recon Explore",
+    statusLabel: "Launchable",
+    summary: "First Recon map shape with a movement-heavy exploration deck.",
+    detail: "Use this when you want to validate tile flow without combat pressure.",
+    launchConfig: {
+      scenarioId: SCENARIO_FIRST_RECONNAISSANCE,
+      serverScenario: SETUP_SCENARIO_RECON_EXPLORE,
+    },
+    minPlayers: 1,
+    maxPlayers: 1,
+    rounds: "Explore drill",
+    objective: "Reach the city",
+  },
+  {
+    key: SETUP_SCENARIO_EXPLORATION,
+    category: SETUP_CATEGORY_DRILLS,
+    title: "Exploration",
+    statusLabel: "Launchable",
+    summary: "Compact countryside route for fast map and movement checks.",
+    detail: "A shorter no-enemy drill that still exercises reveal decisions.",
+    launchConfig: {
+      scenarioId: SCENARIO_FIRST_RECONNAISSANCE,
+      serverScenario: SETUP_SCENARIO_EXPLORATION,
+    },
+    minPlayers: 1,
+    maxPlayers: 1,
+    rounds: "Short drill",
+    objective: "Reveal a city",
+  },
+  {
+    key: SETUP_SCENARIO_EXPLORATION_TINY,
+    category: SETUP_CATEGORY_DRILLS,
+    title: "Tiny Exploration",
+    statusLabel: "Launchable",
+    summary: "Smallest supported exploration setup for quick smoke tests.",
+    detail: "Useful when you want to get from setup to board interaction fast.",
+    launchConfig: {
+      scenarioId: SCENARIO_FIRST_RECONNAISSANCE,
+      serverScenario: SETUP_SCENARIO_EXPLORATION_TINY,
+    },
+    minPlayers: 1,
+    maxPlayers: 1,
+    rounds: "Tiny drill",
+    objective: "Reveal a city",
+  },
+] as const;
+
+function getSetupScenario(key: SetupScenarioKey): SetupScenarioOption {
+  return (
+    SETUP_SCENARIOS.find((scenario) => scenario.key === key) ??
+    SETUP_SCENARIOS[0]!
+  );
+}
+
+function clampPlayerCount(count: number, scenario: SetupScenarioOption): number {
+  return Math.min(Math.max(count, scenario.minPlayers), scenario.maxPlayers);
+}
+
+function toSetupPlayerCount(count: number): SetupPlayerCount {
+  return Math.min(Math.max(count, 1), SETUP_MAX_PLAYERS) as SetupPlayerCount;
+}
+
+export function getSetupScenarioLaunchConfig(
+  scenarioKey: SetupScenarioKey,
+  playerCount: number
+): SetupScenarioLaunchConfig | undefined {
+  return getLaunchConfig(getSetupScenario(scenarioKey), playerCount);
+}
+
+function getLaunchConfig(
+  scenario: SetupScenarioOption,
+  playerCount: number
+): SetupScenarioLaunchConfig | undefined {
+  return (
+    scenario.launchVariants?.[toSetupPlayerCount(playerCount)] ??
+    scenario.launchConfig
+  );
+}
+
+export function createGameConfigForSetup(
+  playerCount: number,
+  selectedHeroes: readonly (HeroId | null)[],
+  launchConfig: SetupScenarioLaunchConfig
+): GameConfig | null {
+  const heroIds = selectedHeroes.slice(0, playerCount);
+  if (heroIds.length !== playerCount || heroIds.some((hero) => hero == null)) {
+    return null;
+  }
+
+  const playerIds = Array.from(
+    { length: playerCount },
+    (_, i) => `${SETUP_PLAYER_ID_PREFIX}${i}`
+  );
+  const seats = heroIds.map((heroId, index) => ({
+    playerId: playerIds[index]!,
+    heroId: heroId!,
+    controller: GAME_SEAT_CONTROLLER_LOCAL,
+  }));
+
+  const config: GameConfig = {
+    launchMode:
+      playerCount > 1 ? GAME_LAUNCH_MODE_HOTSEAT : GAME_LAUNCH_MODE_SOLO,
+    playerIds,
+    heroIds: heroIds as HeroId[],
+    seats,
+    scenarioId: launchConfig.scenarioId,
+  };
+
+  if (!launchConfig.serverScenario) return config;
+
+  return {
+    ...config,
+    serverScenario: launchConfig.serverScenario,
+  };
 }
 
 interface SetupScreenProps {
@@ -32,6 +261,10 @@ interface SetupScreenProps {
 
 export function SetupScreen({ onComplete }: SetupScreenProps) {
   const [setupStep, setSetupStep] = useState<SetupStep>("table");
+  const [selectedScenarioKey, setSelectedScenarioKey] =
+    useState<SetupScenarioKey>(SETUP_SCENARIO_STANDARD);
+  const [selectedFilter, setSelectedFilter] =
+    useState<SetupScenarioFilter>(SETUP_CATEGORY_ALL);
 
   // Player count (1-4)
   const [playerCount, setPlayerCount] = useState(1);
@@ -46,11 +279,47 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
    * Preserves selections for seats that remain active.
    */
   const handlePlayerCountChange = useCallback((count: number) => {
-    setPlayerCount(count);
+    const selectedScenario = getSetupScenario(selectedScenarioKey);
+    const nextCount = clampPlayerCount(count, selectedScenario);
+    setPlayerCount(nextCount);
     setSelectedHeroes((prev) =>
-      Array.from({ length: count }, (_, index) => prev[index] ?? null)
+      Array.from({ length: nextCount }, (_, index) => prev[index] ?? null)
     );
+  }, [selectedScenarioKey]);
+
+  const handleScenarioChange = useCallback((scenarioKey: SetupScenarioKey) => {
+    const scenario = getSetupScenario(scenarioKey);
+    setSelectedScenarioKey(scenarioKey);
+    setPlayerCount((currentCount) => {
+      const nextCount = clampPlayerCount(currentCount, scenario);
+      setSelectedHeroes((prev) =>
+        Array.from({ length: nextCount }, (_, index) => prev[index] ?? null)
+      );
+      return nextCount;
+    });
   }, []);
+
+  const handleFilterChange = useCallback((filter: SetupScenarioFilter) => {
+    setSelectedFilter(filter);
+    if (
+      filter === SETUP_CATEGORY_ALL ||
+      getSetupScenario(selectedScenarioKey).category === filter
+    ) {
+      return;
+    }
+
+    const nextScenario =
+      SETUP_SCENARIOS.find((scenario) => scenario.category === filter) ??
+      SETUP_SCENARIOS[0]!;
+    setSelectedScenarioKey(nextScenario.key);
+    setPlayerCount((currentCount) => {
+      const nextCount = clampPlayerCount(currentCount, nextScenario);
+      setSelectedHeroes((prev) =>
+        Array.from({ length: nextCount }, (_, index) => prev[index] ?? null)
+      );
+      return nextCount;
+    });
+  }, [selectedScenarioKey]);
 
   /**
    * Handle hero selection for a specific player slot.
@@ -76,31 +345,29 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
    * Check if all players have selected heroes.
    */
   const allSelected = selectedHeroes.every((h) => h !== null);
+  const selectedScenario = getSetupScenario(selectedScenarioKey);
+  const scenarioTitle = selectedScenario.title;
+  const launchConfig = getLaunchConfig(selectedScenario, playerCount);
+  const isScenarioLaunchable = Boolean(launchConfig);
+  const visibleScenarios = SETUP_SCENARIOS.filter(
+    (scenario) =>
+      selectedFilter === SETUP_CATEGORY_ALL ||
+      scenario.category === selectedFilter
+  );
 
   /**
    * Handle start game button click.
    */
   const handleStartGame = useCallback(() => {
-    if (!allSelected) return;
+    if (!allSelected || !launchConfig) return;
 
-    // Generate player IDs
-    const playerIds = Array.from(
-      { length: playerCount },
-      (_, i) => `player${i + 1}`
+    const config = createGameConfigForSetup(
+      playerCount,
+      selectedHeroes,
+      launchConfig
     );
-
-    // Cast is safe because we've verified allSelected
-    const heroIds = selectedHeroes as HeroId[];
-
-    onComplete({
-      playerIds,
-      heroIds,
-      scenarioId: SCENARIO_FIRST_RECONNAISSANCE,
-    });
-  }, [allSelected, playerCount, selectedHeroes, onComplete]);
-
-  const scenarioTitle =
-    SCENARIO_DISPLAY_NAMES[SCENARIO_FIRST_RECONNAISSANCE];
+    if (config) onComplete(config);
+  }, [allSelected, playerCount, selectedHeroes, launchConfig, onComplete]);
 
   const activeSeatIndex =
     currentPlayerIndex >= 0 ? currentPlayerIndex : playerCount - 1;
@@ -144,54 +411,134 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
             <h1 className="setup-table__title">Prepare the table</h1>
           </div>
 
-          <section className="setup-table__slots" aria-label="Player slots">
-            {Array.from({ length: SETUP_MAX_PLAYERS }, (_, index) => {
-              const isEnabled = index < playerCount;
-              const hero = selectedHeroes[index] ?? null;
-              const heroName = hero ? HERO_NAMES[hero] : "Open";
-              const slotState = getSlotState(index, isEnabled);
+          <section className="setup-scenario-browser" aria-label="Scenario library">
+            <div className="setup-scenario-browser__header">
+              <span className="setup-table-setting__label">
+                Scenario library
+              </span>
+              <strong>{SETUP_SCENARIOS.length} entries</strong>
+            </div>
 
-              return (
+            <div className="setup-scenario-tabs" role="tablist" aria-label="Scenario filters">
+              {SETUP_SCENARIO_CATEGORIES.map((category) => (
                 <button
-                  key={`table-seat-${index + 1}`}
+                  key={category.key}
                   type="button"
-                  className={`setup-table-seat ${
-                    isEnabled ? "setup-table-seat--open" : ""
+                  className={`setup-scenario-tab ${
+                    selectedFilter === category.key
+                      ? "setup-scenario-tab--selected"
+                      : ""
                   }`}
-                  onClick={() => handlePlayerCountChange(index + 1)}
-                  aria-pressed={isEnabled}
+                  onClick={() => handleFilterChange(category.key)}
+                  aria-selected={selectedFilter === category.key}
+                  role="tab"
                 >
-                  <span className="setup-table-seat__number">
-                    P{index + 1}
-                  </span>
-                  <span className="setup-table-seat__name">
-                    {isEnabled ? heroName : "Closed"}
-                  </span>
-                  <span className="setup-table-seat__state">{slotState}</span>
+                  {category.label}
                 </button>
-              );
-            })}
+              ))}
+            </div>
+
+            <div className="setup-scenario-list setup-scenario-list--catalog">
+              {visibleScenarios.map((scenario) => {
+                const isSelected = scenario.key === selectedScenarioKey;
+
+                return (
+                  <button
+                    key={scenario.key}
+                    type="button"
+                    className={`setup-scenario-option ${
+                      isSelected ? "setup-scenario-option--selected" : ""
+                    }`}
+                    onClick={() => handleScenarioChange(scenario.key)}
+                    aria-pressed={isSelected}
+                  >
+                    <span className="setup-scenario-option__topline">
+                      <span className="setup-scenario-option__eyebrow">
+                        {scenario.statusLabel}
+                      </span>
+                      <span className="setup-scenario-option__players">
+                        {scenario.minPlayers === scenario.maxPlayers
+                          ? `${scenario.maxPlayers}P`
+                          : `${scenario.minPlayers}-${scenario.maxPlayers}P`}
+                      </span>
+                    </span>
+                    <span className="setup-scenario-option__title">
+                      {scenario.title}
+                    </span>
+                    <span className="setup-scenario-option__summary">
+                      {scenario.summary}
+                    </span>
+                    <span className="setup-scenario-option__facts">
+                      <span>{scenario.rounds}</span>
+                      <span>{scenario.objective}</span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
           </section>
 
           <section
             className="setup-table__settings"
-            aria-label="Scenario settings"
+            aria-label="Scenario selection"
           >
-            <div className="setup-table-setting">
+            <div className="setup-table__scenario-heading">
               <span className="setup-table-setting__label">Scenario</span>
               <strong className="setup-table-setting__value">
                 {scenarioTitle}
               </strong>
+              <span className="setup-table__scenario-note">
+                {selectedScenario.detail}
+              </span>
             </div>
-            <div className="setup-table-setting">
-              <span className="setup-table-setting__label">Seats</span>
-              <strong className="setup-table-setting__value">
-                {playerCount}
-              </strong>
+
+            <div
+              className="setup-table__table-facts"
+              aria-label="Selected table facts"
+            >
+              <div className="setup-table-fact">
+                <span className="setup-table-setting__label">Seats</span>
+                <strong className="setup-table-setting__value">
+                  {playerCount}
+                </strong>
+              </div>
+              <div className="setup-table-fact">
+                <span className="setup-table-setting__label">Status</span>
+                <strong className="setup-table-setting__value">
+                  {selectedScenario.statusLabel}
+                </strong>
+              </div>
             </div>
-            <div className="setup-table-setting setup-table-setting--muted">
-              <span className="setup-table-setting__label">Variants</span>
-              <strong className="setup-table-setting__value">Standard</strong>
+
+            <div className="setup-seat-selector" aria-label="Player count">
+              <span className="setup-table-setting__label">Players</span>
+              <div className="setup-seat-selector__buttons">
+                {Array.from({ length: SETUP_MAX_PLAYERS }, (_, index) => {
+                  const count = index + 1;
+                  const isSelectedCount = playerCount === count;
+                  const isAvailable =
+                    count >= selectedScenario.minPlayers &&
+                    count <= selectedScenario.maxPlayers;
+
+                  return (
+                    <button
+                      key={`table-seat-count-${count}`}
+                      type="button"
+                      className={`setup-seat-selector__button ${
+                        isSelectedCount
+                          ? "setup-seat-selector__button--open"
+                          : ""
+                      }`}
+                      onClick={() => handlePlayerCountChange(count)}
+                      disabled={!isAvailable}
+                      aria-pressed={isSelectedCount}
+                      aria-label={`${count} player${count === 1 ? "" : "s"}`}
+                    >
+                      {count}
+                    </button>
+                  );
+                })}
+              </div>
             </div>
           </section>
 
@@ -199,9 +546,10 @@ export function SetupScreen({ onComplete }: SetupScreenProps) {
             <button
               type="button"
               className="setup-screen__begin setup-screen__begin--ready"
+              disabled={!isScenarioLaunchable}
               onClick={() => setSetupStep("heroes")}
             >
-              Choose heroes
+              {isScenarioLaunchable ? "Choose heroes" : "Launch path pending"}
             </button>
           </footer>
         </main>

--- a/packages/client/src/context/GameProvider.tsx
+++ b/packages/client/src/context/GameProvider.tsx
@@ -5,42 +5,91 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import type { ClientGameState, GameEvent } from "@mage-knight/shared";
+import {
+  GAME_LAUNCH_MODE_HOTSEAT,
+  type ClientGameState,
+  type GameConfig,
+  type GameEvent,
+} from "@mage-knight/shared";
 import { GameContext, type ActionLogEntry, type GameAction, type GameContextValue } from "./GameContext";
 import { RustGameConnection, type ConnectionStatus } from "../rust/RustGameConnection";
 import type { LegalAction } from "../rust/types";
+import { HotseatPassScreen } from "../components/HotseatPassScreen";
 
 interface GameProviderProps {
   children: ReactNode;
   serverUrl: string;
-  hero: string;
+  gameConfig: GameConfig;
   seed?: number;
   playerId?: string;
-  scenario?: string;
+}
+
+interface GameUpdatePayload {
+  readonly state: ClientGameState;
+  readonly legalActions: LegalAction[];
+  readonly epoch: number;
+  readonly events: readonly GameEvent[];
 }
 
 let nextLogId = 1;
 
 export function GameProvider(props: GameProviderProps) {
-  const { children, serverUrl, hero, seed, playerId, scenario } = props;
+  const { children, serverUrl, gameConfig, seed, playerId } = props;
   const [state, setState] = useState<ClientGameState | null>(null);
   const [events, setEvents] = useState<readonly GameEvent[]>([]);
   const [actionLog, setActionLog] = useState<ActionLogEntry[]>([]);
   const [isActionLogEnabled, setActionLogEnabled] = useState(true);
   const [legalActions, setLegalActions] = useState<LegalAction[]>([]);
   const [epoch, setEpoch] = useState(0);
+  const [visiblePlayerId, setVisiblePlayerId] = useState(playerId ?? "player_0");
+  const [pendingHotseatUpdate, setPendingHotseatUpdate] =
+    useState<GameUpdatePayload | null>(null);
   const [rustConnectionStatus, setRustConnectionStatus] = useState<ConnectionStatus | null>(null);
 
   const rustConnectionRef = useRef<RustGameConnection | null>(null);
   const isActionLogEnabledRef = useRef(isActionLogEnabled);
   const epochRef = useRef(0);
+  const stateRef = useRef<ClientGameState | null>(null);
+  const visiblePlayerIdRef = useRef(visiblePlayerId);
 
-  const myPlayerId = playerId ?? "player_0";
+  const isHotseat = gameConfig.launchMode === GAME_LAUNCH_MODE_HOTSEAT;
+  const myPlayerId = isHotseat ? visiblePlayerId : playerId ?? "player_0";
 
   // Keep ref in sync with state for use in callbacks
   useEffect(() => {
     isActionLogEnabledRef.current = isActionLogEnabled;
   }, [isActionLogEnabled]);
+
+  useEffect(() => {
+    visiblePlayerIdRef.current = visiblePlayerId;
+  }, [visiblePlayerId]);
+
+  const applyGameUpdate = useCallback((update: GameUpdatePayload) => {
+    const nextPlayerId =
+      update.state.currentPlayerId || update.state.players[0]?.id || "player_0";
+    stateRef.current = update.state;
+    setState(update.state);
+    setLegalActions([...update.legalActions]);
+    setEpoch(update.epoch);
+    epochRef.current = update.epoch;
+    visiblePlayerIdRef.current = nextPlayerId;
+    setVisiblePlayerId(nextPlayerId);
+
+    if (update.events.length > 0) {
+      setEvents((prev) => [...prev, ...update.events]);
+    }
+
+    if (import.meta.env.DEV) {
+      (window as unknown as { __MAGE_KNIGHT_STATE__: ClientGameState }).
+        __MAGE_KNIGHT_STATE__ = update.state;
+    }
+  }, []);
+
+  const handleHotseatContinue = useCallback(() => {
+    if (!pendingHotseatUpdate) return;
+    applyGameUpdate(pendingHotseatUpdate);
+    setPendingHotseatUpdate(null);
+  }, [applyGameUpdate, pendingHotseatUpdate]);
 
   // Connect via WebSocket to mk-server
   useEffect(() => {
@@ -48,13 +97,25 @@ export function GameProvider(props: GameProviderProps) {
       serverUrl,
       onGameUpdate: (rawState, actions, newEpoch, rawEvents) => {
         const gameState = rawState as unknown as ClientGameState;
-        setState(gameState);
-        setLegalActions(actions);
-        setEpoch(newEpoch);
-        epochRef.current = newEpoch;
-        if (rawEvents.length > 0) {
-          setEvents((prev) => [...prev, ...(rawEvents as GameEvent[])]);
+        const update: GameUpdatePayload = {
+          state: gameState,
+          legalActions: actions,
+          epoch: newEpoch,
+          events: rawEvents as GameEvent[],
+        };
+        const incomingPlayerId =
+          gameState.currentPlayerId || gameState.players[0]?.id || "player_0";
+
+        if (
+          isHotseat &&
+          stateRef.current != null &&
+          incomingPlayerId !== visiblePlayerIdRef.current
+        ) {
+          setPendingHotseatUpdate(update);
+          return;
         }
+
+        applyGameUpdate(update);
 
         if (import.meta.env.DEV) {
           const player = gameState.players?.[0];
@@ -68,11 +129,6 @@ export function GameProvider(props: GameProviderProps) {
           console.log("[Rust State]", gameState);
           console.log("[Rust LegalActions]", actions);
         }
-
-        if (import.meta.env.DEV) {
-          (window as unknown as { __MAGE_KNIGHT_STATE__: ClientGameState }).
-            __MAGE_KNIGHT_STATE__ = gameState;
-        }
       },
       onError: (message) => {
         console.error("[mk-server]", message);
@@ -84,13 +140,13 @@ export function GameProvider(props: GameProviderProps) {
 
     rustConnectionRef.current = connection;
     connection.connect();
-    connection.sendNewGame(hero, seed, scenario);
+    connection.sendNewGame(gameConfig, seed);
 
     return () => {
       connection.disconnect();
       rustConnectionRef.current = null;
     };
-  }, [serverUrl, hero, seed, scenario]);
+  }, [serverUrl, gameConfig, seed, isHotseat, applyGameUpdate]);
 
   const sendAction = useCallback((action: GameAction) => {
     if (isActionLogEnabledRef.current) {
@@ -137,6 +193,10 @@ export function GameProvider(props: GameProviderProps) {
     epoch,
   };
 
+  const pendingPlayer = pendingHotseatUpdate?.state.players.find(
+    (candidate) => candidate.id === pendingHotseatUpdate.state.currentPlayerId
+  );
+
   // Show loading/connection status
   if (rustConnectionStatus === "connecting" || rustConnectionStatus === null) {
     return (
@@ -175,5 +235,16 @@ export function GameProvider(props: GameProviderProps) {
     );
   }
 
-  return <GameContext.Provider value={value}>{children}</GameContext.Provider>;
+  return (
+    <GameContext.Provider value={value}>
+      {children}
+      {pendingHotseatUpdate && (
+        <HotseatPassScreen
+          playerId={pendingHotseatUpdate.state.currentPlayerId}
+          hero={pendingPlayer?.hero}
+          onContinue={handleHotseatContinue}
+        />
+      )}
+    </GameContext.Provider>
+  );
 }

--- a/packages/client/src/rust/RustGameConnection.ts
+++ b/packages/client/src/rust/RustGameConnection.ts
@@ -2,11 +2,15 @@
  * WebSocket client for the Rust mk-server.
  *
  * Protocol:
- *   Client -> Server: { type: "new_game", hero, seed } | { type: "action", action, epoch } | { type: "ping" } | { type: "undo" }
+ *   Client -> Server: { type: "new_game", ...config } | { type: "action", action, epoch } | { type: "ping" } | { type: "undo" }
  *   Server -> Client: { type: "state_update", state, events, legal_actions, epoch } | { type: "error", message } | { type: "pong" }
  */
 
-import type { LegalAction, ServerMessage } from "./types";
+import {
+  GAME_LAUNCH_MODE_HOTSEAT,
+  type GameConfig,
+} from "@mage-knight/shared";
+import type { ClientMessage, LegalAction, ServerMessage } from "./types";
 
 export type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "disconnected" | "error";
 
@@ -21,13 +25,15 @@ const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 500;
 const HEARTBEAT_INTERVAL_MS = 25_000;
 
+type NewGameMessage = Extract<ClientMessage, { type: "new_game" }>;
+
 export class RustGameConnection {
   private ws: WebSocket | null = null;
   private options: RustGameConnectionOptions;
   private reconnectAttempts = 0;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-  private pendingNewGame: { hero: string; seed?: number; scenario?: string } | null = null;
+  private pendingNewGame: NewGameMessage | null = null;
 
   constructor(options: RustGameConnectionOptions) {
     this.options = options;
@@ -43,12 +49,7 @@ export class RustGameConnection {
       this.startHeartbeat();
       // Send pending new_game if we have one
       if (this.pendingNewGame) {
-        this.sendRaw({
-          type: "new_game",
-          hero: this.pendingNewGame.hero,
-          seed: this.pendingNewGame.seed,
-          scenario: this.pendingNewGame.scenario,
-        });
+        this.sendRaw(this.pendingNewGame);
       }
     };
 
@@ -86,10 +87,11 @@ export class RustGameConnection {
     this.options.onStatusChange("disconnected");
   }
 
-  sendNewGame(hero: string, seed?: number, scenario?: string): void {
-    this.pendingNewGame = { hero, seed, scenario };
+  sendNewGame(config: GameConfig, seed?: number): void {
+    const message = buildNewGameMessage(config, seed);
+    this.pendingNewGame = message;
     if (this.ws?.readyState === WebSocket.OPEN) {
-      this.sendRaw({ type: "new_game", hero, seed, scenario });
+      this.sendRaw(message);
     }
   }
 
@@ -136,4 +138,26 @@ export class RustGameConnection {
       this.connect();
     }, delay);
   }
+}
+
+function buildNewGameMessage(config: GameConfig, seed?: number): NewGameMessage {
+  if (config.launchMode === GAME_LAUNCH_MODE_HOTSEAT) {
+    return {
+      type: "new_game",
+      seed,
+      launchMode: config.launchMode,
+      scenarioId: config.scenarioId,
+      players: config.seats.map((seat) => ({
+        playerId: seat.playerId,
+        hero: seat.heroId,
+      })),
+    };
+  }
+
+  return {
+    type: "new_game",
+    hero: config.heroIds[0],
+    seed,
+    scenario: config.serverScenario,
+  };
 }

--- a/packages/client/src/rust/types.ts
+++ b/packages/client/src/rust/types.ts
@@ -146,9 +146,14 @@ export function isAction(action: LegalAction, type: string): boolean {
 // Wire protocol messages
 // =============================================================================
 
+export interface NewGamePlayer {
+  readonly playerId: string;
+  readonly hero: string;
+}
+
 /** Messages the client sends to the server. */
 export type ClientMessage =
-  | { type: "new_game"; hero: string; seed?: number }
+  | { type: "new_game"; hero?: string; seed?: number; scenario?: string; launchMode?: string; scenarioId?: string; players?: readonly NewGamePlayer[] }
   | { type: "action"; action: LegalAction; epoch: number }
   | { type: "ping" }
   | { type: "undo" };

--- a/packages/engine-rs/tools/mk-server/src/main.rs
+++ b/packages/engine-rs/tools/mk-server/src/main.rs
@@ -505,6 +505,46 @@ ws.onopen = () => ws.send(JSON.stringify({ type: "new_game", hero: "arythea", se
     )
 }
 
+#[tokio::main]
+async fn main() {
+    let port = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse::<u16>().ok())
+        .unwrap_or(3030);
+
+    let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
+        .install_recorder()
+        .expect("failed to install Prometheus metrics recorder");
+
+    let upkeep_handle = prometheus_handle.clone();
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            upkeep_handle.run_upkeep();
+        }
+    });
+
+    let app = Router::new()
+        .route("/", get(index))
+        .route("/health", get(health))
+        .route("/metrics", get(metrics_handler))
+        .route("/ws", get(ws_handler))
+        .layer(CorsLayer::permissive())
+        .layer(Extension(prometheus_handle));
+
+    let addr = format!("0.0.0.0:{port}");
+
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to bind to {addr}: {e}");
+            eprintln!("Hint: kill the old process with `lsof -ti:{port} | xargs kill`");
+            std::process::exit(1);
+        });
+    println!("mk-server listening on {addr}");
+    axum::serve(listener, app).await.unwrap();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -730,44 +770,4 @@ mod tests {
 
         assert_eq!(session.view_player_idx(), 0);
     }
-}
-
-#[tokio::main]
-async fn main() {
-    let port = std::env::var("PORT")
-        .ok()
-        .and_then(|p| p.parse::<u16>().ok())
-        .unwrap_or(3030);
-
-    let prometheus_handle = metrics_exporter_prometheus::PrometheusBuilder::new()
-        .install_recorder()
-        .expect("failed to install Prometheus metrics recorder");
-
-    let upkeep_handle = prometheus_handle.clone();
-    tokio::spawn(async move {
-        loop {
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            upkeep_handle.run_upkeep();
-        }
-    });
-
-    let app = Router::new()
-        .route("/", get(index))
-        .route("/health", get(health))
-        .route("/metrics", get(metrics_handler))
-        .route("/ws", get(ws_handler))
-        .layer(CorsLayer::permissive())
-        .layer(Extension(prometheus_handle));
-
-    let addr = format!("0.0.0.0:{port}");
-
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to bind to {addr}: {e}");
-            eprintln!("Hint: kill the old process with `lsof -ti:{port} | xargs kill`");
-            std::process::exit(1);
-        });
-    println!("mk-server listening on {addr}");
-    axum::serve(listener, app).await.unwrap();
 }

--- a/packages/engine-rs/tools/mk-server/src/main.rs
+++ b/packages/engine-rs/tools/mk-server/src/main.rs
@@ -6,6 +6,7 @@
 //!
 //! Client → Server messages:
 //!   { "type": "new_game", "hero": "arythea", "seed": 42 }
+//!   { "type": "new_game", "launchMode": "hotseat", "scenarioId": "full_conquest_2p", "players": [...] }
 //!   { "type": "action", "action": <LegalAction>, "epoch": 5 }
 //!   { "type": "undo" }
 //!
@@ -28,11 +29,13 @@ use tower_http::cors::CorsLayer;
 use mk_engine::action_pipeline::{apply_legal_action, initial_events, ApplyError};
 use mk_engine::client_state::to_client_state;
 use mk_engine::legal_actions::enumerate_legal_actions_with_undo;
+use mk_engine::setup::create_multiplayer_game;
 use mk_engine::undo::UndoStack;
 use mk_env::training_scenario::{create_training_game, TrainingScenario};
 use mk_types::client_state::ClientGameState;
-use mk_types::enums::Hero;
+use mk_types::enums::{Hero, RoundPhase};
 use mk_types::events::GameEvent;
+use mk_types::ids::PlayerId;
 use mk_types::legal_action::LegalAction;
 use mk_types::state::GameState;
 
@@ -40,16 +43,26 @@ use mk_types::state::GameState;
 // Wire protocol types
 // =============================================================================
 
+const DEFAULT_PLAYER_ID: &str = "player_0";
+const HOTSEAT_PLAYER_ID_PREFIX: &str = "player_";
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum ClientMessage {
     NewGame {
-        hero: Hero,
+        #[serde(default)]
+        hero: Option<Hero>,
         #[serde(default)]
         seed: Option<u32>,
         /// Optional JSON string for TrainingScenario (e.g. ExplorationDrill).
         #[serde(default)]
         scenario: Option<String>,
+        #[serde(default, rename = "launchMode")]
+        launch_mode: Option<LaunchMode>,
+        #[serde(default, rename = "scenarioId")]
+        scenario_id: Option<String>,
+        #[serde(default)]
+        players: Option<Vec<NewGamePlayer>>,
     },
     Action {
         action: LegalAction,
@@ -57,6 +70,21 @@ enum ClientMessage {
     },
     Ping,
     Undo,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum LaunchMode {
+    Solo,
+    Hotseat,
+    Online,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NewGamePlayer {
+    player_id: String,
+    hero: Hero,
 }
 
 static GENERATED_SEED_COUNTER: AtomicU32 = AtomicU32::new(0);
@@ -125,31 +153,106 @@ enum ServerMessage {
 // Game session
 // =============================================================================
 
+#[derive(Debug)]
 struct GameSession {
     state: GameState,
     undo_stack: UndoStack,
-    player_idx: usize,
+    view: SessionView,
     /// Pending events from the last action, consumed by `make_update`.
     pending_events: Vec<GameEvent>,
 }
 
+#[derive(Debug)]
+enum SessionView {
+    Solo { player_id: PlayerId },
+    Hotseat,
+}
+
 impl GameSession {
-    fn new(seed: u32, hero: Hero, scenario: &TrainingScenario) -> Self {
+    fn new_solo(seed: u32, hero: Hero, scenario: &TrainingScenario) -> Self {
         let result = create_training_game(seed, hero, scenario);
         let events = initial_events(&result.state, seed, hero);
         Self {
             state: result.state,
             undo_stack: result.undo_stack,
-            player_idx: 0,
+            view: SessionView::Solo {
+                player_id: PlayerId::from(DEFAULT_PLAYER_ID),
+            },
             pending_events: events,
         }
     }
 
+    fn new_hotseat(
+        seed: u32,
+        scenario_id: &str,
+        players: &[NewGamePlayer],
+    ) -> Result<Self, String> {
+        let player_count = players.len();
+        if !(2..=4).contains(&player_count) {
+            return Err(format!("Hotseat requires 2-4 players, got {player_count}."));
+        }
+
+        for (index, player) in players.iter().enumerate() {
+            let expected_player_id = format!("{HOTSEAT_PLAYER_ID_PREFIX}{index}");
+            if player.player_id != expected_player_id {
+                return Err(format!(
+                    "Hotseat player at seat {} must use playerId '{}'.",
+                    index + 1,
+                    expected_player_id
+                ));
+            }
+        }
+
+        let scenario_config = mk_data::scenarios::get_scenario(scenario_id)
+            .ok_or_else(|| format!("Unknown scenarioId '{scenario_id}'."))?;
+
+        let player_count_u32 = player_count as u32;
+        if player_count_u32 < scenario_config.min_players
+            || player_count_u32 > scenario_config.max_players
+        {
+            return Err(format!(
+                "Scenario '{scenario_id}' requires {}-{} players, got {player_count}.",
+                scenario_config.min_players, scenario_config.max_players
+            ));
+        }
+
+        let heroes: Vec<Hero> = players.iter().map(|player| player.hero).collect();
+        let state = create_multiplayer_game(seed, &heroes, scenario_config, scenario_id);
+        let first_hero = heroes
+            .first()
+            .copied()
+            .ok_or_else(|| "Hotseat requires at least one hero.".to_string())?;
+        let active_player_id = state
+            .current_tactic_selector
+            .clone()
+            .or_else(|| state.turn_order.first().cloned())
+            .unwrap_or_else(|| PlayerId::from(DEFAULT_PLAYER_ID));
+        let events = vec![
+            GameEvent::GameStarted {
+                seed,
+                hero: first_hero,
+            },
+            GameEvent::TurnStarted {
+                player_id: active_player_id,
+                round: state.round,
+                time_of_day: state.time_of_day,
+            },
+        ];
+
+        Ok(Self {
+            state,
+            undo_stack: UndoStack::new(),
+            view: SessionView::Hotseat,
+            pending_events: events,
+        })
+    }
+
     fn make_update(&mut self) -> ServerMessage {
-        let player_id = self.state.players[self.player_idx].id.clone();
+        let player_idx = self.view_player_idx();
+        let player_id = self.state.players[player_idx].id.clone();
         let client_state = to_client_state(&self.state, &player_id);
         let action_set =
-            enumerate_legal_actions_with_undo(&self.state, self.player_idx, &self.undo_stack);
+            enumerate_legal_actions_with_undo(&self.state, player_idx, &self.undo_stack);
         let events = std::mem::take(&mut self.pending_events);
 
         ServerMessage::StateUpdate {
@@ -161,10 +264,11 @@ impl GameSession {
     }
 
     fn apply_action(&mut self, action: &LegalAction, epoch: u64) -> Result<(), ApplyError> {
+        let player_idx = self.view_player_idx();
         let result = apply_legal_action(
             &mut self.state,
             &mut self.undo_stack,
-            self.player_idx,
+            player_idx,
             action,
             epoch,
         )?;
@@ -175,13 +279,82 @@ impl GameSession {
     fn undo(&mut self) -> bool {
         if let Some(restored) = self.undo_stack.undo() {
             self.state = restored;
+            let player_idx = self.view_player_idx();
             self.pending_events = vec![GameEvent::Undone {
-                player_id: self.state.players[self.player_idx].id.clone(),
+                player_id: self.state.players[player_idx].id.clone(),
             }];
             true
         } else {
             false
         }
+    }
+
+    fn view_player_idx(&self) -> usize {
+        let player_id = match &self.view {
+            SessionView::Solo { player_id } => player_id.clone(),
+            SessionView::Hotseat => self.hotseat_active_player_id(),
+        };
+
+        self.state
+            .players
+            .iter()
+            .position(|player| player.id == player_id)
+            .unwrap_or(0)
+    }
+
+    fn hotseat_active_player_id(&self) -> PlayerId {
+        match self.state.round_phase {
+            RoundPhase::TacticsSelection => self
+                .state
+                .current_tactic_selector
+                .clone()
+                .unwrap_or_else(|| self.first_player_id()),
+            RoundPhase::PlayerTurns => {
+                let idx = self.state.current_player_index as usize;
+                self.state
+                    .turn_order
+                    .get(idx)
+                    .cloned()
+                    .unwrap_or_else(|| self.first_player_id())
+            }
+        }
+    }
+
+    fn first_player_id(&self) -> PlayerId {
+        self.state
+            .players
+            .first()
+            .map(|player| player.id.clone())
+            .unwrap_or_else(|| PlayerId::from(DEFAULT_PLAYER_ID))
+    }
+}
+
+fn create_session_from_new_game(
+    hero: Option<Hero>,
+    seed: Option<u32>,
+    scenario: Option<String>,
+    launch_mode: Option<LaunchMode>,
+    scenario_id: Option<String>,
+    players: Option<Vec<NewGamePlayer>>,
+) -> Result<GameSession, String> {
+    let seed = resolve_new_game_seed(seed);
+    match launch_mode.unwrap_or(LaunchMode::Solo) {
+        LaunchMode::Solo => {
+            let hero = hero.ok_or_else(|| "Solo new_game requires hero.".to_string())?;
+            let training_scenario = match scenario.as_deref() {
+                None | Some("") => TrainingScenario::FullGame,
+                Some(s) => parse_scenario_string(s)?,
+            };
+            Ok(GameSession::new_solo(seed, hero, &training_scenario))
+        }
+        LaunchMode::Hotseat => {
+            let scenario_id =
+                scenario_id.ok_or_else(|| "Hotseat new_game requires scenarioId.".to_string())?;
+            let players =
+                players.ok_or_else(|| "Hotseat new_game requires players.".to_string())?;
+            GameSession::new_hotseat(seed, &scenario_id, &players)
+        }
+        LaunchMode::Online => Err("Online launch mode is not supported by this server yet.".into()),
     }
 }
 
@@ -227,28 +400,34 @@ async fn handle_socket(mut socket: WebSocket) {
                 hero,
                 seed,
                 scenario,
+                launch_mode,
+                scenario_id,
+                players,
             } => {
-                let seed = resolve_new_game_seed(seed);
-                let training_scenario = match scenario.as_deref() {
-                    None | Some("") => TrainingScenario::FullGame,
-                    Some(s) => match parse_scenario_string(s) {
-                        Ok(ts) => ts,
-                        Err(e) => {
-                            let _ = send_json(
-                                &mut socket,
-                                &ServerMessage::Error {
-                                    message: format!("Invalid scenario: {e}"),
-                                },
-                            )
-                            .await;
-                            continue;
-                        }
-                    },
-                };
-                let mut s = GameSession::new(seed, hero, &training_scenario);
-                let update = s.make_update();
-                session = Some(s);
-                update
+                match create_session_from_new_game(
+                    hero,
+                    seed,
+                    scenario,
+                    launch_mode,
+                    scenario_id,
+                    players,
+                ) {
+                    Ok(mut s) => {
+                        let update = s.make_update();
+                        session = Some(s);
+                        update
+                    }
+                    Err(e) => {
+                        let _ = send_json(
+                            &mut socket,
+                            &ServerMessage::Error {
+                                message: format!("Invalid new_game: {e}"),
+                            },
+                        )
+                        .await;
+                        continue;
+                    }
+                }
             }
 
             ClientMessage::Action { action, epoch } => match session.as_mut() {
@@ -329,6 +508,7 @@ ws.onopen = () => ws.send(JSON.stringify({ type: "new_game", hero: "arythea", se
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mk_types::ids::TacticId;
 
     #[test]
     fn new_game_without_seed_deserializes_as_unseeded() {
@@ -368,6 +548,187 @@ mod tests {
         let second = resolve_new_game_seed(None);
 
         assert_ne!(first, second);
+    }
+
+    #[test]
+    fn hotseat_new_game_deserializes() {
+        let msg: ClientMessage = serde_json::from_str(
+            r#"{
+                "type":"new_game",
+                "launchMode":"hotseat",
+                "scenarioId":"full_conquest_2p",
+                "players":[
+                    {"playerId":"player_0","hero":"arythea"},
+                    {"playerId":"player_1","hero":"tovak"}
+                ]
+            }"#,
+        )
+        .unwrap();
+
+        match msg {
+            ClientMessage::NewGame {
+                launch_mode,
+                scenario_id,
+                players,
+                ..
+            } => {
+                assert_eq!(launch_mode, Some(LaunchMode::Hotseat));
+                assert_eq!(scenario_id.as_deref(), Some("full_conquest_2p"));
+                assert_eq!(players.unwrap().len(), 2);
+            }
+            _ => panic!("expected new_game"),
+        }
+    }
+
+    #[test]
+    fn hotseat_rejects_unknown_scenario() {
+        let result = create_session_from_new_game(
+            None,
+            Some(42),
+            None,
+            Some(LaunchMode::Hotseat),
+            Some("unknown".to_string()),
+            Some(vec![
+                NewGamePlayer {
+                    player_id: "player_0".to_string(),
+                    hero: Hero::Arythea,
+                },
+                NewGamePlayer {
+                    player_id: "player_1".to_string(),
+                    hero: Hero::Tovak,
+                },
+            ]),
+        );
+
+        assert!(result.unwrap_err().contains("Unknown scenarioId"));
+    }
+
+    #[test]
+    fn hotseat_rejects_wrong_player_count_for_scenario() {
+        let result = create_session_from_new_game(
+            None,
+            Some(42),
+            None,
+            Some(LaunchMode::Hotseat),
+            Some("full_conquest_3p".to_string()),
+            Some(vec![
+                NewGamePlayer {
+                    player_id: "player_0".to_string(),
+                    hero: Hero::Arythea,
+                },
+                NewGamePlayer {
+                    player_id: "player_1".to_string(),
+                    hero: Hero::Tovak,
+                },
+            ]),
+        );
+
+        assert!(result.unwrap_err().contains("requires 3-3 players"));
+    }
+
+    #[test]
+    fn hotseat_creates_full_conquest_2p_session() {
+        let session = create_session_from_new_game(
+            None,
+            Some(42),
+            None,
+            Some(LaunchMode::Hotseat),
+            Some("full_conquest_2p".to_string()),
+            Some(vec![
+                NewGamePlayer {
+                    player_id: "player_0".to_string(),
+                    hero: Hero::Arythea,
+                },
+                NewGamePlayer {
+                    player_id: "player_1".to_string(),
+                    hero: Hero::Tovak,
+                },
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(session.state.players.len(), 2);
+        assert_eq!(session.state.scenario_config.total_rounds, 6);
+        assert!(session.state.dummy_player.is_none());
+    }
+
+    #[test]
+    fn hotseat_creates_blitz_conquest_2p_session() {
+        let session = create_session_from_new_game(
+            None,
+            Some(42),
+            None,
+            Some(LaunchMode::Hotseat),
+            Some("blitz_conquest_2p".to_string()),
+            Some(vec![
+                NewGamePlayer {
+                    player_id: "player_0".to_string(),
+                    hero: Hero::Arythea,
+                },
+                NewGamePlayer {
+                    player_id: "player_1".to_string(),
+                    hero: Hero::Tovak,
+                },
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(session.state.players.len(), 2);
+        assert_eq!(session.state.scenario_config.total_rounds, 4);
+        assert!(session.state.dummy_player.is_none());
+    }
+
+    #[test]
+    fn hotseat_updates_use_current_tactic_selector() {
+        let mut session = create_session_from_new_game(
+            None,
+            Some(42),
+            None,
+            Some(LaunchMode::Hotseat),
+            Some("full_conquest_2p".to_string()),
+            Some(vec![
+                NewGamePlayer {
+                    player_id: "player_0".to_string(),
+                    hero: Hero::Arythea,
+                },
+                NewGamePlayer {
+                    player_id: "player_1".to_string(),
+                    hero: Hero::Tovak,
+                },
+            ]),
+        )
+        .unwrap();
+
+        assert_eq!(session.view_player_idx(), 1);
+        let update = session.make_update();
+        let epoch = match update {
+            ServerMessage::StateUpdate {
+                legal_actions,
+                epoch,
+                ..
+            } => {
+                assert!(legal_actions.iter().any(|action| {
+                    matches!(
+                        action,
+                        LegalAction::SelectTactic { tactic_id }
+                            if tactic_id.as_str() == "early_bird"
+                    )
+                }));
+                epoch
+            }
+            _ => panic!("expected state update"),
+        };
+
+        session
+            .apply_action(
+                &LegalAction::SelectTactic {
+                    tactic_id: TacticId::from("early_bird"),
+                },
+                epoch,
+            )
+            .unwrap();
+
+        assert_eq!(session.view_player_idx(), 0);
     }
 }
 

--- a/packages/shared/src/gameConfig.ts
+++ b/packages/shared/src/gameConfig.ts
@@ -8,19 +8,47 @@
 import type { HeroId } from "./hero.js";
 import type { ScenarioId } from "./scenarios.js";
 
+export const GAME_LAUNCH_MODE_SOLO = "solo" as const;
+export const GAME_LAUNCH_MODE_HOTSEAT = "hotseat" as const;
+export const GAME_LAUNCH_MODE_ONLINE = "online" as const;
+
+export type GameLaunchMode =
+  | typeof GAME_LAUNCH_MODE_SOLO
+  | typeof GAME_LAUNCH_MODE_HOTSEAT
+  | typeof GAME_LAUNCH_MODE_ONLINE;
+
+export const GAME_SEAT_CONTROLLER_LOCAL = "local" as const;
+
+export type GameSeatController = typeof GAME_SEAT_CONTROLLER_LOCAL;
+
+export interface GameSeatConfig {
+  readonly playerId: string;
+  readonly heroId: HeroId;
+  readonly controller: GameSeatController;
+}
+
 /**
  * Configuration for initializing a game.
  * Created by the setup screen and passed to GameServer.initializeGame().
  */
 export interface GameConfig {
+  /** Launch flow for this game. */
+  readonly launchMode: GameLaunchMode;
+
   /** Player IDs (e.g., ["player1", "player2"]) */
   readonly playerIds: readonly string[];
 
   /** Hero IDs corresponding to each player (same length as playerIds) */
   readonly heroIds: readonly HeroId[];
 
+  /** Explicit player seats. Kept shape-compatible with future lobby joins. */
+  readonly seats: readonly GameSeatConfig[];
+
   /** Scenario to play */
   readonly scenarioId: ScenarioId;
+
+  /** Optional Rust server scenario preset. Omitted for the default full game. */
+  readonly serverScenario?: string;
 
   /** Optional city level override (1-11). Defaults to scenario's defaultCityLevel. */
   readonly cityLevel?: number;

--- a/packages/shared/src/scenarios.ts
+++ b/packages/shared/src/scenarios.ts
@@ -31,16 +31,46 @@ export type DummyTacticOrder =
 
 // === Scenario IDs ===
 export const SCENARIO_FIRST_RECONNAISSANCE = "first_reconnaissance" as const;
+export const SCENARIO_FIRST_RECONNAISSANCE_2P = "first_reconnaissance_2p" as const;
+export const SCENARIO_FIRST_RECONNAISSANCE_3P = "first_reconnaissance_3p" as const;
+export const SCENARIO_FIRST_RECONNAISSANCE_4P = "first_reconnaissance_4p" as const;
 export const SCENARIO_FULL_CONQUEST = "full_conquest" as const;
+export const SCENARIO_FULL_CONQUEST_2P = "full_conquest_2p" as const;
+export const SCENARIO_FULL_CONQUEST_3P = "full_conquest_3p" as const;
+export const SCENARIO_FULL_CONQUEST_4P = "full_conquest_4p" as const;
+export const SCENARIO_BLITZ_CONQUEST = "blitz_conquest" as const;
+export const SCENARIO_BLITZ_CONQUEST_2P = "blitz_conquest_2p" as const;
+export const SCENARIO_BLITZ_CONQUEST_3P = "blitz_conquest_3p" as const;
+export const SCENARIO_BLITZ_CONQUEST_4P = "blitz_conquest_4p" as const;
 
 export type ScenarioId =
   | typeof SCENARIO_FIRST_RECONNAISSANCE
-  | typeof SCENARIO_FULL_CONQUEST;
+  | typeof SCENARIO_FIRST_RECONNAISSANCE_2P
+  | typeof SCENARIO_FIRST_RECONNAISSANCE_3P
+  | typeof SCENARIO_FIRST_RECONNAISSANCE_4P
+  | typeof SCENARIO_FULL_CONQUEST
+  | typeof SCENARIO_FULL_CONQUEST_2P
+  | typeof SCENARIO_FULL_CONQUEST_3P
+  | typeof SCENARIO_FULL_CONQUEST_4P
+  | typeof SCENARIO_BLITZ_CONQUEST
+  | typeof SCENARIO_BLITZ_CONQUEST_2P
+  | typeof SCENARIO_BLITZ_CONQUEST_3P
+  | typeof SCENARIO_BLITZ_CONQUEST_4P;
 
 /** Human-readable scenario titles for UI copy */
 export const SCENARIO_DISPLAY_NAMES: Record<ScenarioId, string> = {
   [SCENARIO_FIRST_RECONNAISSANCE]: "First Reconnaissance",
+  [SCENARIO_FIRST_RECONNAISSANCE_2P]: "First Reconnaissance",
+  [SCENARIO_FIRST_RECONNAISSANCE_3P]: "First Reconnaissance",
+  [SCENARIO_FIRST_RECONNAISSANCE_4P]: "First Reconnaissance",
   [SCENARIO_FULL_CONQUEST]: "Full Conquest",
+  [SCENARIO_FULL_CONQUEST_2P]: "Full Conquest",
+  [SCENARIO_FULL_CONQUEST_3P]: "Full Conquest",
+  [SCENARIO_FULL_CONQUEST_4P]: "Full Conquest",
+  [SCENARIO_BLITZ_CONQUEST]: "Blitz Conquest",
+  [SCENARIO_BLITZ_CONQUEST_2P]: "Blitz Conquest",
+  [SCENARIO_BLITZ_CONQUEST_3P]: "Blitz Conquest",
+  [SCENARIO_BLITZ_CONQUEST_4P]: "Blitz Conquest",
 };
 
 // === Map Shape Types ===


### PR DESCRIPTION
## Summary

Adds a scenario picker to the setup screen and **local hotseat multiplayer** for the conquest scenarios, end-to-end across the client, shared types, and the Rust `mk-server`.

- **Setup screen** — replaces the old seat picker with a categorized scenario library (Learning / Conquest / Drills). Player count is clamped to each scenario's min/max. Two pure helpers (`createGameConfigForSetup`, `getSetupScenarioLaunchConfig`) are extracted and unit-tested.
- **Shared types** — `GameConfig` now carries a `launchMode` (solo / hotseat / online) and explicit `seats`; adds per-player-count scenario IDs (`full_conquest_2p/3p/4p`, `blitz_conquest_*`, `first_reconnaissance_*`).
- **Hotseat handoff** — in hotseat mode, `GameProvider` holds an incoming state update when the active player changes and shows a full-screen `HotseatPassScreen` until the next player taps "Reveal turn", keeping private hands covered between turns.
- **mk-server** — `new_game` accepts the hotseat shape (`launchMode` / `scenarioId` / `players`) alongside the existing solo shape. A new `SessionView::Hotseat` derives the active player from `current_tactic_selector` (tactics phase) or `current_player_index` (turns).
- **Cleanup** — moves the binary `main()` above the `#[cfg(test)]` module to resolve a pre-existing `clippy::items_after_test_module` warning.

## Testing

- `cargo test -p mk-server` — 10 passed (5 new hotseat tests)
- `cargo clippy --workspace -- -D warnings` (CI's command) — clean; also clean under `--all-targets`
- `bun test hotseatSetup.test.tsx` — 3 passed
- `bun run build` — ✓
- `bun run lint` — 0 warnings / 0 errors

Branch is rebased onto the latest `main`.


---

Closes #460 (Blitz Conquest — engine config implements all special rules; this PR adds the hotseat launch path).

Part of #451 (Full Conquest) — all blockers (#449, #441, #443, #440, #447) are resolved and the scenario engine landed in #1091; this PR provides the 2–4p hotseat launch UI. Leaving the epic open for final review.
