### PR TITLE
chore: add dev-opt profile for faster pre-push test runs

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -30,8 +30,8 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-echo "Running bun run test (cargo test workspace, excludes mk-python)..."
-cd "$REPO_ROOT" && bun run test
+echo "Running bun run test:fast (cargo test --profile dev-opt, excludes mk-python)..."
+cd "$REPO_ROOT" && bun run test:fast
 
 if [ $? -ne 0 ]; then
     echo ""

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "train-rl": "packages/python-sdk/scripts/run-train-rl",
     "build": "bun run --filter '*' build",
     "test": "cd packages/engine-rs && cargo test --workspace --exclude mk-python",
+    "test:fast": "cd packages/engine-rs && cargo test --profile dev-opt --workspace --exclude mk-python",
     "lint": "oxlint -c .oxlintrc.json --deny-warnings packages/*/src",
     "clean": "rm -rf node_modules packages/*/node_modules packages/*/dist bun.lockb",
     "dev:client": "bun run --filter @mage-knight/client dev",

--- a/packages/engine-rs/Cargo.toml
+++ b/packages/engine-rs/Cargo.toml
@@ -45,3 +45,7 @@ metrics = "0.24"
 
 # Testing
 proptest = "1"
+
+[profile.dev-opt]
+inherits = "dev"
+opt-level = 2

--- a/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_banners.rs
+++ b/packages/engine-rs/crates/mk-engine/src/action_pipeline/tests/test_banners.rs
@@ -940,9 +940,6 @@ fn fortitude_damage_test(
     );
 
     let is_wounded = state.players[0].units.get(0).map(|u| u.wounded).unwrap_or(true);
-    let banner_used = state.players[0].attached_banners.get(0)
-        .map(|b| b.is_used_this_round)
-        .unwrap_or(false);
 
     (state, is_wounded)
 }

--- a/packages/engine-rs/crates/mk-engine/src/effect_queue/tests.rs
+++ b/packages/engine-rs/crates/mk-engine/src/effect_queue/tests.rs
@@ -6389,7 +6389,8 @@ use mk_types::state::*;
         queue.drain(&mut state, 0);
 
         // 2 wounds removed, 2 cards drawn → net hand size change: -2 + 2 = 0
-        // But deck should have decreased by 2
+        assert_eq!(state.players[0].hand.len(), initial_hand_size);
+        // Deck decreased by 2 (cards drawn into hand)
         assert_eq!(state.players[0].deck.len(), initial_deck_size - 2);
     }
 

--- a/packages/engine-rs/crates/mk-engine/src/legal_actions/tests/pending.rs
+++ b/packages/engine-rs/crates/mk-engine/src/legal_actions/tests/pending.rs
@@ -223,6 +223,16 @@ fn choose_skill_from_common_pool() {
         state.offers.common_skills.contains(&drawn_1),
         "Drawn skill 1 should go to common pool when picking from common"
     );
+    // Auto-resolved AA should be removed from the offer
+    assert!(
+        !state.offers.advanced_actions.contains(&lowest_aa_id),
+        "Auto-resolved AA should be removed from the offer"
+    );
+    // Auto-resolved AA should be in player's hand or deck (placed on top of deed deck)
+    assert!(
+        state.players[0].hand.contains(&lowest_aa_id) || state.players[0].deck.contains(&lowest_aa_id),
+        "Auto-resolved AA should be in player's hand or deck"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Adds a `[profile.dev-opt]` Cargo profile (`inherits = "dev"`, `opt-level = 2`) — compiles faster than release while still running tests at a useful optimization level
- Adds `test:fast` bun script using `--profile dev-opt`
- Pre-push hook now calls `bun run test:fast` instead of `bun run test`, reducing hook wait time

## Changes
- `Cargo.toml`: new `dev-opt` profile
- `package.json`: new `test:fast` script
- `.githooks/pre-push`: switch to `test:fast`
- `test_banners.rs`: remove unused `banner_used` variable
- `effect_queue/tests.rs`: add missing `hand.len()` assertion
- `legal_actions/tests/pending.rs`: add assertions verifying auto-resolved AA is removed from offer and placed in player's hand/deck

## Test Plan
- Pre-push hook ran `test:fast` successfully (~2300 tests, all passing)