### PR TITLE
Add isolated hypothetical search state branching to VecEnv

### DIFF
--- a/packages/engine-rs/crates/mk-env/src/lib.rs
+++ b/packages/engine-rs/crates/mk-env/src/lib.rs
@@ -6,8 +6,11 @@
 pub mod batch_output;
 pub mod training_scenario;
 
+use std::collections::BTreeMap;
+use std::fmt;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use rayon::prelude::*;
 
@@ -52,6 +55,135 @@ fn achievement_score_no_wounds(state: &GameState) -> i32 {
 }
 
 use batch_output::BatchOutput;
+
+// =============================================================================
+// Search states — isolated hypothetical futures for planning clients
+// =============================================================================
+
+/// Language-binding name for production-Oracle search stepping.
+pub const SEARCH_COMBAT_MODE_FULL_ORACLE: &str = "full_oracle";
+/// Language-binding name for placeholder cheap-combat search stepping.
+pub const SEARCH_COMBAT_MODE_CHEAP: &str = "cheap";
+
+/// Controls how a hypothetical search step handles combat entered by that step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchCombatMode {
+    /// Resolve combat with the same bounded DFS configuration as the real environment.
+    FullOracle,
+    /// Placeholder for a future cheap/greedy resolver. This currently leaves combat
+    /// unresolved so the resulting combat state remains available for further search.
+    Cheap,
+}
+
+impl std::str::FromStr for SearchCombatMode {
+    type Err = SearchStateError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            SEARCH_COMBAT_MODE_FULL_ORACLE => Ok(Self::FullOracle),
+            SEARCH_COMBAT_MODE_CHEAP => Ok(Self::Cheap),
+            _ => Err(SearchStateError::InvalidCombatMode(value.to_owned())),
+        }
+    }
+}
+
+/// Process-unique opaque identifier for a standalone hypothetical state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SearchHandle(u64);
+
+impl SearchHandle {
+    /// Convert this opaque handle to its language-binding transport representation.
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Reconstruct a handle received through a language binding.
+    pub fn from_u64(raw: u64) -> Self {
+        Self(raw)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchStateError {
+    InvalidEnvironmentIndex { index: usize, num_envs: usize },
+    EmptyBatch,
+    UnknownHandle(SearchHandle),
+    LengthMismatch { handles: usize, actions: usize },
+    InvalidActionIndex {
+        handle: SearchHandle,
+        index: usize,
+        action_count: usize,
+    },
+    ApplyFailed {
+        handle: SearchHandle,
+        message: String,
+    },
+    EnginePanicked {
+        handle: SearchHandle,
+        message: String,
+    },
+    InvalidCombatMode(String),
+}
+
+impl fmt::Display for SearchStateError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidEnvironmentIndex { index, num_envs } => write!(
+                f, "environment index {index} is out of range for {num_envs} environments"
+            ),
+            Self::EmptyBatch => write!(f, "search handle batch must not be empty"),
+            Self::UnknownHandle(handle) => write!(
+                f, "unknown or dropped search handle {}", handle.as_u64()
+            ),
+            Self::LengthMismatch { handles, actions } => write!(
+                f, "handles length {handles} does not match actions length {actions}"
+            ),
+            Self::InvalidActionIndex { handle, index, action_count } => write!(
+                f,
+                "action index {index} is out of range for search handle {} with {action_count} actions",
+                handle.as_u64(),
+            ),
+            Self::ApplyFailed { handle, message } => write!(
+                f, "search step failed for handle {}: {message}", handle.as_u64()
+            ),
+            Self::EnginePanicked { handle, message } => write!(
+                f, "search step panicked for handle {}: {message}", handle.as_u64()
+            ),
+            Self::InvalidCombatMode(mode) => write!(
+                f,
+                "invalid search combat mode {mode:?}; expected {SEARCH_COMBAT_MODE_FULL_ORACLE:?} or {SEARCH_COMBAT_MODE_CHEAP:?}",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SearchStateError {}
+
+#[derive(Debug)]
+struct SearchState {
+    state: GameState,
+    action_set: LegalActionSet,
+}
+
+static NEXT_SEARCH_HANDLE: AtomicU64 = AtomicU64::new(1);
+
+fn next_search_handle() -> SearchHandle {
+    SearchHandle(NEXT_SEARCH_HANDLE.fetch_add(1, Ordering::Relaxed))
+}
+
+/// Clone a true engine state into an independently owned search state.
+///
+/// # Hidden-information warning
+///
+/// This clones the complete `GameState`, including true RNG state, deck order, token
+/// piles, and other information hidden from the policy observation. A planner using
+/// these roots can therefore exploit hidden future information.
+///
+/// TODO(search-determinization): add a caller-selected determinization/masking transform
+/// here before the clone enters the search registry. Until then, search is omniscient.
+fn clone_true_state_for_search(state: &GameState) -> GameState {
+    state.clone()
+}
 
 /// Dump a game state + action history to `training/crashes/` for reproduction.
 ///
@@ -461,6 +593,99 @@ impl SingleEnv {
     }
 }
 
+/// Resolve hypothetical combat with the real environment's production Oracle budget.
+fn resolve_search_combat_full(state: &mut GameState, undo_stack: &mut UndoStack) {
+    let config = CombatSearchConfig {
+        node_limit: 1_000_000,
+        seed_rollouts: 500,
+        ..CombatSearchConfig::default()
+    };
+    let result = search_combat(state, &config);
+
+    for action in &result.actions {
+        if state.combat.is_none() || state.game_ended {
+            break;
+        }
+        let epoch = state.action_epoch;
+        let _ = apply_legal_action(state, undo_stack, 0, action, epoch);
+    }
+
+    while state.combat.is_some() && !state.game_ended {
+        let actions = enumerate_legal_actions_with_undo(state, 0, undo_stack);
+        if actions.actions.is_empty() {
+            break;
+        }
+        let epoch = actions.epoch;
+        let fallback_idx = actions.actions.iter()
+            .position(|a| matches!(a, LegalAction::EndCombatPhase))
+            .or_else(|| actions.actions.iter().position(|a| matches!(a, LegalAction::EndTurn)))
+            .unwrap_or(0);
+        let action = actions.actions[fallback_idx].clone();
+        let _ = apply_legal_action(state, undo_stack, 0, &action, epoch);
+    }
+}
+
+fn resolve_search_combat_cheap(_state: &mut GameState, _undo_stack: &mut UndoStack) {
+    // TODO(search-cheap-combat): replace this no-op with a bounded greedy resolver.
+    // Keeping combat unresolved is cheaper than silently invoking the production Oracle
+    // and preserves a valid state for further hypothetical branching.
+}
+
+fn step_search_state(
+    handle: SearchHandle,
+    parent: &SearchState,
+    action_index: usize,
+    combat_mode: SearchCombatMode,
+) -> Result<SearchState, SearchStateError> {
+    let action_count = parent.action_set.actions.len();
+    let action = parent.action_set.actions.get(action_index)
+        .ok_or(SearchStateError::InvalidActionIndex {
+            handle, index: action_index, action_count,
+        })?
+        .clone();
+    let mut child_state = clone_true_state_for_search(&parent.state);
+    let epoch = parent.action_set.epoch;
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        // Match combat_search.rs branching: clone state, then use a clean undo history.
+        let mut undo_stack = UndoStack::new();
+        apply_legal_action(&mut child_state, &mut undo_stack, 0, &action, epoch)
+            .map_err(|error| SearchStateError::ApplyFailed {
+                handle, message: format!("{error:?}"),
+            })?;
+
+        if child_state.combat.is_some() {
+            match combat_mode {
+                SearchCombatMode::FullOracle => {
+                    resolve_search_combat_full(&mut child_state, &mut undo_stack);
+                }
+                SearchCombatMode::Cheap => {
+                    resolve_search_combat_cheap(&mut child_state, &mut undo_stack);
+                }
+            }
+        }
+
+        let action_set = filter_undo(enumerate_legal_actions_with_undo(
+            &child_state, 0, &undo_stack,
+        ));
+        Ok(SearchState { state: child_state, action_set })
+    }));
+
+    match result {
+        Ok(result) => result,
+        Err(panic_info) => {
+            let message = if let Some(value) = panic_info.downcast_ref::<&str>() {
+                (*value).to_owned()
+            } else if let Some(value) = panic_info.downcast_ref::<String>() {
+                value.clone()
+            } else {
+                "unknown engine panic".to_owned()
+            };
+            Err(SearchStateError::EnginePanicked { handle, message })
+        }
+    }
+}
+
 // =============================================================================
 // StepResult — per-env results from step_batch
 // =============================================================================
