### PR TITLE
Adopt design system HUD tokens

### DIFF
--- a/packages/client/src/assets/assetPaths.ts
+++ b/packages/client/src/assets/assetPaths.ts
@@ -2,8 +2,29 @@
  * Asset path helpers for game sprites and images
  */
 
+import {
+  MANA_BLACK,
+  MANA_BLUE,
+  MANA_GOLD,
+  MANA_GREEN,
+  MANA_RED,
+  MANA_WHITE,
+  type ManaColor,
+} from "@mage-knight/shared";
+
 /** Default web path for static game assets (served as `/assets` in dev and production). */
 const DEFAULT_ASSETS_BASE = "/assets";
+
+type ManaIconVariant = "flat" | "glossy";
+
+const MANA_ICON_FILES: Record<ManaColor, string> = {
+  [MANA_RED]: "red",
+  [MANA_BLUE]: "blue",
+  [MANA_GREEN]: "green",
+  [MANA_WHITE]: "white",
+  [MANA_GOLD]: "gold",
+  [MANA_BLACK]: "black",
+};
 
 type RuntimeImportMeta = ImportMeta & {
   env?: {
@@ -91,6 +112,10 @@ export function getCardSheetUrl(sheet: "basic_actions" | "advanced_actions" | "s
 
 export function getCardBackUrl(): string {
   return assetUrl("cards/card_back.jpg");
+}
+
+export function getManaIconUrl(color: ManaColor, variant: ManaIconVariant = "flat"): string {
+  return assetUrl(`mana_icons/${variant}/${MANA_ICON_FILES[color]}.png`);
 }
 
 export function getHeroTokenUrl(heroId: string): string {

--- a/packages/client/src/components/GameBoard/ManaSourceOverlay.css
+++ b/packages/client/src/components/GameBoard/ManaSourceOverlay.css
@@ -48,10 +48,11 @@
   position: absolute;
   top: 1rem;
   right: 1rem;
-  background: rgba(15, 15, 35, 0.9);
-  border: 1px solid #444;
-  border-radius: 6px;
-  padding: 0.5rem;
+  background: color-mix(in oklch, var(--surface-chrome) 92%, transparent);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  box-shadow: var(--elev-2);
   z-index: 10;
 }
 
@@ -64,13 +65,13 @@
 
 /* Container animates in first */
 .mana-source-overlay--intro-reveal {
-  animation: mana-source-reveal 0.5s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: mana-source-reveal var(--dur-slow) var(--ease-bounce) forwards;
 }
 
 /* Individual dice cascade in with stagger */
 .mana-source-overlay--intro-reveal .mana-source-overlay__die {
   opacity: 0;
-  animation: die-intro-cast 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: die-intro-cast 0.4s var(--ease-bounce) forwards;
 }
 
 /* Stagger delays for each die - cast one after another */
@@ -85,10 +86,10 @@
 
 .mana-source-overlay__label {
   font-size: 0.6rem;
-  color: #888;
+  color: var(--text-faint);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: 0.375rem;
+  margin-bottom: var(--space-2);
   text-align: center;
 }
 
@@ -100,37 +101,41 @@
 .mana-source-overlay__die {
   width: clamp(2.5rem, 4vw, 5rem);
   height: clamp(2.5rem, 4vw, 5rem);
-  border-radius: clamp(6px, 0.8vw, 12px);
+  border-radius: var(--radius-round);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  background: linear-gradient(145deg, #f5f5f5, #d0d0d0);
+  background: radial-gradient(circle at 50% 38%, var(--surface-hover-lift), var(--surface-canvas));
   box-shadow:
-    3px 3px 6px rgba(0, 0, 0, 0.3),
-    -2px -2px 4px rgba(255, 255, 255, 0.8),
-    inset 1px 1px 2px rgba(255, 255, 255, 0.9),
-    inset -1px -1px 2px rgba(0, 0, 0, 0.1);
-  border: 1px solid rgba(0, 0, 0, 0.1);
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    var(--elev-1);
+  border: 1px solid var(--border-on-raised);
 }
 
 .mana-source-overlay__die-icon {
-  width: 100%;
-  height: 100%;
+  width: 86%;
+  height: 86%;
   object-fit: contain;
-  filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
 }
 
 /* Clickable dice - available to use */
 .mana-source-overlay__die--clickable {
   cursor: pointer;
-  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    transform var(--dur-fast) var(--ease-out-expo),
+    border-color var(--dur-fast) var(--ease-out-expo),
+    box-shadow var(--dur-fast) var(--ease-out-expo);
   position: relative;
 }
 
 .mana-source-overlay__die--clickable:hover {
-  transform: scale(1.15);
-  box-shadow: 0 0 12px rgba(255, 255, 255, 0.4);
+  transform: translateY(-2px) scale(1.04);
+  border-color: var(--accent);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    var(--elev-2);
 }
 
 .mana-source-overlay__die--clickable:active {
@@ -144,23 +149,27 @@
   left: 50%;
   transform: translateX(-50%);
   display: flex;
-  gap: 4px;
-  padding: 4px;
-  background: rgba(30, 30, 40, 0.95);
-  border-radius: 8px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+  gap: var(--space-1);
+  padding: var(--space-1);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--elev-3);
   z-index: 10;
 }
 
 .mana-source-overlay__color-option {
   width: clamp(1.5rem, 2.5vw, 2.5rem);
   height: clamp(1.5rem, 2.5vw, 2.5rem);
-  border-radius: 6px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(255, 255, 255, 0.1);
+  border-radius: var(--radius-round);
+  border: 1px solid var(--border-on-raised);
+  background: radial-gradient(circle at 50% 38%, var(--surface-hover-lift), var(--surface-canvas));
   cursor: pointer;
   padding: 2px;
-  transition: transform 0.1s ease, background 0.1s ease;
+  transition:
+    transform var(--dur-fast) var(--ease-out-expo),
+    border-color var(--dur-fast) var(--ease-out-expo),
+    background var(--dur-fast) var(--ease-out-expo);
 }
 
 .mana-source-overlay__color-option img {
@@ -170,8 +179,9 @@
 }
 
 .mana-source-overlay__color-option:hover {
-  transform: scale(1.15);
-  background: rgba(255, 255, 255, 0.25);
+  transform: translateY(-1px);
+  border-color: var(--accent);
+  background: var(--surface-hover-lift);
 }
 
 .mana-source-overlay__color-option:active {
@@ -180,7 +190,7 @@
 
 .mana-source-overlay__die--unavailable {
   opacity: 0.5;
-  background: linear-gradient(145deg, #888, #666);
+  background: color-mix(in oklch, var(--surface-canvas) 70%, var(--text-faint));
 }
 
 .mana-source-overlay__die--unavailable .mana-source-overlay__die-icon {
@@ -191,7 +201,8 @@
    Distinct amber/gold tint instead of grayscale to indicate "reserved" status */
 .mana-source-overlay__die--stolen {
   opacity: 0.65;
-  background: linear-gradient(145deg, #d4a574, #b8956a);
+  background: color-mix(in oklch, var(--accent) 18%, var(--surface-canvas));
+  border-color: color-mix(in oklch, var(--accent) 52%, var(--border-on-raised));
   position: relative;
 }
 
@@ -280,25 +291,20 @@
 @keyframes dice-glow {
   0%, 100% {
     box-shadow:
-      3px 3px 6px rgba(0, 0, 0, 0.3),
-      -2px -2px 4px rgba(255, 255, 255, 0.8),
-      inset 1px 1px 2px rgba(255, 255, 255, 0.9),
-      inset -1px -1px 2px rgba(0, 0, 0, 0.1);
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      var(--elev-1);
   }
   50% {
     box-shadow:
-      3px 3px 6px rgba(0, 0, 0, 0.3),
-      -2px -2px 4px rgba(255, 255, 255, 0.8),
-      inset 1px 1px 2px rgba(255, 255, 255, 0.9),
-      inset -1px -1px 2px rgba(0, 0, 0, 0.1),
-      0 0 20px rgba(255, 215, 0, 0.6),
-      0 0 40px rgba(255, 215, 0, 0.3);
+      inset 0 1px 0 rgba(255, 255, 255, 0.04),
+      var(--elev-2),
+      0 0 20px color-mix(in oklch, var(--accent) 42%, transparent);
   }
 }
 
 .mana-source-overlay__die--rolling {
   animation:
-    dice-roll 0.7s cubic-bezier(0.34, 1.56, 0.64, 1),
+    dice-roll 0.7s var(--ease-bounce),
     dice-glow 0.7s ease-in-out;
   will-change: transform, filter;
 }
@@ -330,8 +336,8 @@
     transform: scale(1.2);
     filter: brightness(1.4);
     box-shadow:
-      0 0 15px rgba(255, 255, 255, 0.8),
-      0 0 30px rgba(255, 215, 0, 0.5);
+      var(--elev-2),
+      0 0 24px color-mix(in oklch, var(--accent) 48%, transparent);
   }
   /* Shrink down */
   60% {
@@ -346,5 +352,5 @@
 }
 
 .mana-source-overlay__die--taken {
-  animation: dice-taken 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+  animation: dice-taken 0.4s var(--ease-bounce);
 }

--- a/packages/client/src/components/GameBoard/ManaSourceOverlay.tsx
+++ b/packages/client/src/components/GameBoard/ManaSourceOverlay.tsx
@@ -22,26 +22,11 @@ import {
   MANA_BLUE,
   MANA_GREEN,
   MANA_WHITE,
-  MANA_GOLD,
-  MANA_BLACK,
   BASIC_MANA_COLORS,
 } from "@mage-knight/shared";
 import type { ManaColor, AvailableDie } from "@mage-knight/shared";
-import { assetUrl } from "../../assets/assetPaths";
+import { getManaIconUrl } from "../../assets/assetPaths";
 import "./ManaSourceOverlay.css";
-
-function getManaIconUrl(color: string): string {
-  const colorMap: Record<string, string> = {
-    [MANA_RED]: "red",
-    [MANA_BLUE]: "blue",
-    [MANA_GREEN]: "green",
-    [MANA_WHITE]: "white",
-    [MANA_GOLD]: "gold",
-    [MANA_BLACK]: "black",
-  };
-  const colorName = colorMap[color] || "white";
-  return assetUrl(`mana_icons/glossy/${colorName}.png`);
-}
 
 // Animation durations must match CSS
 const ROLL_ANIMATION_MS = 700;

--- a/packages/client/src/components/PlayerList/PlayerEntry.css
+++ b/packages/client/src/components/PlayerList/PlayerEntry.css
@@ -5,19 +5,23 @@
 .player-entry {
   display: flex;
   align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: 6px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
   background: color-mix(in oklch, var(--surface-chrome) 60%, transparent);
   border: 1px solid var(--border-subtle);
-  transition: all 0.2s ease;
+  transition:
+    opacity var(--dur-fast) var(--ease-out-expo),
+    background var(--dur-fast) var(--ease-out-expo),
+    border-color var(--dur-fast) var(--ease-out-expo),
+    box-shadow var(--dur-fast) var(--ease-out-expo);
   position: relative;
 }
 
 /* Active player - golden glow */
 .player-entry--active {
-  border: 2px solid #f1c40f;
-  box-shadow: 0 0 10px rgba(241, 196, 15, 0.35);
+  border: 2px solid var(--stat-fame);
+  box-shadow: var(--glow-fame);
   background: rgba(241, 196, 15, 0.1);
 }
 
@@ -46,7 +50,7 @@
 .player-entry__stat {
   display: flex;
   align-items: center;
-  gap: 0.15rem;
+  gap: var(--space-1);
 }
 
 .player-entry__icon {
@@ -62,34 +66,34 @@
 
 /* Stat colors (match TopBar) */
 .player-entry__stat--level .player-entry__icon {
-  color: #9b59b6;
+  color: var(--stat-level);
 }
 
 .player-entry__stat--fame .player-entry__icon {
-  color: #f1c40f;
+  color: var(--stat-fame);
 }
 
 .player-entry__stat--armor .player-entry__icon {
-  color: #95a5a6;
+  color: var(--stat-armor);
 }
 
 .player-entry__stat--move .player-entry__icon {
-  color: #4fc3f7;
+  color: var(--stat-move);
 }
 
 .player-entry__stat--influence .player-entry__icon {
-  color: #e91e63;
+  color: var(--stat-influence);
 }
 
 /* YOU badge */
 .player-entry__badge {
   font-size: 0.55rem;
   padding: 1px 4px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: rgba(241, 196, 15, 0.2);
-  color: #f1c40f;
+  color: var(--stat-fame);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.03em;
-  margin-left: 0.25rem;
+  margin-left: var(--space-1);
 }

--- a/packages/client/src/components/PlayerList/PlayerListPanel.css
+++ b/packages/client/src/components/PlayerList/PlayerListPanel.css
@@ -21,14 +21,14 @@
 .player-list-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  padding-left: 1rem;
-  border-left: 1px solid rgba(255, 255, 255, 0.2);
+  gap: var(--space-1);
+  padding-left: var(--space-5);
+  border-left: 1px solid var(--border-default);
   will-change: transform, opacity;
 }
 
 .player-list-panel--intro-reveal {
-  animation: player-list-slide 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: player-list-slide 0.4s var(--ease-bounce) forwards;
 }
 
 /* Turn indicator */
@@ -37,7 +37,7 @@
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #f1c40f;
+  color: var(--stat-fame);
   text-align: center;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
 }
@@ -45,13 +45,13 @@
 /* Player entries container */
 .player-list-panel__entries {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-3);
 }
 
 /* Responsive: stack vertically on narrow screens */
 @media (max-width: 900px) {
   .player-list-panel__entries {
     flex-direction: column;
-    gap: 0.25rem;
+    gap: var(--space-1);
   }
 }

--- a/packages/client/src/components/TopBar/HotkeyHelp.css
+++ b/packages/client/src/components/TopBar/HotkeyHelp.css
@@ -8,7 +8,7 @@
   align-items: center;
   justify-content: center;
   z-index: 1000;
-  animation: hotkey-fade-in 0.15s ease-out;
+  animation: hotkey-fade-in var(--dur-fast) var(--ease-out-expo);
 }
 
 @keyframes hotkey-fade-in {
@@ -21,15 +21,15 @@
 }
 
 .hotkey-help__modal {
-  background: linear-gradient(145deg, var(--surface-ground), var(--surface-raised));
+  background: var(--surface-raised);
   border: 1px solid var(--border-subtle);
-  border-radius: 12px;
+  border-radius: var(--radius-xl);
   width: 90%;
   max-width: 500px;
   max-height: 80vh;
   overflow-y: auto;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-  animation: hotkey-slide-in 0.2s ease-out;
+  box-shadow: var(--elev-3);
+  animation: hotkey-slide-in var(--dur-base) var(--ease-out-expo);
 }
 
 @keyframes hotkey-slide-in {
@@ -47,43 +47,43 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 1rem 1.25rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--border-subtle);
 }
 
 .hotkey-help__title {
   margin: 0;
   font-size: 1.1rem;
   font-weight: 600;
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .hotkey-help__close {
   background: none;
   border: none;
-  color: #888;
+  color: var(--text-faint);
   font-size: 1.5rem;
   cursor: pointer;
   padding: 0;
   line-height: 1;
-  transition: color 0.15s;
+  transition: color var(--dur-fast) var(--ease-out-expo);
 }
 
 .hotkey-help__close:hover {
-  color: #fff;
+  color: var(--text-primary);
 }
 
 .hotkey-help__content {
-  padding: 1rem 1.25rem;
+  padding: var(--space-5) var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: var(--space-6);
 }
 
 .hotkey-help__section {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--space-3);
 }
 
 .hotkey-help__section-title {
@@ -92,13 +92,13 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #888;
+  color: var(--text-faint);
 }
 
 .hotkey-help__grid {
   display: grid;
   grid-template-columns: auto 1fr;
-  gap: 0.5rem 1rem;
+  gap: var(--space-3) var(--space-5);
   align-items: center;
 }
 
@@ -107,33 +107,33 @@
   align-items: center;
   justify-content: center;
   min-width: 28px;
-  padding: 0.25rem 0.5rem;
-  background: rgba(255, 255, 255, 0.1);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
+  padding: var(--space-1) var(--space-3);
+  background: color-mix(in oklch, var(--text-primary) 7%, transparent);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
   font-size: 0.75rem;
   font-weight: 600;
-  font-family: monospace;
-  color: #fff;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
   white-space: nowrap;
 }
 
 .hotkey-help__key--inline {
   display: inline-flex;
   min-width: auto;
-  padding: 0.15rem 0.35rem;
+  padding: 0.15rem var(--space-2);
   font-size: 0.7rem;
 }
 
 .hotkey-help__desc {
   font-size: 0.85rem;
-  color: #ccc;
+  color: var(--text-muted);
 }
 
 .hotkey-help__footer {
-  padding: 0.75rem 1.25rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: var(--space-4) var(--space-6);
+  border-top: 1px solid var(--border-subtle);
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-faint);
   text-align: center;
 }

