### PR TITLE
Fix terminal-reward PPO experiment infrastructure

### DIFF
--- a/packages/engine-rs/crates/mk-env/src/lib.rs
+++ b/packages/engine-rs/crates/mk-env/src/lib.rs
@@ -56,6 +56,17 @@ fn achievement_score_no_wounds(state: &GameState) -> i32 {
 
 use batch_output::BatchOutput;
 
+/// Episode is still active after the step.
+pub const TERMINATION_CAUSE_ONGOING: i32 = 0;
+/// Episode reached a real game ending.
+pub const TERMINATION_CAUSE_NATURAL_END: i32 = 1;
+/// Episode was cut because it still had zero fame at the configured early threshold.
+pub const TERMINATION_CAUSE_EARLY_ZERO_FAME: i32 = 2;
+/// Episode reached the environment's hard maximum step count.
+pub const TERMINATION_CAUSE_HARD_LIMIT: i32 = 3;
+/// The engine returned an error or panicked while applying the action.
+pub const TERMINATION_CAUSE_ENGINE_FAILURE: i32 = 4;
+
 // =============================================================================
 // Search states — isolated hypothetical futures for planning clients
 // =============================================================================
@@ -386,6 +397,23 @@ impl SingleEnv {
         false
     }
 
+    fn termination_cause(&self, panicked: bool) -> i32 {
+        if panicked {
+            TERMINATION_CAUSE_ENGINE_FAILURE
+        } else if self.state.game_ended {
+            TERMINATION_CAUSE_NATURAL_END
+        } else if self.step_count >= self.max_steps {
+            TERMINATION_CAUSE_HARD_LIMIT
+        } else if self.early_term_fame_step > 0
+            && self.step_count >= self.early_term_fame_step
+            && self.state.players[0].fame == 0
+        {
+            TERMINATION_CAUSE_EARLY_ZERO_FAME
+        } else {
+            TERMINATION_CAUSE_ONGOING
+        }
+    }
+
     /// Auto-resolve combat using the exhaustive search oracle.
     /// Replays the optimal action sequence, falling back to action[0] if needed.
     fn resolve_combat_oracle(&mut self) {
@@ -700,8 +728,14 @@ pub struct StepResult {
     pub fames: Vec<i32>,
     /// (N,) — whether each env panicked (subset of dones)
     pub panicked: Vec<bool>,
-    /// (N,) — whether done due to max_steps (not natural game end)
+    /// (N,) — whether an episode ended through any artificial cutoff.
     pub truncated: Vec<bool>,
+    /// (N,) — stable termination-cause code; zero while the episode remains active.
+    pub termination_causes: Vec<i32>,
+    /// Pre-reset observations for artificially truncated environments only.
+    pub bootstrap_batch: Option<BatchOutput>,
+    /// Original environment index for each row in `bootstrap_batch`.
+    pub bootstrap_indices: Vec<i32>,
     /// (N,) — whether scenario end condition was triggered
     pub scenario_end_triggered: Vec<bool>,
     /// (N,) — number of new hexes visited this step (0 or 1)
@@ -990,6 +1024,7 @@ impl VecEnv {
         let mut fames_after = Vec::with_capacity(n);
         let mut panicked = Vec::with_capacity(n);
         let mut truncated = Vec::with_capacity(n);
+        let mut termination_causes = Vec::with_capacity(n);
         let mut scenario_end_triggered = Vec::with_capacity(n);
         let mut new_hexes = Vec::with_capacity(n);
         let mut wound_deltas = Vec::with_capacity(n);
@@ -1018,8 +1053,13 @@ impl VecEnv {
             dones.push(done);
             fames_after.push(fame_now);
             panicked.push(*did_panic);
-            // Truncated = done due to max_steps, not natural game end
+            // Truncated means any artificial cutoff (early-zero-fame or hard limit).
             truncated.push(done && !env.state.game_ended);
+            termination_causes.push(if done {
+                env.termination_cause(*did_panic)
+            } else {
+                TERMINATION_CAUSE_ONGOING
+            });
             scenario_end_triggered.push(env.state.scenario_end_triggered);
             new_hexes.push(if new_hex_flags[i] { 1 } else { 0 });
             wound_deltas.push(env.wound_count() - wounds_before[i]);
@@ -1079,6 +1119,37 @@ impl VecEnv {
             }
         }
 
+        // Preserve the real post-step state for time-limit value bootstrapping before reset.
+        let bootstrap_indices: Vec<usize> = termination_causes
+            .iter()
+            .enumerate()
+            .filter_map(|(index, cause)| {
+                matches!(
+                    *cause,
+                    TERMINATION_CAUSE_EARLY_ZERO_FAME | TERMINATION_CAUSE_HARD_LIMIT
+                )
+                .then_some(index)
+            })
+            .collect();
+        let bootstrap_batch = if bootstrap_indices.is_empty() {
+            None
+        } else {
+            let encoded: Vec<(EncodedStep, i32)> = bootstrap_indices
+                .par_iter()
+                .map(|&index| {
+                    let env = &self.envs[index];
+                    (env.encode(), env.fame() as i32)
+                })
+                .collect();
+            let steps: Vec<EncodedStep> = encoded.iter().map(|(step, _)| step.clone()).collect();
+            let fames: Vec<i32> = encoded.iter().map(|(_, fame)| *fame).collect();
+            Some(BatchOutput::pack(&steps, &fames))
+        };
+        let bootstrap_indices = bootstrap_indices
+            .into_iter()
+            .map(|index| index as i32)
+            .collect();
+
         // Auto-reset finished environments
         for (i, &done) in dones.iter().enumerate() {
             if done {
@@ -1094,6 +1165,9 @@ impl VecEnv {
             fames: fames_after,
             panicked,
             truncated,
+            termination_causes,
+            bootstrap_batch,
+            bootstrap_indices,
             scenario_end_triggered,
             new_hexes,
             wound_deltas,

--- a/packages/engine-rs/crates/mk-python/src/lib.rs
+++ b/packages/engine-rs/crates/mk-python/src/lib.rs
@@ -1131,7 +1131,8 @@ impl PyVecEnv {
     /// Args:
     ///     actions: numpy array or list of i32 action indices, one per env.
     ///
-    /// Returns a dict with fame_deltas, dones, fames, panicked, truncated, scenario_end_triggered.
+    /// Returns outcomes, distinct termination causes, and pre-reset bootstrap
+    /// observations for artificial truncations, plus per-step reward signals.
     fn step_batch(&mut self, py: Python<'_>, actions: Vec<i32>) -> PyResult<Py<PyAny>> {
         let result = self.inner.step_batch(&actions);
         let np = py.import("numpy")?;
@@ -1143,6 +1144,21 @@ impl PyVecEnv {
         dict.set_item("fames", vec_i32_to_numpy(py, &np, &result.fames, &[n])?)?;
         dict.set_item("panicked", vec_bool_to_numpy(py, &np, &result.panicked)?)?;
         dict.set_item("truncated", vec_bool_to_numpy(py, &np, &result.truncated)?)?;
+        dict.set_item("termination_causes", vec_i32_to_numpy(py, &np, &result.termination_causes, &[n])?)?;
+        dict.set_item(
+            "bootstrap_indices",
+            vec_i32_to_numpy(
+                py,
+                &np,
+                &result.bootstrap_indices,
+                &[result.bootstrap_indices.len()],
+            )?,
+        )?;
+        if let Some(batch) = &result.bootstrap_batch {
+            dict.set_item("bootstrap_batch", search_batch_to_python(py, batch)?)?;
+        } else {
+            dict.set_item("bootstrap_batch", py.None())?;
+        }
         dict.set_item("scenario_end_triggered", vec_bool_to_numpy(py, &np, &result.scenario_end_triggered)?)?;
         dict.set_item("new_hexes", vec_i32_to_numpy(py, &np, &result.new_hexes, &[n])?)?;
         dict.set_item("wound_deltas", vec_i32_to_numpy(py, &np, &result.wound_deltas, &[n])?)?;
@@ -1208,6 +1224,11 @@ fn mk_python(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", "0.1.0")?;
     m.add("SEARCH_COMBAT_MODE_FULL_ORACLE", mk_env::SEARCH_COMBAT_MODE_FULL_ORACLE)?;
     m.add("SEARCH_COMBAT_MODE_CHEAP", mk_env::SEARCH_COMBAT_MODE_CHEAP)?;
+    m.add("TERMINATION_CAUSE_ONGOING", mk_env::TERMINATION_CAUSE_ONGOING)?;
+    m.add("TERMINATION_CAUSE_NATURAL_END", mk_env::TERMINATION_CAUSE_NATURAL_END)?;
+    m.add("TERMINATION_CAUSE_EARLY_ZERO_FAME", mk_env::TERMINATION_CAUSE_EARLY_ZERO_FAME)?;
+    m.add("TERMINATION_CAUSE_HARD_LIMIT", mk_env::TERMINATION_CAUSE_HARD_LIMIT)?;
+    m.add("TERMINATION_CAUSE_ENGINE_FAILURE", mk_env::TERMINATION_CAUSE_ENGINE_FAILURE)?;
     m.add_class::<GameEngine>()?;
     m.add_class::<PyEncodedStep>()?;
     m.add_class::<PyVecEnv>()?;

--- a/packages/python-sdk/README.md
+++ b/packages/python-sdk/README.md
@@ -99,6 +99,18 @@ training/
 - **Resume** derives the run directory from the checkpoint path automatically.
 - Rewards are configurable: fame deltas (dense), step penalty, and terminal bonuses/penalties. See `sim/rl/rewards.py`.
 
+#### PPO reward-normalization units
+
+The curriculum PPO path normalizes the combined per-step reward before GAE,
+then normalizes the resulting value targets separately for critic training.
+`reward_breakdown/terminal_fame_raw` records the additive terminal-fame reward
+in environment units, while `reward_breakdown/terminal_fame_normalized` records
+its marginal contribution after the reward normalizer's standard-deviation
+scaling (`raw / std`; no mean subtraction for an individual component). These
+two metrics are diagnostic only: the normalization algorithm is unchanged.
+Time-limit bootstrap values are evaluated from the actual post-step state before
+the Rust vector environment resets; natural game endings bootstrap with zero.
+
 ### TensorBoard
 
 Training automatically logs to TensorBoard when installed (included in `.[rl]` extras).

--- a/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
+++ b/packages/python-sdk/src/mage_knight_sdk/cli/train_rl.py
@@ -39,13 +39,26 @@ class RunningMeanStd:
         std = max(self.var ** 0.5, 1e-8)
         return [(v - self.mean) / std for v in values]
 
+    def normalize_component(self, value: float) -> float:
+        """Scale one additive reward component without applying the total-reward mean."""
+        std = max(self.var ** 0.5, 1e-8)
+        return value / std
+
+    def state_dict(self) -> dict[str, float | int]:
+        return {"mean": self.mean, "var": self.var, "count": self.count}
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        self.mean = float(state["mean"])
+        self.var = float(state["var"])
+        self.count = int(state["count"])
+
 
 _METRIC_DESCRIPTIONS: dict[str, str] = {
     "reward/total": "Total shaped reward for the episode. Includes fame, step penalty, end bonus, and victory bonuses.",
-    "reward/fame": "Fame earned this episode (total_reward - 1.0, floored at 0). The core game objective.",
+    "reward/fame": "Actual fame earned this episode, independent of shaped or terminal reward terms.",
     "reward/fame_max": "Running max fame across all episodes. Tracks the best game so far.",
     "episode/steps": "Number of game steps (actions taken) in the episode. Longer = surviving more turns.",
-    "episode/fame_binary": "1.0 if total_reward > 1.5, else 0.0. Tracks what fraction of games earn meaningful fame.",
+    "episode/fame_binary": "1.0 if actual fame is positive, else 0.0.",
     "optimization/loss": "PPO clipped surrogate policy loss. Negative = policy improving. Should hover near zero, not diverge.",
     "optimization/entropy": "Action distribution entropy. High = exploring, low = exploiting. Should gradually decline, not collapse to zero.",
     "optimization/critic_loss": "MSE between value head predictions and actual returns. Lower = better state value estimates.",
@@ -80,17 +93,26 @@ class _TBWriter:
         md = f"| Metric | Description |\n|--------|-------------|\n{rows}"
         self._writer.add_text("metric_guide", md, 0)
 
-    def log_episode(self, episode: int, stats: Any, reward_breakdown: Any = None) -> None:
+    def log_episode(
+        self,
+        episode: int,
+        stats: Any,
+        fame: float,
+        game_score: int | None = None,
+        reward_breakdown: Any = None,
+        normalized_terminal_fame: float = 0.0,
+    ) -> None:
         if self._writer is None:
             return
         self._write_metric_guide()
-        fame = max(0, stats.total_reward - 1.0)
         self._max_fame = max(self._max_fame, fame)
         self._writer.add_scalar("reward/total", stats.total_reward, episode)
         self._writer.add_scalar("reward/fame", fame, episode)
         self._writer.add_scalar("reward/fame_max", self._max_fame, episode)
         self._writer.add_scalar("episode/steps", stats.steps, episode)
-        self._writer.add_scalar("episode/fame_binary", 1.0 if stats.total_reward > 1.5 else 0.0, episode)
+        self._writer.add_scalar("episode/fame_binary", 1.0 if fame > 0 else 0.0, episode)
+        if game_score is not None:
+            self._writer.add_scalar("episode/game_score", game_score, episode)
         self._writer.add_scalar("episode/scenario_ended", 1.0 if getattr(stats, "scenario_triggered", False) else 0.0, episode)
         self._writer.add_scalar("optimization/loss", stats.optimization.loss, episode)
         self._writer.add_scalar("optimization/entropy", stats.optimization.entropy, episode)
@@ -105,6 +127,8 @@ class _TBWriter:
             self._writer.add_scalar("reward_breakdown/new_hex", reward_breakdown.new_hex_bonus, episode)
             self._writer.add_scalar("reward_breakdown/step_penalty", reward_breakdown.step_penalty, episode)
             self._writer.add_scalar("reward_breakdown/terminal", reward_breakdown.terminal_bonus, episode)
+            self._writer.add_scalar("reward_breakdown/terminal_fame_raw", reward_breakdown.terminal_fame, episode)
+            self._writer.add_scalar("reward_breakdown/terminal_fame_normalized", normalized_terminal_fame, episode)
             self._writer.add_scalar("reward_breakdown/scenario_trigger", reward_breakdown.scenario_trigger_bonus, episode)
             self._writer.add_scalar("reward_breakdown/wasted_move", reward_breakdown.wasted_move_penalty, episode)
             self._writer.add_scalar("reward_breakdown/backtrack", reward_breakdown.backtrack_penalty, episode)
@@ -174,6 +198,7 @@ def main() -> int:
     parser.add_argument("--fame-delta-scale", type=float, default=1.0, help="Reward multiplier for fame deltas (1.0 = match game scoring)")
     parser.add_argument("--step-penalty", type=float, default=0.0, help="Per-step reward penalty")
     parser.add_argument("--terminal-end-bonus", type=float, default=0.0, help="Bonus when game ends normally")
+    parser.add_argument("--terminal-fame-scale", type=float, default=0.0, help="Final-fame multiplier applied only when a game ends naturally")
     parser.add_argument("--terminal-max-steps-penalty", type=float, default=-0.5, help="Penalty when episode hits max steps")
     parser.add_argument("--terminal-failure-penalty", type=float, default=-1.0, help="Penalty for engine failures")
     parser.add_argument("--new-hex-bonus", type=float, default=0.0, help="One-time bonus for each new hex visited")
@@ -215,7 +240,7 @@ def main() -> int:
     parser.add_argument("--no-commerce-oracle", dest="commerce_oracle", action="store_false", help="Disable commerce oracle")
 
     # Early termination
-    parser.add_argument("--early-term-fame-step", type=int, default=60, help="Terminate episode early if fame == 0 after this many steps (0 to disable)")
+    parser.add_argument("--early-term-fame-step", type=int, default=60, help="Fallback zero-fame cutoff for curriculum phases without their own setting (0 to disable)")
 
     # Hierarchical RL
     parser.add_argument("--hrl", action="store_true", help="Enable Hierarchical RL (CEO + Worker dual-policy training)")
@@ -235,12 +260,16 @@ def main() -> int:
     RewardConfig = components["RewardConfig"]
 
     resume_episode_offset = 0
+    resume_reward_normalizer_state: dict[str, Any] | None = None
     if args.resume:
         policy, resume_meta = ReinforcePolicy.load_checkpoint(
             args.resume,
             device_override=args.device,
         )
         resume_episode_offset = resume_meta.get("episode", 0)
+        saved_reward_normalizer = resume_meta.get("reward_normalizer")
+        if isinstance(saved_reward_normalizer, dict):
+            resume_reward_normalizer_state = saved_reward_normalizer
         print(f"Resumed from {args.resume} (episode {resume_episode_offset})")
     else:
         policy_config = PolicyGradientConfig(
@@ -260,6 +289,7 @@ def main() -> int:
         fame_delta_scale=args.fame_delta_scale,
         step_penalty=args.step_penalty,
         terminal_end_bonus=args.terminal_end_bonus,
+        terminal_fame_scale=args.terminal_fame_scale,
         terminal_max_steps_penalty=args.terminal_max_steps_penalty,
         terminal_failure_penalty=args.terminal_failure_penalty,
         new_hex_bonus=args.new_hex_bonus,
@@ -278,10 +308,6 @@ def main() -> int:
     checkpoint_dir.mkdir(exist_ok=True)
     metrics_path = run_dir / "training_log.ndjson"
 
-    if not args.resume:
-        _write_run_manifest(run_dir, args, policy, reward_config,
-                            curriculum_name=args.curriculum)
-
     algo = "PPO" if args.ppo else "REINFORCE"
     hero_display = args.hero if args.hero.lower() != "random" else "random (seeded rotation)"
     seed_display = f"{args.seed} (FIXED)" if args.fixed_seed else str(args.seed)
@@ -291,6 +317,7 @@ def main() -> int:
         f"fame_delta_scale={args.fame_delta_scale} "
         f"step_penalty={args.step_penalty} "
         f"end_bonus={args.terminal_end_bonus} "
+        f"terminal_fame_scale={args.terminal_fame_scale} "
         f"max_steps_penalty={args.terminal_max_steps_penalty} "
         f"failure_penalty={args.terminal_failure_penalty}"
     )
@@ -298,6 +325,7 @@ def main() -> int:
     if args.ppo:
         print(f"PPO: batch_episodes={args.batch_episodes} ppo_epochs={args.ppo_epochs} clip={args.clip_epsilon} gae_lambda={args.gae_lambda}")
 
+    resolved_schedule: Any | None = None
     if args.curriculum:
         from dataclasses import replace
 
@@ -314,6 +342,7 @@ def main() -> int:
             "fame_delta_scale": "fame_delta_scale",
             "step_penalty": "step_penalty",
             "terminal_end_bonus": "terminal_end_bonus",
+            "terminal_fame_scale": "terminal_fame_scale",
             "terminal_max_steps_penalty": "terminal_max_steps_penalty",
             "terminal_failure_penalty": "terminal_failure_penalty",
             "new_hex_bonus": "new_hex_bonus",
@@ -343,6 +372,17 @@ def main() -> int:
         phase_names = [p.name for p in schedule.phases]
         print(f"Curriculum: {args.curriculum} ({len(schedule.phases)} phases, {total_episodes} total episodes)")
         print(f"  Phases: {' → '.join(phase_names)}")
+        resolved_schedule = schedule
+
+    if not args.resume:
+        _write_run_manifest(
+            run_dir,
+            args,
+            policy,
+            reward_config,
+            curriculum_name=args.curriculum,
+            curriculum_schedule=resolved_schedule,
+        )
 
     # Recover running max fame from existing NDJSON so fame_max doesn't reset on resume.
     initial_max_fame = 0.0
@@ -351,7 +391,7 @@ def main() -> int:
             with open(metrics_path, encoding="utf-8") as mf:
                 for line in mf:
                     rec = json.loads(line)
-                    initial_max_fame = max(initial_max_fame, rec.get("total_reward", 0.0) - 1.0)
+                    initial_max_fame = max(initial_max_fame, rec.get("fame", 0.0))
             initial_max_fame = max(0.0, initial_max_fame)
         except Exception:
             pass  # best-effort
@@ -363,11 +403,22 @@ def main() -> int:
 
     try:
         if args.hrl:
-            return _train_hrl(args, policy, checkpoint_dir, metrics_path, tb, resume_episode_offset)
+            return _train_hrl(
+                args, policy, checkpoint_dir, metrics_path, tb,
+                resume_episode_offset, resume_reward_normalizer_state,
+                resolved_schedule,
+            )
         if args.curriculum:
-            return _train_curriculum(args, policy, checkpoint_dir, metrics_path, tb, resume_episode_offset)
+            return _train_curriculum(
+                args, policy, checkpoint_dir, metrics_path, tb,
+                resume_episode_offset, resume_reward_normalizer_state,
+                resolved_schedule,
+            )
         if args.ppo:
-            return _train_ppo_native(args, policy, reward_config, checkpoint_dir, metrics_path, tb, resume_episode_offset)
+            return _train_ppo_native(
+                args, policy, reward_config, checkpoint_dir, metrics_path, tb,
+                resume_episode_offset, resume_reward_normalizer_state,
+            )
         return _train_native_sequential(args, policy, reward_config, checkpoint_dir, metrics_path, tb, resume_episode_offset)
     finally:
         tb.close()
@@ -422,7 +473,7 @@ def _train_native_sequential(
         )
 
         if tb is not None:
-            tb.log_episode(global_ep, stats)
+            tb.log_episode(global_ep, stats, fame=result.fame)
 
         if args.checkpoint_every > 0 and global_ep % args.checkpoint_every == 0:
             checkpoint_path = checkpoint_dir / f"policy_ep_{global_ep:06d}.pt"
@@ -465,6 +516,7 @@ def _train_ppo_native(
     metrics_path: Path,
     tb: _TBWriter | None = None,
     resume_episode_offset: int = 0,
+    resume_reward_normalizer_state: dict[str, Any] | None = None,
 ) -> int:
     """Native PPO training: collect batch of episodes, compute GAE, optimize, repeat."""
     from mage_knight_sdk.sim.rl.native_rl_runner import EpisodeTrainingStats, run_native_rl_game_ppo
@@ -472,6 +524,8 @@ def _train_ppo_native(
 
     episode_num = 0
     reward_normalizer = RunningMeanStd()
+    if resume_reward_normalizer_state is not None:
+        reward_normalizer.load_state_dict(resume_reward_normalizer_state)
 
     while episode_num < args.episodes:
         batch_size = min(args.batch_episodes, args.episodes - episode_num)
@@ -542,6 +596,7 @@ def _train_ppo_native(
                         log_prob=t.log_prob,
                         value=t.value,
                         reward=nr,
+                        bootstrap_value=t.bootstrap_value,
                     )
                     for t, nr in zip(ep, norm_rewards)
                 ])
@@ -590,7 +645,7 @@ def _train_ppo_native(
             )
 
             if tb is not None:
-                tb.log_episode(global_ep, logged_stats)
+                tb.log_episode(global_ep, logged_stats, fame=batch_fames[i])
 
         # Log explained variance for the batch
         if tb is not None and episodes_data:
@@ -613,6 +668,7 @@ def _train_ppo_native(
                     "seed": args.seed + resume_episode_offset + episode_num - 1,
                     "timestamp": datetime.now(UTC).isoformat(),
                 },
+                reward_normalizer_state=reward_normalizer.state_dict(),
             )
 
     if not args.no_final_checkpoint:
@@ -625,6 +681,7 @@ def _train_ppo_native(
                 "seed": args.seed + resume_episode_offset + args.episodes - 1,
                 "timestamp": datetime.now(UTC).isoformat(),
             },
+            reward_normalizer_state=reward_normalizer.state_dict(),
         )
         print(f"Final checkpoint: {final_path}")
 
@@ -644,6 +701,8 @@ def _train_hrl(
     metrics_path: Path,
     tb: _TBWriter | None = None,
     resume_episode_offset: int = 0,
+    resume_reward_normalizer_state: dict[str, Any] | None = None,
+    resolved_schedule: Any | None = None,
 ) -> int:
     """Train with Hierarchical RL: CEO picks goals, Worker executes."""
     from mk_python import PyVecEnv
@@ -681,7 +740,9 @@ def _train_hrl(
     ceo_policy = CEOPolicy(ceo_config)
 
     # Use curriculum if specified, else default
-    if args.curriculum:
+    if resolved_schedule is not None:
+        schedule = resolved_schedule
+    elif args.curriculum:
         schedule = CURRICULA[args.curriculum]()
     else:
         from mage_knight_sdk.sim.rl.curriculum import CURRICULA
@@ -689,6 +750,8 @@ def _train_hrl(
 
     global_ep = resume_episode_offset
     reward_normalizer = RunningMeanStd()
+    if resume_reward_normalizer_state is not None:
+        reward_normalizer.load_state_dict(resume_reward_normalizer_state)
     hero = args.hero if args.hero.lower() != "random" else "arythea"
     target_selector = RandomTargetSelector()
     rng = np.random.default_rng(args.seed)
@@ -709,7 +772,9 @@ def _train_hrl(
             scenario=scenario_json,
             combat_oracle=args.combat_oracle,
             commerce_oracle=args.commerce_oracle,
-            early_term_fame_step=args.early_term_fame_step,
+            early_term_fame_step=phase.resolve_early_term_fame_step(
+                args.early_term_fame_step,
+            ),
         )
 
         hrl_buffers = HRLEpisodeBuffers()
@@ -753,6 +818,7 @@ def _train_hrl(
                             log_prob=t.log_prob,
                             value=t.value,
                             reward=nr,
+                            bootstrap_value=t.bootstrap_value,
                         )
                         for t, nr in zip(ep, norm_rewards)
                     ])
@@ -812,6 +878,9 @@ def _train_hrl(
                 total_reward = sum(vt.reward for vt in ep_transitions)
                 fame = meta.total_fame_delta
                 steps = len(ep_transitions)
+                normalized_terminal_fame = reward_normalizer.normalize_component(
+                    meta.reward_breakdown.terminal_fame,
+                )
 
                 log_entry = {
                     "episode": global_ep,
@@ -820,6 +889,12 @@ def _train_hrl(
                     "game_score": meta.game_score,
                     "steps": steps,
                     "total_reward": round(total_reward, 2),
+                    "termination_cause": meta.termination_cause,
+                    "reward_breakdown": {
+                        "terminal": meta.reward_breakdown.terminal_bonus,
+                        "terminal_fame": meta.reward_breakdown.terminal_fame,
+                        "terminal_fame_normalized": normalized_terminal_fame,
+                    },
                     "worker_loss": round(worker_stats.loss, 4),
                     "worker_entropy": round(worker_stats.entropy, 4),
                     "ceo_loss": round(ceo_stats["loss"], 4),
@@ -837,9 +912,22 @@ def _train_hrl(
 
                 if tb and tb._writer:
                     tb._writer.add_scalar("reward/total", total_reward, global_ep)
-                    tb._writer.add_scalar("episode/fame", fame, global_ep)
+                    tb._writer.add_scalar("reward/fame", fame, global_ep)
+                    tb._writer.add_scalar(
+                        "episode/fame_binary", 1.0 if fame > 0 else 0.0, global_ep,
+                    )
                     tb._writer.add_scalar("episode/game_score", meta.game_score, global_ep)
                     tb._writer.add_scalar("episode/steps", steps, global_ep)
+                    tb._writer.add_scalar(
+                        "reward_breakdown/terminal_fame_raw",
+                        meta.reward_breakdown.terminal_fame,
+                        global_ep,
+                    )
+                    tb._writer.add_scalar(
+                        "reward_breakdown/terminal_fame_normalized",
+                        normalized_terminal_fame,
+                        global_ep,
+                    )
                     tb._writer.add_scalar("hrl/worker_loss", worker_stats.loss, global_ep)
                     tb._writer.add_scalar("hrl/ceo_loss", ceo_stats["loss"], global_ep)
                     tb._writer.add_scalar("hrl/ceo_entropy", ceo_stats["entropy"], global_ep)
@@ -853,7 +941,11 @@ def _train_hrl(
                 ckpt_dir = checkpoint_dir / "checkpoints"
                 ckpt_dir.mkdir(exist_ok=True)
                 worker_path = ckpt_dir / f"worker_ep_{global_ep:06d}.pt"
-                worker_policy.save_checkpoint(worker_path, {"episode": global_ep})
+                worker_policy.save_checkpoint(
+                    worker_path,
+                    {"episode": global_ep},
+                    reward_normalizer_state=reward_normalizer.state_dict(),
+                )
                 # TODO: save CEO checkpoint too
 
         del vec_env
@@ -862,7 +954,11 @@ def _train_hrl(
         ckpt_dir = checkpoint_dir / "checkpoints"
         ckpt_dir.mkdir(exist_ok=True)
         final_path = ckpt_dir / "worker_final.pt"
-        worker_policy.save_checkpoint(final_path, {"episode": global_ep})
+        worker_policy.save_checkpoint(
+            final_path,
+            {"episode": global_ep},
+            reward_normalizer_state=reward_normalizer.state_dict(),
+        )
         print(f"Final Worker checkpoint: {final_path}")
 
     print(f"Metrics log: {metrics_path}")
@@ -881,6 +977,8 @@ def _train_curriculum(
     metrics_path: Path,
     tb: _TBWriter | None = None,
     resume_episode_offset: int = 0,
+    resume_reward_normalizer_state: dict[str, Any] | None = None,
+    resolved_schedule: Any | None = None,
 ) -> int:
     """Train with curriculum learning: iterate phases, each with its own scenario + rewards."""
     from mk_python import PyVecEnv
@@ -894,16 +992,32 @@ def _train_curriculum(
         vec_transition_to_transition,
     )
 
-    schedule = CURRICULA[args.curriculum]()
+    schedule = (
+        resolved_schedule
+        if resolved_schedule is not None
+        else CURRICULA[args.curriculum]()
+    )
     global_ep = resume_episode_offset
     reward_normalizer = RunningMeanStd()
+    if resume_reward_normalizer_state is not None:
+        reward_normalizer.load_state_dict(resume_reward_normalizer_state)
     hero = args.hero if args.hero.lower() != "random" else "arythea"
 
     for phase_idx, phase in enumerate(schedule.phases):
         print(f"\n{'=' * 88}")
         print(f"Phase {phase_idx + 1}/{len(schedule.phases)}: {phase.name}")
         print(f"  Scenario: {phase.scenario.kind} | Episodes: {phase.episodes} | Max steps: {phase.max_steps}")
-        print(f"  Rewards: fame_scale={phase.reward_config.fame_delta_scale} step_penalty={phase.reward_config.step_penalty} end_bonus={phase.reward_config.terminal_end_bonus}")
+        print(
+            "  Rewards: "
+            f"fame_scale={phase.reward_config.fame_delta_scale} "
+            f"step_penalty={phase.reward_config.step_penalty} "
+            f"end_bonus={phase.reward_config.terminal_end_bonus} "
+            f"terminal_fame_scale={phase.reward_config.terminal_fame_scale}"
+        )
+        print(
+            "  Early zero-fame cutoff: "
+            f"{phase.resolve_early_term_fame_step(args.early_term_fame_step)}"
+        )
         print(f"{'=' * 88}")
 
         scenario_json = phase.scenario.to_rust_json()
@@ -916,7 +1030,9 @@ def _train_curriculum(
             scenario=scenario_json,
             combat_oracle=args.combat_oracle,
             commerce_oracle=args.commerce_oracle,
-            early_term_fame_step=args.early_term_fame_step,
+            early_term_fame_step=phase.resolve_early_term_fame_step(
+                args.early_term_fame_step,
+            ),
         )
 
         episode_buffers = EpisodeBuffers()
@@ -931,6 +1047,31 @@ def _train_curriculum(
                 total_steps=steps_per_collect,
                 episode_buffers=episode_buffers,
             )
+
+            for failed_meta in result.failed_episode_metas:
+                global_ep += 1
+                phase_episodes_done += 1
+                failure_stats = EpisodeTrainingStats(
+                    outcome="engine_error",
+                    steps=len(failed_meta.action_indices),
+                    total_reward=0.0,
+                    optimization=OptimizationStats(
+                        loss=0.0,
+                        total_reward=0.0,
+                        mean_reward=0.0,
+                        entropy=0.0,
+                        action_count=0,
+                    ),
+                )
+                _append_metrics_log(
+                    path=metrics_path,
+                    episode=global_ep - 1,
+                    seed=failed_meta.seed,
+                    stats=failure_stats,
+                    phase_name=phase.name,
+                    phase_index=phase_idx,
+                    termination_cause=failed_meta.termination_cause,
+                )
 
             if not result.episodes:
                 continue
@@ -959,6 +1100,7 @@ def _train_curriculum(
                             log_prob=t.log_prob,
                             value=t.value,
                             reward=nr,
+                            bootstrap_value=t.bootstrap_value,
                         )
                         for t, nr in zip(ep, norm_rewards)
                     ])
@@ -1013,10 +1155,23 @@ def _train_curriculum(
                     reward_breakdown=meta.reward_breakdown,
                     game_score=meta.game_score,
                     achievement_breakdown=meta.achievement_breakdown,
+                    termination_cause=meta.termination_cause,
+                    normalized_terminal_fame=reward_normalizer.normalize_component(
+                        meta.reward_breakdown.terminal_fame,
+                    ),
                 )
 
                 if tb is not None:
-                    tb.log_episode(global_ep, stats, reward_breakdown=meta.reward_breakdown)
+                    tb.log_episode(
+                        global_ep,
+                        stats,
+                        fame=meta.total_fame_delta,
+                        game_score=meta.game_score,
+                        reward_breakdown=meta.reward_breakdown,
+                        normalized_terminal_fame=reward_normalizer.normalize_component(
+                            meta.reward_breakdown.terminal_fame,
+                        ),
+                    )
                     wounds_per_combat = (
                         meta.total_wounds / meta.combats_entered
                         if meta.combats_entered > 0 else 0.0
@@ -1053,29 +1208,41 @@ def _train_curriculum(
             # Checkpoint at interval
             if args.checkpoint_every > 0 and global_ep % args.checkpoint_every < len(result.episodes):
                 cp_path = checkpoint_dir / f"policy_ep_{global_ep:06d}.pt"
-                policy.save_checkpoint(cp_path, metadata={
-                    "episode": global_ep,
-                    "phase": phase.name,
-                    "phase_index": phase_idx,
-                    "timestamp": datetime.now(UTC).isoformat(),
-                })
+                policy.save_checkpoint(
+                    cp_path,
+                    metadata={
+                        "episode": global_ep,
+                        "phase": phase.name,
+                        "phase_index": phase_idx,
+                        "timestamp": datetime.now(UTC).isoformat(),
+                    },
+                    reward_normalizer_state=reward_normalizer.state_dict(),
+                )
 
         # Phase boundary checkpoint
         cp_path = checkpoint_dir / f"policy_phase_{phase_idx}_{phase.name}.pt"
-        policy.save_checkpoint(cp_path, metadata={
-            "episode": global_ep,
-            "phase": phase.name,
-            "phase_index": phase_idx,
-            "timestamp": datetime.now(UTC).isoformat(),
-        })
+        policy.save_checkpoint(
+            cp_path,
+            metadata={
+                "episode": global_ep,
+                "phase": phase.name,
+                "phase_index": phase_idx,
+                "timestamp": datetime.now(UTC).isoformat(),
+            },
+            reward_normalizer_state=reward_normalizer.state_dict(),
+        )
         print(f"Phase checkpoint: {cp_path}")
 
     if not args.no_final_checkpoint:
         final_path = checkpoint_dir / "policy_final.pt"
-        policy.save_checkpoint(final_path, metadata={
-            "episode": global_ep,
-            "timestamp": datetime.now(UTC).isoformat(),
-        })
+        policy.save_checkpoint(
+            final_path,
+            metadata={
+                "episode": global_ep,
+                "timestamp": datetime.now(UTC).isoformat(),
+            },
+            reward_normalizer_state=reward_normalizer.state_dict(),
+        )
         print(f"Final checkpoint: {final_path}")
 
     print(f"Metrics log: {metrics_path}")
@@ -1150,6 +1317,7 @@ def _write_run_manifest(
     policy: Any,
     reward_config: Any,
     curriculum_name: str | None = None,
+    curriculum_schedule: Any | None = None,
 ) -> None:
     """Write run_config.json with policy/reward config and CLI args for reproducibility."""
     manifest: dict[str, Any] = {
@@ -1160,6 +1328,7 @@ def _write_run_manifest(
             "fame_delta_scale": reward_config.fame_delta_scale,
             "step_penalty": reward_config.step_penalty,
             "terminal_end_bonus": reward_config.terminal_end_bonus,
+            "terminal_fame_scale": reward_config.terminal_fame_scale,
             "terminal_max_steps_penalty": reward_config.terminal_max_steps_penalty,
             "terminal_failure_penalty": reward_config.terminal_failure_penalty,
             "new_hex_bonus": reward_config.new_hex_bonus,
@@ -1175,9 +1344,11 @@ def _write_run_manifest(
     }
     if curriculum_name:
         from mage_knight_sdk.sim.rl.curriculum import CURRICULA
-        schedule_fn = CURRICULA.get(curriculum_name)
-        if schedule_fn:
-            schedule = schedule_fn()
+        schedule = curriculum_schedule
+        if schedule is None:
+            schedule_fn = CURRICULA.get(curriculum_name)
+            schedule = schedule_fn() if schedule_fn is not None else None
+        if schedule is not None:
             manifest["curriculum"] = {
                 "name": curriculum_name,
                 "phases": [
@@ -1186,6 +1357,9 @@ def _write_run_manifest(
                         "scenario": {"kind": p.scenario.kind, **p.scenario.params},
                         "episodes": p.episodes,
                         "max_steps": p.max_steps,
+                        "early_term_fame_step": p.resolve_early_term_fame_step(
+                            args.early_term_fame_step,
+                        ),
                         "reward_config": asdict(p.reward_config),
                     }
                     for p in schedule.phases
@@ -1231,6 +1405,8 @@ def _append_metrics_log(
     reward_breakdown: Any = None,
     game_score: int | None = None,
     achievement_breakdown: dict[str, int] | None = None,
+    termination_cause: str | None = None,
+    normalized_terminal_fame: float = 0.0,
 ) -> None:
     """Write metrics from EpisodeTrainingStats."""
     explore_fame = tiles_explored * 1
@@ -1242,6 +1418,11 @@ def _append_metrics_log(
         "tiles_explored": tiles_explored,
         "combat_fame": combat_fame,
         "outcome": stats.outcome,
+        "termination_cause": termination_cause or (
+            "natural_end" if stats.outcome == "ended" else
+            "engine_failure" if stats.outcome == "engine_error" else
+            "hard_limit"
+        ),
         "steps": stats.steps,
         "reason": None,
         "scenario_triggered": getattr(stats, "scenario_triggered", False),
@@ -1274,6 +1455,8 @@ def _append_metrics_log(
             "new_hex": reward_breakdown.new_hex_bonus,
             "step_penalty": reward_breakdown.step_penalty,
             "terminal": reward_breakdown.terminal_bonus,
+            "terminal_fame": reward_breakdown.terminal_fame,
+            "terminal_fame_normalized": normalized_terminal_fame,
             "scenario_trigger": reward_breakdown.scenario_trigger_bonus,
             "wasted_move": reward_breakdown.wasted_move_penalty,
             "backtrack": reward_breakdown.backtrack_penalty,

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/curriculum.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/curriculum.py
@@ -119,6 +119,13 @@ class CurriculumPhase:
     reward_config: RewardConfig
     episodes: int
     max_steps: int = 2000
+    early_term_fame_step: int | None = None
+
+    def resolve_early_term_fame_step(self, global_default: int) -> int:
+        """Return the phase cutoff, falling back to the legacy CLI default."""
+        if self.early_term_fame_step is None:
+            return global_default
+        return self.early_term_fame_step
 
 
 @dataclass(frozen=True)

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/hrl_runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/hrl_runner.py
@@ -7,7 +7,7 @@ together over a VecEnv, collecting separate transition buffers for each.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 import numpy as np
 
@@ -19,7 +19,13 @@ from .hrl_policy import CEOPolicy, CEOTransition
 from .policy_gradient import ReinforcePolicy
 from .rewards import RewardConfig
 from .vec_env_runner import (
-    VecTransition, _extract_vec_transition, CompletedEpisodeMeta, RewardBreakdown, EpisodeBuffers,
+    EpisodeBuffers,
+    CompletedEpisodeMeta,
+    RewardBreakdown,
+    TERMINATION_CAUSE_HARD_LIMIT,
+    VecTransition,
+    _extract_vec_transition,
+    termination_cause_name,
 )
 
 logger = logging.getLogger(__name__)
@@ -204,10 +210,33 @@ def collect_hrl_rollout(
 
         # 5. Step all envs
         step_result = vec_env.step_batch(actions)
+        bootstrap_values_by_env: dict[int, float] = {}
+        bootstrap_batch = step_result["bootstrap_batch"]
+        if bootstrap_batch is not None:
+            bootstrap_indices = np.asarray(
+                step_result["bootstrap_indices"], dtype=np.int64,
+            )
+            augmented_bootstrap_batch = dict(bootstrap_batch)
+            augmented_bootstrap_batch["state_scalars"] = np.concatenate(
+                [
+                    goal_encodings[bootstrap_indices],
+                    bootstrap_batch["state_scalars"],
+                ],
+                axis=1,
+            )
+            bootstrap_values = worker_policy.evaluate_values_batch(
+                augmented_bootstrap_batch,
+            )
+            bootstrap_values_by_env = {
+                int(env_index): float(value)
+                for env_index, value in zip(bootstrap_indices, bootstrap_values)
+            }
         fame_deltas = step_result["fame_deltas"]
+        final_fames = step_result["fames"]
         dones = step_result["dones"]
         panicked = step_result["panicked"]
         truncated_flags = step_result["truncated"]
+        termination_causes = step_result["termination_causes"]
         scenario_flags = step_result["scenario_end_triggered"]
         new_hexes = step_result["new_hexes"]
         wound_deltas = step_result["wound_deltas"]
@@ -360,39 +389,38 @@ def collect_hrl_rollout(
 
                 # Normal completion — finalize Worker episode
                 episode = bufs[i]
-                terminal = reward_config.terminal_end_bonus
+                is_truncated = bool(truncated_flags[i])
+                is_hard_limit = (
+                    int(termination_causes[i]) == TERMINATION_CAUSE_HARD_LIMIT
+                )
+                if is_hard_limit:
+                    terminal_base = reward_config.terminal_max_steps_penalty
+                elif is_truncated:
+                    terminal_base = 0.0
+                else:
+                    terminal_base = reward_config.terminal_end_bonus
+                terminal_fame = 0.0
+                if not is_truncated:
+                    terminal_fame = (
+                        reward_config.terminal_fame_scale * float(final_fames[i])
+                    )
                 cards_bonus = 0.0
                 if reward_config.cards_remaining_bonus != 0.0:
                     cards_bonus = reward_config.cards_remaining_bonus * float(non_wound_hand_sizes[i])
-                    terminal += cards_bonus
-                worker_bufs.reward_terminal[i] += reward_config.terminal_end_bonus
+                terminal = terminal_base + terminal_fame + cards_bonus
+                worker_bufs.reward_terminal[i] += terminal_base
+                worker_bufs.reward_terminal_fame[i] += terminal_fame
                 worker_bufs.reward_cards_remaining[i] += cards_bonus
 
                 if episode:
                     last = episode[-1]
-                    episode[-1] = VecTransition(
-                        state_scalars=last.state_scalars,
-                        state_ids=last.state_ids,
-                        hand_card_ids=last.hand_card_ids,
-                        deck_card_ids=last.deck_card_ids,
-                        discard_card_ids=last.discard_card_ids,
-                        unit_ids=last.unit_ids,
-                        unit_scalars=last.unit_scalars,
-                        combat_enemy_ids=last.combat_enemy_ids,
-                        combat_enemy_scalars=last.combat_enemy_scalars,
-                        skill_ids=last.skill_ids,
-                        visible_site_ids=last.visible_site_ids,
-                        visible_site_scalars=last.visible_site_scalars,
-                        map_enemy_ids=last.map_enemy_ids,
-                        map_enemy_scalars=last.map_enemy_scalars,
-                        revealed_hex_terrain_ids=last.revealed_hex_terrain_ids,
-                        revealed_hex_scalars=last.revealed_hex_scalars,
-                        action_ids=last.action_ids,
-                        action_scalars=last.action_scalars,
-                        action_index=last.action_index,
-                        log_prob=last.log_prob,
-                        value=last.value,
+                    episode[-1] = replace(
+                        last,
                         reward=last.reward + terminal,
+                        bootstrap_value=(
+                            bootstrap_values_by_env.get(i)
+                            if is_truncated else None
+                        ),
                     )
 
                 breakdown = RewardBreakdown(
@@ -402,6 +430,7 @@ def collect_hrl_rollout(
                     new_hex_bonus=worker_bufs.reward_new_hex[i],
                     step_penalty=worker_bufs.reward_step_penalty[i],
                     terminal_bonus=worker_bufs.reward_terminal[i],
+                    terminal_fame=worker_bufs.reward_terminal_fame[i],
                     scenario_trigger_bonus=worker_bufs.reward_scenario_trigger[i],
                     wasted_move_penalty=worker_bufs.reward_wasted_move[i],
                     backtrack_penalty=worker_bufs.reward_backtrack[i],
@@ -413,7 +442,10 @@ def collect_hrl_rollout(
                 completed_metas.append(CompletedEpisodeMeta(
                     seed=worker_bufs.seeds[i],
                     action_indices=list(worker_bufs.action_indices[i]),
-                    truncated=bool(truncated_flags[i]),
+                    truncated=is_truncated,
+                    termination_cause=termination_cause_name(
+                        int(termination_causes[i]),
+                    ),
                     scenario_end_triggered=worker_bufs.scenario_end_triggered[i],
                     total_fame_delta=worker_bufs.fame_deltas[i],
                     tiles_explored=worker_bufs.tiles_explored[i],
@@ -470,6 +502,7 @@ def _reset_worker_buffers(bufs: EpisodeBuffers, i: int) -> None:
     bufs.reward_new_hex[i] = 0.0
     bufs.reward_step_penalty[i] = 0.0
     bufs.reward_terminal[i] = 0.0
+    bufs.reward_terminal_fame[i] = 0.0
     bufs.reward_scenario_trigger[i] = 0.0
     bufs.reward_wasted_move[i] = 0.0
     bufs.reward_backtrack[i] = 0.0

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/native_rl_runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/native_rl_runner.py
@@ -184,7 +184,10 @@ def run_native_rl_game(
 
         # Terminal reward
         if outcome == "ended":
-            terminal = reward_config.terminal_end_bonus
+            terminal = (
+                reward_config.terminal_end_bonus
+                + reward_config.terminal_fame_scale * float(engine.fame())
+            )
         else:
             terminal = reward_config.terminal_max_steps_penalty
         # Scenario trigger bonus (e.g. city revealed)
@@ -308,7 +311,10 @@ def run_native_rl_game_ppo(
 
         # Terminal reward added to last transition
         if outcome == "ended":
-            terminal = reward_config.terminal_end_bonus
+            terminal = (
+                reward_config.terminal_end_bonus
+                + reward_config.terminal_fame_scale * float(engine.fame())
+            )
         else:
             terminal = reward_config.terminal_max_steps_penalty
         # Scenario trigger bonus
@@ -316,12 +322,17 @@ def run_native_rl_game_ppo(
             terminal += reward_config.scenario_trigger_bonus
         if transitions:
             last = transitions[-1]
+            bootstrap_value = None
+            if outcome != "ended":
+                final_encoded = py_encoded_to_encoded_step(engine.encode_step())
+                bootstrap_value = policy.evaluate_encoded_value(final_encoded)
             transitions[-1] = Transition(
                 encoded_step=last.encoded_step,
                 action_index=last.action_index,
                 log_prob=last.log_prob,
                 value=last.value,
                 reward=last.reward + terminal,
+                bootstrap_value=bootstrap_value,
             )
 
     except Exception as e:

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
@@ -1187,6 +1187,7 @@ class ReinforcePolicy:
 
         return selected_index
 
+    @torch.inference_mode()
     def choose_actions_batch(
         self, batch_dict: dict,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/policy_gradient.py
@@ -115,6 +115,7 @@ class Transition:
     log_prob: float
     value: float
     reward: float
+    bootstrap_value: float | None = None
 
 
 @dataclass(frozen=True)
@@ -154,6 +155,7 @@ class TensorizedTransition:
     log_prob: float
     value: float
     reward: float
+    bootstrap_value: float | None = None
 
 
 def tensorize_transition(t: Transition) -> TensorizedTransition:
@@ -192,6 +194,7 @@ def tensorize_transition(t: Transition) -> TensorizedTransition:
         log_prob=t.log_prob,
         value=t.value,
         reward=t.reward,
+        bootstrap_value=t.bootstrap_value,
     )
 
 
@@ -239,6 +242,7 @@ def detensorize_transition(tt: TensorizedTransition) -> Transition:
         log_prob=tt.log_prob,
         value=tt.value,
         reward=tt.reward,
+        bootstrap_value=tt.bootstrap_value,
     )
 
 
@@ -1232,6 +1236,28 @@ class ReinforcePolicy:
             values.detach().cpu().numpy().astype(np.float32),
         )
 
+    def evaluate_values_batch(self, batch_dict: dict[str, Any]) -> np.ndarray:
+        """Evaluate state values without sampling actions or recording PPO data."""
+        was_training = self._network.training
+        self._network.eval()
+        try:
+            with torch.inference_mode():
+                _, values = self._network.forward_batch(batch_dict, self._device)
+        finally:
+            self._network.train(was_training)
+        return values.cpu().numpy().astype(np.float32)
+
+    def evaluate_encoded_value(self, encoded_step: EncodedStep) -> float:
+        """Evaluate one post-step state for time-limit bootstrapping."""
+        was_training = self._network.training
+        self._network.eval()
+        try:
+            with torch.inference_mode():
+                _, value = self._network(encoded_step, self._device)
+        finally:
+            self._network.train(was_training)
+        return float(value.detach().cpu().item())
+
     def record_step_reward(self, reward: float) -> None:
         if self._next_reward_index >= len(self._episode_rewards):
             return
@@ -1582,7 +1608,12 @@ class ReinforcePolicy:
         for pg in self._optimizer.param_groups:
             pg["lr"] = new_lr
 
-    def save_checkpoint(self, path: str | Path, metadata: dict[str, Any] | None = None) -> None:
+    def save_checkpoint(
+        self,
+        path: str | Path,
+        metadata: dict[str, Any] | None = None,
+        reward_normalizer_state: dict[str, float | int] | None = None,
+    ) -> None:
         target = Path(path)
         target.parent.mkdir(parents=True, exist_ok=True)
         payload: dict[str, Any] = {
@@ -1593,6 +1624,8 @@ class ReinforcePolicy:
         }
         if metadata is not None:
             payload["metadata"] = metadata
+        if reward_normalizer_state is not None:
+            payload["reward_normalizer"] = reward_normalizer_state
         torch.save(payload, target)
 
     @classmethod
@@ -1618,6 +1651,9 @@ class ReinforcePolicy:
         metadata = payload.get("metadata")
         if not isinstance(metadata, dict):
             metadata = {}
+        reward_normalizer = payload.get("reward_normalizer")
+        if isinstance(reward_normalizer, dict):
+            metadata["reward_normalizer"] = reward_normalizer
         return policy, metadata
 
     def _reset_episode_buffers(self) -> None:
@@ -1674,7 +1710,15 @@ def compute_gae(
         gae = 0.0
         for t in reversed(range(n)):
             if t == n - 1:
-                next_value = 0.0 if ep_terminated else values[t]
+                if ep_terminated:
+                    next_value = 0.0
+                else:
+                    bootstrap_value = episode[-1].bootstrap_value
+                    if bootstrap_value is None:
+                        raise ValueError(
+                            "truncated episode is missing its post-step bootstrap value"
+                        )
+                    next_value = bootstrap_value
             else:
                 next_value = values[t + 1]
             delta = rewards[t] + gamma * next_value - values[t]

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/rewards.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/rewards.py
@@ -14,6 +14,7 @@ class RewardConfig:
     fame_delta_scale: float = 1.0
     step_penalty: float = 0.0
     terminal_end_bonus: float = 0.0
+    terminal_fame_scale: float = 0.0
     terminal_max_steps_penalty: float = -0.5
     terminal_failure_penalty: float = -1.0
     scenario_trigger_bonus: float = 0.0

--- a/packages/python-sdk/src/mage_knight_sdk/sim/rl/vec_env_runner.py
+++ b/packages/python-sdk/src/mage_knight_sdk/sim/rl/vec_env_runner.py
@@ -17,6 +17,32 @@ from .features import EncodedStep, StateFeatures, ActionFeatures
 
 logger = logging.getLogger(__name__)
 
+TERMINATION_CAUSE_ONGOING = 0
+TERMINATION_CAUSE_NATURAL_END = 1
+TERMINATION_CAUSE_EARLY_ZERO_FAME = 2
+TERMINATION_CAUSE_HARD_LIMIT = 3
+TERMINATION_CAUSE_ENGINE_FAILURE = 4
+
+TERMINATION_NATURAL_END = "natural_end"
+TERMINATION_EARLY_ZERO_FAME = "early_zero_fame"
+TERMINATION_HARD_LIMIT = "hard_limit"
+TERMINATION_ENGINE_FAILURE = "engine_failure"
+
+_TERMINATION_CAUSE_NAMES = {
+    TERMINATION_CAUSE_NATURAL_END: TERMINATION_NATURAL_END,
+    TERMINATION_CAUSE_EARLY_ZERO_FAME: TERMINATION_EARLY_ZERO_FAME,
+    TERMINATION_CAUSE_HARD_LIMIT: TERMINATION_HARD_LIMIT,
+    TERMINATION_CAUSE_ENGINE_FAILURE: TERMINATION_ENGINE_FAILURE,
+}
+
+
+def termination_cause_name(code: int) -> str:
+    """Map the stable Rust termination code to its logged name."""
+    try:
+        return _TERMINATION_CAUSE_NAMES[code]
+    except KeyError as error:
+        raise ValueError(f"unknown termination cause code: {code}") from error
+
 
 @dataclass(frozen=True)
 class VecTransition:
@@ -52,6 +78,7 @@ class VecTransition:
     log_prob: float
     value: float
     reward: float
+    bootstrap_value: float | None = None
 
 
 def _extract_vec_transition(
@@ -126,6 +153,7 @@ def _extract_vec_transition(
         log_prob=log_prob,
         value=value,
         reward=reward,
+        bootstrap_value=None,
     )
 
 
@@ -172,6 +200,7 @@ def vec_transition_to_transition(vt: VecTransition) -> Transition:
         log_prob=vt.log_prob,
         value=vt.value,
         reward=vt.reward,
+        bootstrap_value=vt.bootstrap_value,
     )
 
 
@@ -184,6 +213,7 @@ class RewardBreakdown:
     new_hex_bonus: float = 0.0
     step_penalty: float = 0.0
     terminal_bonus: float = 0.0
+    terminal_fame: float = 0.0
     scenario_trigger_bonus: float = 0.0
     wasted_move_penalty: float = 0.0
     backtrack_penalty: float = 0.0
@@ -197,7 +227,8 @@ class CompletedEpisodeMeta:
     """Metadata for a completed episode: seed and action indices for replay."""
     seed: int
     action_indices: list[int]
-    truncated: bool = False  # True if episode hit max_steps (not natural game end)
+    truncated: bool = False  # True for any artificial cutoff (early or hard limit)
+    termination_cause: str = TERMINATION_NATURAL_END
     scenario_end_triggered: bool = False  # True if scenario end condition was met (e.g. city revealed)
     total_fame_delta: int = 0  # Cumulative fame gained during the episode
     tiles_explored: int = 0  # Number of new tiles revealed during the episode
@@ -225,6 +256,7 @@ class EpisodeBuffers:
     reward_new_hex: list[float] = field(default_factory=list)
     reward_step_penalty: list[float] = field(default_factory=list)
     reward_terminal: list[float] = field(default_factory=list)
+    reward_terminal_fame: list[float] = field(default_factory=list)
     reward_scenario_trigger: list[float] = field(default_factory=list)
     reward_wasted_move: list[float] = field(default_factory=list)
     reward_backtrack: list[float] = field(default_factory=list)
@@ -253,6 +285,7 @@ class EpisodeBuffers:
         for lst in (self.reward_fame, self.reward_wound_penalty,
                     self.reward_cards_remaining, self.reward_new_hex,
                     self.reward_step_penalty, self.reward_terminal,
+                    self.reward_terminal_fame,
                     self.reward_scenario_trigger, self.reward_wasted_move,
                     self.reward_backtrack, self.reward_wound_shaping,
                     self.reward_achievement, self.reward_tile_explore):
@@ -282,6 +315,7 @@ class CollectionResult:
     total_episodes: int
     panicked_episodes: int
     episode_metas: list[CompletedEpisodeMeta] = field(default_factory=list)
+    failed_episode_metas: list[CompletedEpisodeMeta] = field(default_factory=list)
 
 
 def collect_vecenv_rollout(
@@ -317,6 +351,7 @@ def collect_vecenv_rollout(
 
     completed_episodes: list[list[VecTransition]] = []
     completed_metas: list[CompletedEpisodeMeta] = []
+    failed_metas: list[CompletedEpisodeMeta] = []
     panicked_count = 0
     steps_collected = 0
 
@@ -352,10 +387,22 @@ def collect_vecenv_rollout(
 
         # 3. Step all envs
         step_result = vec_env.step_batch(actions)
+        bootstrap_values_by_env: dict[int, float] = {}
+        bootstrap_batch = step_result["bootstrap_batch"]
+        if bootstrap_batch is not None:
+            bootstrap_values = policy.evaluate_values_batch(bootstrap_batch)
+            bootstrap_values_by_env = {
+                int(env_index): float(value)
+                for env_index, value in zip(
+                    step_result["bootstrap_indices"], bootstrap_values,
+                )
+            }
         fame_deltas = step_result["fame_deltas"]
+        final_fames = step_result["fames"]
         dones = step_result["dones"]
         panicked = step_result["panicked"]
         truncated_flags = step_result["truncated"]
+        termination_causes = step_result["termination_causes"]
         scenario_flags = step_result["scenario_end_triggered"]
         new_hexes = step_result["new_hexes"]
         wound_deltas = step_result["wound_deltas"]
@@ -477,9 +524,16 @@ def collect_vecenv_rollout(
             steps_collected += 1
 
             if dones[i]:
+                termination_cause = termination_cause_name(int(termination_causes[i]))
                 if panicked[i]:
                     # Engine crashed — discard this episode entirely
                     panicked_count += 1
+                    failed_metas.append(CompletedEpisodeMeta(
+                        seed=episode_buffers.seeds[i],
+                        action_indices=list(episode_buffers.action_indices[i]),
+                        truncated=False,
+                        termination_cause=termination_cause,
+                    ))
                     bufs[i] = []
                     episode_buffers.buffers[i] = bufs[i]
                     episode_buffers.action_indices[i] = []
@@ -492,6 +546,7 @@ def collect_vecenv_rollout(
                     episode_buffers.reward_new_hex[i] = 0.0
                     episode_buffers.reward_step_penalty[i] = 0.0
                     episode_buffers.reward_terminal[i] = 0.0
+                    episode_buffers.reward_terminal_fame[i] = 0.0
                     episode_buffers.reward_scenario_trigger[i] = 0.0
                     episode_buffers.reward_wasted_move[i] = 0.0
                     episode_buffers.reward_backtrack[i] = 0.0
@@ -511,12 +566,23 @@ def collect_vecenv_rollout(
 
                 # Normal completion — add terminal reward
                 episode = bufs[i]
-                terminal = reward_config.terminal_end_bonus
+                is_truncated = bool(truncated_flags[i])
+                is_hard_limit = int(termination_causes[i]) == TERMINATION_CAUSE_HARD_LIMIT
+                if is_hard_limit:
+                    terminal_base = reward_config.terminal_max_steps_penalty
+                elif is_truncated:
+                    terminal_base = 0.0
+                else:
+                    terminal_base = reward_config.terminal_end_bonus
+                terminal_fame = 0.0
+                if not is_truncated:
+                    terminal_fame = reward_config.terminal_fame_scale * float(final_fames[i])
                 cards_bonus = 0.0
                 if reward_config.cards_remaining_bonus != 0.0:
                     cards_bonus = reward_config.cards_remaining_bonus * float(non_wound_hand_sizes[i])
-                    terminal += cards_bonus
-                episode_buffers.reward_terminal[i] += reward_config.terminal_end_bonus
+                terminal = terminal_base + terminal_fame + cards_bonus
+                episode_buffers.reward_terminal[i] += terminal_base
+                episode_buffers.reward_terminal_fame[i] += terminal_fame
                 episode_buffers.reward_cards_remaining[i] += cards_bonus
                 last = episode[-1]
                 episode[-1] = VecTransition(
@@ -542,6 +608,9 @@ def collect_vecenv_rollout(
                     log_prob=last.log_prob,
                     value=last.value,
                     reward=last.reward + terminal,
+                    bootstrap_value=(
+                        bootstrap_values_by_env.get(i) if is_truncated else None
+                    ),
                 )
                 breakdown = RewardBreakdown(
                     fame=episode_buffers.reward_fame[i],
@@ -550,6 +619,7 @@ def collect_vecenv_rollout(
                     new_hex_bonus=episode_buffers.reward_new_hex[i],
                     step_penalty=episode_buffers.reward_step_penalty[i],
                     terminal_bonus=episode_buffers.reward_terminal[i],
+                    terminal_fame=episode_buffers.reward_terminal_fame[i],
                     scenario_trigger_bonus=episode_buffers.reward_scenario_trigger[i],
                     wasted_move_penalty=episode_buffers.reward_wasted_move[i],
                     backtrack_penalty=episode_buffers.reward_backtrack[i],
@@ -562,6 +632,7 @@ def collect_vecenv_rollout(
                     seed=episode_buffers.seeds[i],
                     action_indices=list(episode_buffers.action_indices[i]),
                     truncated=bool(truncated_flags[i]),
+                    termination_cause=termination_cause,
                     scenario_end_triggered=episode_buffers.scenario_end_triggered[i],
                     total_fame_delta=episode_buffers.fame_deltas[i],
                     tiles_explored=episode_buffers.tiles_explored[i],
@@ -592,6 +663,7 @@ def collect_vecenv_rollout(
                 episode_buffers.reward_new_hex[i] = 0.0
                 episode_buffers.reward_step_penalty[i] = 0.0
                 episode_buffers.reward_terminal[i] = 0.0
+                episode_buffers.reward_terminal_fame[i] = 0.0
                 episode_buffers.reward_scenario_trigger[i] = 0.0
                 episode_buffers.reward_wasted_move[i] = 0.0
                 episode_buffers.reward_backtrack[i] = 0.0
@@ -614,4 +686,5 @@ def collect_vecenv_rollout(
         total_episodes=len(completed_episodes),
         panicked_episodes=panicked_count,
         episode_metas=completed_metas,
+        failed_episode_metas=failed_metas,
     )

--- a/packages/python-sdk/tests/test_rl_embedding_network.py
+++ b/packages/python-sdk/tests/test_rl_embedding_network.py
@@ -381,6 +381,22 @@ class ReinforcePolicyTest(unittest.TestCase):
 
 
 class CheckpointRoundTripTest(unittest.TestCase):
+    def test_reward_normalizer_checkpoint_round_trip(self) -> None:
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            embedding_dim=8, hidden_size=64, device="cpu", d_model=32,
+        ))
+        reward_state = {"mean": 1.25, "var": 3.5, "count": 99}
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "test.pt"
+            policy.save_checkpoint(
+                path,
+                metadata={"episode": 5},
+                reward_normalizer_state=reward_state,
+            )
+            _, meta = ReinforcePolicy.load_checkpoint(path, device_override="cpu")
+
+        self.assertEqual(meta["reward_normalizer"], reward_state)
+
     def test_checkpoint_save_load(self) -> None:
         config = PolicyGradientConfig(
             embedding_dim=8, hidden_size=64, device="cpu", d_model=32,

--- a/packages/python-sdk/tests/test_rl_embedding_network.py
+++ b/packages/python-sdk/tests/test_rl_embedding_network.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import torch
 
@@ -361,6 +362,29 @@ class EmbeddingNetworkForwardTest(unittest.TestCase):
 
 
 class ReinforcePolicyTest(unittest.TestCase):
+    def test_choose_actions_batch_disables_autograd(self) -> None:
+        from mk_python import PyVecEnv
+
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            embedding_dim=8, hidden_size=64, device="cpu", d_model=32,
+        ))
+        batch = PyVecEnv(num_envs=2, base_seed=42).encode_batch()
+        grad_enabled_during_forward: list[bool] = []
+        original_forward = policy._network.forward_batch
+
+        def recording_forward(batch_dict: dict, device: torch.device):
+            grad_enabled_during_forward.append(torch.is_grad_enabled())
+            return original_forward(batch_dict, device)
+
+        with patch.object(
+            policy._network,
+            "forward_batch",
+            side_effect=recording_forward,
+        ):
+            policy.choose_actions_batch(batch)
+
+        self.assertEqual(grad_enabled_during_forward, [False])
+
     def test_choose_action_from_encoded(self) -> None:
         config = PolicyGradientConfig(
             embedding_dim=8, hidden_size=64, device="cpu", d_model=32,

--- a/packages/python-sdk/tests/test_rl_features.py
+++ b/packages/python-sdk/tests/test_rl_features.py
@@ -163,7 +163,7 @@ class VocabSyncWithRustTest(unittest.TestCase):
 
 class DimensionConstantsTest(unittest.TestCase):
     def test_dimensions(self) -> None:
-        self.assertEqual(STATE_SCALAR_DIM, 91)
+        self.assertEqual(STATE_SCALAR_DIM, 99)
         self.assertEqual(ACTION_SCALAR_DIM, 34)
         self.assertEqual(SITE_SCALAR_DIM, 8)
         self.assertEqual(MAP_ENEMY_SCALAR_DIM, 11)

--- a/packages/python-sdk/tests/test_rl_rewards.py
+++ b/packages/python-sdk/tests/test_rl_rewards.py
@@ -1,11 +1,36 @@
 """Tests for RL reward config and EpisodeTrainingStats."""
 from __future__ import annotations
 
+import argparse
 import unittest
+import json
+import tempfile
+from pathlib import Path
 
+from mage_knight_sdk.cli.train_rl import (
+    _TBWriter,
+    _append_metrics_log,
+    _write_run_manifest,
+)
 from mage_knight_sdk.sim.rl.rewards import RewardConfig
 from mage_knight_sdk.sim.rl.native_rl_runner import EpisodeTrainingStats
-from mage_knight_sdk.sim.rl.policy_gradient import OptimizationStats
+from mage_knight_sdk.sim.rl.curriculum import (
+    CurriculumPhase,
+    CurriculumSchedule,
+    TrainingScenario,
+)
+from mage_knight_sdk.sim.rl.policy_gradient import (
+    OptimizationStats,
+    PolicyGradientConfig,
+    ReinforcePolicy,
+    Transition,
+    compute_gae,
+)
+from mage_knight_sdk.sim.rl.vec_env_runner import (
+    RewardBreakdown,
+    TERMINATION_CAUSE_ENGINE_FAILURE,
+    termination_cause_name,
+)
 
 
 class RewardConfigTest(unittest.TestCase):
@@ -14,6 +39,7 @@ class RewardConfigTest(unittest.TestCase):
         self.assertAlmostEqual(config.fame_delta_scale, 1.0)
         self.assertAlmostEqual(config.step_penalty, 0.0)
         self.assertAlmostEqual(config.terminal_end_bonus, 0.0)
+        self.assertAlmostEqual(config.terminal_fame_scale, 0.0)
         self.assertAlmostEqual(config.terminal_max_steps_penalty, -0.5)
         self.assertAlmostEqual(config.terminal_failure_penalty, -1.0)
 
@@ -22,10 +48,12 @@ class RewardConfigTest(unittest.TestCase):
             fame_delta_scale=2.0,
             step_penalty=-0.01,
             terminal_end_bonus=5.0,
+            terminal_fame_scale=0.5,
         )
         self.assertAlmostEqual(config.fame_delta_scale, 2.0)
         self.assertAlmostEqual(config.step_penalty, -0.01)
         self.assertAlmostEqual(config.terminal_end_bonus, 5.0)
+        self.assertAlmostEqual(config.terminal_fame_scale, 0.5)
 
 
 class EpisodeTrainingStatsDefaultsTest(unittest.TestCase):
@@ -41,3 +69,182 @@ class EpisodeTrainingStatsDefaultsTest(unittest.TestCase):
         )
         self.assertFalse(stats.scenario_triggered)
         self.assertAlmostEqual(stats.achievement_bonus, 0.0)
+
+
+class GaeBootstrapTest(unittest.TestCase):
+    def test_truncation_uses_post_step_bootstrap_value(self) -> None:
+        transition = Transition(
+            encoded_step=None,  # type: ignore[arg-type]
+            action_index=0,
+            log_prob=0.0,
+            value=2.0,
+            reward=1.0,
+            bootstrap_value=7.0,
+        )
+
+        _, advantages, returns = compute_gae(
+            [[transition]],
+            gamma=0.9,
+            gae_lambda=1.0,
+            terminated=[False],
+        )
+
+        self.assertAlmostEqual(advantages[0], 1.0 + 0.9 * 7.0 - 2.0)
+        self.assertAlmostEqual(returns[0], 1.0 + 0.9 * 7.0)
+
+
+class CurriculumPhaseTerminationTest(unittest.TestCase):
+    def test_phase_can_override_global_early_termination(self) -> None:
+        phase = CurriculumPhase(
+            name="terminal_phase",
+            scenario=TrainingScenario.full_game(),
+            reward_config=RewardConfig(),
+            episodes=10,
+            early_term_fame_step=0,
+        )
+
+        self.assertEqual(phase.resolve_early_term_fame_step(global_default=60), 0)
+
+    def test_phase_without_override_uses_global_default(self) -> None:
+        phase = CurriculumPhase(
+            name="warmup",
+            scenario=TrainingScenario.full_game(),
+            reward_config=RewardConfig(),
+            episodes=10,
+        )
+
+        self.assertEqual(phase.resolve_early_term_fame_step(global_default=60), 60)
+
+    def test_manifest_records_resolved_phase_reward_and_cutoff(self) -> None:
+        phase = CurriculumPhase(
+            name="terminal_phase",
+            scenario=TrainingScenario.full_game(),
+            reward_config=RewardConfig(terminal_fame_scale=0.5),
+            episodes=10,
+            early_term_fame_step=0,
+        )
+        schedule = CurriculumSchedule(phases=[phase])
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32,
+            embedding_dim=8,
+            d_model=32,
+            device="cpu",
+        ))
+        args = argparse.Namespace(early_term_fame_step=60)
+
+        with tempfile.TemporaryDirectory() as directory:
+            _write_run_manifest(
+                Path(directory),
+                args,
+                policy,
+                RewardConfig(),
+                curriculum_name="test",
+                curriculum_schedule=schedule,
+            )
+            record = json.loads(
+                (Path(directory) / "run_config.json").read_text(encoding="utf-8"),
+            )
+
+        recorded_phase = record["curriculum"]["phases"][0]
+        self.assertEqual(recorded_phase["early_term_fame_step"], 0)
+        self.assertEqual(
+            recorded_phase["reward_config"]["terminal_fame_scale"], 0.5,
+        )
+
+
+class TerminationLoggingTest(unittest.TestCase):
+    def test_engine_failure_code_has_stable_name(self) -> None:
+        self.assertEqual(
+            termination_cause_name(TERMINATION_CAUSE_ENGINE_FAILURE),
+            "engine_failure",
+        )
+
+    def test_ndjson_records_explicit_termination_cause(self) -> None:
+        stats = EpisodeTrainingStats(
+            outcome="max_steps",
+            steps=3,
+            total_reward=-0.5,
+            optimization=OptimizationStats(
+                loss=0.0,
+                total_reward=-0.5,
+                mean_reward=-1.0 / 6.0,
+                entropy=0.0,
+                action_count=3,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "training_log.ndjson"
+            _append_metrics_log(
+                path=path,
+                episode=0,
+                seed=42,
+                stats=stats,
+                termination_cause="early_zero_fame",
+            )
+            record = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(record["termination_cause"], "early_zero_fame")
+
+    def test_ndjson_records_raw_and_normalized_terminal_fame(self) -> None:
+        stats = EpisodeTrainingStats(
+            outcome="ended",
+            steps=3,
+            total_reward=4.0,
+            optimization=OptimizationStats(
+                loss=0.0,
+                total_reward=4.0,
+                mean_reward=4.0 / 3.0,
+                entropy=0.0,
+                action_count=3,
+            ),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "training_log.ndjson"
+            _append_metrics_log(
+                path=path,
+                episode=0,
+                seed=42,
+                stats=stats,
+                reward_breakdown=RewardBreakdown(terminal_fame=4.0),
+                normalized_terminal_fame=2.0,
+            )
+            record = json.loads(path.read_text(encoding="utf-8"))
+
+        self.assertEqual(record["reward_breakdown"]["terminal_fame"], 4.0)
+        self.assertEqual(
+            record["reward_breakdown"]["terminal_fame_normalized"], 2.0,
+        )
+
+
+class TensorBoardFameMetricTest(unittest.TestCase):
+    def test_fame_metrics_use_explicit_fame_not_shaped_reward(self) -> None:
+        class CaptureWriter:
+            def __init__(self) -> None:
+                self.scalars: dict[str, float] = {}
+
+            def add_scalar(self, tag: str, value: float, _step: int) -> None:
+                self.scalars[tag] = value
+
+        capture = CaptureWriter()
+        writer = _TBWriter.__new__(_TBWriter)
+        writer._writer = capture
+        writer._max_fame = 0.0
+        writer._wrote_guide = True
+        stats = EpisodeTrainingStats(
+            outcome="ended",
+            steps=10,
+            total_reward=100.0,
+            optimization=OptimizationStats(
+                loss=0.0,
+                total_reward=100.0,
+                mean_reward=10.0,
+                entropy=0.0,
+                action_count=10,
+            ),
+        )
+
+        writer.log_episode(1, stats, fame=0, game_score=12)
+
+        self.assertEqual(capture.scalars["reward/fame"], 0)
+        self.assertEqual(capture.scalars["episode/fame_binary"], 0.0)
+        self.assertEqual(capture.scalars["episode/game_score"], 12)

--- a/packages/python-sdk/tests/test_vec_env.py
+++ b/packages/python-sdk/tests/test_vec_env.py
@@ -28,8 +28,8 @@ class TestPyVecEnv(unittest.TestCase):
         env = self.PyVecEnv(num_envs=n, base_seed=1)
         batch = env.encode_batch()
 
-        # State scalars: (N, STATE_SCALAR_DIM=91)
-        self.assertEqual(batch["state_scalars"].shape, (n, 91))
+        # State scalars: (N, STATE_SCALAR_DIM=99)
+        self.assertEqual(batch["state_scalars"].shape, (n, 99))
         self.assertEqual(batch["state_scalars"].dtype, np.float32)
 
         # State IDs: (N, 3)
@@ -276,6 +276,173 @@ class TestBatchedForward(unittest.TestCase):
 class TestVecEnvRunner(unittest.TestCase):
     """Tests for the VecEnv collection loop."""
 
+    def test_terminal_end_bonus_is_not_applied_to_hard_limit(self) -> None:
+        """A time-limit truncation must not be rewarded as a natural ending."""
+        from mk_python import PyVecEnv
+        from mage_knight_sdk.sim.rl.policy_gradient import (
+            PolicyGradientConfig,
+            ReinforcePolicy,
+        )
+        from mage_knight_sdk.sim.rl.rewards import RewardConfig
+        from mage_knight_sdk.sim.rl.vec_env_runner import collect_vecenv_rollout
+
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32, embedding_dim=8, device="cpu",
+        ))
+        env = PyVecEnv(num_envs=2, base_seed=42, max_steps=1)
+        rewards = RewardConfig(
+            fame_delta_scale=0.0,
+            terminal_end_bonus=7.0,
+            terminal_fame_scale=5.0,
+            terminal_max_steps_penalty=0.0,
+        )
+
+        result = collect_vecenv_rollout(env, policy, rewards, total_steps=2)
+
+        self.assertEqual(result.total_episodes, 2)
+        self.assertTrue(all(meta.truncated for meta in result.episode_metas))
+        self.assertTrue(
+            all(meta.termination_cause == "hard_limit" for meta in result.episode_metas)
+        )
+        for episode in result.episodes:
+            self.assertAlmostEqual(sum(t.reward for t in episode), 0.0)
+
+    def test_terminal_fame_reward_is_applied_to_natural_end(self) -> None:
+        """Natural endings receive final fame through the dedicated scale."""
+        from mk_python import PyVecEnv
+        from mage_knight_sdk.sim.rl.curriculum import TrainingScenario
+        from mage_knight_sdk.sim.rl.policy_gradient import (
+            PolicyGradientConfig,
+            ReinforcePolicy,
+        )
+        from mage_knight_sdk.sim.rl.rewards import RewardConfig
+        from mage_knight_sdk.sim.rl.vec_env_runner import collect_vecenv_rollout
+
+        scenario = TrainingScenario.combat_drill(
+            enemy_tokens=["diggers_1"],
+            hand_override=["rage", "determination", "stamina"],
+        ).to_rust_json()
+        env = PyVecEnv(
+            num_envs=2,
+            base_seed=42,
+            max_steps=20,
+            scenario=scenario,
+            combat_oracle=True,
+        )
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32, embedding_dim=8, device="cpu",
+        ))
+        rewards = RewardConfig(
+            fame_delta_scale=0.0,
+            terminal_fame_scale=0.5,
+            terminal_max_steps_penalty=-3.0,
+        )
+
+        result = collect_vecenv_rollout(env, policy, rewards, total_steps=2)
+
+        self.assertEqual(result.total_episodes, 2)
+        for episode, meta in zip(result.episodes, result.episode_metas):
+            self.assertFalse(meta.truncated)
+            self.assertEqual(meta.termination_cause, "natural_end")
+            expected = 0.5 * meta.total_fame_delta
+            self.assertAlmostEqual(sum(t.reward for t in episode), expected)
+            self.assertAlmostEqual(meta.reward_breakdown.terminal_fame, expected)
+            self.assertAlmostEqual(meta.reward_breakdown.terminal_bonus, 0.0)
+
+    def test_zero_fame_cutoff_has_distinct_termination_cause(self) -> None:
+        from mk_python import PyVecEnv
+        from mage_knight_sdk.sim.rl.policy_gradient import (
+            PolicyGradientConfig,
+            ReinforcePolicy,
+        )
+        from mage_knight_sdk.sim.rl.rewards import RewardConfig
+        from mage_knight_sdk.sim.rl.vec_env_runner import collect_vecenv_rollout
+
+        env = PyVecEnv(
+            num_envs=2,
+            base_seed=42,
+            max_steps=10,
+            early_term_fame_step=1,
+        )
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32, embedding_dim=8, device="cpu",
+        ))
+
+        result = collect_vecenv_rollout(
+            env,
+            policy,
+            RewardConfig(fame_delta_scale=0.0),
+            total_steps=2,
+        )
+
+        self.assertEqual(result.total_episodes, 2)
+        self.assertTrue(
+            all(
+                meta.termination_cause == "early_zero_fame"
+                for meta in result.episode_metas
+            )
+        )
+
+    def test_terminal_max_steps_penalty_is_applied_to_hard_limit(self) -> None:
+        """A hard environment time limit receives its configured penalty."""
+        from mk_python import PyVecEnv
+        from mage_knight_sdk.sim.rl.policy_gradient import (
+            PolicyGradientConfig,
+            ReinforcePolicy,
+        )
+        from mage_knight_sdk.sim.rl.rewards import RewardConfig
+        from mage_knight_sdk.sim.rl.vec_env_runner import collect_vecenv_rollout
+
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32, embedding_dim=8, device="cpu",
+        ))
+        env = PyVecEnv(num_envs=2, base_seed=42, max_steps=1)
+        rewards = RewardConfig(
+            fame_delta_scale=0.0,
+            terminal_end_bonus=0.0,
+            terminal_max_steps_penalty=-3.0,
+        )
+
+        result = collect_vecenv_rollout(env, policy, rewards, total_steps=2)
+
+        self.assertEqual(result.total_episodes, 2)
+        for episode in result.episodes:
+            self.assertAlmostEqual(sum(t.reward for t in episode), -3.0)
+
+    def test_hard_limit_captures_post_step_bootstrap_value(self) -> None:
+        """The runner evaluates the pre-reset resulting state at truncation."""
+        from mk_python import PyVecEnv
+        from mage_knight_sdk.sim.rl.policy_gradient import (
+            PolicyGradientConfig,
+            ReinforcePolicy,
+        )
+        from mage_knight_sdk.sim.rl.rewards import RewardConfig
+        from mage_knight_sdk.sim.rl.vec_env_runner import collect_vecenv_rollout
+
+        policy = ReinforcePolicy(PolicyGradientConfig(
+            hidden_size=32, embedding_dim=8, device="cpu",
+        ))
+        evaluated_batches: list[dict] = []
+
+        def fixed_post_step_values(batch: dict) -> np.ndarray:
+            evaluated_batches.append(batch)
+            return np.full(len(batch["action_counts"]), 7.0, dtype=np.float32)
+
+        policy.evaluate_values_batch = fixed_post_step_values  # type: ignore[method-assign]
+        env = PyVecEnv(num_envs=2, base_seed=42, max_steps=1)
+
+        result = collect_vecenv_rollout(
+            env,
+            policy,
+            RewardConfig(fame_delta_scale=0.0, terminal_max_steps_penalty=0.0),
+            total_steps=2,
+        )
+
+        self.assertEqual(len(evaluated_batches), 1)
+        self.assertEqual(len(evaluated_batches[0]["action_counts"]), 2)
+        for episode in result.episodes:
+            self.assertAlmostEqual(episode[-1].bootstrap_value or 0.0, 7.0)
+
     def test_collect_rollout(self) -> None:
         """Collect a small rollout and verify structure."""
         from mk_python import PyVecEnv
@@ -304,7 +471,7 @@ class TestVecEnvRunner(unittest.TestCase):
         self.assertGreater(len(ep), 0)
 
         vt = ep[0]
-        self.assertEqual(vt.state_scalars.shape, (91,))
+        self.assertEqual(vt.state_scalars.shape, (99,))
         self.assertEqual(vt.state_ids.shape, (3,))
         self.assertGreater(vt.action_ids.shape[0], 0)
 
@@ -332,7 +499,7 @@ class TestVecEnvRunner(unittest.TestCase):
         vt = result.episodes[0][0]
         t = vec_transition_to_transition(vt)
 
-        self.assertEqual(len(t.encoded_step.state.scalars), 91)
+        self.assertEqual(len(t.encoded_step.state.scalars), 99)
         self.assertGreater(len(t.encoded_step.actions), 0)
         self.assertIsInstance(t.reward, float)
 


### PR DESCRIPTION
## Summary

- distinguish `natural_end`, `early_zero_fame`, `hard_limit`, and `engine_failure` from the Rust vector environment through Python logging
- apply end bonuses and the new configurable `terminal_fame_scale` only to natural endings, and apply `terminal_max_steps_penalty` only to hard limits
- bootstrap truncated PPO episodes from the encoded post-step/pre-reset state instead of the stale pre-action value
- make the early zero-fame cutoff curriculum-phase-specific while preserving the global fallback
- report actual fame/game score in TensorBoard and expose raw versus normalized terminal-fame contributions
- checkpoint and restore the reward normalizer alongside the existing policy/value checkpoint state
- document reward/value normalization units and add regression coverage across the Rust-backed vector path, PPO GAE, metrics, curricula, and checkpointing

## Why

The planned shaped-versus-shaped-plus-terminal-fame experiment would otherwise be confounded by successful-end rewards on truncated games, missing hard-limit penalties, stale time-limit bootstrapping, shared curriculum cutoffs, misleading fame metrics, and a reward normalizer that reset on resume.

Defaults remain backward compatible: `terminal_fame_scale` is `0.0`, and phases without an explicit cutoff continue to use the CLI fallback.

## Self-review notes

- The terminal-reward work was isolated onto a fresh branch from current `origin/main`; unrelated MCTS/combat changes in the original worktree are not included.
- Review caught stale Python assertions that still expected 91 state scalars even though the current Rust/Python encoder dimension is 99. Those assertions were corrected without changing the encoder.

## Validation

- `cargo test`
- `cargo clippy`
- `ruff check src tests`
- `python -m unittest discover -s tests -p 'test_*.py'` — 100 passed
- repository pre-push hook: Clippy, `bun run lint`, and optimized Rust workspace tests
- 8-environment/256-episode PPO smoke:
  - all 256 treatment episodes ended naturally and received `0.5 × final fame`
  - `terminal_fame_scale=0` matched the existing shaped path exactly
  - all 8 hard-limit episodes used post-step bootstrap values distinct from their pre-action values
  - 2 positive-fame hard-limit episodes received no terminal fame or natural-end bonus
  - early-zero-fame and hard-limit causes remained distinct
  - TensorBoard fame/game-score values matched NDJSON
  - reward-normalizer checkpoint round-trip preserved count, mean, and variance