@@ -542,6 +767,8 @@ pub struct VecEnvConfig {
 pub struct VecEnv {
     envs: Vec<SingleEnv>,
     next_seed: u32,
+    /// Standalone hypothetical states. These never alias or mutate `envs`.
+    search_states: BTreeMap<SearchHandle, SearchState>,
 }
 
 impl VecEnv {
@@ -565,6 +792,7 @@ impl VecEnv {
         Self {
             envs,
             next_seed: config.base_seed + config.num_envs as u32,
+            search_states: BTreeMap::new(),
         }
     }
 
@@ -575,6 +803,113 @@ impl VecEnv {
     /// Get the current seed for each environment.
     pub fn seeds(&self) -> Vec<u32> {
         self.envs.iter().map(|e| e.seed).collect()
+    }
+
+    /// Fork independently owned hypothetical roots from current real environments.
+    ///
+    /// Repeated indices produce distinct roots. Cloning is parallelized with Rayon.
+    ///
+    /// # Hidden-information warning
+    ///
+    /// Roots clone the true `GameState`, including real RNG and deck/token order. Search
+    /// is omniscient until the TODO hook in `clone_true_state_for_search` is implemented.
+    pub fn fork_roots(
+        &mut self,
+        env_indices: &[usize],
+    ) -> Result<Vec<SearchHandle>, SearchStateError> {
+        let num_envs = self.envs.len();
+        let roots: Vec<Result<SearchState, SearchStateError>> = env_indices.par_iter()
+            .map(|&index| {
+                let env = self.envs.get(index).ok_or(
+                    SearchStateError::InvalidEnvironmentIndex { index, num_envs },
+                )?;
+                Ok(SearchState {
+                    state: clone_true_state_for_search(&env.state),
+                    action_set: env.action_set.clone(),
+                })
+            })
+            .collect();
+        let roots: Vec<SearchState> = roots.into_iter().collect::<Result<_, _>>()?;
+
+        let mut handles = Vec::with_capacity(roots.len());
+        for root in roots {
+            let handle = next_search_handle();
+            self.search_states.insert(handle, root);
+            handles.push(handle);
+        }
+        Ok(handles)
+    }
+
+    /// Step hypothetical parents in parallel and register independently owned children.
+    ///
+    /// Parents remain valid and unchanged, so repeated handles can create sibling branches.
+    /// Every child gets a cloned `GameState` and a fresh `UndoStack`.
+    pub fn step_search_batch(
+        &mut self,
+        handles: &[SearchHandle],
+        action_indices: &[usize],
+        combat_mode: SearchCombatMode,
+    ) -> Result<Vec<SearchHandle>, SearchStateError> {
+        if handles.len() != action_indices.len() {
+            return Err(SearchStateError::LengthMismatch {
+                handles: handles.len(), actions: action_indices.len(),
+            });
+        }
+
+        let search_states = &self.search_states;
+        let children: Vec<Result<SearchState, SearchStateError>> = handles.par_iter()
+            .zip(action_indices.par_iter())
+            .map(|(&handle, &action_index)| {
+                let parent = search_states.get(&handle)
+                    .ok_or(SearchStateError::UnknownHandle(handle))?;
+                step_search_state(handle, parent, action_index, combat_mode)
+            })
+            .collect();
+        let children: Vec<SearchState> = children.into_iter().collect::<Result<_, _>>()?;
+
+        let mut child_handles = Vec::with_capacity(children.len());
+        for child in children {
+            let handle = next_search_handle();
+            self.search_states.insert(handle, child);
+            child_handles.push(handle);
+        }
+        Ok(child_handles)
+    }
+
+    /// Encode hypothetical states in handle order with normal feature/padding semantics.
+    pub fn encode_search_batch(
+        &self,
+        handles: &[SearchHandle],
+    ) -> Result<BatchOutput, SearchStateError> {
+        if handles.is_empty() {
+            return Err(SearchStateError::EmptyBatch);
+        }
+        let encoded: Vec<Result<(EncodedStep, i32), SearchStateError>> = handles.par_iter()
+            .map(|&handle| {
+                let search_state = self.search_states.get(&handle)
+                    .ok_or(SearchStateError::UnknownHandle(handle))?;
+                let step = mk_features::encode_step(
+                    &search_state.state, 0, &search_state.action_set,
+                );
+                Ok((step, search_state.state.players[0].fame as i32))
+            })
+            .collect();
+        let encoded: Vec<(EncodedStep, i32)> = encoded.into_iter().collect::<Result<_, _>>()?;
+        let steps: Vec<EncodedStep> = encoded.iter().map(|(step, _)| step.clone()).collect();
+        let fames: Vec<i32> = encoded.iter().map(|(_, fame)| *fame).collect();
+        Ok(BatchOutput::pack(&steps, &fames))
+    }
+
+    /// Release hypothetical states. Unknown/already-dropped handles are ignored.
+    pub fn drop_search_states(&mut self, handles: &[SearchHandle]) -> usize {
+        handles.iter()
+            .filter(|handle| self.search_states.remove(handle).is_some())
+            .count()
+    }
+
+    /// Number of hypothetical states currently retained by this environment.
+    pub fn search_state_count(&self) -> usize {
+        self.search_states.len()
     }
 
     /// Encode all environments in parallel, returning padded batch output.
@@ -795,6 +1130,7 @@ impl VecEnv {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::Instant;
 
     fn test_config(num_envs: usize, base_seed: u32, max_steps: u64) -> VecEnvConfig {
         VecEnvConfig {
@@ -807,6 +1143,179 @@ mod tests {
             commerce_oracle: false,
             early_term_fame_step: 0,
         }
+    }
+
+    fn assert_encoded_batches_equal(left: &BatchOutput, right: &BatchOutput) {
+        assert_eq!(left.num_envs, right.num_envs);
+        assert_eq!(left.state_scalars, right.state_scalars);
+        assert_eq!(left.state_ids, right.state_ids);
+        assert_eq!(left.hand_card_ids, right.hand_card_ids);
+        assert_eq!(left.hand_counts, right.hand_counts);
+        assert_eq!(left.deck_card_ids, right.deck_card_ids);
+        assert_eq!(left.deck_counts, right.deck_counts);
+        assert_eq!(left.discard_card_ids, right.discard_card_ids);
+        assert_eq!(left.discard_counts, right.discard_counts);
+        assert_eq!(left.unit_ids, right.unit_ids);
+        assert_eq!(left.unit_counts, right.unit_counts);
+        assert_eq!(left.unit_scalars, right.unit_scalars);
+        assert_eq!(left.combat_enemy_ids, right.combat_enemy_ids);
+        assert_eq!(left.combat_enemy_counts, right.combat_enemy_counts);
+        assert_eq!(left.combat_enemy_scalars, right.combat_enemy_scalars);
+        assert_eq!(left.skill_ids, right.skill_ids);
+        assert_eq!(left.skill_counts, right.skill_counts);
+        assert_eq!(left.visible_site_ids, right.visible_site_ids);
+        assert_eq!(left.visible_site_counts, right.visible_site_counts);
+        assert_eq!(left.visible_site_scalars, right.visible_site_scalars);
+        assert_eq!(left.map_enemy_ids, right.map_enemy_ids);
+        assert_eq!(left.map_enemy_counts, right.map_enemy_counts);
+        assert_eq!(left.map_enemy_scalars, right.map_enemy_scalars);
+        assert_eq!(left.revealed_hex_terrain_ids, right.revealed_hex_terrain_ids);
+        assert_eq!(left.revealed_hex_counts, right.revealed_hex_counts);
+        assert_eq!(left.revealed_hex_scalars, right.revealed_hex_scalars);
+        assert_eq!(left.action_ids, right.action_ids);
+        assert_eq!(left.action_scalars, right.action_scalars);
+        assert_eq!(left.action_counts, right.action_counts);
+        assert_eq!(left.action_target_offsets, right.action_target_offsets);
+        assert_eq!(left.action_target_ids, right.action_target_ids);
+        assert_eq!(left.fames, right.fames);
+    }
+
+    #[test]
+    fn search_steps_are_isolated_from_real_environment() {
+        let config = test_config(1, 9_001, 500);
+        let mut env = VecEnv::new(config.clone());
+        let mut control = VecEnv::new(config);
+        let state_before = serde_json::to_vec(&env.envs[0].state).unwrap();
+        let encoding_before = env.encode_batch();
+        let mut handles = env.fork_roots(&[0]).unwrap();
+        assert_encoded_batches_equal(
+            &encoding_before,
+            &env.encode_search_batch(&handles).unwrap(),
+        );
+
+        for step in 0..8usize {
+            let batch = env.encode_search_batch(&handles).unwrap();
+            let count = batch.action_counts[0] as usize;
+            assert!(count > 0, "search state has no actions at step {step}");
+            let children = env.step_search_batch(
+                &handles, &[(step * 3 + 1) % count], SearchCombatMode::Cheap,
+            ).unwrap();
+            assert_eq!(env.drop_search_states(&handles), 1);
+            handles = children;
+        }
+
+        assert_eq!(state_before, serde_json::to_vec(&env.envs[0].state).unwrap());
+        let encoding_after = env.encode_batch();
+        assert_encoded_batches_equal(&encoding_before, &encoding_after);
+
+        // Normal stepping must still match an untouched control after search branching.
+        let real_action = encoding_after.action_counts[0] - 1;
+        let stepped = env.step_batch(&[real_action]);
+        let control_stepped = control.step_batch(&[real_action]);
+        assert_eq!(stepped.dones, control_stepped.dones);
+        assert_eq!(stepped.fames, control_stepped.fames);
+        assert_eq!(stepped.applied_actions, control_stepped.applied_actions);
+        assert_encoded_batches_equal(&env.encode_batch(), &control.encode_batch());
+
+        assert_eq!(env.drop_search_states(&handles), 1);
+        assert_eq!(env.search_state_count(), 0);
+    }
+
+    #[test]
+    fn search_parent_is_immutable_and_can_create_siblings() {
+        let mut env = VecEnv::new(test_config(1, 42, 500));
+        let parent = env.fork_roots(&[0]).unwrap()[0];
+        let parent_before = env.encode_search_batch(&[parent]).unwrap();
+        let count = parent_before.action_counts[0] as usize;
+        assert!(count >= 2);
+
+        let children = env.step_search_batch(
+            &[parent, parent], &[0, count - 1], SearchCombatMode::Cheap,
+        ).unwrap();
+        assert_ne!(children[0], children[1]);
+        assert_eq!(env.search_state_count(), 3);
+        assert_encoded_batches_equal(
+            &parent_before, &env.encode_search_batch(&[parent]).unwrap(),
+        );
+
+        assert_eq!(env.drop_search_states(&[parent, children[0], children[1]]), 3);
+        assert_eq!(env.drop_search_states(&[parent]), 0);
+    }
+
+    #[test]
+    fn search_combat_modes_preserve_full_vs_cheap_contract() {
+        let scenario = TrainingScenario::CombatDrill {
+            enemy_tokens: vec!["diggers_1".to_string()],
+            is_fortified: false,
+            hand_override: None,
+            extra_cards: None,
+            units: None,
+            skills: None,
+            crystals: None,
+        };
+        let mut env = VecEnv::new(VecEnvConfig {
+            scenario,
+            ..test_config(1, 42, 500)
+        });
+        let parent = env.fork_roots(&[0]).unwrap()[0];
+        let action_index = env.search_states.get(&parent).unwrap().action_set.actions.iter()
+            .position(|action| !matches!(action, LegalAction::EndCombatPhase))
+            .unwrap();
+
+        let cheap = env.step_search_batch(
+            &[parent], &[action_index], SearchCombatMode::Cheap,
+        ).unwrap()[0];
+        assert!(env.search_states.get(&cheap).unwrap().state.combat.is_some());
+
+        let full = env.step_search_batch(
+            &[parent], &[action_index], SearchCombatMode::FullOracle,
+        ).unwrap()[0];
+        assert!(env.search_states.get(&full).unwrap().state.combat.is_none());
+    }
+
+    /// Run manually with:
+    /// `cargo test -p mk-env search_state_clone_step_perf_sanity -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual performance sanity check"]
+    fn search_state_clone_step_perf_sanity() {
+        const ROOTS: usize = 64;
+        const STEPS: usize = 50;
+        let mut env = VecEnv::new(test_config(ROOTS, 70_000, 500));
+        let started = Instant::now();
+        let mut handles = env.fork_roots(&(0..ROOTS).collect::<Vec<_>>()).unwrap();
+        let mut all_handles = handles.clone();
+
+        for step in 0..STEPS {
+            let batch = env.encode_search_batch(&handles).unwrap();
+            let actions: Vec<usize> = batch.action_counts.iter().enumerate()
+                .map(|(index, &count)| {
+                    assert!(count > 0, "root {index} has no actions at search step {step}");
+                    (step + index) % count as usize
+                })
+                .collect();
+            let children = env.step_search_batch(
+                &handles, &actions, SearchCombatMode::Cheap,
+            ).unwrap();
+            all_handles.extend_from_slice(&children);
+            handles = children;
+        }
+        let step_elapsed = started.elapsed();
+
+        // Serialized size is a stable rough proxy, not allocator/RSS measurement.
+        let serialized_bytes: usize = all_handles.iter().map(|handle| {
+            let node = env.search_states.get(handle).unwrap();
+            serde_json::to_vec(&node.state).unwrap().len()
+                + serde_json::to_vec(&node.action_set).unwrap().len()
+        }).sum();
+        eprintln!(
+            "search-state baseline: roots={ROOTS}, steps_per_root={STEPS}, total_steps={}, retained_states={}, step_elapsed={step_elapsed:?}, serialized_memory_proxy={} bytes ({:.2} MiB)",
+            ROOTS * STEPS, all_handles.len(), serialized_bytes,
+            serialized_bytes as f64 / (1024.0 * 1024.0),
+        );
+        assert!(serialized_bytes > 0);
+        assert_eq!(env.search_state_count(), ROOTS * (STEPS + 1));
+        assert_eq!(env.drop_search_states(&all_handles), ROOTS * (STEPS + 1));
+        assert_eq!(env.search_state_count(), 0);
     }
 
     /// Reproduce: seed=15604 with 156 action indices yields 0 legal actions.

--- a/packages/engine-rs/crates/mk-python/src/lib.rs
+++ b/packages/engine-rs/crates/mk-python/src/lib.rs
@@ -21,7 +21,7 @@ use mk_engine::legal_actions::enumerate_legal_actions_with_undo;
 use mk_engine::scoring::calculate_final_scores;
 use mk_engine::setup::{create_solo_game, place_initial_tiles};
 use mk_engine::undo::UndoStack;
-use mk_env::{TrainingScenario, VecEnv};
+use mk_env::{SearchCombatMode, SearchHandle, TrainingScenario, VecEnv};
 use mk_features::EncodedStep;
 use mk_types::enums::Hero;
 use mk_types::events::GameEvent;
@@ -923,6 +923,51 @@ fn vec_bool_to_numpy<'py>(
     Ok(arr.unbind())
 }
 
+/// Convert a hypothetical-state batch to the exact dictionary schema used by
+/// `PyVecEnv.encode_batch()`. The real-environment method remains unchanged.
+fn search_batch_to_python(
+    py: Python<'_>,
+    batch: &mk_env::batch_output::BatchOutput,
+) -> PyResult<Py<PyAny>> {
+    let np = py.import("numpy")?;
+    let dict = pyo3::types::PyDict::new(py);
+    let n = batch.num_envs;
+
+    dict.set_item("state_scalars", vec_f32_to_numpy(py, &np, &batch.state_scalars, &[n, batch.state_scalars.len() / n])?)?;
+    dict.set_item("state_ids", vec_i32_to_numpy(py, &np, &batch.state_ids, &[n, 3])?)?;
+    dict.set_item("hand_card_ids", vec_i32_to_numpy(py, &np, &batch.hand_card_ids, &[n, batch.max_hand])?)?;
+    dict.set_item("hand_counts", vec_i32_to_numpy(py, &np, &batch.hand_counts, &[n])?)?;
+    dict.set_item("deck_card_ids", vec_i32_to_numpy(py, &np, &batch.deck_card_ids, &[n, batch.max_deck])?)?;
+    dict.set_item("deck_counts", vec_i32_to_numpy(py, &np, &batch.deck_counts, &[n])?)?;
+    dict.set_item("discard_card_ids", vec_i32_to_numpy(py, &np, &batch.discard_card_ids, &[n, batch.max_discard])?)?;
+    dict.set_item("discard_counts", vec_i32_to_numpy(py, &np, &batch.discard_counts, &[n])?)?;
+    dict.set_item("unit_ids", vec_i32_to_numpy(py, &np, &batch.unit_ids, &[n, batch.max_units])?)?;
+    dict.set_item("unit_counts", vec_i32_to_numpy(py, &np, &batch.unit_counts, &[n])?)?;
+    dict.set_item("unit_scalars", vec_f32_to_numpy(py, &np, &batch.unit_scalars, &[n * batch.max_units, mk_features::UNIT_SCALAR_DIM])?)?;
+    dict.set_item("combat_enemy_ids", vec_i32_to_numpy(py, &np, &batch.combat_enemy_ids, &[n, batch.max_combat_enemies])?)?;
+    dict.set_item("combat_enemy_counts", vec_i32_to_numpy(py, &np, &batch.combat_enemy_counts, &[n])?)?;
+    dict.set_item("combat_enemy_scalars", vec_f32_to_numpy(py, &np, &batch.combat_enemy_scalars, &[n * batch.max_combat_enemies, mk_features::COMBAT_ENEMY_SCALAR_DIM])?)?;
+    dict.set_item("skill_ids", vec_i32_to_numpy(py, &np, &batch.skill_ids, &[n, batch.max_skills])?)?;
+    dict.set_item("skill_counts", vec_i32_to_numpy(py, &np, &batch.skill_counts, &[n])?)?;
+    dict.set_item("visible_site_ids", vec_i32_to_numpy(py, &np, &batch.visible_site_ids, &[n, batch.max_visible_sites])?)?;
+    dict.set_item("visible_site_counts", vec_i32_to_numpy(py, &np, &batch.visible_site_counts, &[n])?)?;
+    dict.set_item("visible_site_scalars", vec_f32_to_numpy(py, &np, &batch.visible_site_scalars, &[n * batch.max_visible_sites, mk_features::SITE_SCALAR_DIM])?)?;
+    dict.set_item("map_enemy_ids", vec_i32_to_numpy(py, &np, &batch.map_enemy_ids, &[n, batch.max_map_enemies])?)?;
+    dict.set_item("map_enemy_counts", vec_i32_to_numpy(py, &np, &batch.map_enemy_counts, &[n])?)?;
+    dict.set_item("map_enemy_scalars", vec_f32_to_numpy(py, &np, &batch.map_enemy_scalars, &[n * batch.max_map_enemies, mk_features::MAP_ENEMY_SCALAR_DIM])?)?;
+    dict.set_item("revealed_hex_terrain_ids", vec_i32_to_numpy(py, &np, &batch.revealed_hex_terrain_ids, &[n, batch.max_revealed_hexes])?)?;
+    dict.set_item("revealed_hex_counts", vec_i32_to_numpy(py, &np, &batch.revealed_hex_counts, &[n])?)?;
+    dict.set_item("revealed_hex_scalars", vec_f32_to_numpy(py, &np, &batch.revealed_hex_scalars, &[n * batch.max_revealed_hexes, mk_features::HEX_SCALAR_DIM])?)?;
+    dict.set_item("action_ids", vec_i32_to_numpy(py, &np, &batch.action_ids, &[n * batch.max_actions, 6])?)?;
+    dict.set_item("action_scalars", vec_f32_to_numpy(py, &np, &batch.action_scalars, &[n * batch.max_actions, mk_features::ACTION_SCALAR_DIM])?)?;
+    dict.set_item("action_counts", vec_i32_to_numpy(py, &np, &batch.action_counts, &[n])?)?;
+    dict.set_item("action_target_offsets", vec_i32_to_numpy(py, &np, &batch.action_target_offsets, &[n * (batch.max_actions + 1)])?)?;
+    dict.set_item("action_target_ids", vec_i32_to_numpy(py, &np, &batch.action_target_ids, &[batch.action_target_ids.len()])?)?;
+    dict.set_item("fames", vec_i32_to_numpy(py, &np, &batch.fames, &[n])?)?;
+    dict.set_item("max_actions", batch.max_actions)?;
+    Ok(dict.into_any().unbind())
+}
+
 #[pymethods]
 impl PyVecEnv {
     /// Create a vectorized environment.
@@ -970,6 +1015,60 @@ impl PyVecEnv {
 
     fn seeds(&self) -> Vec<u32> {
         self.inner.seeds()
+    }
+
+    /// Clone real environments into independently owned hypothetical roots.
+    ///
+    /// Warning: roots contain the true RNG, deck order, and token piles. Search is
+    /// omniscient until a future determinization/masking hook is implemented.
+    fn fork_roots(&mut self, env_indices: Vec<usize>) -> PyResult<Vec<u64>> {
+        self.inner.fork_roots(&env_indices)
+            .map(|handles| handles.into_iter().map(SearchHandle::as_u64).collect())
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    /// Step hypothetical parents and return new child handles. Parents remain unchanged.
+    /// `combat_mode` is "full_oracle" or "cheap"; cheap currently leaves combat unresolved.
+    fn step_search_batch(
+        &mut self,
+        handles: Vec<u64>,
+        action_indices: Vec<usize>,
+        combat_mode: &str,
+    ) -> PyResult<Vec<u64>> {
+        let combat_mode = combat_mode.parse::<SearchCombatMode>()
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        let handles: Vec<SearchHandle> = handles.into_iter()
+            .map(SearchHandle::from_u64)
+            .collect();
+        self.inner.step_search_batch(&handles, &action_indices, combat_mode)
+            .map(|children| children.into_iter().map(SearchHandle::as_u64).collect())
+            .map_err(|error| PyValueError::new_err(error.to_string()))
+    }
+
+    /// Encode hypothetical states with the same schema as `encode_batch()`.
+    fn encode_search_batch(
+        &self,
+        py: Python<'_>,
+        handles: Vec<u64>,
+    ) -> PyResult<Py<PyAny>> {
+        let handles: Vec<SearchHandle> = handles.into_iter()
+            .map(SearchHandle::from_u64)
+            .collect();
+        let batch = self.inner.encode_search_batch(&handles)
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        search_batch_to_python(py, &batch)
+    }
+
+    /// Explicitly release hypothetical states. Cleanup is idempotent.
+    fn drop_search_states(&mut self, handles: Vec<u64>) -> usize {
+        let handles: Vec<SearchHandle> = handles.into_iter()
+            .map(SearchHandle::from_u64)
+            .collect();
+        self.inner.drop_search_states(&handles)
+    }
+
+    fn search_state_count(&self) -> usize {
+        self.inner.search_state_count()
     }
 
     /// Encode all envs into a dict of numpy arrays.
@@ -1107,6 +1206,8 @@ fn get_vocab_sizes() -> std::collections::HashMap<String, usize> {
 #[pymodule]
 fn mk_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.1.0")?;
+    m.add("SEARCH_COMBAT_MODE_FULL_ORACLE", mk_env::SEARCH_COMBAT_MODE_FULL_ORACLE)?;
+    m.add("SEARCH_COMBAT_MODE_CHEAP", mk_env::SEARCH_COMBAT_MODE_CHEAP)?;
     m.add_class::<GameEngine>()?;
     m.add_class::<PyEncodedStep>()?;
     m.add_class::<PyVecEnv>()?;

--- a/packages/python-sdk/tests/test_vec_env.py
+++ b/packages/python-sdk/tests/test_vec_env.py
@@ -114,6 +114,82 @@ class TestPyVecEnv(unittest.TestCase):
         self.assertEqual(batch["action_scalars"].shape[1], 34)
 
 
+class TestSearchStateApi(unittest.TestCase):
+    """Hypothetical states must remain isolated from the live PyVecEnv batch."""
+
+    def setUp(self) -> None:
+        from mk_python import PyVecEnv, SEARCH_COMBAT_MODE_CHEAP
+        self.env = PyVecEnv(num_envs=2, base_seed=42, max_steps=500)
+        self.cheap_combat_mode = SEARCH_COMBAT_MODE_CHEAP
+
+    @staticmethod
+    def _copy_batch(batch: dict) -> dict:
+        return {
+            key: value.copy() if isinstance(value, np.ndarray) else value
+            for key, value in batch.items()
+        }
+
+    @staticmethod
+    def _assert_batches_equal(left: dict, right: dict) -> None:
+        assert left.keys() == right.keys()
+        for key in left:
+            if isinstance(left[key], np.ndarray):
+                np.testing.assert_array_equal(left[key], right[key], err_msg=key)
+            else:
+                assert left[key] == right[key], key
+
+    def test_fork_step_encode_and_drop_are_isolated(self) -> None:
+        real_before = self._copy_batch(self.env.encode_batch())
+        roots = self.env.fork_roots([0, 1, 0])
+        self.assertEqual(len(roots), 3)
+        self.assertEqual(len(set(roots)), 3)
+        self.assertEqual(self.env.search_state_count(), 3)
+        self._assert_batches_equal(
+            real_before,
+            self.env.encode_search_batch(roots[:2]),
+        )
+
+        root_batch = self.env.encode_search_batch(roots)
+        self.assertEqual(root_batch["state_scalars"].shape[0], 3)
+        np.testing.assert_array_equal(
+            root_batch["state_scalars"][0], root_batch["state_scalars"][2],
+        )
+        self.assertEqual(root_batch["action_counts"][0], root_batch["action_counts"][2])
+
+        parent_before = self._copy_batch(self.env.encode_search_batch([roots[0]]))
+        parent_action_count = int(parent_before["action_counts"][0])
+        children = self.env.step_search_batch(
+            [roots[0], roots[0]],
+            [0, parent_action_count - 1],
+            self.cheap_combat_mode,
+        )
+        self.assertEqual(len(children), 2)
+        self.assertEqual(self.env.search_state_count(), 5)
+        self._assert_batches_equal(
+            parent_before,
+            self.env.encode_search_batch([roots[0]]),
+        )
+
+        # Neither search branching nor search encoding may alter the real environments.
+        self._assert_batches_equal(real_before, self.env.encode_batch())
+
+        self.assertEqual(self.env.drop_search_states(roots + children), 5)
+        self.assertEqual(self.env.drop_search_states(roots), 0)
+        self.assertEqual(self.env.search_state_count(), 0)
+
+    def test_search_api_rejects_invalid_inputs(self) -> None:
+        root = self.env.fork_roots([0])[0]
+        with self.assertRaises(ValueError):
+            self.env.step_search_batch([root], [], self.cheap_combat_mode)
+        with self.assertRaises(ValueError):
+            self.env.step_search_batch([root], [0], "unknown")
+        with self.assertRaises(ValueError):
+            self.env.encode_search_batch([])
+        self.env.drop_search_states([root])
+        with self.assertRaises(ValueError):
+            self.env.encode_search_batch([root])
+
+
 class TestBatchedForward(unittest.TestCase):
     """Tests for the batched forward pass on _EmbeddingActionScoringNetwork."""
 


### PR DESCRIPTION
## Summary

- add opaque search-state handles that clone live `VecEnv` states without mutating the real environments
- expose batched fork, step, encode, and explicit cleanup APIs through the Rust and Python layers
- parallelize hypothetical stepping and encoding with Rayon
- support production-oracle and placeholder cheap combat modes without adding MCTS policy logic
- document that roots currently clone true RNG/deck state and provide a determinization hook
- add isolation, sibling immutability, combat-mode, invalid-input, and Python binding coverage

## Why

This provides the engine infrastructure needed to build MCTS or other lookahead systems later while preserving the existing `PyVecEnv.encode_batch()` / `step_batch()` training path unchanged.

## Important caveat

`fork_roots` currently clones the true `GameState`, including RNG and hidden deck/token order. Search callers must not treat this as an information-safe belief state; a documented determinization hook remains TODO.

## Performance baseline

The ignored manual sanity test retains 64 roots across 50 sequential hypothetical steps each (3,200 steps; 3,264 retained states). The latest debug run reported:

- stepping: 115.94 ms
- serialized state/action-set size proxy: 53.94 MiB

The memory figure is a serialization-based proxy, not allocator RSS.

## Validation

- `cd packages/engine-rs && cargo test`
- `cd packages/engine-rs && cargo clippy`
- `cd packages/python-sdk && .venv/bin/python -m unittest tests.test_vec_env.TestSearchStateApi -v`
- `cd packages/python-sdk && .venv/bin/ruff check tests/test_vec_env.py`
- repository pre-push hook: Clippy, `bun run lint`, and `bun run test:fast`