--- a/packages/client/src/components/TopBar/TopBar.css
+++ b/packages/client/src/components/TopBar/TopBar.css
@@ -19,7 +19,7 @@
   align-items: center;
   justify-content: space-between;
   height: 36px;
-  padding: 0 1rem;
+  padding: 0 var(--space-5);
   background: var(--surface-chrome);
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
@@ -41,26 +41,26 @@
 .top-bar__section {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: var(--space-5);
 }
 
 .top-bar__section--left {
-  gap: 0.75rem;
+  gap: var(--space-4);
 }
 
 .top-bar__section--center {
-  gap: 1.5rem;
+  gap: var(--space-6);
 }
 
 .top-bar__section--right {
-  gap: 1rem;
+  gap: var(--space-5);
 }
 
 /* Hero identity */
 .top-bar__hero {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: var(--space-3);
 }
 
 .top-bar__hero-name {
@@ -74,7 +74,7 @@
 .top-bar__stat {
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: var(--space-1);
   cursor: default;
 }
 
@@ -84,27 +84,27 @@
 }
 
 .top-bar__icon--level {
-  color: #9b59b6;
+  color: var(--stat-level);
 }
 
 .top-bar__icon--fame {
-  color: #f1c40f;
+  color: var(--stat-fame);
 }
 
 .top-bar__icon--armor {
-  color: #95a5a6;
+  color: var(--stat-armor);
 }
 
 .top-bar__icon--reputation {
-  color: #3498db;
+  color: var(--stat-reputation);
 }
 
 .top-bar__icon--move {
-  color: #4fc3f7;
+  color: var(--stat-move);
 }
 
 .top-bar__icon--influence {
-  color: #e91e63;
+  color: var(--stat-influence);
 }
 
 .top-bar__stat--move .top-bar__value,
@@ -117,7 +117,7 @@
   width: 1px;
   height: 20px;
   background: var(--border-default);
-  margin: 0 0.25rem;
+  margin: 0 var(--space-1);
 }
 
 .top-bar__value {
@@ -130,85 +130,73 @@
 .top-bar__mana-group {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .top-bar__mana-group--tokens {
-  padding-left: 0.5rem;
+  padding-left: var(--space-3);
   border-left: 1px solid var(--border-default);
 }
 
 .top-bar__crystal {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  font-weight: 700;
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  border: 1px solid var(--border-on-raised);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.04),
+    var(--elev-1);
+}
+
+.top-bar__crystal-count {
+  position: absolute;
+  right: -5px;
+  bottom: -5px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  border-radius: var(--radius-xs);
+  display: grid;
+  place-items: center;
+  background: var(--surface-chrome);
+  border: 1px solid var(--border-on-raised);
   color: var(--text-primary);
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
-}
-
-.top-bar__crystal--red {
-  background: linear-gradient(135deg, #e74c3c, #c0392b);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-.top-bar__crystal--blue {
-  background: linear-gradient(135deg, #3498db, #2980b9);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-.top-bar__crystal--green {
-  background: linear-gradient(135deg, #2ecc71, #27ae60);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-
-.top-bar__crystal--white {
-  background: linear-gradient(135deg, #ecf0f1, #bdc3c7);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
-  color: oklch(0.32 0.012 78);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1;
 }
 
 /* Mana tokens */
 .top-bar__token {
-  width: 14px;
-  height: 14px;
-  border-radius: 50%;
-  box-shadow: 0 0 3px rgba(0, 0, 0, 0.3);
+  position: relative;
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-round);
+  background: radial-gradient(circle at 50% 38%, var(--surface-hover-lift), var(--surface-canvas));
+  border: 1px solid var(--border-on-raised);
+  box-shadow: var(--elev-1);
 }
 
-.top-bar__token--red {
-  background: radial-gradient(circle at 30% 30%, #ff6b6b, #c0392b);
-}
-
-.top-bar__token--blue {
-  background: radial-gradient(circle at 30% 30%, #74b9ff, #2980b9);
-}
-
-.top-bar__token--green {
-  background: radial-gradient(circle at 30% 30%, #55efc4, #27ae60);
-}
-
-.top-bar__token--white {
-  background: radial-gradient(circle at 30% 30%, oklch(0.98 0.004 82), #bdc3c7);
-}
-
-.top-bar__token--gold {
-  background: radial-gradient(circle at 30% 30%, #ffeaa7, #f39c12);
-}
-
-.top-bar__token--black {
-  background: radial-gradient(circle at 30% 30%, #636e72, #2d3436);
+.top-bar__mana-glyph {
+  display: block;
+  width: 88%;
+  height: 88%;
+  object-fit: contain;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.45));
 }
 
 /* Round/Time */
 .top-bar__round {
   display: flex;
   align-items: center;
-  gap: 0.35rem;
+  gap: var(--space-2);
 }
 
 .top-bar__round-label {
@@ -230,20 +218,20 @@
   justify-content: center;
   width: 26px;
   height: 26px;
-  border-radius: 50%;
+  border-radius: var(--radius-round);
   font-size: 1rem;
 }
 
 .top-bar__time--day {
-  background: linear-gradient(135deg, #f39c12, #e67e22);
+  background: linear-gradient(135deg, var(--time-day), #e67e22);
   color: var(--text-primary);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--elev-1);
 }
 
 .top-bar__time--night {
-  background: linear-gradient(135deg, #2c3e50, #1a252f);
+  background: linear-gradient(135deg, var(--time-night), #1a252f);
   color: #bdc3c7;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--elev-1);
 }
 
 /* Help button */
@@ -253,7 +241,7 @@
   justify-content: center;
   width: 24px;
   height: 24px;
-  border-radius: 50%;
+  border-radius: var(--radius-round);
   border: 1px solid var(--border-default);
   background: color-mix(in oklch, var(--text-primary) 6%, transparent);
   color: var(--text-faint);
@@ -261,9 +249,9 @@
   font-weight: 600;
   cursor: pointer;
   transition:
-    background 0.15s var(--ease-out-expo),
-    border-color 0.15s var(--ease-out-expo),
-    color 0.15s var(--ease-out-expo);
+    background var(--dur-fast) var(--ease-out-expo),
+    border-color var(--dur-fast) var(--ease-out-expo),
+    color var(--dur-fast) var(--ease-out-expo);
 }
 
 .top-bar__help-btn:hover {
@@ -274,7 +262,7 @@
 
 /* Stolen mana section (Mana Steal tactic) */
 .top-bar__mana-group--stolen {
-  padding-left: 0.5rem;
+  padding-left: var(--space-3);
   border-left: 1px solid color-mix(in oklch, var(--accent) 45%, transparent);
 }
 
@@ -286,10 +274,10 @@
 
 /* Dashed amber border around stolen token */
 .top-bar__token--stolen::before {
-  content: '';
+  content: "";
   position: absolute;
   inset: -3px;
-  border-radius: 50%;
+  border-radius: var(--radius-round);
   border: 1.5px dashed color-mix(in oklch, var(--accent) 72%, transparent);
   animation: stolen-border-spin 8s linear infinite;
 }

--- a/packages/client/src/components/TopBar/TopBar.tsx
+++ b/packages/client/src/components/TopBar/TopBar.tsx
@@ -1,11 +1,27 @@
 import { useState, useEffect, useRef } from "react";
-import { TIME_OF_DAY_DAY, TIME_OF_DAY_NIGHT, LEVEL_THRESHOLDS } from "@mage-knight/shared";
+import {
+  LEVEL_THRESHOLDS,
+  MANA_BLUE,
+  MANA_GREEN,
+  MANA_RED,
+  MANA_WHITE,
+  TIME_OF_DAY_DAY,
+  TIME_OF_DAY_NIGHT,
+  type BasicManaColor,
+} from "@mage-knight/shared";
 import { useGame } from "../../hooks/useGame";
 import { useMyPlayer } from "../../hooks/useMyPlayer";
 import { useGameIntro, UI_REVEAL_TIMING } from "../../contexts/GameIntroContext";
+import { getManaIconUrl } from "../../assets/assetPaths";
 import { HotkeyHelp } from "./HotkeyHelp";
 import { PlayerListPanel } from "../PlayerList";
 import "./TopBar.css";
+
+const CRYSTAL_COLORS = [MANA_RED, MANA_BLUE, MANA_GREEN, MANA_WHITE] as const;
+
+function getCrystalTitle(color: BasicManaColor): string {
+  return `${color[0]?.toUpperCase() ?? ""}${color.slice(1)} Crystal`;
+}
 
 export function TopBar() {
   const { state } = useGame();
@@ -112,26 +128,25 @@ export function TopBar() {
       {/* Center section: Mana */}
       <div className="top-bar__section top-bar__section--center">
         <div className="top-bar__mana-group" title="Mana Crystals">
-          {player.crystals.red > 0 && (
-            <span className="top-bar__crystal top-bar__crystal--red" title="Red Crystal">
-              {player.crystals.red}
-            </span>
-          )}
-          {player.crystals.blue > 0 && (
-            <span className="top-bar__crystal top-bar__crystal--blue" title="Blue Crystal">
-              {player.crystals.blue}
-            </span>
-          )}
-          {player.crystals.green > 0 && (
-            <span className="top-bar__crystal top-bar__crystal--green" title="Green Crystal">
-              {player.crystals.green}
-            </span>
-          )}
-          {player.crystals.white > 0 && (
-            <span className="top-bar__crystal top-bar__crystal--white" title="White Crystal">
-              {player.crystals.white}
-            </span>
-          )}
+          {CRYSTAL_COLORS.map((color) => {
+            const count = player.crystals[color];
+            if (count <= 0) return null;
+            return (
+              <span
+                key={color}
+                className={`top-bar__crystal top-bar__crystal--${color}`}
+                title={getCrystalTitle(color)}
+              >
+                <img
+                  className="top-bar__mana-glyph"
+                  src={getManaIconUrl(color)}
+                  alt=""
+                  aria-hidden="true"
+                />
+                <span className="top-bar__crystal-count">{count}</span>
+              </span>
+            );
+          })}
         </div>
 
         {player.manaTokens.length > 0 && (
@@ -141,7 +156,14 @@ export function TopBar() {
                 key={i}
                 className={`top-bar__token top-bar__token--${token.color}`}
                 title={`${token.color} mana token`}
-              />
+              >
+                <img
+                  className="top-bar__mana-glyph"
+                  src={getManaIconUrl(token.color)}
+                  alt=""
+                  aria-hidden="true"
+                />
+              </span>
             ))}
           </div>
         )}
@@ -151,7 +173,14 @@ export function TopBar() {
             <span
               className={`top-bar__token top-bar__token--${player.stolenManaDie.color} top-bar__token--stolen`}
               title={`${player.stolenManaDie.color} mana (stolen via Mana Steal tactic - use anytime this turn)`}
-            />
+            >
+              <img
+                className="top-bar__mana-glyph"
+                src={getManaIconUrl(player.stolenManaDie.color)}
+                alt=""
+                aria-hidden="true"
+              />
+            </span>
           </div>
         )}
       </div>

--- a/packages/client/src/components/TurnActions/TurnActions.css
+++ b/packages/client/src/components/TurnActions/TurnActions.css
@@ -32,13 +32,13 @@
   /* Circular seal shape */
   width: clamp(80px, 10vh, 140px);
   height: clamp(80px, 10vh, 140px);
-  border-radius: 50%;
+  border-radius: var(--radius-round);
 
   /* Medieval seal aesthetic */
-  background: radial-gradient(circle at 30% 30%, #8b6914, #5c4a0f 60%, #3d3108);
-  border: 4px solid #a67c00;
+  background: radial-gradient(circle at 30% 30%, var(--seal-core-1), var(--seal-core-2) 60%, var(--seal-core-3));
+  border: 4px solid var(--seal-rim);
   box-shadow:
-    0 4px 20px rgba(0, 0, 0, 0.5),
+    var(--elev-3),
     inset 0 2px 10px rgba(255, 215, 0, 0.2),
     0 0 0 2px #2a2a2a;
 
@@ -53,7 +53,7 @@
   /* GPU acceleration for stamp animation */
   will-change: transform, opacity;
   /* Only transition GPU-friendly properties */
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  transition: transform var(--dur-fast) var(--ease-out-expo), border-color var(--dur-fast) var(--ease-out-expo);
 }
 
 /* Hidden during intro - before ui-settle phase */
@@ -65,7 +65,7 @@
 
 /* Animate in during ui-settle phase */
 .end-turn-seal--intro-reveal {
-  animation: seal-stamp 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  animation: seal-stamp 0.45s var(--ease-bounce) forwards;
 }
 
 .end-turn-seal:not(:disabled):hover {
@@ -73,7 +73,7 @@
   box-shadow:
     0 6px 25px rgba(0, 0, 0, 0.6),
     inset 0 2px 15px rgba(255, 215, 0, 0.3),
-    0 0 20px rgba(166, 124, 0, 0.4),
+    var(--glow-accent),
     0 0 0 2px #2a2a2a;
   border-color: #c9a227;
 }
@@ -90,14 +90,14 @@
 
 .end-turn-seal__icon {
   font-size: clamp(1.5rem, 3vh, 2.5rem);
-  color: #f4d03f;
+  color: var(--seal-gold);
   text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .end-turn-seal__text {
   font-size: clamp(0.6rem, 1.2vh, 0.9rem);
   font-weight: 700;
-  color: #f4d03f;
+  color: var(--seal-gold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.7);
@@ -115,77 +115,80 @@
 }
 
 .turn-actions__btn {
-  padding: 0.5rem 1rem;
-  border: none;
-  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.9rem;
+  border: 1px solid var(--border-on-raised);
+  border-radius: var(--radius-md);
+  background: var(--surface-canvas);
+  color: var(--text-secondary);
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;
-  /* Only transition GPU-friendly properties */
-  transition: transform 0.15s ease, background 0.15s ease;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  letter-spacing: 0.005em;
+  box-shadow: var(--elev-2);
+  transition:
+    transform var(--dur-fast) var(--ease-out-expo),
+    background var(--dur-fast) var(--ease-out-expo),
+    border-color var(--dur-fast) var(--ease-out-expo),
+    color var(--dur-fast) var(--ease-out-expo);
+}
+
+.turn-actions__btn:not(:disabled):hover {
+  background: var(--surface-hover-lift);
+  border-color: var(--accent);
+  color: var(--text-primary);
+  transform: translateX(-2px);
+}
+
+.turn-actions__btn:active {
+  transform: translateX(-1px);
 }
 
 .turn-actions__btn:disabled {
   opacity: 0.4;
   cursor: not-allowed;
+  transform: none;
 }
 
 .turn-actions__btn--undo {
-  background: rgba(50, 50, 70, 0.9);
-  color: #fff;
   font-size: 1.25rem;
   padding: 0.5rem 0.75rem;
 }
 
-.turn-actions__btn--undo:not(:disabled):hover {
-  background: rgba(70, 70, 100, 0.9);
-  transform: translateX(-2px);
+.turn-actions__btn--tactic::before,
+.turn-actions__btn--tactic-dark::before,
+.turn-actions__btn--rest::before,
+.turn-actions__btn--announce::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  background: var(--turn-action-dot, var(--text-muted));
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.3);
 }
 
 .turn-actions__btn--tactic {
-  background: linear-gradient(135deg, #f39c12, #e67e22);
-  color: #fff;
-}
-
-.turn-actions__btn--tactic:hover {
-  background: linear-gradient(135deg, #e67e22, #d35400);
-  transform: translateX(-2px);
+  --turn-action-dot: var(--parchment-gold);
 }
 
 .turn-actions__btn--tactic-dark {
-  background: linear-gradient(135deg, #8e44ad, #9b59b6);
-  color: #fff;
-}
-
-.turn-actions__btn--tactic-dark:hover {
-  background: linear-gradient(135deg, #9b59b6, #a569bd);
-  transform: translateX(-2px);
+  --turn-action-dot: var(--stat-level);
 }
 
 .turn-actions__btn--rest {
-  background: linear-gradient(135deg, #27ae60, #2ecc71);
-  color: #fff;
-}
-
-.turn-actions__btn--rest:hover {
-  background: linear-gradient(135deg, #2ecc71, #58d68d);
-  transform: translateX(-2px);
+  --turn-action-dot: var(--mana-green);
 }
 
 .turn-actions__btn--announce {
-  background: linear-gradient(135deg, #8e3b2f, #b04b3b);
-  color: #fff;
-}
-
-.turn-actions__btn--announce:hover {
-  background: linear-gradient(135deg, #b04b3b, #c85a47);
-  transform: translateX(-2px);
+  --turn-action-dot: #b04b3b;
 }
 
 .turn-actions__status {
   padding: 0.5rem 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-lg);
   font-size: 0.875rem;
   font-weight: 600;
   text-align: center;

--- a/packages/client/src/styles/index.css
+++ b/packages/client/src/styles/index.css
@@ -27,7 +27,82 @@
   --accent: oklch(0.74 0.085 72);
   --accent-muted: oklch(0.74 0.05 72 / 0.35);
 
+  /* Game-semantic stat colors */
+  --stat-level: #9b59b6;
+  --stat-fame: #f1c40f;
+  --stat-armor: #95a5a6;
+  --stat-reputation: #3498db;
+  --stat-move: #4fc3f7;
+  --stat-influence: #e91e63;
+
+  /* Mana base hues */
+  --mana-red: #c0392b;
+  --mana-blue: #2980b9;
+  --mana-green: #27ae60;
+  --mana-white: #ecf0f1;
+  --mana-gold: #f39c12;
+  --mana-black: #2d3436;
+
+  /* Day / night and elemental resistances */
+  --time-day: #f39c12;
+  --time-night: #2c3e50;
+  --resist-fire: #e8a090;
+  --resist-ice: #90c8e8;
+  --resist-physical: #c4a882;
+
+  /* Parchment and seal surfaces */
+  --parchment-bg-a: rgba(45, 36, 28, 0.98);
+  --parchment-bg-b: rgba(35, 28, 22, 0.99);
+  --parchment-border: #5c4a3a;
+  --parchment-text: #f0e6d2;
+  --parchment-text-soft: #d4c4a8;
+  --parchment-text-faint: #a89878;
+  --parchment-gold: #e8c476;
+  --seal-core-1: #8b6914;
+  --seal-core-2: #5c4a0f;
+  --seal-core-3: #3d3108;
+  --seal-rim: #a67c00;
+  --seal-gold: #f4d03f;
+
+  /* Motion */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --dur-fast: 0.15s;
+  --dur-base: 0.3s;
+  --dur-slow: 0.5s;
+
+  /* Spacing */
+  --space-1: 0.25rem;
+  --space-2: 0.35rem;
+  --space-3: 0.5rem;
+  --space-4: 0.75rem;
+  --space-5: 1rem;
+  --space-6: 1.5rem;
+  --space-7: 2rem;
+  --space-8: 3rem;
+
+  /* Radius */
+  --radius-xs: 3px;
+  --radius-sm: 4px;
+  --radius-md: 6px;
+  --radius-lg: 8px;
+  --radius-xl: 12px;
+  --radius-pill: 999px;
+  --radius-round: 50%;
+
+  /* Elevation */
+  --elev-1: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --elev-2: 0 2px 8px rgba(0, 0, 0, 0.3);
+  --elev-3: 0 4px 20px rgba(0, 0, 0, 0.5);
+  --elev-panel: -4px 0 24px rgba(0, 0, 0, 0.7);
+  --glow-fame: 0 0 10px rgba(241, 196, 15, 0.35);
+  --glow-accent: 0 0 20px rgba(166, 124, 0, 0.4);
+
+  /* Type */
+  --font-display: "Spectral", Georgia, "Times New Roman", serif;
+  --font-ui: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
 }
 
 * {


### PR DESCRIPTION
## Summary
- add semantic design-system tokens for stats, mana, surfaces, motion, radius, elevation, and type
- switch HUD mana/source visuals to shared flat mana glyph assets
- migrate turn actions, player list, and hotkey chrome toward matte tokenized patterns

## Verification
- cargo test && cargo clippy
- bun run build && bun run lint
- git diff --check
- Vite smoke test with Rust server: setup flow loads and live Source tray renders flat glyphs
